### PR TITLE
Trigger docs rebuild on release publish

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -10,6 +10,8 @@ on:
       - 'buffer-compression/src/**'
       - 'MODULE.md'
       - '.github/workflows/docs.yaml'
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Add `release: types: [published]` trigger to docs workflow
- Fixes stale version numbers in API documentation (e.g., showing 1.5.7 instead of 1.6.0)

## Problem
The API docs at https://ditchoom.github.io/buffer/api/buffer/index.html were showing version 1.5.7 even though Maven Central has 1.6.0. This happened because the docs workflow only triggered on source file changes, so releases without source changes (dependency bumps, CI changes, etc.) never rebuilt the docs.

## Test plan
- [ ] Verify PR triggers `review.yaml` workflow (docs validation job)
- [ ] After merge, verify `docs.yaml` workflow runs and deploys updated docs
- [ ] Confirm API reference shows current version (1.6.x)