### PR TITLE
Fix publish signing for .aar and .json files

### DIFF
--- a/.github/workflows/publish-to-central.yaml
+++ b/.github/workflows/publish-to-central.yaml
@@ -68,7 +68,7 @@ jobs:
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
         run: |
           cd /tmp/maven-repo
-          find . -type f \( -name "*.jar" -o -name "*.klib" -o -name "*.pom" -o -name "*.module" \) | while read -r file; do
+          find . -type f \( -name "*.jar" -o -name "*.klib" -o -name "*.pom" -o -name "*.module" -o -name "*.aar" -o -name "*.json" \) | while read -r file; do
             gpg --batch --yes --pinentry-mode loopback --passphrase "$SIGNING_PASSWORD" \
               --detach-sign --armor "$file"
           done
@@ -78,7 +78,7 @@ jobs:
         run: |
           cd /tmp/maven-repo
           # Generate checksums for all publishable files and their signatures
-          find . -type f \( -name "*.jar" -o -name "*.klib" -o -name "*.pom" -o -name "*.module" -o -name "*.asc" \) | while read -r file; do
+          find . -type f \( -name "*.jar" -o -name "*.klib" -o -name "*.pom" -o -name "*.module" -o -name "*.aar" -o -name "*.json" -o -name "*.asc" \) | while read -r file; do
             md5sum "$file" | cut -d' ' -f1 > "${file}.md5"
             sha1sum "$file" | cut -d' ' -f1 > "${file}.sha1"
           done

--- a/.github/workflows/validate-artifacts.yaml
+++ b/.github/workflows/validate-artifacts.yaml
@@ -118,6 +118,58 @@ jobs:
           done
           echo ""
 
+          # 5. Signing coverage - detect file types not covered by publish signing glob
+          echo "--- Signing Coverage Check ---"
+          # The publish-to-central signing step signs: .jar .klib .pom .module .aar .json
+          # Flag any artifact file types that would be missed
+          KNOWN_SIGNABLE="jar klib pom module aar json"
+          KNOWN_METADATA="xml repositories"
+          UNCOVERED=0
+          while IFS= read -r file; do
+            ext="${file##*.}"
+            COVERED=false
+            for known in $KNOWN_SIGNABLE $KNOWN_METADATA; do
+              if [ "$ext" = "$known" ]; then
+                COVERED=true
+                break
+              fi
+            done
+            if [ "$COVERED" = "false" ]; then
+              REL=$(echo "$file" | sed "s|${BASE}/||")
+              echo "  FAIL: Unsignable file type '.${ext}': ${REL}"
+              UNCOVERED=$((UNCOVERED + 1))
+            fi
+          done < <(find "${BASE}" -type f ! -name "*.md5" ! -name "*.sha1" ! -name "*.asc")
+          if [ "$UNCOVERED" -gt 0 ]; then
+            echo "  ${UNCOVERED} files with types not covered by publish signing glob"
+            FAILED=true
+          else
+            echo "  All artifact file types covered by signing glob"
+          fi
+          echo ""
+
+          # 6. Android AAR and kotlin-tooling-metadata presence
+          echo "--- Android & Metadata Artifacts ---"
+          for module in buffer buffer-compression; do
+            AAR_DIR="${BASE}/${module}-android/${version}"
+            if [ -d "$AAR_DIR" ]; then
+              AAR=$(find "$AAR_DIR" -name "*.aar" | head -1)
+              if [ -z "$AAR" ]; then
+                echo "  FAIL: ${module}-android AAR not found in ${AAR_DIR}"
+                FAILED=true
+              else
+                echo "  ${module}-android AAR present"
+              fi
+            fi
+            METADATA="${BASE}/${module}/${version}/${module}-${version}-kotlin-tooling-metadata.json"
+            if [ -f "$METADATA" ]; then
+              echo "  ${module} kotlin-tooling-metadata.json present"
+            else
+              echo "  WARN: ${module} kotlin-tooling-metadata.json not found (may not be generated for all modules)"
+            fi
+          done
+          echo ""
+
           if [ "$FAILED" = true ]; then
             echo "=== VALIDATION FAILED ==="
             exit 1


### PR DESCRIPTION
## Summary
- **publish-to-central.yaml**: Add `.aar` and `.json` to the `find` globs in both "Sign all artifacts" and "Generate checksums" steps. Maven Central rejected bundles because `buffer-android-*.aar` and `*-kotlin-tooling-metadata.json` files were missing signatures and checksums.
- **validate-artifacts.yaml**: Add signing coverage check that scans all artifact file types and flags any not covered by the signing glob, plus verify Android AAR and kotlin-tooling-metadata.json presence.

## Context
PR #115's merge triggered a publish to Maven Central that failed because these files were unsigned:
- `buffer-2.4.0-kotlin-tooling-metadata.json`
- `buffer-android-2.4.0.aar`
- `buffer-compression-android-2.4.0.aar`
- `buffer-compression-2.4.0-kotlin-tooling-metadata.json`

## Test plan
- [ ] Verify validate-artifacts workflow catches missing file types (signing coverage check)
- [ ] Verify publish-to-central signing step signs .aar and .json files
- [ ] After merge: draft-release publish should succeed