### PR TITLE
Add streaming compression improvements: flush, windowBits, reset, benchmarks

### DIFF
--- a/buffer-compression/src/commonBenchmark/kotlin/com/ditchoom/buffer/compression/benchmark/StreamingCompressionBenchmark.kt
+++ b/buffer-compression/src/commonBenchmark/kotlin/com/ditchoom/buffer/compression/benchmark/StreamingCompressionBenchmark.kt
@@ -1,0 +1,312 @@
+package com.ditchoom.buffer.compression.benchmark
+
+import com.ditchoom.buffer.AllocationZone
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.allocate
+import com.ditchoom.buffer.compression.BufferAllocator
+import com.ditchoom.buffer.compression.CompressionAlgorithm
+import com.ditchoom.buffer.compression.CompressionLevel
+import com.ditchoom.buffer.compression.StreamingCompressor
+import com.ditchoom.buffer.compression.StreamingDecompressor
+import com.ditchoom.buffer.compression.create
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.BenchmarkMode
+import kotlinx.benchmark.BenchmarkTimeUnit
+import kotlinx.benchmark.Measurement
+import kotlinx.benchmark.Mode
+import kotlinx.benchmark.OutputTimeUnit
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+import kotlinx.benchmark.TearDown
+import kotlinx.benchmark.Warmup
+
+/**
+ * Benchmarks for streaming compression operations.
+ * Measures per-message deflate overhead to identify JVM vs Linux gaps.
+ *
+ * Each benchmark simulates one WebSocket message compression cycle:
+ * compress() + flush() + reset() or decompress() + finish() + reset().
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(BenchmarkTimeUnit.SECONDS)
+open class StreamingCompressionBenchmark {
+    private lateinit var compressor: StreamingCompressor
+    private lateinit var decompressor: StreamingDecompressor
+
+    // Input buffers at different sizes
+    private lateinit var input16B: PlatformBuffer
+    private lateinit var input4KB: PlatformBuffer
+    private lateinit var input64KB: PlatformBuffer
+
+    // Pre-compressed buffers for decompress benchmarks
+    private lateinit var compressed16B: PlatformBuffer
+    private lateinit var compressed4KB: PlatformBuffer
+    private lateinit var compressed64KB: PlatformBuffer
+
+    // Pre-decompressed buffers for string decode benchmarks
+    private lateinit var decompressed4KB: PlatformBuffer
+    private lateinit var decompressed64KB: PlatformBuffer
+
+    @Setup
+    fun setup() {
+        val allocator = BufferAllocator.Direct
+        compressor = StreamingCompressor.create(CompressionAlgorithm.Raw, CompressionLevel.Default, allocator)
+        decompressor = StreamingDecompressor.create(CompressionAlgorithm.Raw, allocator)
+
+        // Generate compressible text data (simulates WebSocket text messages)
+        val text16B = "Hello, WebSocket!" // ~16 bytes
+        val text4KB = buildCompressibleText(4 * 1024)
+        val text64KB = buildCompressibleText(64 * 1024)
+
+        input16B = textToDirectBuffer(text16B)
+        input4KB = textToDirectBuffer(text4KB)
+        input64KB = textToDirectBuffer(text64KB)
+
+        // Pre-compress for decompress benchmarks
+        compressed16B = compressForBenchmark(input16B)
+        compressed4KB = compressForBenchmark(input4KB)
+        compressed64KB = compressForBenchmark(input64KB)
+
+        // Pre-decompress for string decode benchmarks
+        decompressed4KB = decompressForBenchmark(compressed4KB)
+        decompressed64KB = decompressForBenchmark(compressed64KB)
+    }
+
+    @TearDown
+    fun tearDown() {
+        compressor.close()
+        decompressor.close()
+    }
+
+    // --- Compress + Flush + Reset (simulates one outgoing message) ---
+
+    @Benchmark
+    fun compressAndFlush16B(): Int {
+        input16B.position(0)
+        var totalBytes = 0
+        compressor.compress(input16B) { totalBytes += it.remaining() }
+        compressor.flush { totalBytes += it.remaining() }
+        compressor.reset()
+        return totalBytes
+    }
+
+    @Benchmark
+    fun compressAndFlush4KB(): Int {
+        input4KB.position(0)
+        var totalBytes = 0
+        compressor.compress(input4KB) { totalBytes += it.remaining() }
+        compressor.flush { totalBytes += it.remaining() }
+        compressor.reset()
+        return totalBytes
+    }
+
+    @Benchmark
+    fun compressAndFlush64KB(): Int {
+        input64KB.position(0)
+        var totalBytes = 0
+        compressor.compress(input64KB) { totalBytes += it.remaining() }
+        compressor.flush { totalBytes += it.remaining() }
+        compressor.reset()
+        return totalBytes
+    }
+
+    // --- Decompress + Finish + Reset (simulates one incoming message) ---
+
+    @Benchmark
+    fun decompressAndFinish16B(): Int {
+        compressed16B.position(0)
+        var totalBytes = 0
+        decompressor.decompress(compressed16B) { totalBytes += it.remaining() }
+        decompressor.finish { totalBytes += it.remaining() }
+        decompressor.reset()
+        return totalBytes
+    }
+
+    @Benchmark
+    fun decompressAndFinish4KB(): Int {
+        compressed4KB.position(0)
+        var totalBytes = 0
+        decompressor.decompress(compressed4KB) { totalBytes += it.remaining() }
+        decompressor.finish { totalBytes += it.remaining() }
+        decompressor.reset()
+        return totalBytes
+    }
+
+    @Benchmark
+    fun decompressAndFinish64KB(): Int {
+        compressed64KB.position(0)
+        var totalBytes = 0
+        decompressor.decompress(compressed64KB) { totalBytes += it.remaining() }
+        decompressor.finish { totalBytes += it.remaining() }
+        decompressor.reset()
+        return totalBytes
+    }
+
+    // --- Round-trip with String Decode (compress + decompress + readString) ---
+
+    @Benchmark
+    fun roundTripWithStringDecode4KB(): Int {
+        // Compress
+        input4KB.position(0)
+        val compressedChunks = mutableListOf<ReadBuffer>()
+        compressor.compress(input4KB) { compressedChunks.add(it) }
+        compressor.flush { compressedChunks.add(it) }
+        compressor.reset()
+
+        // Decompress
+        val decompressedChunks = mutableListOf<ReadBuffer>()
+        for (chunk in compressedChunks) {
+            chunk.position(0)
+            decompressor.decompress(chunk) { decompressedChunks.add(it) }
+        }
+        decompressor.finish { decompressedChunks.add(it) }
+        decompressor.reset()
+
+        // String decode
+        var totalChars = 0
+        for (chunk in decompressedChunks) {
+            chunk.position(0)
+            totalChars += chunk.readString(chunk.remaining(), Charset.UTF8).length
+        }
+        return totalChars
+    }
+
+    @Benchmark
+    fun roundTripWithStringDecode64KB(): Int {
+        // Compress
+        input64KB.position(0)
+        val compressedChunks = mutableListOf<ReadBuffer>()
+        compressor.compress(input64KB) { compressedChunks.add(it) }
+        compressor.flush { compressedChunks.add(it) }
+        compressor.reset()
+
+        // Decompress
+        val decompressedChunks = mutableListOf<ReadBuffer>()
+        for (chunk in compressedChunks) {
+            chunk.position(0)
+            decompressor.decompress(chunk) { decompressedChunks.add(it) }
+        }
+        decompressor.finish { decompressedChunks.add(it) }
+        decompressor.reset()
+
+        // String decode
+        var totalChars = 0
+        for (chunk in decompressedChunks) {
+            chunk.position(0)
+            totalChars += chunk.readString(chunk.remaining(), Charset.UTF8).length
+        }
+        return totalChars
+    }
+
+    // --- Reset Only (isolate deflateReset/inflateReset overhead) ---
+
+    @Benchmark
+    fun resetOnlyCompressor(): Int {
+        compressor.reset()
+        return 1
+    }
+
+    @Benchmark
+    fun resetOnlyDecompressor(): Int {
+        decompressor.reset()
+        return 1
+    }
+
+    // --- String Decode Only (isolate readString overhead) ---
+
+    @Benchmark
+    fun stringDecodeOnly4KB(): Int {
+        decompressed4KB.position(0)
+        return decompressed4KB.readString(decompressed4KB.remaining(), Charset.UTF8).length
+    }
+
+    @Benchmark
+    fun stringDecodeOnly64KB(): Int {
+        decompressed64KB.position(0)
+        return decompressed64KB.readString(decompressed64KB.remaining(), Charset.UTF8).length
+    }
+
+    // --- Helpers ---
+
+    private fun buildCompressibleText(targetBytes: Int): String {
+        val sb = StringBuilder(targetBytes)
+        val words =
+            arrayOf(
+                "the",
+                "quick",
+                "brown",
+                "fox",
+                "jumps",
+                "over",
+                "lazy",
+                "dog",
+                "hello",
+                "world",
+                "websocket",
+                "compression",
+                "benchmark",
+                "test",
+                "message",
+                "payload",
+                "streaming",
+                "deflate",
+                "inflate",
+                "buffer",
+            )
+        var i = 0
+        while (sb.length < targetBytes) {
+            if (sb.isNotEmpty()) sb.append(' ')
+            sb.append(words[i % words.size])
+            i++
+        }
+        return sb.substring(0, targetBytes.coerceAtMost(sb.length))
+    }
+
+    private fun textToDirectBuffer(text: String): PlatformBuffer {
+        val bytes = text.encodeToByteArray()
+        val buffer = PlatformBuffer.allocate(bytes.size, AllocationZone.Direct)
+        buffer.writeBytes(bytes)
+        buffer.resetForRead()
+        return buffer
+    }
+
+    private fun compressForBenchmark(input: PlatformBuffer): PlatformBuffer {
+        input.position(0)
+        val chunks = mutableListOf<ReadBuffer>()
+        compressor.compress(input) { chunks.add(it) }
+        compressor.flush { chunks.add(it) }
+        compressor.reset()
+
+        val totalSize = chunks.sumOf { it.remaining() }
+        val result = PlatformBuffer.allocate(totalSize, AllocationZone.Direct)
+        for (chunk in chunks) {
+            chunk.position(0)
+            result.write(chunk)
+        }
+        result.resetForRead()
+        return result
+    }
+
+    private fun decompressForBenchmark(compressed: PlatformBuffer): PlatformBuffer {
+        compressed.position(0)
+        val chunks = mutableListOf<ReadBuffer>()
+        decompressor.decompress(compressed) { chunks.add(it) }
+        decompressor.finish { chunks.add(it) }
+        decompressor.reset()
+
+        val totalSize = chunks.sumOf { it.remaining() }
+        val result = PlatformBuffer.allocate(totalSize, AllocationZone.Direct)
+        for (chunk in chunks) {
+            chunk.position(0)
+            result.write(chunk)
+        }
+        result.resetForRead()
+        return result
+    }
+}

--- a/buffer-compression/src/commonTest/kotlin/com/ditchoom/buffer/compression/StreamingCompressionResetTest.kt
+++ b/buffer-compression/src/commonTest/kotlin/com/ditchoom/buffer/compression/StreamingCompressionResetTest.kt
@@ -1,0 +1,403 @@
+package com.ditchoom.buffer.compression
+
+import com.ditchoom.buffer.AllocationZone
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.allocate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests that StreamingCompressor/StreamingDecompressor reset() properly restores state
+ * for repeated compress/decompress cycles. Validates correctness assumptions used by
+ * the websocket benchmark harness and production per-message-deflate.
+ *
+ * IMPORTANT: To re-read a buffer that is already in read mode, use `position(0)` -- NOT
+ * `resetForRead()`. `resetForRead()` does `limit = position; position = 0` which is a
+ * write->read flip. Calling it on a buffer with position=0 zeroes the limit.
+ */
+class StreamingCompressionResetTest {
+    companion object {
+        private const val SYNC_FLUSH_MARKER = 0x0000FFFF
+    }
+
+    // --- Buffer re-read semantics tests ---
+
+    @Test
+    fun resetForReadIsWriteToReadFlipNotRewind() {
+        // resetForRead() sets limit=position, position=0.
+        // For a buffer already in read mode (position=0), this zeroes the limit.
+        val buf = PlatformBuffer.allocate(16, AllocationZone.Direct)
+        buf.writeBytes(ByteArray(10) { it.toByte() })
+        buf.resetForRead() // Now: position=0, limit=10
+        assertEquals(10, buf.remaining())
+
+        // Calling resetForRead() again on a buffer with position=0 zeroes limit
+        buf.resetForRead()
+        assertEquals(0, buf.remaining(), "resetForRead on pos=0 buffer should zero the limit")
+    }
+
+    @Test
+    fun positionZeroIsCorrectWayToRewindReadableBuffer() {
+        val buf = PlatformBuffer.allocate(16, AllocationZone.Direct)
+        buf.writeBytes(ByteArray(10) { it.toByte() })
+        buf.resetForRead() // position=0, limit=10
+
+        // Read some bytes to advance position
+        buf.readByte()
+        buf.readByte()
+        assertEquals(8, buf.remaining())
+
+        // position(0) rewinds without touching limit
+        buf.position(0)
+        assertEquals(10, buf.remaining(), "position(0) should rewind without changing limit")
+    }
+
+    @Test
+    fun resetForReadAfterFullConsumptionPreservesLimit() {
+        // After fully reading a buffer, position == limit.
+        // resetForRead() does limit = position (== old limit), position = 0 -> correct!
+        val buf = PlatformBuffer.allocate(16, AllocationZone.Direct)
+        buf.writeBytes(ByteArray(10) { it.toByte() })
+        buf.resetForRead() // position=0, limit=10
+
+        // Fully consume
+        buf.position(buf.limit())
+        assertEquals(0, buf.remaining())
+
+        // resetForRead works here because position == limit (the data end)
+        buf.resetForRead()
+        assertEquals(10, buf.remaining(), "resetForRead after full consumption should restore")
+    }
+
+    // --- Decompressor reset tests ---
+
+    @Test
+    fun decompressorResetProducesIdenticalOutput() {
+        if (!supportsSyncCompression) return
+        val decompressor = StreamingDecompressor.create(CompressionAlgorithm.Raw)
+        val compressor = StreamingCompressor.create(CompressionAlgorithm.Raw)
+
+        val text = "Hello, WebSocket compression reset test!"
+        val compressed = compressWithSyncFlushMarkerStrip(text, compressor)
+        compressor.close()
+
+        val results = mutableListOf<String>()
+        repeat(5) {
+            compressed.position(0) // rewind, don't flip
+            val result = decompressToString(compressed, decompressor)
+            results.add(result)
+            decompressor.reset()
+        }
+
+        decompressor.close()
+
+        results.forEach { assertEquals(text, it, "Decompress after reset should produce identical output") }
+    }
+
+    @Test
+    fun decompressorResetWorksWithSmallPayload() {
+        if (!supportsSyncCompression) return
+        val decompressor = StreamingDecompressor.create(CompressionAlgorithm.Raw)
+        val compressor = StreamingCompressor.create(CompressionAlgorithm.Raw)
+
+        val text = "A".repeat(16) // 16 bytes
+        val compressed = compressWithSyncFlushMarkerStrip(text, compressor)
+        compressor.close()
+
+        repeat(3) { cycle ->
+            compressed.position(0)
+            val result = decompressToString(compressed, decompressor)
+            assertEquals(text, result, "Small payload decompress cycle $cycle")
+            decompressor.reset()
+        }
+
+        decompressor.close()
+    }
+
+    @Test
+    fun decompressorResetWorksWithMediumPayload() {
+        if (!supportsSyncCompression) return
+        val decompressor = StreamingDecompressor.create(CompressionAlgorithm.Raw)
+        val compressor = StreamingCompressor.create(CompressionAlgorithm.Raw)
+
+        val text = "ABCDEFGHIJ".repeat(400) // 4KB
+        val compressed = compressWithSyncFlushMarkerStrip(text, compressor)
+        compressor.close()
+
+        repeat(3) { cycle ->
+            compressed.position(0)
+            val result = decompressToString(compressed, decompressor)
+            assertEquals(text, result, "Medium payload decompress cycle $cycle")
+            decompressor.reset()
+        }
+
+        decompressor.close()
+    }
+
+    @Test
+    fun decompressorResetWorksWithLargePayload() {
+        if (!supportsSyncCompression) return
+        val decompressor = StreamingDecompressor.create(CompressionAlgorithm.Raw)
+        val compressor = StreamingCompressor.create(CompressionAlgorithm.Raw)
+
+        val text = "ABCDEFGHIJ".repeat(6400) // 64KB
+        val compressed = compressWithSyncFlushMarkerStrip(text, compressor)
+        compressor.close()
+
+        repeat(3) { cycle ->
+            compressed.position(0)
+            val result = decompressToString(compressed, decompressor)
+            assertEquals(text, result, "Large payload decompress cycle $cycle")
+            decompressor.reset()
+        }
+
+        decompressor.close()
+    }
+
+    @Test
+    fun decompressorResetAfterFinishRestoresState() {
+        if (!supportsSyncCompression) return
+        // finish() sets streamEnded on Linux -- verify reset() clears it
+        val decompressor = StreamingDecompressor.create(CompressionAlgorithm.Raw)
+        val compressor = StreamingCompressor.create(CompressionAlgorithm.Raw)
+
+        val text = "Testing finish then reset"
+        val compressed = compressWithSyncFlushMarkerStrip(text, compressor)
+        compressor.close()
+
+        // First cycle: decompress with finish
+        compressed.position(0)
+        val result1 = decompressToString(compressed, decompressor)
+        assertEquals(text, result1)
+
+        // Reset and decompress again
+        decompressor.reset()
+        compressed.position(0)
+        val result2 = decompressToString(compressed, decompressor)
+        assertEquals(text, result2, "Decompress after finish+reset should work")
+
+        decompressor.close()
+    }
+
+    @Test
+    fun decompressorOutputSizeScalesWithInput() {
+        if (!supportsSyncCompression) return
+        // Validates that decompression actually processes the full payload.
+        // If reset is broken, all sizes would produce the same (empty/trivial) output.
+        val decompressor = StreamingDecompressor.create(CompressionAlgorithm.Raw)
+        val compressor = StreamingCompressor.create(CompressionAlgorithm.Raw)
+
+        val smallText = "A".repeat(16)
+        val mediumText = "A".repeat(4096)
+        val largeText = "A".repeat(65536)
+
+        val smallCompressed = compressWithSyncFlushMarkerStrip(smallText, compressor)
+        compressor.reset()
+        val mediumCompressed = compressWithSyncFlushMarkerStrip(mediumText, compressor)
+        compressor.reset()
+        val largeCompressed = compressWithSyncFlushMarkerStrip(largeText, compressor)
+        compressor.close()
+
+        // Cycle 1
+        smallCompressed.position(0)
+        val r1 = decompressToString(smallCompressed, decompressor)
+        assertEquals(16, r1.length, "Small output length")
+        decompressor.reset()
+
+        // Cycle 2
+        mediumCompressed.position(0)
+        val r2 = decompressToString(mediumCompressed, decompressor)
+        assertEquals(4096, r2.length, "Medium output length")
+        decompressor.reset()
+
+        // Cycle 3
+        largeCompressed.position(0)
+        val r3 = decompressToString(largeCompressed, decompressor)
+        assertEquals(65536, r3.length, "Large output length")
+        decompressor.reset()
+
+        // Verify output length scales (not uniform like a broken reset would produce)
+        assertTrue(r2.length > r1.length * 10, "Medium should be much larger than small")
+        assertTrue(r3.length > r2.length * 10, "Large should be much larger than medium")
+
+        decompressor.close()
+    }
+
+    // --- Compressor reset tests ---
+
+    @Test
+    fun compressorResetProducesIdenticalOutput() {
+        if (!supportsSyncCompression) return
+        val compressor = StreamingCompressor.create(CompressionAlgorithm.Raw)
+        val text = "Compressor reset test with some repeated data repeated data repeated data"
+
+        val outputs = mutableListOf<ByteArray>()
+        repeat(5) {
+            val input = textToBuffer(text)
+            val chunks = mutableListOf<ReadBuffer>()
+            compressor.compress(input) { chunks.add(it) }
+            compressor.flush { chunks.add(it) }
+            outputs.add(chunksToByteArray(chunks))
+            compressor.reset()
+        }
+
+        compressor.close()
+
+        for (i in 1 until outputs.size) {
+            assertTrue(
+                outputs[0].contentEquals(outputs[i]),
+                "Compressed output at iteration $i should match iteration 0",
+            )
+        }
+    }
+
+    @Test
+    fun compressorResetClearsState() {
+        if (!supportsSyncCompression) return
+        // Verify that compressor doesn't carry state from previous messages
+        val compressor = StreamingCompressor.create(CompressionAlgorithm.Raw)
+        val decompressor = StreamingDecompressor.create(CompressionAlgorithm.Raw)
+
+        val texts = listOf("First message", "Second different message", "Third unique content")
+
+        for (text in texts) {
+            val input = textToBuffer(text)
+            val compressed = compressWithSyncFlushMarkerStripFromBuf(input, compressor)
+            compressor.reset()
+
+            compressed.position(0)
+            val decompressed = decompressToString(compressed, decompressor)
+            assertEquals(text, decompressed, "Round-trip for: $text")
+            decompressor.reset()
+        }
+
+        compressor.close()
+        decompressor.close()
+    }
+
+    // --- Helper functions ---
+
+    private fun textToBuffer(text: String): ReadBuffer {
+        val bytes = text.encodeToByteArray()
+        val buf = PlatformBuffer.allocate(bytes.size, AllocationZone.Direct)
+        buf.writeBytes(bytes)
+        buf.resetForRead()
+        return buf
+    }
+
+    private fun compressWithSyncFlushMarkerStrip(
+        text: String,
+        compressor: StreamingCompressor,
+    ): ReadBuffer {
+        val input = textToBuffer(text)
+        return compressWithSyncFlushMarkerStripFromBuf(input, compressor)
+    }
+
+    private fun compressWithSyncFlushMarkerStripFromBuf(
+        input: ReadBuffer,
+        compressor: StreamingCompressor,
+    ): ReadBuffer {
+        val chunks = mutableListOf<ReadBuffer>()
+        compressor.compress(input) { chunks.add(it) }
+        compressor.flush { chunks.add(it) }
+
+        if (chunks.isEmpty()) return PlatformBuffer.allocate(0, AllocationZone.Direct)
+
+        // Strip sync flush marker from end
+        val lastChunk = chunks.last()
+        if (lastChunk.remaining() >= 4) {
+            val pos = lastChunk.position()
+            val endPos = pos + lastChunk.remaining()
+            lastChunk.position(endPos - 4)
+            val marker = lastChunk.readInt()
+            if (marker == SYNC_FLUSH_MARKER) {
+                lastChunk.position(pos)
+                lastChunk.setLimit(endPos - 4)
+                if (lastChunk.remaining() == 0) {
+                    chunks.removeLast()
+                }
+            } else {
+                lastChunk.position(pos)
+            }
+        }
+
+        // Combine into single buffer
+        var totalSize = 0
+        for (chunk in chunks) totalSize += chunk.remaining()
+        val combined = PlatformBuffer.allocate(totalSize, AllocationZone.Direct)
+        for (chunk in chunks) {
+            chunk.position(0)
+            combined.write(chunk)
+        }
+        combined.resetForRead()
+        return combined
+    }
+
+    /**
+     * Reproduces websocket decompression pipeline:
+     * decompress input -> decompress sync flush marker -> finish -> readString
+     */
+    private fun decompressToString(
+        buffer: ReadBuffer,
+        decompressor: StreamingDecompressor,
+    ): String {
+        val chunks = mutableListOf<ReadBuffer>()
+
+        decompressor.decompress(buffer) { chunk ->
+            if (chunk.position() != 0) chunk.position(0)
+            if (chunk.remaining() > 0) chunks.add(chunk)
+        }
+
+        // Append sync marker and decompress
+        val marker = PlatformBuffer.allocate(4, AllocationZone.Direct)
+        marker.writeInt(SYNC_FLUSH_MARKER)
+        marker.resetForRead()
+        decompressor.decompress(marker) { chunk ->
+            if (chunk.position() != 0) chunk.position(0)
+            if (chunk.remaining() > 0) chunks.add(chunk)
+        }
+
+        decompressor.finish { chunk ->
+            if (chunk.position() != 0) chunk.position(0)
+            if (chunk.remaining() > 0) chunks.add(chunk)
+        }
+
+        if (chunks.isEmpty()) return ""
+
+        if (chunks.size == 1) {
+            val chunk = chunks[0]
+            return chunk.readString(chunk.remaining(), Charset.UTF8)
+        }
+
+        var totalSize = 0
+        for (chunk in chunks) totalSize += chunk.remaining()
+        val combined = PlatformBuffer.allocate(totalSize, AllocationZone.Heap)
+        for (chunk in chunks) {
+            chunk.position(0)
+            combined.write(chunk)
+        }
+        combined.resetForRead()
+        return combined.readString(totalSize, Charset.UTF8)
+    }
+
+    private fun chunksToByteArray(chunks: List<ReadBuffer>): ByteArray {
+        var totalSize = 0
+        for (chunk in chunks) {
+            if (chunk.position() != 0) chunk.position(0)
+            totalSize += chunk.remaining()
+        }
+        val result = ByteArray(totalSize)
+        var offset = 0
+        for (chunk in chunks) {
+            chunk.position(0)
+            val remaining = chunk.remaining()
+            for (i in 0 until remaining) {
+                result[offset++] = chunk.readByte()
+            }
+        }
+        return result
+    }
+}

