### PR TITLE
Add documentation for Linux NativeBuffer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,11 +58,11 @@ src/
 | Apple | `ByteArrayBuffer` | `MutableDataBuffer` | Falls back to Direct |
 | JS | `JsBuffer` | `JsBuffer` | `JsBuffer` (SharedArrayBuffer) |
 | WASM | `ByteArrayBuffer` | `LinearBuffer` | Falls back to Direct |
-| Linux | `ByteArrayBuffer` | `ByteArrayBuffer` | Falls back to Direct |
+| Linux | `ByteArrayBuffer` | `NativeBuffer` | Falls back to Direct |
 
 ### Memory Access Interfaces
 
-- `NativeMemoryAccess` - Direct native memory pointer (DirectJvmBuffer, MutableDataBuffer, LinearBuffer, JsBuffer)
+- `NativeMemoryAccess` - Direct native memory pointer (DirectJvmBuffer, MutableDataBuffer, LinearBuffer, JsBuffer, NativeBuffer)
 - `ManagedMemoryAccess` - Kotlin ByteArray backing (HeapJvmBuffer, ByteArrayBuffer)
 - `SharedMemoryAccess` - Cross-process shared memory (ParcelableSharedMemoryBuffer, JsBuffer with SharedArrayBuffer)
 
@@ -186,7 +186,7 @@ PlatformBuffer.wrap(byteArray)
 - **Apple NSData interop:** Use `PlatformBuffer.wrap(nsData)` or `PlatformBuffer.wrap(nsMutableData)` for zero-copy Apple API interop
 - **JS SharedArrayBuffer:** Requires CORS headers (`Cross-Origin-Opener-Policy`, `Cross-Origin-Embedder-Policy`)
 - **WASM:** `LinearBuffer` (Direct) uses native WASM memory for JS interop; `ByteArrayBuffer` (Heap) for compute workloads
-- **Linux:** Only `ByteArrayBuffer` available (no native memory access)
+- **Linux:** `NativeBuffer` (Direct) uses malloc/free for zero-copy io_uring I/O; `ByteArrayBuffer` (Heap) for managed memory
 
 ## Benchmarking
 

--- a/Readme.md
+++ b/Readme.md
@@ -11,7 +11,7 @@ memory copies:
 - **iOS/macOS**: `NSMutableData` (native) or `ByteArray` (managed)
 - **JavaScript**: `Uint8Array` with `SharedArrayBuffer` support
 - **WASM**: Native linear memory (Direct) or `ByteArray` (Heap)
