### PR TITLE
PlatformBuffer.readString should throw an exception on malformed data

### DIFF
--- a/src/androidMain/kotlin/com/ditchoom/buffer/BaseJvmBuffer.kt
+++ b/src/androidMain/kotlin/com/ditchoom/buffer/BaseJvmBuffer.kt
@@ -4,6 +4,7 @@ import java.io.RandomAccessFile
 import java.nio.Buffer
 import java.nio.ByteBuffer
 import java.nio.CharBuffer
+import java.nio.charset.CodingErrorAction
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
@@ -50,7 +51,7 @@ abstract class BaseJvmBuffer(open val byteBuffer: ByteBuffer, val fileRef: Rando
         val finalPosition = buffer.position() + length
         val readBuffer = byteBuffer.asReadOnlyBuffer()
         (readBuffer as Buffer).limit(finalPosition)
-        val decoded = when (charset) {
+        val charsetConverted = when (charset) {
             Charset.UTF8 -> Charsets.UTF_8
             Charset.UTF16 -> Charsets.UTF_16
             Charset.UTF16BigEndian -> Charsets.UTF_16BE
@@ -60,7 +61,11 @@ abstract class BaseJvmBuffer(open val byteBuffer: ByteBuffer, val fileRef: Rando
             Charset.UTF32 -> Charsets.UTF_32
             Charset.UTF32LittleEndian -> Charsets.UTF_32LE
             Charset.UTF32BigEndian -> Charsets.UTF_32BE
-        }.decode(readBuffer)
+        }
+        val decoded = charsetConverted.newDecoder()
+            .onMalformedInput(CodingErrorAction.REPORT)
+            .onUnmappableCharacter(CodingErrorAction.REPORT)
+            .decode(readBuffer)
         buffer.position(finalPosition)
         return decoded.toString()
     }

--- a/src/appleMain/kotlin/com/ditchoom/buffer/MutableDataBuffer.kt
+++ b/src/appleMain/kotlin/com/ditchoom/buffer/MutableDataBuffer.kt
@@ -104,7 +104,6 @@ class MutableDataBuffer(
             text.toString() as NSString
         }
         val charsetEncoding = charset.toEncoding()
-        charset.toEncoding()
         write(DataBuffer(string.dataUsingEncoding(charsetEncoding)!!, byteOrder))
         return this
     }

--- a/src/commonTest/kotlin/com/ditchoom/buffer/BufferTests.kt
+++ b/src/commonTest/kotlin/com/ditchoom/buffer/BufferTests.kt
@@ -4,6 +4,7 @@ import kotlin.math.absoluteValue
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertFails
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -724,5 +725,14 @@ class BufferTests {
             }
         }
         assertTrue { successfulCount > 0 }
+    }
+
+    @Test
+    fun invalidCharacterInBufferThrows() {
+        assertFails {
+            val buffer = PlatformBuffer.wrap(byteArrayOf(2, 126, 33, -66, -100, 4, -39, 108))
+            buffer.readString(buffer.remaining())
+            println("should have failed by now")
+        }
     }
 }

--- a/src/jsMain/kotlin/com/ditchoom/buffer/JsBuffer.kt
+++ b/src/jsMain/kotlin/com/ditchoom/buffer/JsBuffer.kt
@@ -6,6 +6,7 @@ import org.khronos.webgl.DataView
 import org.khronos.webgl.Int8Array
 import org.khronos.webgl.Uint8Array
 import web.encoding.TextDecoder
+import web.encoding.TextDecoderOptions
 
 data class JsBuffer(
     val buffer: Uint8Array,
@@ -116,8 +117,7 @@ data class JsBuffer(
             Charset.UTF32LittleEndian -> throw UnsupportedOperationException("Not sure how to implement")
             Charset.UTF32BigEndian -> throw UnsupportedOperationException("Not sure how to implement")
         }
-
-        val textDecoder = TextDecoder(encoding)
+        val textDecoder = TextDecoder(encoding, js("{fatal: true}") as TextDecoderOptions)
         val result = textDecoder.decode(
             buffer.subarray(position, position + length).unsafeCast<BufferSource>()
         )


### PR DESCRIPTION
Before this PR, sometimes `readString` would throw an exception (apple targets) and sometimes would silently discard the bad characters (non-apple targets). Now, we ensure the readString will consistently throw an exception on all platforms.

It would be nice to be able to pass in a parameter controlling this behavior but I am not sure how to do that on apple platforms using kotlin multiplatform.