--- a/buffer-compression/src/jsMain/kotlin/com/ditchoom/buffer/compression/JsStreamingCompression.kt
+++ b/buffer-compression/src/jsMain/kotlin/com/ditchoom/buffer/compression/JsStreamingCompression.kt
@@ -18,6 +18,7 @@ actual fun StreamingCompressor.Companion.create(
     level: CompressionLevel,
     allocator: BufferAllocator,
     outputBufferSize: Int,
+    windowBits: Int,
 ): StreamingCompressor =
     if (isNodeJs) {
         JsNodeStreamingCompressor(algorithm, level, allocator)

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/NativeMemoryAccess.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/NativeMemoryAccess.kt
@@ -58,25 +58,25 @@ interface NativeMemoryAccess {
  * ```
  */
 val PlatformBuffer.nativeMemoryAccess: NativeMemoryAccess?
-    get() = this as? NativeMemoryAccess
+    get() = unwrap() as? NativeMemoryAccess
 
 /**
  * Extension for ReadBuffer to access native memory if available.
- * Handles PooledBuffer by delegating to its inner buffer.
+ * Unwraps pooled buffers to reach the underlying platform buffer.
  */
 val ReadBuffer.nativeMemoryAccess: NativeMemoryAccess?
-    get() =
-        (this as? com.ditchoom.buffer.pool.PooledBuffer)?.nativeMemoryAccess
-            ?: (this as? NativeMemoryAccess)
+    get() {
+        if (this is NativeMemoryAccess) return this
+        if (this is PlatformBuffer) return unwrap() as? NativeMemoryAccess
+        return null
+    }
 
 /**
  * Extension for WriteBuffer to access native memory if available.
- * Handles PooledBuffer by delegating to its inner buffer.
+ * Unwraps pooled buffers to reach the underlying platform buffer.
  */
 val WriteBuffer.nativeMemoryAccess: NativeMemoryAccess?
-    get() =
-        (this as? com.ditchoom.buffer.pool.PooledBuffer)?.nativeMemoryAccess
-            ?: (this as? NativeMemoryAccess)
+    get() = ((this as? PlatformBuffer)?.unwrap() ?: this) as? NativeMemoryAccess
 
 /**
  * Allocates a buffer with guaranteed native memory access.
@@ -140,25 +140,25 @@ interface ManagedMemoryAccess {
  * ```
  */
 val PlatformBuffer.managedMemoryAccess: ManagedMemoryAccess?
-    get() = this as? ManagedMemoryAccess
+    get() = unwrap() as? ManagedMemoryAccess
 
 /**
  * Extension for ReadBuffer to access managed memory if available.
- * Handles PooledBuffer by delegating to its inner buffer.
+ * Unwraps pooled buffers to reach the underlying platform buffer.
  */
 val ReadBuffer.managedMemoryAccess: ManagedMemoryAccess?
-    get() =
-        (this as? com.ditchoom.buffer.pool.PooledBuffer)?.managedMemoryAccess
-            ?: (this as? ManagedMemoryAccess)
+    get() {
+        if (this is ManagedMemoryAccess) return this
+        if (this is PlatformBuffer) return unwrap() as? ManagedMemoryAccess
+        return null
+    }
 
 /**
  * Extension for WriteBuffer to access managed memory if available.
- * Handles PooledBuffer by delegating to its inner buffer.
+ * Unwraps pooled buffers to reach the underlying platform buffer.
  */
 val WriteBuffer.managedMemoryAccess: ManagedMemoryAccess?
-    get() =
-        (this as? com.ditchoom.buffer.pool.PooledBuffer)?.managedMemoryAccess
-            ?: (this as? ManagedMemoryAccess)
+    get() = ((this as? PlatformBuffer)?.unwrap() ?: this) as? ManagedMemoryAccess
 
 /**
  * Interface for buffers backed by shared memory that can be accessed across

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/PlatformBuffer.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/PlatformBuffer.kt
@@ -4,5 +4,19 @@ interface PlatformBuffer :
     ReadWriteBuffer,
     SuspendCloseable,
     Parcelable {
+    /**
+     * Frees native memory resources without requiring suspend context.
+     * No-op on JVM/JS where GC handles cleanup. On Linux, frees the underlying malloc'd memory.
+     * For pool-acquired buffers, returns the buffer to its pool instead of freeing.
+     */
+    fun freeNativeMemory() {}
+
+    /**
+     * Returns the underlying platform buffer, unwrapping any decorators (e.g. [PooledBuffer][com.ditchoom.buffer.pool.PooledBuffer]).
+     * For non-wrapped buffers, returns itself.
+     * Use this when you need to downcast to a platform-specific type (e.g. BaseJvmBuffer, NativeBuffer).
+     */
+    fun unwrap(): PlatformBuffer = this
+
     companion object
 }

--- a/buffer/src/linuxMain/kotlin/com/ditchoom/buffer/NativeBuffer.kt
+++ b/buffer/src/linuxMain/kotlin/com/ditchoom/buffer/NativeBuffer.kt
@@ -543,7 +543,7 @@ class NativeBuffer private constructor(
         ).toInt()
     }
 