-- **Linux/Native**: `ByteArray`
+- **Linux**: `NativeBuffer` (malloc/free) for zero-copy I/O, or `ByteArray` (managed)
 
 ## Features
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -27,7 +27,7 @@ Buffer provides a unified API for managing byte buffers across all Kotlin platfo
 | iOS/macOS | [`NSData`](https://developer.apple.com/documentation/foundation/nsdata) / [`NSMutableData`](https://developer.apple.com/documentation/foundation/nsmutabledata) | Foundation integration |
 | JavaScript | [`Uint8Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) | SharedArrayBuffer support |
 | WASM | `LinearBuffer` (native memory) / `ByteArrayBuffer` | Zero-copy JS interop |
-| Linux | [`ByteArray`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-byte-array/) | Native target |
+| Linux | `NativeBuffer` (malloc) / `ByteArrayBuffer` | Zero-copy io_uring I/O |
 
 ## Quick Example
 

--- a/docs/docs/platforms/linux.md
+++ b/docs/docs/platforms/linux.md
@@ -1,0 +1,108 @@
+---
+sidebar_position: 6
+title: Linux
+---
+
+# Linux Platform
+
+Buffer on Kotlin/Native Linux uses native memory allocation (malloc/free) for zero-copy I/O operations, particularly optimized for io_uring.
+
+## Implementation
+
+| Zone | Linux Type | Use Case |
+|------|------------|----------|
+| `Heap` | `ByteArrayBuffer` | Managed memory, GC-friendly |
+| `Direct` | `NativeBuffer` | Zero-copy I/O, io_uring, FFI |
+| `SharedMemory` | `NativeBuffer` | Same as Direct |
+
+## NativeBuffer: Native Memory
+
+`NativeBuffer` uses `malloc`/`free` to allocate memory outside the Kotlin/Native GC heap:
+
+- **Zero-copy I/O**: Memory can be passed directly to io_uring, epoll, or other system calls
+- **No GC pressure**: Memory is not tracked by Kotlin/Native garbage collector
+- **No pinning required**: Unlike `ByteArray`, no need to pin memory for native calls
+- **Explicit cleanup**: Must be closed to free memory (or use `ScopedBuffer`)
+
+### Memory Access
+
+`NativeBuffer` implements `NativeMemoryAccess`, providing:
+
+```kotlin
+val buffer = NativeBuffer.allocate(65536)
+
+// Direct native address for FFI/system calls
+val ptr = buffer.nativeAddress.toCPointer<ByteVar>()!!
+val size = buffer.nativeSize
+```
+
+## Usage with io_uring
+
+`NativeBuffer` is designed for high-performance async I/O with io_uring:
+
+```kotlin
+val buffer = NativeBuffer.allocate(65536)
+val ptr = buffer.nativeAddress.toCPointer<ByteVar>()!!
+
+// Prepare io_uring read
+io_uring_prep_recv(sqe, sockfd, ptr, buffer.capacity, 0)
+
+// After completion, set position to bytes read
+buffer.position(bytesRead)
+buffer.resetForRead()
+
+// Process data
+val header = buffer.readInt()
+// ...
+
+// Caller must close when done
+buffer.close()
+```
+
+## ScopedBuffer for Deterministic Cleanup
+
+For automatic memory management, use `ScopedBuffer`:
+
+```kotlin
+withScope { scope ->
+    val buffer = scope.allocate(65536)
+    val ptr = buffer.nativeAddress.toCPointer<ByteVar>()!!
+
+    // Use with io_uring...
+    io_uring_prep_recv(sqe, sockfd, ptr, buffer.capacity.toULong(), 0)
+
+    // Process after completion
+    buffer.position(bytesRead)
+    buffer.resetForRead()
+    processData(buffer)
+} // Memory freed automatically
+```
+
+## ByteArrayBuffer: Managed Memory
+
+For workloads that don't need native memory access, `ByteArrayBuffer` provides GC-managed buffers:
+
+```kotlin
+// Explicitly request heap allocation
+val buffer = PlatformBuffer.allocate(1024, AllocationZone.Heap)
+
+// Or wrap existing ByteArray
+val wrapped = PlatformBuffer.wrap(existingByteArray)
+```
+
+### When to Use Each
+
+| Use Case | Recommended |
+|----------|-------------|
+| io_uring / epoll | `NativeBuffer` (Direct) |
+| FFI / C interop | `NativeBuffer` (Direct) |
+| General compute | `ByteArrayBuffer` (Heap) |
+| Wrapping existing data | `ByteArrayBuffer` (wrap) |
+
+## Best Practices
+
+1. **Use Direct for I/O** - `NativeBuffer` avoids copies to/from kernel space
+2. **Use ScopedBuffer** - Ensures memory is freed even on exceptions
+3. **Pool buffers** - Reuse `NativeBuffer` instances to reduce malloc/free overhead
+4. **Close explicitly** - If not using scopes, always close `NativeBuffer` when done
+5. **Use Heap for short-lived data** - `ByteArrayBuffer` is simpler when native access isn't needed


### PR DESCRIPTION
## Summary
Documentation updates for the new Linux `NativeBuffer` implementation.

## Changes
- **README.md**: Updated Linux platform description
- **CLAUDE.md**: Updated Buffer Types table, Memory Access Interfaces, and Platform Notes
- **docs/docs/intro.md**: Updated platform table
- **docs/docs/platforms/linux.md**: New platform documentation page

## Release Validation
This PR contains **only documentation files** (*.md). Per the CI workflow, it should:
- Build and test normally
- **Skip release** (no code changes detected)

The workflow checks changed files and skips release for: `.github/*|*.md|.gitignore|.editorconfig|CLAUDE.md|LICENSE|*.txt`