### PR TITLE
Add multi-release JAR support for ByteBuffer.mismatch() optimization

### DIFF
--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -24,6 +24,43 @@ jobs:
       - name: Run tests
         run: ./gradlew ktlintCheck jvmTest jsNodeTest jsBrowserTest wasmJsNodeTest wasmJsBrowserTest --no-build-cache
 
+  multi-release-jar:
+    name: "Validate Multi-Release JAR"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 19
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '19'
+          cache: gradle
+      - name: Build JAR
+        run: ./gradlew :buffer:jvmJar --no-build-cache
+      - name: Verify JAR structure
+        run: |
+          JAR_FILE=$(ls buffer/build/libs/buffer-jvm-*.jar | head -1)
+          echo "=== Multi-Release JAR Validation ==="
+          echo "JAR: $JAR_FILE"
+
+          echo "--- Manifest ---"
+          unzip -p "$JAR_FILE" META-INF/MANIFEST.MF
+
+          echo "--- Structure ---"
+          jar tf "$JAR_FILE" | grep -E "BufferMismatch|META-INF/versions"
+
+          echo "--- Validation ---"
+          unzip -p "$JAR_FILE" META-INF/MANIFEST.MF | grep -q "Multi-Release: true" || (echo "FAIL: Multi-Release attribute missing" && exit 1)
+          echo "✓ Multi-Release: true"
+
+          jar tf "$JAR_FILE" | grep -q "^com/ditchoom/buffer/BufferMismatchHelper.class" || (echo "FAIL: Base class missing" && exit 1)
+          echo "✓ Base BufferMismatchHelper.class present"
+
+          jar tf "$JAR_FILE" | grep -q "META-INF/versions/11/com/ditchoom/buffer/BufferMismatchHelper.class" || (echo "FAIL: Java 11 class missing" && exit 1)
+          echo "✓ Java 11 BufferMismatchHelper.class present"
+
+          echo "=== JAR structure verified ==="
+
   apple:
     name: "Apple Target Tests"
     runs-on: macos-latest

--- a/buffer/src/androidMain/kotlin/com/ditchoom/buffer/BufferMismatchHelper.kt
+++ b/buffer/src/androidMain/kotlin/com/ditchoom/buffer/BufferMismatchHelper.kt
@@ -1,0 +1,11 @@
+package com.ditchoom.buffer
+
+import java.nio.ByteBuffer
+
+/** Uses default ReadBuffer.mismatch() implementation on Android. */
+internal actual object BufferMismatchHelper {
+    actual fun mismatch(
+        buffer1: ByteBuffer,
+        buffer2: ByteBuffer,
+    ): Int = USE_DEFAULT_MISMATCH
+}

--- a/buffer/src/jvm11Main/kotlin/com/ditchoom/buffer/BufferMismatchHelper.kt
+++ b/buffer/src/jvm11Main/kotlin/com/ditchoom/buffer/BufferMismatchHelper.kt
@@ -1,0 +1,12 @@
+@file:Suppress("unused") // Loaded at runtime via multi-release JAR, not referenced directly
+
+package com.ditchoom.buffer
+
+import java.nio.ByteBuffer
+
+internal object BufferMismatchHelper {
+    fun mismatch(
+        buffer1: ByteBuffer,
+        buffer2: ByteBuffer,
+    ): Int = buffer1.mismatch(buffer2)
+}

--- a/buffer/src/jvmCommonMain/kotlin/com/ditchoom/buffer/BufferMismatchHelper.kt
+++ b/buffer/src/jvmCommonMain/kotlin/com/ditchoom/buffer/BufferMismatchHelper.kt
@@ -1,0 +1,24 @@
+package com.ditchoom.buffer
+
+import java.nio.ByteBuffer
+
+/** Sentinel value indicating the default ReadBuffer.mismatch() should be used. */
+internal const val USE_DEFAULT_MISMATCH = Int.MIN_VALUE
+
+/**
+ * Helper for buffer mismatch operations.
+ *
+ * Returns [USE_DEFAULT_MISMATCH] to use the default ReadBuffer.mismatch(),
+ * or the actual result from native ByteBuffer.mismatch().
+ *
+ * Platform-specific implementations:
+ * - JVM Java 8: Returns USE_DEFAULT_MISMATCH
+ * - JVM Java 11+: Returns ByteBuffer.mismatch() result via multi-release JAR
+ * - Android: Returns USE_DEFAULT_MISMATCH
+ */
+internal expect object BufferMismatchHelper {
+    fun mismatch(
+        buffer1: ByteBuffer,
+        buffer2: ByteBuffer,
+    ): Int
+}