-    fun freeNativeMemory() {
+    override fun freeNativeMemory() {
         if (!closed) {
             closed = true
             free(ptr)


### PR DESCRIPTION
## Summary
Streaming compression API improvements for the buffer-compression module:

- **API additions**: `flush()`, `reset()` on `StreamingCompressor`/`StreamingDecompressor` + suspending variants; `windowBits` parameter on `create()`
- **BufferAllocator**: New sealed interface (`Default`, `Direct`, `Heap`, `FromZone`) for compression buffer allocation
- **Buffer core**: `unwrap()` and `freeNativeMemory()` on PlatformBuffer; `NativeMemoryAccess` refactored to use `unwrap()`
- **Platform implementations**:
  - Apple: `withOutputPointer()` for zero-copy compression output
  - Linux: `deflateReset`/`inflateReset`, `OutputBuffer` refactor
  - JVM: unwrap-aware compression
  - JS: minimal changes
- **Benchmarks**: `StreamingCompressionBenchmark.kt` (312 lines)
- **Publish fix**: Include `.aar` and `.json` in signing/checksum globs; add signing coverage validation

This is PR3 of 4 from the websocket integration split (see #111).

## Files changed (14 files, ~1500 lines)
- `buffer-compression/build.gradle.kts` — benchmark config + dependencies
- `StreamingCompression.kt` — new API (flush, reset, windowBits)
- `AppleStreamingCompression.kt` — withOutputPointer, flush/reset
- `LinuxStreamingCompression.kt` — deflateReset/inflateReset, OutputBuffer
- `JvmCommonStreamingCompression.kt` — unwrap-aware compression
- `NativeMemoryAccess.kt` — refactored with unwrap() support
- `PlatformBuffer.kt` — unwrap() and freeNativeMemory()
- `StreamingCompressionResetTest.kt` (403 lines)
- `CompressionStressTests.kt` (+152 lines)
- `StreamingCompressionBenchmark.kt` (312 lines)
- `publish-to-central.yaml` — sign .aar and .json files
- `validate-artifacts.yaml` — signing coverage + AAR/metadata checks

## Test plan
- [ ] `allTests` pass on all platforms
- [ ] Compression benchmarks run successfully
- [ ] Validate-artifacts catches unsignable file types
- [ ] Publish signing includes .aar and .json