### PR TITLE
Fix Linux cross-compilation metadata resolution

### DIFF
--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -97,10 +97,8 @@ jobs:
           path: ~/.konan
           key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
           restore-keys: konan-${{ runner.os }}-
-      - name: Run tests
-        run: ./gradlew macosArm64Test iosSimulatorArm64Test --no-build-cache
-      - name: Verify Linux cross-compilation
-        run: ./gradlew compileKotlinLinuxX64 compileKotlinLinuxArm64 --no-build-cache
+      - name: Run tests and verify Linux cross-compilation
+        run: ./gradlew macosArm64Test iosSimulatorArm64Test compileKotlinLinuxX64 compileKotlinLinuxArm64 :buffer-compression:compileLinuxMainKotlinMetadata
 
   linux:
     name: "Linux Target Tests"


### PR DESCRIPTION
## Summary
- Replace `NativeBuffer` with `NativeMemoryAccess` interface to fix cross-compilation from macOS
- `NativeBuffer` is only defined in `linuxMain` and wasn't resolvable during `compileLinuxMainKotlinMetadata` on macOS CI runners
- Add CI check to catch this issue earlier in the review workflow

## Changes
- Use `NativeMemoryAccess` interface (from `commonMain`) instead of concrete `NativeBuffer` class
- Use `PlatformBuffer.allocate()` with `AllocationZone.Direct` instead of `NativeBuffer.allocate()`
- Add metadata compilation step to Apple CI job

## Test plan
- [x] Local Linux tests pass
- [ ] CI passes metadata compilation check
- [ ] Deploy to Maven Central staging for validation