--- a/buffer/src/jvmMain/kotlin/com/ditchoom/buffer/BufferMismatchHelper.kt
+++ b/buffer/src/jvmMain/kotlin/com/ditchoom/buffer/BufferMismatchHelper.kt
@@ -1,0 +1,10 @@
+package com.ditchoom.buffer
+
+import java.nio.ByteBuffer
+
+internal actual object BufferMismatchHelper {
+    actual fun mismatch(
+        buffer1: ByteBuffer,
+        buffer2: ByteBuffer,
+    ): Int = USE_DEFAULT_MISMATCH
+}

--- a/buffer/src/jvmTest/kotlin/com/ditchoom/buffer/MultiReleaseJarTest.kt
+++ b/buffer/src/jvmTest/kotlin/com/ditchoom/buffer/MultiReleaseJarTest.kt
@@ -1,0 +1,70 @@
+package com.ditchoom.buffer
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests to verify multi-release JAR structure and mismatch correctness.
+ */
+class MultiReleaseJarTest {
+    @Test
+    fun `mismatch produces correct results`() {
+        val buffer1 = PlatformBuffer.allocate(100)
+        val buffer2 = PlatformBuffer.allocate(100)
+
+        // Write same data to both
+        repeat(100) {
+            buffer1.writeByte(it.toByte())
+            buffer2.writeByte(it.toByte())
+        }
+        buffer1.resetForRead()
+        buffer2.resetForRead()
+
+        // Should match
+        assertTrue(buffer1.contentEquals(buffer2), "Identical buffers should match")
+        assertEquals(-1, buffer1.mismatch(buffer2), "Identical buffers should have no mismatch")
+
+        // Reset and modify one byte
+        buffer1.position(0)
+        buffer2.position(0)
+        buffer2.position(50)
+        buffer2.writeByte(99.toByte()) // Change byte at position 50
+        buffer1.position(0)
+        buffer2.position(0)
+
+        // Should find mismatch at position 50
+        assertEquals(50, buffer1.mismatch(buffer2), "Should find mismatch at position 50")
+    }
+
+    @Test
+    fun `mismatch handles edge cases`() {
+        // Empty buffers
+        val empty1 = PlatformBuffer.allocate(0)
+        val empty2 = PlatformBuffer.allocate(0)
+        assertEquals(-1, empty1.mismatch(empty2), "Empty buffers should match")
+
+        // Different sizes
+        val small = PlatformBuffer.allocate(10)
+        val large = PlatformBuffer.allocate(20)
+        repeat(10) {
+            small.writeByte(it.toByte())
+            large.writeByte(it.toByte())
+        }
+        repeat(10) { large.writeByte(it.toByte()) }
+        small.resetForRead()
+        large.resetForRead()
+
+        // Should return index where they differ (at end of smaller buffer)
+        assertEquals(10, small.mismatch(large), "Should find mismatch at end of smaller buffer")
+
+        // First byte mismatch
+        val a = PlatformBuffer.allocate(10)
+        val b = PlatformBuffer.allocate(10)
+        a.writeByte(1)
+        b.writeByte(2)
+        a.resetForRead()
+        b.resetForRead()
+        assertEquals(0, a.mismatch(b), "Should find mismatch at first byte")
+    }
+}

