### PR TITLE
Empty buffer crash fix on `FragmentedReadBuffer.slice`

### DIFF
--- a/src/commonMain/kotlin/com/ditchoom/buffer/FragmentedReadBuffer.kt
+++ b/src/commonMain/kotlin/com/ditchoom/buffer/FragmentedReadBuffer.kt
@@ -80,6 +80,11 @@ class FragmentedReadBuffer(
     }
 
     override fun slice(): ReadBuffer {
+        if (first.position() == 0 && first.limit() == 0) {
+            return second
+        } else if (second.position() == 0 && second.limit() == 0) {
+            return first
+        }
         val first = first.slice()
         val second = second.slice()
         val buffer = PlatformBuffer.allocate(first.limit() + second.limit())


### PR DESCRIPTION
TSIA. Also simplifies the overall work involved if the buffer is empty