### PR TITLE
avoid crashing on apple when an empty string is passed in to `String.toReadBuffer`

### DIFF
--- a/src/commonMain/kotlin/com/ditchoom/buffer/BufferFactory.kt
+++ b/src/commonMain/kotlin/com/ditchoom/buffer/BufferFactory.kt
@@ -25,6 +25,9 @@ fun CharSequence.maxBufferSize(charset: Charset): Int {
 }
 
 fun String.toReadBuffer(charset: Charset = Charset.UTF8, zone: AllocationZone = AllocationZone.Heap): ReadBuffer {
+    if (this == "") {
+        return ReadBuffer.EMPTY_BUFFER
+    }
     val maxBytes = maxBufferSize(charset)
     val buffer = PlatformBuffer.allocate(maxBytes, zone)
     buffer.writeString(this, charset)

--- a/src/commonTest/kotlin/com/ditchoom/buffer/BufferTests.kt
+++ b/src/commonTest/kotlin/com/ditchoom/buffer/BufferTests.kt
@@ -735,4 +735,11 @@ class BufferTests {
             println("should have failed by now")
         }
     }
+
+    @Test
+    fun emptyString() {
+        val s = "".toReadBuffer()
+        assertEquals(0, s.position())
+        assertEquals(0, s.limit())
+    }
 }


### PR DESCRIPTION
for some odd reason, apple platforms are crashing with a NPE when passing an empty string. This avoids that issue by simply returning an empty buffer