### PR TITLE
Fix JSBuffer.readByteArray

### DIFF
--- a/src/commonTest/kotlin/com/ditchoom/buffer/BufferTests.kt
+++ b/src/commonTest/kotlin/com/ditchoom/buffer/BufferTests.kt
@@ -202,14 +202,13 @@ class BufferTests {
     fun byteArray() {
         val size = 200
         val platformBuffer = PlatformBuffer.allocate(size)
-        val bytes = ByteArray(200) { -1 }
+        val bytes = ByteArray(size) { -1 }
         platformBuffer.writeBytes(bytes)
         platformBuffer.resetForRead()
         val byteArray = platformBuffer.readByteArray(size)
         assertEquals(bytes.count(), byteArray.count())
-        var count = 0
-        for (byte in bytes) {
-            assertEquals(byte, byteArray[count++])
+        bytes.forEachIndexed { index, byte ->
+            assertEquals(byte, byteArray[index], "Index $index")
         }
     }
 

--- a/src/commonTest/kotlin/com/ditchoom/buffer/BufferTests.kt
+++ b/src/commonTest/kotlin/com/ditchoom/buffer/BufferTests.kt
@@ -787,11 +787,11 @@ class BufferTests {
         assertEquals(0, s.limit())
     }
 
-
     @OptIn(ExperimentalStdlibApi::class)
     @Test
     fun complexReadWrapReadAgain1() {
         val str = "0001A960DBD8A500006500006400010A003132333435363738"
+
         @OptIn(ExperimentalStdlibApi::class)
         fun String.toByteArrayFromHex(): ByteArray {
             var value = this
@@ -857,5 +857,4 @@ class BufferTests {
         val buffer2 = PlatformBuffer.wrap(bytesRead)
         assertBufferEquals(buffer2, byteArrayOf(3, 4, 5))
     }
-
 }

--- a/src/commonTest/kotlin/com/ditchoom/buffer/BufferTests.kt
+++ b/src/commonTest/kotlin/com/ditchoom/buffer/BufferTests.kt
@@ -1,6 +1,7 @@
 package com.ditchoom.buffer
 
 import kotlin.math.absoluteValue
+import kotlin.math.ceil
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
@@ -785,4 +786,76 @@ class BufferTests {
         assertEquals(0, s.position())
         assertEquals(0, s.limit())
     }
+
+
+    @OptIn(ExperimentalStdlibApi::class)
+    @Test
+    fun complexReadWrapReadAgain1() {
+        val str = "0001A960DBD8A500006500006400010A003132333435363738"
+        @OptIn(ExperimentalStdlibApi::class)
+        fun String.toByteArrayFromHex(): ByteArray {
+            var value = this
+            if (value.isEmpty()) return byteArrayOf()
+            val length = ceil(value.length / 2.0).toInt()
+            value = value.padStart(length * 2, '0')
+            return value.hexToByteArray()
+        }
+        val hex = str.toByteArrayFromHex()
+        assertContentEquals(hex, byteArrayOf(0, 1, -87, 96, -37, -40, -91, 0, 0, 101, 0, 0, 100, 0, 1, 10, 0, 49, 50, 51, 52, 53, 54, 55, 56))
+        val buf = PlatformBuffer.wrap(hex)
+        assertBufferEquals(buf, byteArrayOf(0, 1, -87, 96, -37, -40, -91, 0, 0, 101, 0, 0, 100, 0, 1, 10, 0, 49, 50, 51, 52, 53, 54, 55, 56))
+        assertEquals(0, buf.position())
+        assertEquals(25, buf.limit())
+        val messageId = buf.readUnsignedShort()
+        assertBufferEquals(buf, byteArrayOf(-87, 96, -37, -40, -91, 0, 0, 101, 0, 0, 100, 0, 1, 10, 0, 49, 50, 51, 52, 53, 54, 55, 56))
+        assertEquals(messageId.toInt(), 1)
+        assertEquals(2, buf.position())
+        assertEquals(25, buf.limit())
+        val cmd = buf.readByte()
+        assertBufferEquals(buf, byteArrayOf(96, -37, -40, -91, 0, 0, 101, 0, 0, 100, 0, 1, 10, 0, 49, 50, 51, 52, 53, 54, 55, 56))
+        assertEquals(-87, cmd)
+        assertEquals(3, buf.position())
+        assertEquals(25, buf.limit())
+        val rem = buf.remaining()
+        assertEquals(22, rem)
+        val data = buf.readByteArray(rem)
+        assertContentEquals(data, byteArrayOf(96, -37, -40, -91, 0, 0, 101, 0, 0, 100, 0, 1, 10, 0, 49, 50, 51, 52, 53, 54, 55, 56))
+        val newBuffer = PlatformBuffer.wrap(data)
+        assertEquals(0, newBuffer.position())
+        assertEquals(22, newBuffer.limit())
+        assertBufferEquals(newBuffer, byteArrayOf(96, -37, -40, -91, 0, 0, 101, 0, 0, 100, 0, 1, 10, 0, 49, 50, 51, 52, 53, 54, 55, 56))
+        val b = newBuffer.readByteArray(4)
+        assertEquals(b.toHexString().uppercase(), "60DBD8A5")
+    }
+
+    fun assertBufferEquals(b: ReadBuffer, byteArray: ByteArray) {
+        val p = b.position()
+        val l = b.limit()
+        assertContentEquals(b.readByteArray(b.remaining()), byteArray)
+        b.position(p)
+        b.setLimit(l)
+    }
+
+    @Test
+    fun wrapByteArraySharesBuffer() {
+        val array = byteArrayOf(0, 1, 2, 3, 4, 5)
+        val buf = PlatformBuffer.wrap(array)
+        assertEquals(1, buf[1])
+        array[1] = -1
+        assertEquals(-1, buf[1])
+    }
+
+    @Test
+    fun simpleReadWrapReadAgain() {
+        val array = byteArrayOf(0, 1, 2, 3, 4, 5)
+        val buf = PlatformBuffer.wrap(array)
+        buf.readBytes(3)
+        val bytesRead = buf.readByteArray(buf.remaining())
+        assertEquals(buf.position(), 6)
+        assertEquals(buf.limit(), 6)
+        assertEquals(bytesRead.size, 3)
+        val buffer2 = PlatformBuffer.wrap(bytesRead)
+        assertBufferEquals(buffer2, byteArrayOf(3, 4, 5))
+    }
+
 }

--- a/src/jsMain/kotlin/com/ditchoom/buffer/BufferFactory.kt
+++ b/src/jsMain/kotlin/com/ditchoom/buffer/BufferFactory.kt
@@ -2,7 +2,7 @@ package com.ditchoom.buffer
 
 import js.buffer.SharedArrayBuffer
 import org.khronos.webgl.ArrayBuffer
-import org.khronos.webgl.Uint8Array
+import org.khronos.webgl.Int8Array
 
 fun PlatformBuffer.Companion.allocate(
     size: Int,
@@ -36,17 +36,17 @@ actual fun PlatformBuffer.Companion.allocate(
     return if (sharedArrayBuffer != null) {
         val arrayBuffer = sharedArrayBuffer.unsafeCast<ArrayBuffer>().slice(0, size)
         JsBuffer(
-            Uint8Array(arrayBuffer),
+            Int8Array(arrayBuffer),
             littleEndian = byteOrder == ByteOrder.LITTLE_ENDIAN,
             sharedArrayBuffer = sharedArrayBuffer
         )
     } else {
-        JsBuffer(Uint8Array(size), littleEndian = byteOrder == ByteOrder.LITTLE_ENDIAN)
+        JsBuffer(Int8Array(size), littleEndian = byteOrder == ByteOrder.LITTLE_ENDIAN)
     }
 }
 
 actual fun PlatformBuffer.Companion.wrap(array: ByteArray, byteOrder: ByteOrder): PlatformBuffer =
     JsBuffer(
-        array.unsafeCast<Uint8Array>(),
+        array.unsafeCast<Int8Array>(),
         littleEndian = byteOrder == ByteOrder.LITTLE_ENDIAN
     )

--- a/src/jsMain/kotlin/com/ditchoom/buffer/JsBuffer.kt
+++ b/src/jsMain/kotlin/com/ditchoom/buffer/JsBuffer.kt
@@ -4,12 +4,11 @@ import js.buffer.BufferSource
 import js.buffer.SharedArrayBuffer
 import org.khronos.webgl.DataView
 import org.khronos.webgl.Int8Array
-import org.khronos.webgl.Uint8Array
 import web.encoding.TextDecoder
 import web.encoding.TextDecoderOptions
 
 data class JsBuffer(
-    val buffer: Uint8Array,
+    val buffer: Int8Array,
     private val littleEndian: Boolean = false, // network endian is big endian
     private var position: Int = 0,
     private var limit: Int = 0,
@@ -52,16 +51,17 @@ data class JsBuffer(
 
     override fun slice(): ReadBuffer {
         return JsBuffer(
-            Uint8Array(buffer.buffer.slice(position, limit)),
+            Int8Array(buffer.buffer.slice(position, limit)),
             littleEndian,
             sharedArrayBuffer = sharedArrayBuffer
         )
     }
 
     override fun readByteArray(size: Int): ByteArray {
-        val byteArray = Int8Array(buffer.buffer, position, size).unsafeCast<ByteArray>()
+        val subArray = buffer.subarray(position, position + size)
+        val byteArray = Int8Array(subArray.buffer, subArray.byteOffset, size)
         position += size
-        return byteArray
+        return byteArray.unsafeCast<ByteArray>()
     }
 
     override fun readShort(): Short {
@@ -149,9 +149,9 @@ data class JsBuffer(
     }
 
     override fun writeBytes(bytes: ByteArray, offset: Int, length: Int): WriteBuffer {
-        val uint8Array = bytes.unsafeCast<Uint8Array>().subarray(offset, offset + length)
-        this.buffer.set(uint8Array, position)
-        position += uint8Array.length
+        val int8Array = bytes.unsafeCast<Int8Array>().subarray(offset, offset + length)
+        this.buffer.set(int8Array, position)
+        position += int8Array.length
         return this
     }
 
@@ -189,8 +189,8 @@ data class JsBuffer(
 
     override fun set(index: Int, long: Long): WriteBuffer {
         val bytes = if (littleEndian) long.toByteArray().reversedArray() else long.toByteArray()
-        val uint8Array = bytes.unsafeCast<Uint8Array>().subarray(0, Long.SIZE_BYTES)
-        this.buffer.set(uint8Array, index)
+        val int8Array = bytes.unsafeCast<Int8Array>().subarray(0, Long.SIZE_BYTES)
+        this.buffer.set(int8Array, index)
         return this
     }
 


### PR DESCRIPTION
Fixes https://github.com/DitchOoM/buffer/issues/56
- Use `Int8Array` instead of `UInt8Array` in JSBuffer
- Ensure JSBuffer.readByteArray works correctly
   - It was not extracting the correct part of the buffer correctly, leading to bugs