### PR TITLE
Fix build warnings

### DIFF
--- a/buffer-compression/src/appleMain/kotlin/com/ditchoom/buffer/compression/AppleStreamingCompression.kt
+++ b/buffer-compression/src/appleMain/kotlin/com/ditchoom/buffer/compression/AppleStreamingCompression.kt
@@ -1,3 +1,5 @@
+@file:Suppress("UNCHECKED_CAST")
+
 package com.ditchoom.buffer.compression
 
 import com.ditchoom.buffer.ByteArrayBuffer

--- a/buffer/build.gradle.kts
+++ b/buffer/build.gradle.kts
@@ -2,6 +2,7 @@
 
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetTree
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
@@ -52,6 +53,10 @@ kotlin {
     androidTarget {
         publishLibraryVariants("release")
         compilerOptions.jvmTarget.set(JvmTarget.JVM_1_8)
+        // Include commonTest in Android instrumented tests
+        instrumentedTestVariant {
+            sourceSetTree.set(KotlinSourceSetTree.test)
+        }
     }
     jvm {
         compilerOptions.jvmTarget.set(JvmTarget.JVM_1_8)
@@ -165,8 +170,6 @@ kotlin {
         }
 
         val androidInstrumentedTest by getting {
-            // Include commonTest so tests can run on device/emulator
-            dependsOn(commonTest.get())
             dependencies {
                 implementation(kotlin("test"))
                 implementation(libs.androidx.test.runner)

--- a/buffer/src/appleMain/kotlin/com/ditchoom/buffer/BufferFactory.kt
+++ b/buffer/src/appleMain/kotlin/com/ditchoom/buffer/BufferFactory.kt
@@ -71,7 +71,7 @@ fun PlatformBuffer.Companion.wrap(
     data: NSData,
     byteOrder: ByteOrder = ByteOrder.BIG_ENDIAN,
 ): MutableDataBuffer {
-    val mutableData = NSMutableData.create(data)!!
+    val mutableData = NSMutableData.create(data)
     return MutableDataBuffer(mutableData, byteOrder)
 }
 

--- a/buffer/src/appleMain/kotlin/com/ditchoom/buffer/MutableDataBuffer.kt
+++ b/buffer/src/appleMain/kotlin/com/ditchoom/buffer/MutableDataBuffer.kt
@@ -453,6 +453,7 @@ class MutableDataBufferSlice(
     private var limit: Int = sliceLength
 
     // Pointer to the start of this slice's data
+    @Suppress("UNCHECKED_CAST")
     val bytePointer: CPointer<ByteVar> = (parent.data.mutableBytes as CPointer<ByteVar> + sliceOffset)!!
 
     override val byteOrder: ByteOrder get() = parent.byteOrder

--- a/buffer/src/commonTest/kotlin/com/ditchoom/buffer/TransformedReadBufferTest.kt
+++ b/buffer/src/commonTest/kotlin/com/ditchoom/buffer/TransformedReadBufferTest.kt
@@ -26,7 +26,7 @@ class TransformedReadBufferTest {
         buffer.resetForRead()
 
         val transformed = TransformedReadBuffer(buffer, xorTransformer)
-        assertEquals((3.toInt() xor 0xFF).toByte(), transformed[2])
+        assertEquals((3 xor 0xFF).toByte(), transformed[2])
         assertEquals(0, transformed.position()) // Position unchanged
     }
 


### PR DESCRIPTION
## Summary
Fixes various build warnings identified in CI.

## Changes
- Remove unnecessary `!!` non-null assertion in `BufferFactory.kt`
- Suppress unchecked cast warnings in `MutableDataBuffer.kt` and `AppleStreamingCompression.kt`
- Fix redundant `3.toInt()` conversion in `TransformedReadBufferTest.kt`
- Use `sourceSetTree` to properly include `commonTest` in `androidInstrumentedTest` (fixes "Invalid Source Set Dependency Across Trees" warning)

## Not addressed (external/plugin issues)
- `atomicfu` API dependency in test source sets - caused by atomicfu plugin
- `org.jetbrains.kotlin.multiplatform` deprecation warning - requires AGP 9.0 migration

## Test plan
- [x] JVM tests pass
- [x] Android benchmark compilation works
- [ ] CI passes