### PR TITLE
Fix linuxX64 cross-compilation and add Linux CI check

### DIFF
--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -99,6 +99,8 @@ jobs:
           restore-keys: konan-${{ runner.os }}-
       - name: Run tests
         run: ./gradlew macosArm64Test iosSimulatorArm64Test --no-build-cache
+      - name: Verify Linux cross-compilation
+        run: ./gradlew compileKotlinLinuxX64 compileKotlinLinuxArm64 --no-build-cache
 
   docs:
     name: "Validate Docs Generation"

--- a/buffer/src/linuxMain/kotlin/com/ditchoom/buffer/NativeBuffer.kt
+++ b/buffer/src/linuxMain/kotlin/com/ditchoom/buffer/NativeBuffer.kt
@@ -16,6 +16,7 @@ import kotlinx.cinterop.UByteVar
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.convert
 import kotlinx.cinterop.get
+import kotlinx.cinterop.plus
 import kotlinx.cinterop.reinterpret
 import kotlinx.cinterop.set
 import kotlinx.cinterop.toLong


### PR DESCRIPTION
## Summary
- Add missing `import kotlinx.cinterop.plus` to `NativeBuffer.kt` — required for CPointer arithmetic when cross-compiling linuxX64/linuxArm64 on macOS
- Add Linux cross-compilation verification step to review CI so this is caught before merge

## Context
PR #104 merged with a missing import that only manifests during cross-compilation (the `CPointer.plus` extension resolves implicitly for same-platform builds but not cross-platform). The deploy workflow failed at `compileKotlinLinuxX64`.

## Test plan
- [ ] CI "Apple Target Tests" job now includes `compileKotlinLinuxX64 compileKotlinLinuxArm64`
- [ ] Deploy workflow succeeds after merge