### PR TITLE
Fix CI: Remove buffer-compression references until module exists

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -6,7 +6,8 @@ on:
       - main
     paths:
       - 'docs/**'
-      - 'src/**'
+      - 'buffer/src/**'
+      - 'buffer-compression/src/**'
       - 'MODULE.md'
       - '.github/workflows/docs.yaml'
   workflow_dispatch:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,26 +16,23 @@ plugins {
 tasks.register("allTests") {
     description = "Run tests for all modules and platforms"
     group = "verification"
-    dependsOn(":buffer:allTests", ":buffer-compression:jvmTest")
+    dependsOn(":buffer:allTests")
 }
 
 tasks.register("buildAll") {
     description = "Build all modules"
     group = "build"
-    dependsOn(":buffer:build", ":buffer-compression:build")
+    dependsOn(":buffer:build")
 }
 
 // Copy Dokka output to Docusaurus static directory
 tasks.register<Copy>("copyDokkaToDocusaurus") {
     description = "Generate and copy API documentation to Docusaurus"
     group = "documentation"
-    dependsOn(":buffer:dokkaGenerateHtml", ":buffer-compression:dokkaGenerateHtml")
+    dependsOn(":buffer:dokkaGenerateHtml")
 
     from(layout.projectDirectory.dir("buffer/build/dokka/html")) {
         into("buffer")
-    }
-    from(layout.projectDirectory.dir("buffer-compression/build/dokka/html")) {
-        into("buffer-compression")
     }
     into(layout.projectDirectory.dir("docs/static/api"))
 }


### PR DESCRIPTION
## Summary

Fixes the documentation CI failure caused by PR #88 (monorepo restructure).

### Issue 1: Missing buffer-compression module
`build.gradle.kts` references `:buffer-compression` tasks, but the module isn't included in `settings.gradle.kts` yet (it will be added in PR #89).

**Error:**
```
Task with path ':buffer-compression:dokkaGenerateHtml' not found in root project 'buffer'.
```

### Issue 2: Outdated path filters in docs.yaml
The docs workflow was watching `src/**` but with the monorepo structure, source is now at `buffer/src/**`.

## Changes

1. Remove `buffer-compression` references from root build tasks:
   - `allTests` task
   - `buildAll` task
   - `copyDokkaToDocusaurus` task

2. Update `docs.yaml` path filters:
   - `src/**` → `buffer/src/**`, `buffer-compression/src/**`

These will work correctly once PR #89 adds the buffer-compression module.

## Test plan

- [x] `./gradlew help` succeeds (configuration works)
- [x] `copyDokkaToDocusaurus` task is registered
- [ ] CI passes after merge