### PR TITLE
Fix API reference links to include baseUrl prefix

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -30,8 +30,9 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
+          distribution: 'zulu'
           java-version: '19'
+          cache: gradle
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -95,11 +95,11 @@ const config: Config = {
           position: 'left',
           items: [
             {
-              href: 'pathname:///api/buffer/index.html',
+              href: 'pathname:///buffer/api/buffer/index.html',
               label: 'Buffer (Core)',
             },
             {
-              href: 'pathname:///api/buffer-compression/index.html',
+              href: 'pathname:///buffer/api/buffer-compression/index.html',
               label: 'Buffer Compression',
             },
           ],


### PR DESCRIPTION
## Summary

- Fix API reference dropdown links that were returning 404 on GitHub Pages
- Use consistent 'zulu' JDK distribution in docs.yaml workflow

## Problem

The API reference links used `pathname:///api/buffer/index.html` which creates absolute URLs that don't include the `/buffer/` baseUrl. Since the site is deployed at `https://ditchoom.github.io/buffer/`, the links were pointing to `/api/buffer/index.html` (404) instead of `/buffer/api/buffer/index.html`.

## Solution

Changed links to include the baseUrl prefix:
- `pathname:///api/buffer/index.html` → `pathname:///buffer/api/buffer/index.html`
- `pathname:///api/buffer-compression/index.html` → `pathname:///buffer/api/buffer-compression/index.html`

## Test plan

- [x] Verified API docs exist in `docs/static/api/`
- [x] Verified docs build succeeds locally (`npm run build`)
- [x] Verified API docs are copied to build output at `docs/build/api/`
- [x] Verified HTTP 200 when serving locally