--- a/buffer/src/jvmTest/kotlin/com/ditchoom/buffer/ValidateMultiReleaseJar.kt
+++ b/buffer/src/jvmTest/kotlin/com/ditchoom/buffer/ValidateMultiReleaseJar.kt
@@ -1,0 +1,85 @@
+@file:JvmName("ValidateMultiReleaseJar")
+
+package com.ditchoom.buffer
+
+/**
+ * Standalone validator for multi-release JAR.
+ *
+ * Run this with different JVM versions to verify the correct class is loaded:
+ *
+ *   # Build the JAR first
+ *   ./gradlew :buffer:jvmJar
+ *
+ *   # Run with Java 8 (should use fallback)
+ *   /path/to/java8/bin/java -cp buffer/build/libs/buffer-jvm-*.jar \
+ *       com.ditchoom.buffer.ValidateMultiReleaseJar
+ *
+ *   # Run with Java 11+ (should use ByteBuffer.mismatch)
+ *   /path/to/java11/bin/java -cp buffer/build/libs/buffer-jvm-*.jar \
+ *       com.ditchoom.buffer.ValidateMultiReleaseJar
+ */
+fun main() {
+    val javaVersion = System.getProperty("java.specification.version")
+    val javaHome = System.getProperty("java.home")
+
+    println("=== Multi-Release JAR Validation ===")
+    println("Java version: $javaVersion")
+    println("Java home: $javaHome")
+    println()
+
+    // Check which class file is being used
+    val helperClass = BufferMismatchHelper::class.java
+    val resourceName = helperClass.name.replace('.', '/') + ".class"
+    val classUrl = helperClass.classLoader?.getResource(resourceName)
+
+    println("BufferMismatchHelper loaded from:")
+    println("  $classUrl")
+    println()
+
+    // Determine expected behavior
+    val majorVersion = javaVersion?.substringBefore('.')?.toIntOrNull() ?: 8
+    val expectedImpl =
+        if (majorVersion >= 11) {
+            "META-INF/versions/11 (ByteBuffer.mismatch)"
+        } else {
+            "root (Long comparisons fallback)"
+        }
+
+    println("Expected implementation: $expectedImpl")
+
+    // Verify by checking URL
+    val urlStr = classUrl?.toString() ?: ""
+    val actualImpl =
+        when {
+            urlStr.contains("META-INF/versions/11") -> "META-INF/versions/11 (ByteBuffer.mismatch)"
+            urlStr.contains(".jar!") -> "root (Long comparisons fallback)"
+            else -> "build directory (not from JAR)"
+        }
+
+    println("Actual implementation: $actualImpl")
+    println()
+
+    // Quick functional test
+    println("=== Functional Test ===")
+    val buffer1 = java.nio.ByteBuffer.allocate(1000)
+    val buffer2 = java.nio.ByteBuffer.allocate(1000)
+    repeat(1000) {
+        buffer1.put(it.toByte())
+        buffer2.put(it.toByte())
+    }
+    buffer1.flip()
+    buffer2.flip()
+
+    // Modify one byte
+    buffer2.put(500, 99.toByte())
+
+    val result = BufferMismatchHelper.mismatch(buffer1, buffer2)
+
+    if (result == USE_DEFAULT_MISMATCH) {
+        println("Result: USE_DEFAULT_MISMATCH (fallback to ReadBuffer.mismatch)")
+        println("This is expected on Java 8")
+    } else {
+        println("Mismatch at position: $result (expected: 500)")
+        println("Test ${if (result == 500) "PASSED" else "FAILED"}")
+    }
+}


### PR DESCRIPTION
## Summary
Adds multi-release JAR support to use `ByteBuffer.mismatch()` on Java 11+ (SIMD optimized), falling back to the default `ReadBuffer.mismatch()` implementation on Java 8 and Android.

## Implementation
| Platform | Version | Implementation |
|----------|---------|----------------|
| JVM | Java 11+ | `ByteBuffer.mismatch()` via MR-JAR |
| JVM | Java 8-10 | Default `ReadBuffer.mismatch()` |
| Android | All | Default `ReadBuffer.mismatch()` |

## Changes
- Add `jvm11` source set with `BufferMismatchHelper` using native `ByteBuffer.mismatch()`
- Configure multi-release JAR with `META-INF/versions/11/` structure  
- Add expect/actual `BufferMismatchHelper` for platform-specific behavior
- Add CI job to validate multi-release JAR structure

## Test plan
- [ ] JVM tests pass (`MultiReleaseJarTest`)
- [ ] Multi-release JAR structure is validated in CI
- [ ] Android/Apple/JS/WASM tests unaffected