### PR TITLE
Fix JS/WasmJS bulk write to respect source buffer position

### DIFF
--- a/src/jsMain/kotlin/com/ditchoom/buffer/JsBuffer.kt
+++ b/src/jsMain/kotlin/com/ditchoom/buffer/JsBuffer.kt
@@ -135,7 +135,9 @@ data class JsBuffer(
     override fun write(buffer: ReadBuffer) {
         val size = buffer.remaining()
         if (buffer is JsBuffer) {
-            this.buffer.set(buffer.buffer, position)
+            // Copy only the remaining portion (from position to limit)
+            val sourceSubarray = buffer.buffer.subarray(buffer.position(), buffer.position() + size)
+            this.buffer.set(sourceSubarray, position)
         } else {
             this.buffer.set(buffer.readByteArray(size).toTypedArray(), position)
         }

--- a/src/wasmJsMain/kotlin/com/ditchoom/buffer/BufferFactory.wasmJs.kt
+++ b/src/wasmJsMain/kotlin/com/ditchoom/buffer/BufferFactory.wasmJs.kt
@@ -95,17 +95,15 @@ data class KotlinJsBuffer(
     }
 
     override fun write(buffer: ReadBuffer) {
-        val start = position()
-        val byteSize =
-            if (buffer is KotlinJsBuffer) {
-                writeBytes(buffer.data)
-                buffer.data.size
-            } else {
-                val numBytes = buffer.remaining()
-                writeBytes(buffer.readByteArray(numBytes))
-                numBytes
-            }
-        buffer.position(start + byteSize)
+        val numBytes = buffer.remaining()
+        if (buffer is KotlinJsBuffer) {
+            // Copy only the remaining portion (from position to limit)
+            buffer.data.copyInto(data, position, buffer.position(), buffer.position() + numBytes)
+            position += numBytes
+        } else {
+            writeBytes(buffer.readByteArray(numBytes))
+        }
+        buffer.position(buffer.position() + numBytes)
     }
 
     override fun writeString(


### PR DESCRIPTION
## Summary
- Fix bug where `JsBuffer.write()` and `KotlinJsBuffer.write()` ignored the source buffer's position/limit
- Both implementations now correctly copy only the remaining bytes from the source buffer

## Problem
When copying from a source buffer that had already been partially read (position > 0), the old code would copy from the beginning of the underlying array instead of from the current position.

## Changes
- **JsBuffer (JS)**: Use `subarray()` to create a view of only the remaining portion before copying
- **KotlinJsBuffer (WasmJS)**: Use `copyInto()` with proper source range parameters (startIndex, endIndex)

## Test plan
- [x] Build passes on all platforms
- [x] Existing tests pass