### PR TITLE
readBytes(size) - return a shared subsequence buffer and update the original position

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -207,6 +207,10 @@ val double = buffer.readDouble()
 val string = buffer.readUtf8(numOfBytesToRead)
 // read byte array
 val byteArray = buffer.readByteArray(numOfBytesToRead)
+// read a shared subsequence read buffer (changes to the original reflect here)
+val readBuffer = buffer.readBytes(numOfBytesForBuffer)
+// slice the buffer without adjusting the position or limit (changes to the original reflect here)
+val slicedBuffer = buffer.slice()
 ```
 
 ## Building Locally

--- a/src/commonMain/kotlin/com/ditchoom/buffer/ReadBuffer.kt
+++ b/src/commonMain/kotlin/com/ditchoom/buffer/ReadBuffer.kt
@@ -3,7 +3,20 @@ package com.ditchoom.buffer
 interface ReadBuffer : PositionBuffer {
     fun resetForRead()
     fun readByte(): Byte
+
+    // slice does not change the position
     fun slice(): ReadBuffer
+
+    fun readBytes(size: Int): ReadBuffer {
+        val oldLimit = limit()
+        val oldPosition = position()
+        setLimit(position() + size)
+        val bytes = slice()
+        position(oldPosition + size)
+        setLimit(oldLimit)
+        return bytes
+    }
+
     fun readByteArray(size: Int): ByteArray
     fun readUnsignedByte(): UByte = readByte().toUByte()
     fun readShort(): Short = readNumberWithByteSize(Short.SIZE_BYTES).toShort()

--- a/src/commonTest/kotlin/com/ditchoom/buffer/BufferTests.kt
+++ b/src/commonTest/kotlin/com/ditchoom/buffer/BufferTests.kt
@@ -16,6 +16,23 @@ class BufferTests {
         platformBuffer.writeByte((-1).toByte())
         platformBuffer.resetForRead()
         val slicedBuffer = platformBuffer.slice()
+        assertEquals(0, platformBuffer.position())
+        assertEquals(1, platformBuffer.limit())
+        assertEquals(0, slicedBuffer.position())
+        assertEquals(1, slicedBuffer.limit())
+        assertEquals(-1, slicedBuffer.readByte())
+        assertEquals(1, slicedBuffer.position())
+        assertEquals(1, slicedBuffer.limit())
+    }
+
+    @Test
+    fun readBytes() {
+        val platformBuffer = PlatformBuffer.allocate(3)
+        platformBuffer.writeByte((-1).toByte())
+        platformBuffer.resetForRead()
+        val slicedBuffer = platformBuffer.readBytes(1)
+        assertEquals(1, platformBuffer.position())
+        assertEquals(1, platformBuffer.limit())
         assertEquals(0, slicedBuffer.position())
         assertEquals(1, slicedBuffer.limit())
         assertEquals(-1, slicedBuffer.readByte())


### PR DESCRIPTION
add `fun readBytes(size: Int): ReadBuffer` so we can read a shared subsequence buffer while also adjusting the position of the original buffer. Changes in the original buffer will reflect in this new buffer.