### PR TITLE
Fix Android JVM target mismatch in buffer-compression

### DIFF
--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -64,6 +64,22 @@ jobs:
 
           echo "=== JAR structure verified ==="
 
+  android:
+    name: "Android Unit Tests"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+          cache: gradle
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
+      - name: Run Android unit tests
+        run: ./gradlew testDebugUnitTest testReleaseUnitTest --no-build-cache
+
   apple:
     name: "Apple Target Tests"
     runs-on: macos-latest

--- a/buffer-compression/build.gradle.kts
+++ b/buffer-compression/build.gradle.kts
@@ -33,7 +33,7 @@ kotlin {
 
     androidTarget {
         publishLibraryVariants("release")
-        // Use JVM 1.8 for Android to maintain minSdk 19 compatibility
+        // Use JVM 1.8 for Android to maintain maximum compatibility
         compilerOptions.jvmTarget.set(JvmTarget.JVM_1_8)
     }
     jvm {
@@ -104,7 +104,7 @@ android {
     }
     namespace = "$group.buffer.compression"
 
-    // Use Java 1.8 for Android to maintain minSdk 19 compatibility
+    // Use Java 1.8 for Android to maintain maximum compatibility
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8

--- a/buffer/build.gradle.kts
+++ b/buffer/build.gradle.kts
@@ -55,8 +55,8 @@ kotlin {
 
     androidTarget {
         publishLibraryVariants("release")
-        // D8/R8 desugars bytecode for minSdk 19
-        compilerOptions.jvmTarget.set(JvmTarget.JVM_17)
+        // Use JVM 1.8 for Android to maintain maximum compatibility
+        compilerOptions.jvmTarget.set(JvmTarget.JVM_1_8)
         // Include commonTest in Android instrumented tests
         instrumentedTestVariant {
             sourceSetTree.set(KotlinSourceSetTree.test)
@@ -256,10 +256,10 @@ android {
     }
     namespace = "com.ditchoom.buffer"
 
-    // D8/R8 desugars bytecode for minSdk 19
+    // Use Java 1.8 for Android to maintain maximum compatibility
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     buildTypes {


### PR DESCRIPTION
## Summary
- Standardize both buffer and buffer-compression to use JVM 1.8 for Android
- Add Android unit tests to PR review workflow to catch compilation issues before merge

## Problem
The deploy workflow failed after merge because `buffer` was configured with JVM 17 for Android while `buffer-compression` used JVM 1.8. When buffer-compression tests tried to use inline functions from buffer (like `withPool`), the compiler couldn't inline JVM 17 bytecode into JVM 1.8 bytecode.

## Root Cause
The PR review workflow only ran JVM/JS/WASM tests but skipped Android unit tests. The mismatch was only detected post-merge when the deploy workflow ran `./gradlew check` which includes all targets.

## Solution
Use JVM 1.8 for Android in both modules. JVM 17 provides no meaningful performance benefit for Android since:
- Android runs on ART, not the JVM
- D8/R8 converts bytecode to DEX format anyway
- JVM-specific runtime optimizations don't apply

JVM 1.8 provides maximum compatibility with no downside.

## Changes
1. **buffer/build.gradle.kts**: Changed Android JVM target from 17 to 1.8
2. **buffer-compression/build.gradle.kts**: Keep Android JVM target at 1.8 (unchanged from before the failed PR)
3. **.github/workflows/review.yaml**: Added Android unit test job to catch these issues during PR review

## Test plan
- [x] Local build passes: `./gradlew testDebugUnitTest testReleaseUnitTest`
- [ ] CI Android unit tests pass
- [ ] CI deploy workflow succeeds