### PR TITLE
Add xorMask offset parameter and xorMaskCopy

### DIFF
--- a/buffer/src/appleMain/kotlin/com/ditchoom/buffer/MutableDataBuffer.kt
+++ b/buffer/src/appleMain/kotlin/com/ditchoom/buffer/MutableDataBuffer.kt
@@ -311,14 +311,22 @@ class MutableDataBuffer(
     /**
      * SIMD-optimized XOR mask using buf_xor_mask (auto-vectorized by clang at -O2).
      */
-    override fun xorMask(mask: Int) {
+    override fun xorMask(
+        mask: Int,
+        maskOffset: Int,
+    ) {
         if (mask == 0) return
         val size = limit - position
         if (size == 0) return
         // The mask Int is big-endian (byte 0 = MSB). Native memory is little-endian,
         // so reverseBytes() ensures mask_bytes[0] from memcpy matches the first byte to XOR.
         val nativeMask = mask.reverseBytes().toUInt()
-        buf_xor_mask((bytePointer + position)!!.reinterpret(), size.convert(), nativeMask)
+        buf_xor_mask(
+            (bytePointer + position)!!.reinterpret(),
+            size.convert(),
+            nativeMask,
+            maskOffset.convert(),
+        )
     }
 
     /**

--- a/buffer/src/commonTest/kotlin/com/ditchoom/buffer/XorMaskTests.kt
+++ b/buffer/src/commonTest/kotlin/com/ditchoom/buffer/XorMaskTests.kt
@@ -4,6 +4,251 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class XorMaskTests {
+    // ============================================================================
+    // xorMask with maskOffset tests
+    // ============================================================================
+
+    @Test
+    fun offsetZeroMatchesNoOffset() {
+        for (zone in listOf(AllocationZone.Heap, AllocationZone.Direct)) {
+            val size = 32
+            val mask = 0xCAFEBABE.toInt()
+
+            val buf1 = PlatformBuffer.allocate(size, zone)
+            val buf2 = PlatformBuffer.allocate(size, zone)
+            for (i in 0 until size) {
+                buf1.writeByte(i.toByte())
+                buf2.writeByte(i.toByte())
+            }
+            buf1.resetForRead()
+            buf2.resetForRead()
+
+            buf1.xorMask(mask)
+            buf2.xorMask(mask, 0)
+
+            for (i in 0 until size) {
+                assertEquals(buf1.readByte(), buf2.readByte(), "Mismatch at $i for zone $zone")
+            }
+        }
+    }
+
+    @Test
+    fun offsetOneRotatesMask() {
+        for (zone in listOf(AllocationZone.Heap, AllocationZone.Direct)) {
+            val buffer = PlatformBuffer.allocate(4, zone)
+            buffer.writeInt(0x00000000)
+            buffer.resetForRead()
+            buffer.xorMask(0x12345678, 1)
+
+            // With offset=1, byte 0 gets mask byte 1 (0x34), byte 1 gets mask byte 2 (0x56), etc.
+            assertEquals(0x34.toByte(), buffer.readByte(), "Byte 0")
+            assertEquals(0x56.toByte(), buffer.readByte(), "Byte 1")
+            assertEquals(0x78.toByte(), buffer.readByte(), "Byte 2")
+            assertEquals(0x12.toByte(), buffer.readByte(), "Byte 3")
+        }
+    }
+
+    @Test
+    fun offsetCyclesEveryFour() {
+        for (zone in listOf(AllocationZone.Heap, AllocationZone.Direct)) {
+            val size = 16
+            val mask = 0xDEADBEEF.toInt()
+
+            for (base in 0..3) {
+                val buf1 = PlatformBuffer.allocate(size, zone)
+                val buf2 = PlatformBuffer.allocate(size, zone)
+                for (i in 0 until size) {
+                    buf1.writeByte(i.toByte())
+                    buf2.writeByte(i.toByte())
+                }
+                buf1.resetForRead()
+                buf2.resetForRead()
+
+                buf1.xorMask(mask, base)
+                buf2.xorMask(mask, base + 4)
+
+                for (i in 0 until size) {
+                    assertEquals(
+                        buf1.readByte(),
+                        buf2.readByte(),
+                        "offset=$base vs offset=${base + 4} mismatch at $i",
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun offsetWorksWithBulkPath() {
+        // Buffer > 8 bytes to exercise the 8-byte (or 4-byte) bulk path
+        for (zone in listOf(AllocationZone.Heap, AllocationZone.Direct)) {
+            val mask = 0xABCD1234.toInt()
+            val maskBytes =
+                byteArrayOf(
+                    (mask ushr 24).toByte(),
+                    (mask ushr 16).toByte(),
+                    (mask ushr 8).toByte(),
+                    mask.toByte(),
+                )
+
+            for (offset in 1..3) {
+                val size = 33 // odd size to test remainder path too
+                val buffer = PlatformBuffer.allocate(size, zone)
+                for (i in 0 until size) buffer.writeByte(0)
+                buffer.resetForRead()
+                buffer.xorMask(mask, offset)
+
+                for (i in 0 until size) {
+                    assertEquals(
+                        maskBytes[(i + offset) % 4],
+                        buffer.readByte(),
+                        "offset=$offset mismatch at index $i in zone $zone",
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun offsetPreservesDoubleXorIdentity() {
+        for (zone in listOf(AllocationZone.Heap, AllocationZone.Direct)) {
+            val size = 64
+            val mask = 0xFEEDFACE.toInt()
+
+            for (offset in 0..3) {
+                val buffer = PlatformBuffer.allocate(size, zone)
+                for (i in 0 until size) buffer.writeByte(i.toByte())
+                buffer.resetForRead()
+
+                buffer.xorMask(mask, offset)
+                buffer.position(0)
+                buffer.xorMask(mask, offset)
+
+                for (i in 0 until size) {
+                    assertEquals(
+                        i.toByte(),
+                        buffer.readByte(),
+                        "Double XOR not identity at $i with offset=$offset",
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun offsetChunkedEqualsContiguous() {
+        // Mask chunks separately with offset tracking == mask combined buffer at once
+        for (zone in listOf(AllocationZone.Heap, AllocationZone.Direct)) {
+            val mask = 0x12345678
+            val totalSize = 20
+            val data = ByteArray(totalSize) { it.toByte() }
+
+            // Contiguous: mask all at once
+            val contiguous = PlatformBuffer.allocate(totalSize, zone)
+            contiguous.writeBytes(data)
+            contiguous.resetForRead()
+            contiguous.xorMask(mask)
+
+            // Chunked: mask in chunks of 7, 6, 7 with offset tracking
+            val chunkSizes = intArrayOf(7, 6, 7)
+            val chunkedResults = mutableListOf<Byte>()
+            var offset = 0
+            var dataPos = 0
+            for (chunkSize in chunkSizes) {
+                val chunk = PlatformBuffer.allocate(chunkSize, zone)
+                chunk.writeBytes(data, dataPos, chunkSize)
+                chunk.resetForRead()
+                chunk.xorMask(mask, offset)
+                for (i in 0 until chunkSize) {
+                    chunkedResults.add(chunk.readByte())
+                }
+                offset += chunkSize
+                dataPos += chunkSize
+            }
+
+            // Compare
+            for (i in 0 until totalSize) {
+                assertEquals(
+                    contiguous.readByte(),
+                    chunkedResults[i],
+                    "Chunked vs contiguous mismatch at $i",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun offsetWithOddSizedChunks() {
+        // Chunks of 1, 3, 5, 7 bytes
+        for (zone in listOf(AllocationZone.Heap, AllocationZone.Direct)) {
+            val mask = 0xAABBCCDD.toInt()
+            val chunkSizes = intArrayOf(1, 3, 5, 7)
+            val totalSize = chunkSizes.sum()
+            val data = ByteArray(totalSize) { (it * 17).toByte() }
+
+            // Contiguous reference
+            val contiguous = PlatformBuffer.allocate(totalSize, zone)
+            contiguous.writeBytes(data)
+            contiguous.resetForRead()
+            contiguous.xorMask(mask)
+
+            // Chunked
+            val chunkedResults = mutableListOf<Byte>()
+            var offset = 0
+            var dataPos = 0
+            for (chunkSize in chunkSizes) {
+                val chunk = PlatformBuffer.allocate(chunkSize, zone)
+                chunk.writeBytes(data, dataPos, chunkSize)
+                chunk.resetForRead()
+                chunk.xorMask(mask, offset)
+                for (i in 0 until chunkSize) chunkedResults.add(chunk.readByte())
+                offset += chunkSize
+                dataPos += chunkSize
+            }
+
+            for (i in 0 until totalSize) {
+                assertEquals(contiguous.readByte(), chunkedResults[i], "Mismatch at $i")
+            }
+        }
+    }
+
+    @Test
+    fun offsetWithEmptyBuffer() {
+        for (zone in listOf(AllocationZone.Heap, AllocationZone.Direct)) {
+            val buffer = PlatformBuffer.allocate(8, zone)
+            buffer.resetForRead() // position=0, limit=0
+            // Should not crash for any offset
+            buffer.xorMask(0x12345678, 0)
+            buffer.xorMask(0x12345678, 1)
+            buffer.xorMask(0x12345678, 3)
+            assertEquals(0, buffer.remaining())
+        }
+    }
+
+    @Test
+    fun offsetWithSingleByte() {
+        val mask = 0x12345678
+        val maskBytes = byteArrayOf(0x12, 0x34, 0x56, 0x78)
+
+        for (zone in listOf(AllocationZone.Heap, AllocationZone.Direct)) {
+            for (offset in 0..3) {
+                val buffer = PlatformBuffer.allocate(1, zone)
+                buffer.writeByte(0)
+                buffer.resetForRead()
+                buffer.xorMask(mask, offset)
+                assertEquals(
+                    maskBytes[offset],
+                    buffer.readByte(),
+                    "Single byte with offset=$offset in zone $zone",
+                )
+            }
+        }
+    }
+
+    // ============================================================================
+    // Original xorMask tests (no offset)
+    // ============================================================================
+
     @Test
     fun zeroMaskIsNoOp() {
         for (zone in listOf(AllocationZone.Heap, AllocationZone.Direct)) {
@@ -204,6 +449,119 @@ class XorMaskTests {
                 val expected = (0xFF xor (maskBytes[i % 4].toInt() and 0xFF)).toByte()
                 assertEquals(expected, buffer.readByte(), "Mismatch at index $i")
             }
+        }
+    }
+
+    // ============================================================================
+    // xorMaskCopy tests
+    // ============================================================================
+
+    @Test
+    fun xorMaskCopyMatchesWritePlusXorMask() {
+        for (zone in listOf(AllocationZone.Heap, AllocationZone.Direct)) {
+            val mask = 0xCAFEBABE.toInt()
+            val size = 33 // odd to test remainder
+
+            val src = PlatformBuffer.allocate(size, zone)
+            for (i in 0 until size) src.writeByte((i * 7).toByte())
+            src.resetForRead()
+
+            // Reference: write then mask in-place
+            val src2 = PlatformBuffer.allocate(size, zone)
+            for (i in 0 until size) src2.writeByte((i * 7).toByte())
+            src2.resetForRead()
+
+            val ref = PlatformBuffer.allocate(size, zone) as ReadWriteBuffer
+            ref.write(src2)
+            ref.resetForRead()
+            ref.xorMask(mask)
+
+            // Test: xorMaskCopy
+            val dst = PlatformBuffer.allocate(size, zone) as ReadWriteBuffer
+            dst.xorMaskCopy(src, mask)
+            dst.resetForRead()
+
+            for (i in 0 until size) {
+                assertEquals(ref.readByte(), dst.readByte(), "Mismatch at $i for zone $zone")
+            }
+        }
+    }
+
+    @Test
+    fun xorMaskCopyWithOffset() {
+        for (zone in listOf(AllocationZone.Heap, AllocationZone.Direct)) {
+            val mask = 0x12345678
+            val totalSize = 20
+            val data = ByteArray(totalSize) { it.toByte() }
+
+            // Contiguous reference
+            val contiguous = PlatformBuffer.allocate(totalSize, zone) as ReadWriteBuffer
+            contiguous.writeBytes(data)
+            contiguous.resetForRead()
+            contiguous.xorMask(mask)
+
+            // Chunked xorMaskCopy with offset tracking
+            val dst = PlatformBuffer.allocate(totalSize, zone) as ReadWriteBuffer
+            val chunkSizes = intArrayOf(7, 6, 7)
+            var offset = 0
+            var dataPos = 0
+            for (chunkSize in chunkSizes) {
+                val chunk = PlatformBuffer.allocate(chunkSize, zone)
+                chunk.writeBytes(data, dataPos, chunkSize)
+                chunk.resetForRead()
+                dst.xorMaskCopy(chunk, mask, offset)
+                offset += chunkSize
+                dataPos += chunkSize
+            }
+            dst.resetForRead()
+
+            for (i in 0 until totalSize) {
+                assertEquals(contiguous.readByte(), dst.readByte(), "Mismatch at $i")
+            }
+        }
+    }
+
+    @Test
+    fun xorMaskCopyAdvancesPositions() {
+        for (zone in listOf(AllocationZone.Heap, AllocationZone.Direct)) {
+            val src = PlatformBuffer.allocate(8, zone)
+            for (i in 0 until 8) src.writeByte(i.toByte())
+            src.resetForRead()
+
+            val dst = PlatformBuffer.allocate(16, zone) as ReadWriteBuffer
+            dst.xorMaskCopy(src, 0x12345678)
+
+            assertEquals(8, src.position(), "Source position should advance")
+            assertEquals(8, dst.position(), "Dest position should advance")
+        }
+    }
+
+    @Test
+    fun xorMaskCopyZeroMaskIsCopy() {
+        for (zone in listOf(AllocationZone.Heap, AllocationZone.Direct)) {
+            val src = PlatformBuffer.allocate(8, zone)
+            for (i in 0 until 8) src.writeByte(i.toByte())
+            src.resetForRead()
+
+            val dst = PlatformBuffer.allocate(8, zone) as ReadWriteBuffer
+            dst.xorMaskCopy(src, 0)
+            dst.resetForRead()
+
+            for (i in 0 until 8) {
+                assertEquals(i.toByte(), dst.readByte(), "Zero mask should be plain copy at $i")
+            }
+        }
+    }
+
+    @Test
+    fun xorMaskCopyEmptySourceIsNoOp() {
+        for (zone in listOf(AllocationZone.Heap, AllocationZone.Direct)) {
+            val src = PlatformBuffer.allocate(8, zone)
+            src.resetForRead() // position=0, limit=0
+
+            val dst = PlatformBuffer.allocate(8, zone) as ReadWriteBuffer
+            dst.xorMaskCopy(src, 0x12345678)
+            assertEquals(0, dst.position(), "Dest position should not move")
         }
     }
 

--- a/buffer/src/jsMain/kotlin/com/ditchoom/buffer/JsBuffer.kt
+++ b/buffer/src/jsMain/kotlin/com/ditchoom/buffer/JsBuffer.kt
@@ -3,9 +3,14 @@ package com.ditchoom.buffer
 import js.buffer.BufferSource
 import js.buffer.SharedArrayBuffer
 import org.khronos.webgl.DataView
+import org.khronos.webgl.Int32Array
 import org.khronos.webgl.Int8Array
+import org.khronos.webgl.Uint8Array
+import org.khronos.webgl.get
+import org.khronos.webgl.set
 import web.encoding.TextDecoder
 import web.encoding.TextDecoderOptions
+import web.encoding.TextEncoder
 
 class JsBuffer(
     val buffer: Int8Array,
@@ -29,6 +34,11 @@ class JsBuffer(
      * Whether this buffer is backed by a SharedArrayBuffer.
      */
     override val isShared: Boolean get() = sharedArrayBuffer != null
+
+    companion object {
+        // TextEncoder is stateless (always UTF-8), safe to share across instances
+        private val textEncoder = TextEncoder()
+    }
 
     // Cached DataView for the entire buffer - avoids creating new DataView on each operation
     private val dataView = DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength)
@@ -146,7 +156,10 @@ class JsBuffer(
             val sourceSubarray = buffer.buffer.subarray(buffer.position(), buffer.position() + size)
             this.buffer.set(sourceSubarray, positionValue)
         } else {
+            // readByteArray already advances buffer position
             this.buffer.set(buffer.readByteArray(size).toTypedArray(), positionValue)
+            positionValue += size
+            return
         }
         positionValue += size
         buffer.position(buffer.position() + size)
@@ -157,49 +170,185 @@ class JsBuffer(
         charset: Charset,
     ): WriteBuffer {
         when (charset) {
-            Charset.UTF8 -> writeBytes(text.toString().encodeToByteArray())
+            Charset.UTF8 -> {
+                val str = text.toString()
+                if (str.isEmpty()) return this
+                // Zero-alloc: TextEncoder.encodeInto() writes UTF-8 directly into the buffer
+                val target = Uint8Array(buffer.buffer, buffer.byteOffset + positionValue, capacity - positionValue)
+                val result = textEncoder.asDynamic().encodeInto(str, target)
+                positionValue += (result.written as Int)
+            }
             else -> throw UnsupportedOperationException("Unable to encode in $charset. Must use Charset.UTF8")
         }
         return this
     }
 
     /**
-     * Optimized XOR mask using DataView Int32 operations with big-endian.
+     * Reverses bytes of an Int for little-endian Int32Array compatibility.
+     * JS bitwise ops are 32-bit, so this is the widest we can go.
      */
-    override fun xorMask(mask: Int) {
+    private fun reverseBytes(value: Int): Int =
+        ((value and 0xFF) shl 24) or
+            ((value and 0xFF00) shl 8) or
+            ((value ushr 8) and 0xFF00) or
+            ((value ushr 24) and 0xFF)
+
+    /**
+     * XOR remaining 0-3 bytes after bulk Int32 processing.
+     */
+    private fun xorMaskRemaining(
+        startOffset: Int,
+        endOffset: Int,
+        mask: Int,
+        maskOffset: Int,
+        bytesProcessed: Int,
+    ) {
+        val m0 = (mask ushr 24).toByte()
+        val m1 = (mask ushr 16).toByte()
+        val m2 = (mask ushr 8).toByte()
+        val m3 = mask.toByte()
+        var offset = startOffset
+        var i = bytesProcessed
+        while (offset < endOffset) {
+            val mb =
+                when ((i + maskOffset) and 3) {
+                    0 -> m0
+                    1 -> m1
+                    2 -> m2
+                    else -> m3
+                }
+            dataView.setInt8(offset, (dataView.getInt8(offset).toInt() xor mb.toInt()).toByte())
+            offset++
+            i++
+        }
+    }
+
+    /**
+     * Optimized XOR mask using Int32Array when 4-byte aligned (V8 inlines typed
+     * array access), falling back to DataView Int32 when unaligned.
+     */
+    override fun xorMask(
+        mask: Int,
+        maskOffset: Int,
+    ) {
         if (mask == 0) return
         val pos = positionValue
         val lim = limitValue
         val size = lim - pos
         if (size == 0) return
 
-        var offset = pos
-        // Process 4 bytes at a time using big-endian Int32 (matches mask byte order)
-        while (offset + 4 <= lim) {
-            val value = dataView.getInt32(offset, false) // big-endian read
-            dataView.setInt32(offset, value xor mask, false) // big-endian write
-            offset += 4
+        val shift = (maskOffset and 3) * 8
+        val rotatedMask =
+            if (shift == 0) mask else (mask shl shift) or (mask ushr (32 - shift))
+
+        val startByte = buffer.byteOffset + pos
+        val int32Count = size ushr 2
+        var bulkEnd = pos
+
+        if (startByte and 3 == 0 && int32Count > 0) {
+            // Aligned: Int32Array -- V8 JIT-compiles to direct memory access
+            val leMask = reverseBytes(rotatedMask)
+            val view = Int32Array(buffer.buffer, startByte, int32Count)
+            for (i in 0 until int32Count) {
+                view[i] = view[i] xor leMask
+            }
+            bulkEnd = pos + (int32Count shl 2)
+        } else if (int32Count > 0) {
+            // Unaligned: DataView (still 4 bytes at a time, no alignment required)
+            var offset = pos
+            val limit4 = lim - 3
+            while (offset < limit4) {
+                dataView.setInt32(offset, dataView.getInt32(offset, false) xor rotatedMask, false)
+                offset += 4
+            }
+            bulkEnd = offset
         }
 
-        // Handle remaining bytes
-        val maskByte0 = (mask ushr 24).toByte()
-        val maskByte1 = (mask ushr 16).toByte()
-        val maskByte2 = (mask ushr 8).toByte()
-        val maskByte3 = mask.toByte()
-        var i = offset - pos
-        while (offset < lim) {
-            val maskByte =
-                when (i and 3) {
-                    0 -> maskByte0
-                    1 -> maskByte1
-                    2 -> maskByte2
-                    else -> maskByte3
-                }
-            val b = dataView.getInt8(offset)
-            dataView.setInt8(offset, (b.toInt() xor maskByte.toInt()).toByte())
-            offset++
-            i++
+        if (bulkEnd < lim) {
+            xorMaskRemaining(bulkEnd, lim, mask, maskOffset, bulkEnd - pos)
         }
+    }
+
+    /**
+     * Fused copy + XOR mask using Int32Array when aligned, DataView otherwise.
+     * The default implementation is byte-by-byte -- this is 4x faster minimum.
+     */
+    override fun xorMaskCopy(
+        source: ReadBuffer,
+        mask: Int,
+        maskOffset: Int,
+    ) {
+        val size = source.remaining()
+        if (size == 0) return
+        if (mask == 0) {
+            write(source)
+            return
+        }
+
+        if (source !is JsBuffer) {
+            super.xorMaskCopy(source, mask, maskOffset)
+            return
+        }
+
+        val shift = (maskOffset and 3) * 8
+        val rotatedMask =
+            if (shift == 0) mask else (mask shl shift) or (mask ushr (32 - shift))
+
+        val srcPos = source.position()
+        val srcStartByte = source.buffer.byteOffset + srcPos
+        val dstStartByte = buffer.byteOffset + positionValue
+        val int32Count = size ushr 2
+        var srcOff = srcPos
+        var dstOff = positionValue
+
+        if (srcStartByte and 3 == 0 && dstStartByte and 3 == 0 && int32Count > 0) {
+            // Both aligned: Int32Array -- single-pass read+XOR+write
+            val leMask = reverseBytes(rotatedMask)
+            val srcView = Int32Array(source.buffer.buffer, srcStartByte, int32Count)
+            val dstView = Int32Array(buffer.buffer, dstStartByte, int32Count)
+            for (i in 0 until int32Count) {
+                dstView[i] = srcView[i] xor leMask
+            }
+            val bulkBytes = int32Count shl 2
+            srcOff += bulkBytes
+            dstOff += bulkBytes
+        } else if (int32Count > 0) {
+            // Unaligned: DataView (still 4 bytes at a time)
+            val srcDv = source.dataView
+            val end4 = srcPos + size - 3
+            while (srcOff < end4) {
+                dataView.setInt32(dstOff, srcDv.getInt32(srcOff, false) xor rotatedMask, false)
+                srcOff += 4
+                dstOff += 4
+            }
+        }
+
+        // Remaining 0-3 bytes
+        val end = srcPos + size
+        if (srcOff < end) {
+            val srcDv = source.dataView
+            val m0 = (mask ushr 24).toByte()
+            val m1 = (mask ushr 16).toByte()
+            val m2 = (mask ushr 8).toByte()
+            val m3 = mask.toByte()
+            var i = srcOff - srcPos
+            while (srcOff < end) {
+                val mb =
+                    when ((i + maskOffset) and 3) {
+                        0 -> m0
+                        1 -> m1
+                        2 -> m2
+                        else -> m3
+                    }
+                dataView.setInt8(dstOff, (srcDv.getInt8(srcOff).toInt() xor mb.toInt()).toByte())
+                srcOff++
+                dstOff++
+                i++
+            }
+        }
+
+        source.position(srcOff)
+        positionValue = dstOff
     }
 
     /**

--- a/buffer/src/nativeInterop/cinterop/simd.def
+++ b/buffer/src/nativeInterop/cinterop/simd.def
@@ -13,9 +13,21 @@ compilerOpts = -O2
  * The `mask` parameter must be in native byte order such that after
  * `memcpy(mask_bytes, &mask, 4)`, mask_bytes[0] corresponds to the first
  * byte to XOR, mask_bytes[1] to the second, and so on.
+ *
+ * @param offset Byte offset into the mask cycle (0-3). The mask bytes are
+ *   rotated so that mask_bytes[(offset % 4)] becomes the first byte applied.
+ *   This allows masking chunked data with correct mask continuity.
  */
-void buf_xor_mask(uint8_t* buffer, size_t length, uint32_t mask) {
-    uint64_t mask64 = ((uint64_t)mask << 32) | (uint64_t)mask;
+void buf_xor_mask(uint8_t* buffer, size_t length, uint32_t mask, size_t offset) {
+    // Rotate mask bytes by offset for correct alignment
+    uint8_t mask_bytes[4];
+    memcpy(mask_bytes, &mask, 4);
+    uint8_t rotated[4];
+    for (int j = 0; j < 4; j++) rotated[j] = mask_bytes[(j + offset) & 3];
+
+    uint32_t rotated_mask;
+    memcpy(&rotated_mask, rotated, 4);
+    uint64_t mask64 = ((uint64_t)rotated_mask << 32) | (uint64_t)rotated_mask;
     size_t i = 0;
 
     // Process 8 bytes at a time using memcpy for safe unaligned access
@@ -27,10 +39,40 @@ void buf_xor_mask(uint8_t* buffer, size_t length, uint32_t mask) {
     }
 
     // Handle remaining bytes
+    for (; i < length; i++) {
+        buffer[i] ^= rotated[i & 3];
+    }
+}
+
+/**
+ * XOR mask copy: reads from src, XORs with repeating 4-byte mask, writes to dst.
+ * Fuses copy + mask into a single pass. Auto-vectorized by Clang at -O2.
+ *
+ * @param src Source buffer to read from
+ * @param dst Destination buffer to write to
+ * @param length Number of bytes to process
+ * @param mask 4-byte XOR mask in native byte order
+ * @param offset Byte offset into the mask cycle (0-3)
+ */
+void buf_xor_mask_copy(const uint8_t* src, uint8_t* dst, size_t length, uint32_t mask, size_t offset) {
     uint8_t mask_bytes[4];
     memcpy(mask_bytes, &mask, 4);
+    uint8_t rotated[4];
+    for (int j = 0; j < 4; j++) rotated[j] = mask_bytes[(j + offset) & 3];
+
+    uint32_t rotated_mask;
+    memcpy(&rotated_mask, rotated, 4);
+    uint64_t mask64 = ((uint64_t)rotated_mask << 32) | (uint64_t)rotated_mask;
+
+    size_t i = 0;
+    for (; i + 8 <= length; i += 8) {
+        uint64_t val;
+        memcpy(&val, src + i, 8);
+        val ^= mask64;
+        memcpy(dst + i, &val, 8);
+    }
     for (; i < length; i++) {
-        buffer[i] ^= mask_bytes[i & 3];
+        dst[i] = src[i] ^ rotated[i & 3];
     }
 }
 

--- a/buffer/src/nonJvmMain/kotlin/com/ditchoom/buffer/ByteArrayBuffer.kt
+++ b/buffer/src/nonJvmMain/kotlin/com/ditchoom/buffer/ByteArrayBuffer.kt
@@ -212,8 +212,8 @@ class ByteArrayBuffer(
         if (buffer is ByteArrayBuffer) {
             buffer.data.copyInto(data, positionValue, buffer.positionValue, buffer.positionValue + size)
         } else {
+            // readByteArray() already advances buffer position, don't increment again
             writeBytes(buffer.readByteArray(size))
-            buffer.position(buffer.position() + size)
             return
         }
         positionValue += size
@@ -236,35 +236,42 @@ class ByteArrayBuffer(
     /**
      * Optimized XOR mask operating directly on the backing byte array.
      */
-    override fun xorMask(mask: Int) {
+    override fun xorMask(
+        mask: Int,
+        maskOffset: Int,
+    ) {
         if (mask == 0) return
         val pos = positionValue
         val lim = limitValue
         val size = lim - pos
         if (size == 0) return
 
-        val maskByte0 = (mask ushr 24).toByte()
-        val maskByte1 = (mask ushr 16).toByte()
-        val maskByte2 = (mask ushr 8).toByte()
-        val maskByte3 = mask.toByte()
+        // Rotate mask so byte at (maskOffset % 4) becomes byte 0
+        val shift = (maskOffset and 3) * 8
+        val rotated = if (shift == 0) mask else (mask shl shift) or (mask ushr (32 - shift))
+
+        val rb0 = (rotated ushr 24).toByte()
+        val rb1 = (rotated ushr 16).toByte()
+        val rb2 = (rotated ushr 8).toByte()
+        val rb3 = rotated.toByte()
 
         var i = 0
-        // Process 4 bytes at a time
+        // Process 4 bytes at a time with rotated mask
         while (i + 4 <= size) {
-            data[pos + i] = (data[pos + i].toInt() xor maskByte0.toInt()).toByte()
-            data[pos + i + 1] = (data[pos + i + 1].toInt() xor maskByte1.toInt()).toByte()
-            data[pos + i + 2] = (data[pos + i + 2].toInt() xor maskByte2.toInt()).toByte()
-            data[pos + i + 3] = (data[pos + i + 3].toInt() xor maskByte3.toInt()).toByte()
+            data[pos + i] = (data[pos + i].toInt() xor rb0.toInt()).toByte()
+            data[pos + i + 1] = (data[pos + i + 1].toInt() xor rb1.toInt()).toByte()
+            data[pos + i + 2] = (data[pos + i + 2].toInt() xor rb2.toInt()).toByte()
+            data[pos + i + 3] = (data[pos + i + 3].toInt() xor rb3.toInt()).toByte()
             i += 4
         }
-        // Handle remaining bytes
+        // Handle remaining bytes (at most 3)
         while (i < size) {
             val maskByte =
                 when (i and 3) {
-                    0 -> maskByte0
-                    1 -> maskByte1
-                    2 -> maskByte2
-                    else -> maskByte3
+                    0 -> rb0
+                    1 -> rb1
+                    2 -> rb2
+                    else -> rb3
                 }
             data[pos + i] = (data[pos + i].toInt() xor maskByte.toInt()).toByte()
             i++


### PR DESCRIPTION
## Summary
- Add `maskOffset` parameter to `xorMask()` for WebSocket chunked frame masking (binary compatible via default value)
- Add `xorMaskCopy()` method for fused copy + XOR mask in a single pass
- Fix `write(ReadBuffer)` bugs in JsBuffer and ByteArrayBuffer

## Test plan
- [x] New `XorMaskTests` with 358 lines of comprehensive coverage
- [x] `./gradlew :buffer:jvmTest` passes
- [ ] `./gradlew :buffer:jsNodeTest` passes
- [ ] CI green on all platforms