### PR TITLE
Fix release tag version mismatch and add skip-release mechanism

### DIFF
--- a/.github/workflows/merged.yaml
+++ b/.github/workflows/merged.yaml
@@ -1,8 +1,6 @@
 name: "Build Test and Deploy"
 on:
   pull_request_target:
-    paths-ignore:
-      - '*.md'
     branches: [ main ]
     types:
       - closed
@@ -11,9 +9,55 @@ permissions:
   contents: write
 
 jobs:
+  check-release:
+    name: Check if release is needed
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.check.outputs.should_release }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check for skip-release label or non-code changes only
+        id: check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Check for skip-release label
+          if ${{ contains(github.event.pull_request.labels.*.name, 'skip-release') }}; then
+            echo "skip-release label found, skipping release"
+            echo "should_release=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Get list of changed files
+          changed_files=$(gh pr diff ${{ github.event.pull_request.number }} --name-only)
+
+          # Check if all changed files are non-code (CI, docs, config)
+          should_release=true
+          for file in $changed_files; do
+            case "$file" in
+              .github/*|*.md|.gitignore|.editorconfig|CLAUDE.md|LICENSE|*.txt)
+                # Non-code file, continue checking
+                ;;
+              *)
+                # Code file found, should release
+                echo "Code file changed: $file"
+                echo "should_release=true" >> $GITHUB_OUTPUT
+                exit 0
+                ;;
+            esac
+          done
+
+          # Only non-code files changed
+          echo "Only non-code files changed, skipping release"
+          echo "should_release=false" >> $GITHUB_OUTPUT
+
   macos:
     name: MacOS Build & Upload artifacts to sonatype
-    if: github.event.pull_request.merged == true
+    needs: check-release
+    if: needs.check-release.outputs.should_release == 'true'
     runs-on: macos-latest
     env:
       ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}


### PR DESCRIPTION
## Summary
- Fix version mismatch by calculating version BEFORE publishing rather than after
- Add `check-release` job to skip releases for non-code changes
- Support both `skip-release` label and automatic detection of non-code files

## Changes
1. **Version calculation fix**: Version is now calculated once before any publishing step and reused for tagging, ensuring the tag matches the published version

2. **Skip-release mechanism**:
   - Manually: Add `skip-release` label to any PR
   - Automatic: Detects when only non-code files changed (`.github/*`, `*.md`, `.gitignore`, etc.)

## Test plan
- [ ] Merge a code change PR and verify version matches in tag and Maven Central
- [ ] Add `skip-release` label to a PR and verify no release is created
- [ ] Merge a docs-only PR and verify no release is created