### PR TITLE
Rewrite buffer pool with PooledBuffer delegation and ref counting

### DIFF
--- a/buffer-compression/src/commonMain/kotlin/com/ditchoom/buffer/compression/BufferAllocator.kt
+++ b/buffer-compression/src/commonMain/kotlin/com/ditchoom/buffer/compression/BufferAllocator.kt
@@ -4,6 +4,7 @@ import com.ditchoom.buffer.AllocationZone
 import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.ReadWriteBuffer
 import com.ditchoom.buffer.allocate
+import com.ditchoom.buffer.pool.BufferPool
 import kotlin.jvm.JvmInline
 
 /**
@@ -39,6 +40,15 @@ sealed interface BufferAllocator {
      */
     data object Heap : BufferAllocator {
         override fun allocate(size: Int): ReadWriteBuffer = PlatformBuffer.allocate(size, AllocationZone.Heap)
+    }
+
+    /**
+     * Allocate buffers from a buffer pool for reuse.
+     */
+    class FromPool(
+        val pool: BufferPool,
+    ) : BufferAllocator {
+        override fun allocate(size: Int): ReadWriteBuffer = pool.acquire(size)
     }
 
     companion object {

--- a/buffer-compression/src/commonMain/kotlin/com/ditchoom/buffer/compression/StreamProcessorExtensions.kt
+++ b/buffer-compression/src/commonMain/kotlin/com/ditchoom/buffer/compression/StreamProcessorExtensions.kt
@@ -25,7 +25,7 @@ import com.ditchoom.buffer.stream.TransformSpec
  */
 fun StreamProcessorBuilder.decompress(
     algorithm: CompressionAlgorithm = CompressionAlgorithm.Gzip,
-    allocator: BufferAllocator = BufferAllocator.Default,
+    allocator: BufferAllocator = BufferAllocator.FromPool(pool),
 ): StreamProcessorBuilder = addTransform(DecompressionSpec(algorithm, allocator))
 
 /**

--- a/buffer-compression/src/commonTest/kotlin/com/ditchoom/buffer/compression/BufferAllocatorAssumptionTests.kt
+++ b/buffer-compression/src/commonTest/kotlin/com/ditchoom/buffer/compression/BufferAllocatorAssumptionTests.kt
@@ -1,0 +1,36 @@
+package com.ditchoom.buffer.compression
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.nativeMemoryAccess
+import com.ditchoom.buffer.pool.BufferPool
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+/**
+ * Verifies that BufferAllocator implementations produce buffers with
+ * nativeMemoryAccess, which is required by the Linux zlib withInputPointer().
+ */
+class BufferAllocatorAssumptionTests {
+    @Test
+    fun directAllocatorOutputHasNativeMemoryAccess() {
+        val allocator = BufferAllocator.Direct
+        val buffer = allocator.allocate(64)
+        assertNotNull(
+            (buffer as ReadBuffer).nativeMemoryAccess,
+            "BufferAllocator.Direct should produce buffers with nativeMemoryAccess",
+        )
+    }
+
+    @Test
+    fun poolAllocatorOutputHasNativeMemoryAccess() {
+        val pool = BufferPool(defaultBufferSize = 1024, maxPoolSize = 4)
+        val allocator = BufferAllocator.FromPool(pool)
+        val buffer = allocator.allocate(64)
+        assertNotNull(
+            (buffer as ReadBuffer).nativeMemoryAccess,
+            "BufferAllocator.FromPool should produce buffers with nativeMemoryAccess",
+        )
+        pool.release(buffer)
+        pool.clear()
+    }
+}

--- a/buffer-compression/src/commonTest/kotlin/com/ditchoom/buffer/compression/PoolAllocatorTests.kt
+++ b/buffer-compression/src/commonTest/kotlin/com/ditchoom/buffer/compression/PoolAllocatorTests.kt
@@ -1,0 +1,305 @@
+package com.ditchoom.buffer.compression
+
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.allocate
+import com.ditchoom.buffer.pool.withPool
+import com.ditchoom.buffer.toReadBuffer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests for BufferAllocator.FromPool and compression with pool-allocated buffers.
+ */
+class PoolAllocatorTests {
+    // =========================================================================
+    // BufferAllocator.FromPool basic tests
+    // =========================================================================
+
+    @Test
+    fun fromPoolAllocatesFromPool() =
+        withPool(defaultBufferSize = 1024, maxPoolSize = 4) { pool ->
+            val allocator = BufferAllocator.FromPool(pool)
+            val buffer = allocator.allocate(512)
+            assertTrue(buffer.capacity >= 512)
+            assertEquals(1, pool.stats().totalAllocations)
+            pool.release(buffer)
+        }
+
+    @Test
+    fun fromPoolReusesBuffers() =
+        withPool(defaultBufferSize = 1024, maxPoolSize = 4) { pool ->
+            val allocator = BufferAllocator.FromPool(pool)
+            val buffer1 = allocator.allocate(512)
+            pool.release(buffer1)
+            val buffer2 = allocator.allocate(512)
+            pool.release(buffer2)
+
+            val stats = pool.stats()
+            assertEquals(2, stats.totalAllocations)
+            assertEquals(1, stats.poolHits)
+        }
+
+    // =========================================================================
+    // Streaming compression with pool allocator
+    // =========================================================================
+
+    @Test
+    fun streamingCompressionWithPoolAllocator() {
+        if (!supportsSyncCompression) return
+
+        withPool(defaultBufferSize = 32768, maxPoolSize = 8) { pool ->
+            val allocator = BufferAllocator.FromPool(pool)
+            val text = "Hello from pool-allocated compression!"
+            val compressedChunks = mutableListOf<ReadBuffer>()
+
+            StreamingCompressor.create(allocator = allocator).use(
+                onOutput = { compressedChunks.add(it) },
+            ) { compress ->
+                compress(text.toReadBuffer())
+            }
+
+            assertTrue(compressedChunks.isNotEmpty(), "Should produce compressed output")
+
+            // Decompress with pool allocator too
+            val decompressedChunks = mutableListOf<ReadBuffer>()
+            val compressed = combineBuffers(compressedChunks)
+
+            StreamingDecompressor.create(allocator = allocator).use(
+                onOutput = { decompressedChunks.add(it) },
+            ) { decompress ->
+                decompress(compressed)
+            }
+
+            val decompressed = combineBuffers(decompressedChunks)
+            assertEquals(text, decompressed.readString(decompressed.remaining()))
+        }
+    }
+
+    @Test
+    fun streamingCompressionMultipleChunksWithPoolAllocator() {
+        if (!supportsSyncCompression) return
+
+        withPool(defaultBufferSize = 32768, maxPoolSize = 8) { pool ->
+            val allocator = BufferAllocator.FromPool(pool)
+            val chunks =
+                listOf(
+                    "First chunk of data. ",
+                    "Second chunk of data. ",
+                    "Third chunk of data.",
+                )
+            val fullText = chunks.joinToString("")
+
+            val compressedChunks = mutableListOf<ReadBuffer>()
+
+            StreamingCompressor.create(allocator = allocator).use(
+                onOutput = { compressedChunks.add(it) },
+            ) { compress ->
+                for (chunk in chunks) {
+                    compress(chunk.toReadBuffer())
+                }
+            }
+
+            val compressed = combineBuffers(compressedChunks)
+            val decompressedChunks = mutableListOf<ReadBuffer>()
+
+            StreamingDecompressor.create(allocator = allocator).use(
+                onOutput = { decompressedChunks.add(it) },
+            ) { decompress ->
+                decompress(compressed)
+            }
+
+            val decompressed = combineBuffers(decompressedChunks)
+            assertEquals(fullText, decompressed.readString(decompressed.remaining()))
+        }
+    }
+
+    @Test
+    fun streamingCompressionWithPoolAllocatorGzip() {
+        if (!supportsSyncCompression) return
+
+        withPool(defaultBufferSize = 32768, maxPoolSize = 8) { pool ->
+            val allocator = BufferAllocator.FromPool(pool)
+            val text = "Gzip with pool allocation test data"
+            val compressedChunks = mutableListOf<ReadBuffer>()
+
+            StreamingCompressor
+                .create(
+                    algorithm = CompressionAlgorithm.Gzip,
+                    allocator = allocator,
+                ).use(
+                    onOutput = { compressedChunks.add(it) },
+                ) { compress ->
+                    compress(text.toReadBuffer())
+                }
+
+            val compressed = combineBuffers(compressedChunks)
+            // Verify gzip magic bytes
+            assertEquals(0x1f.toByte(), compressed.get(0), "Gzip magic byte 1")
+            assertEquals(0x8b.toByte(), compressed.get(1), "Gzip magic byte 2")
+
+            val decompressedChunks = mutableListOf<ReadBuffer>()
+
+            StreamingDecompressor
+                .create(
+                    algorithm = CompressionAlgorithm.Gzip,
+                    allocator = allocator,
+                ).use(
+                    onOutput = { decompressedChunks.add(it) },
+                ) { decompress ->
+                    decompress(compressed)
+                }
+
+            val decompressed = combineBuffers(decompressedChunks)
+            assertEquals(text, decompressed.readString(decompressed.remaining()))
+        }
+    }
+
+    // =========================================================================
+    // Compression with heap allocator
+    // =========================================================================
+
+    @Test
+    fun streamingCompressionWithHeapAllocator() {
+        if (!supportsSyncCompression) return
+
+        val text = "Hello from heap-allocated compression!"
+        val compressedChunks = mutableListOf<ReadBuffer>()
+
+        StreamingCompressor.create(allocator = BufferAllocator.Heap).use(
+            onOutput = { compressedChunks.add(it) },
+        ) { compress ->
+            compress(text.toReadBuffer())
+        }
+
+        assertTrue(compressedChunks.isNotEmpty())
+
+        val compressed = combineBuffers(compressedChunks)
+        val decompressedChunks = mutableListOf<ReadBuffer>()
+
+        StreamingDecompressor.create(allocator = BufferAllocator.Heap).use(
+            onOutput = { decompressedChunks.add(it) },
+        ) { decompress ->
+            decompress(compressed)
+        }
+
+        val decompressed = combineBuffers(decompressedChunks)
+        assertEquals(text, decompressed.readString(decompressed.remaining()))
+    }
+
+    // =========================================================================
+    // Pool allocator with reset (reuse compressor)
+    // =========================================================================
+
+    @Test
+    fun poolAllocatorWithCompressorReset() {
+        if (!supportsSyncCompression) return
+
+        withPool(defaultBufferSize = 32768, maxPoolSize = 8) { pool ->
+            val allocator = BufferAllocator.FromPool(pool)
+            val compressor = StreamingCompressor.create(allocator = allocator)
+            val decompressor = StreamingDecompressor.create(allocator = allocator)
+
+            try {
+                for (i in 1..3) {
+                    val text = "Iteration $i: data to compress"
+                    val compressedChunks = mutableListOf<ReadBuffer>()
+
+                    compressor.compress(text.toReadBuffer()) { compressedChunks.add(it) }
+                    compressor.finish { compressedChunks.add(it) }
+                    compressor.reset()
+
+                    val compressed = combineBuffers(compressedChunks)
+                    val decompressedChunks = mutableListOf<ReadBuffer>()
+
+                    decompressor.decompress(compressed) { decompressedChunks.add(it) }
+                    decompressor.finish { decompressedChunks.add(it) }
+                    decompressor.reset()
+
+                    val decompressed = combineBuffers(decompressedChunks)
+                    assertEquals(
+                        text,
+                        decompressed.readString(decompressed.remaining()),
+                        "Failed on iteration $i",
+                    )
+                }
+            } finally {
+                compressor.close()
+                decompressor.close()
+            }
+
+            // Verify all 3 iterations completed successfully (pool reuse is best-effort)
+        }
+    }
+
+    // =========================================================================
+    // Large data with pool allocator
+    // =========================================================================
+
+    @Test
+    fun poolAllocatorLargeData() {
+        if (!supportsSyncCompression) return
+
+        withPool(defaultBufferSize = 32768, maxPoolSize = 8) { pool ->
+            val allocator = BufferAllocator.FromPool(pool)
+
+            // Generate 100KB of compressible data
+            val sb = StringBuilder()
+            repeat(1000) { i ->
+                sb.append("Line $i: The quick brown fox jumps over the lazy dog.\n")
+            }
+            val text = sb.toString()
+
+            val compressedChunks = mutableListOf<ReadBuffer>()
+
+            StreamingCompressor.create(allocator = allocator).use(
+                onOutput = { compressedChunks.add(it) },
+            ) { compress ->
+                // Send in 4KB chunks like a real network scenario
+                val bytes = text.encodeToByteArray()
+                var offset = 0
+                while (offset < bytes.size) {
+                    val chunkSize = minOf(4096, bytes.size - offset)
+                    val chunk = PlatformBuffer.allocate(chunkSize)
+                    chunk.writeBytes(bytes, offset, chunkSize)
+                    chunk.resetForRead()
+                    compress(chunk)
+                    offset += chunkSize
+                }
+            }
+
+            val compressed = combineBuffers(compressedChunks)
+            assertTrue(
+                compressed.remaining() < text.length,
+                "Compressed should be smaller than original",
+            )
+
+            val decompressedChunks = mutableListOf<ReadBuffer>()
+
+            StreamingDecompressor.create(allocator = allocator).use(
+                onOutput = { decompressedChunks.add(it) },
+            ) { decompress ->
+                decompress(compressed)
+            }
+
+            val decompressed = combineBuffers(decompressedChunks)
+            assertEquals(text, decompressed.readString(decompressed.remaining()))
+        }
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private fun combineBuffers(buffers: List<ReadBuffer>): PlatformBuffer {
+        if (buffers.isEmpty()) return PlatformBuffer.allocate(0)
+        val totalSize = buffers.sumOf { it.remaining() }
+        val combined = PlatformBuffer.allocate(totalSize)
+        for (buffer in buffers) {
+            combined.write(buffer)
+        }
+        combined.resetForRead()
+        return combined
+    }
+}

--- a/buffer/src/appleMain/kotlin/com/ditchoom/buffer/MutableDataBuffer.kt
+++ b/buffer/src/appleMain/kotlin/com/ditchoom/buffer/MutableDataBuffer.kt
@@ -532,12 +532,7 @@ class MutableDataBufferSlice(
     private val parent: MutableDataBuffer,
     private val sliceOffset: Int,
     private val sliceLength: Int,
-) : ReadBuffer,
-    NativeMemoryAccess {
-    override val nativeAddress: Long get() = bytePointer.toLong()
-
-    override val nativeSize: Long get() = sliceLength.toLong()
-
+) : ReadBuffer {
     private var position: Int = 0
     private var limit: Int = sliceLength
 

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/BufferUtils.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/BufferUtils.kt
@@ -1,0 +1,18 @@
+package com.ditchoom.buffer
+
+import com.ditchoom.buffer.pool.PoolReleasable
+
+/** Frees native memory if this is a PlatformBuffer, or releases pool ref if TrackedSlice. */
+fun ReadBuffer.freeIfNeeded() {
+    when (this) {
+        is PlatformBuffer -> freeNativeMemory()
+        is PoolReleasable -> releaseToPool()
+    }
+}
+
+/** Frees all buffers in the list. */
+fun List<ReadBuffer>.freeAll() {
+    for (buffer in this) {
+        buffer.freeIfNeeded()
+    }
+}

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/NativeMemoryAccess.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/NativeMemoryAccess.kt
@@ -62,12 +62,13 @@ val PlatformBuffer.nativeMemoryAccess: NativeMemoryAccess?
 
 /**
  * Extension for ReadBuffer to access native memory if available.
- * Unwraps pooled buffers to reach the underlying platform buffer.
+ * Unwraps pooled buffers and TrackedSlice wrappers to reach the underlying platform buffer.
  */
 val ReadBuffer.nativeMemoryAccess: NativeMemoryAccess?
     get() {
         if (this is NativeMemoryAccess) return this
         if (this is PlatformBuffer) return unwrap() as? NativeMemoryAccess
+        if (this is com.ditchoom.buffer.pool.TrackedSlice) return inner.nativeMemoryAccess
         return null
     }
 
@@ -144,12 +145,13 @@ val PlatformBuffer.managedMemoryAccess: ManagedMemoryAccess?
 
 /**
  * Extension for ReadBuffer to access managed memory if available.
- * Unwraps pooled buffers to reach the underlying platform buffer.
+ * Unwraps pooled buffers and TrackedSlice wrappers to reach the underlying platform buffer.
  */
 val ReadBuffer.managedMemoryAccess: ManagedMemoryAccess?
     get() {
         if (this is ManagedMemoryAccess) return this
         if (this is PlatformBuffer) return unwrap() as? ManagedMemoryAccess
+        if (this is com.ditchoom.buffer.pool.TrackedSlice) return inner.managedMemoryAccess
         return null
     }
 

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/BufferPool.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/BufferPool.kt
@@ -2,6 +2,7 @@ package com.ditchoom.buffer.pool
 
 import com.ditchoom.buffer.AllocationZone
 import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.ReadWriteBuffer
 
 /**
  * High-performance buffer pool that minimizes allocations by reusing buffers.
@@ -33,11 +34,12 @@ import com.ditchoom.buffer.ByteOrder
  *
  * ### Manual acquire/release
  * ```kotlin
+ * val pool = BufferPool()
  * val buffer = pool.acquire(1024)
  * try {
  *     buffer.writeInt(42)
  * } finally {
- *     buffer.release()  // MUST release when done
+ *     pool.release(buffer)
  * }
  * ```
  *
@@ -52,14 +54,18 @@ import com.ditchoom.buffer.ByteOrder
 sealed interface BufferPool {
     /**
      * Acquires a buffer of at least the specified size.
+     * The returned buffer is a [PooledBuffer] wrapper whose [freeNativeMemory][PlatformBuffer.freeNativeMemory]
+     * returns the buffer to this pool instead of freeing it.
      * The buffer may be larger than requested.
      */
-    fun acquire(minSize: Int = 0): PooledBuffer
+    fun acquire(minSize: Int = 0): ReadWriteBuffer
 
     /**
      * Releases a buffer back to the pool for reuse.
+     * The buffer must have been acquired from this pool.
+     * Buffers that are not [PlatformBuffer] instances are silently ignored.
      */
-    fun release(buffer: PooledBuffer)
+    fun release(buffer: ReadWriteBuffer)
 
     /**
      * Returns statistics about pool usage.
@@ -130,38 +136,6 @@ enum class ThreadingMode {
 }
 
 /**
- * A buffer that has been acquired from a [BufferPool].
- *
- * Pooled buffers MUST be released when no longer needed to enable reuse.
- * Use [BufferPool.withBuffer] for automatic release, or call [release] manually.
- *
- * **Warning**: Do not use a buffer after releasing it.
- */
-interface PooledBuffer : com.ditchoom.buffer.ReadWriteBuffer {
-    override val byteOrder: ByteOrder
-
-    /**
-     * Returns this buffer to its pool for reuse.
-     *
-     * After calling this method, the buffer should not be used.
-     * Any further access to the buffer results in undefined behavior.
-     */
-    fun release()
-
-    /**
-     * Access to native memory if the underlying buffer supports it.
-     * Returns null if the buffer uses managed memory (e.g., ByteArrayBuffer).
-     */
-    val nativeMemoryAccess: com.ditchoom.buffer.NativeMemoryAccess?
-
-    /**
-     * Access to managed memory if the underlying buffer supports it.
-     * Returns null if the buffer uses native memory (e.g., NativeBuffer).
-     */
-    val managedMemoryAccess: com.ditchoom.buffer.ManagedMemoryAccess?
-}
-
-/**
  * Statistics about buffer pool usage for monitoring and tuning.
  *
  * @property totalAllocations Total number of acquire() calls
@@ -219,7 +193,7 @@ fun createBufferPool(
  */
 inline fun <T> BufferPool.withBuffer(
     minSize: Int = 0,
-    block: (PooledBuffer) -> T,
+    block: (ReadWriteBuffer) -> T,
 ): T {
     val buffer = acquire(minSize)
     try {

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/LockFreeBufferPool.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/LockFreeBufferPool.kt
@@ -2,12 +2,8 @@ package com.ditchoom.buffer.pool
 
 import com.ditchoom.buffer.AllocationZone
 import com.ditchoom.buffer.ByteOrder
-import com.ditchoom.buffer.Charset
-import com.ditchoom.buffer.ManagedMemoryAccess
-import com.ditchoom.buffer.NativeMemoryAccess
 import com.ditchoom.buffer.PlatformBuffer
-import com.ditchoom.buffer.ReadBuffer
-import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.ReadWriteBuffer
 import com.ditchoom.buffer.allocate
 import kotlinx.atomicfu.atomic
 
@@ -43,35 +39,46 @@ internal class LockFreeBufferPool(
     private val poolMisses = atomic(0L)
     private val peakPoolSize = atomic(0)
 
-    override fun acquire(minSize: Int): PooledBuffer {
+    override fun acquire(minSize: Int): ReadWriteBuffer {
         totalAllocations.incrementAndGet()
         val size = maxOf(minSize, defaultBufferSize)
 
         // Try to pop from stack (lock-free)
         val buffer = pop()
 
-        return if (buffer != null && buffer.capacity >= size) {
-            poolHits.incrementAndGet()
-            buffer.resetForWrite()
-            LockFreePooledBuffer(buffer, this)
-        } else {
-            poolMisses.incrementAndGet()
-            val newBuffer = PlatformBuffer.allocate(size, allocationZone, byteOrder)
-            LockFreePooledBuffer(newBuffer, this)
-        }
+        val raw =
+            if (buffer != null && buffer.capacity >= size) {
+                poolHits.incrementAndGet()
+                buffer.resetForWrite()
+                buffer
+            } else {
+                poolMisses.incrementAndGet()
+                PlatformBuffer.allocate(size, allocationZone, byteOrder)
+            }
+        return PooledBuffer(raw, this)
     }
 
-    override fun release(buffer: PooledBuffer) {
-        if (buffer !is LockFreePooledBuffer) return
+    override fun release(buffer: ReadWriteBuffer) {
+        // Unwrap PooledBuffer to store the raw PlatformBuffer in the pool
+        val platformBuffer =
+            when (buffer) {
+                is PooledBuffer -> buffer.inner
+                is PlatformBuffer -> buffer
+                else -> return
+            }
 
         // Only push if under max size (check first to avoid unnecessary work)
         if (poolSize.value < maxPoolSize) {
-            buffer.inner.resetForWrite()
-            if (push(buffer.inner)) {
+            if (push(platformBuffer)) {
                 // Update peak if needed
                 val currentSize = poolSize.value
                 updatePeak(currentSize)
+            } else {
+                // CAS push failed because pool became full - free the buffer
+                platformBuffer.freeNativeMemory()
             }
+        } else {
+            platformBuffer.freeNativeMemory()
         }
     }
 
@@ -85,9 +92,10 @@ internal class LockFreeBufferPool(
         )
 
     override fun clear() {
-        // Pop all elements
-        while (pop() != null) {
-            // Discard buffer
+        // Pop all elements and free their native memory
+        while (true) {
+            val buffer = pop() ?: break
+            buffer.freeNativeMemory()
         }
     }
 
@@ -143,168 +151,4 @@ internal class LockFreeBufferPool(
             if (peakPoolSize.compareAndSet(peak, currentSize)) return
         }
     }
-}
-
-/**
- * Pooled buffer wrapper for lock-free pool.
- */
-internal class LockFreePooledBuffer(
-    val inner: PlatformBuffer,
-    private val pool: BufferPool,
-) : PooledBuffer {
-    override val capacity: Int get() = inner.capacity
-    override val byteOrder: ByteOrder get() = inner.byteOrder
-
-    override fun release() = pool.release(this)
-
-    // Delegate memory access to inner buffer
-    override val nativeMemoryAccess: NativeMemoryAccess?
-        get() = inner as? NativeMemoryAccess
-
-    override val managedMemoryAccess: ManagedMemoryAccess?
-        get() = inner as? ManagedMemoryAccess
-
-    // Delegate ReadBuffer
-    override fun resetForRead() = inner.resetForRead()
-
-    override fun readByte(): Byte = inner.readByte()
-
-    override fun get(index: Int): Byte = inner.get(index)
-
-    override fun readByteArray(size: Int): ByteArray = inner.readByteArray(size)
-
-    override fun readShort(): Short = inner.readShort()
-
-    override fun getShort(index: Int): Short = inner.getShort(index)
-
-    override fun readInt(): Int = inner.readInt()
-
-    override fun getInt(index: Int): Int = inner.getInt(index)
-
-    override fun readLong(): Long = inner.readLong()
-
-    override fun getLong(index: Int): Long = inner.getLong(index)
-
-    override fun readFloat(): Float = inner.readFloat()
-
-    override fun getFloat(index: Int): Float = inner.getFloat(index)
-
-    override fun readDouble(): Double = inner.readDouble()
-
-    override fun getDouble(index: Int): Double = inner.getDouble(index)
-
-    override fun readString(
-        length: Int,
-        charset: Charset,
-    ): String = inner.readString(length, charset)
-
-    override fun slice(): ReadBuffer = inner.slice()
-
-    override fun limit(): Int = inner.limit()
-
-    override fun position(): Int = inner.position()
-
-    override fun position(newPosition: Int) = inner.position(newPosition)
-
-    override fun setLimit(limit: Int) = inner.setLimit(limit)
-
-    // Delegate WriteBuffer
-    override fun resetForWrite() = inner.resetForWrite()
-
-    override fun writeByte(byte: Byte): WriteBuffer {
-        inner.writeByte(byte)
-        return this
-    }
-
-    override fun set(
-        index: Int,
-        byte: Byte,
-    ): WriteBuffer {
-        inner.set(index, byte)
-        return this
-    }
-
-    override fun writeBytes(
-        bytes: ByteArray,
-        offset: Int,
-        length: Int,
-    ): WriteBuffer {
-        inner.writeBytes(bytes, offset, length)
-        return this
-    }
-
-    override fun writeShort(short: Short): WriteBuffer {
-        inner.writeShort(short)
-        return this
-    }
-
-    override fun set(
-        index: Int,
-        short: Short,
-    ): WriteBuffer {
-        inner.set(index, short)
-        return this
-    }
-
-    override fun writeInt(int: Int): WriteBuffer {
-        inner.writeInt(int)
-        return this
-    }
-
-    override fun set(
-        index: Int,
-        int: Int,
-    ): WriteBuffer {
-        inner.set(index, int)
-        return this
-    }
-
-    override fun writeLong(long: Long): WriteBuffer {
-        inner.writeLong(long)
-        return this
-    }
-
-    override fun set(
-        index: Int,
-        long: Long,
-    ): WriteBuffer {
-        inner.set(index, long)
-        return this
-    }
-
-    override fun writeFloat(float: Float): WriteBuffer {
-        inner.writeFloat(float)
-        return this
-    }
-
-    override fun set(
-        index: Int,
-        float: Float,
-    ): WriteBuffer {
-        inner.set(index, float)
-        return this
-    }
-
-    override fun writeDouble(double: Double): WriteBuffer {
-        inner.writeDouble(double)
-        return this
-    }
-
-    override fun set(
-        index: Int,
-        double: Double,
-    ): WriteBuffer {
-        inner.set(index, double)
-        return this
-    }
-
-    override fun writeString(
-        text: CharSequence,
-        charset: Charset,
-    ): WriteBuffer {
-        inner.writeString(text, charset)
-        return this
-    }
-
-    override fun write(buffer: ReadBuffer) = inner.write(buffer)
 }

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/PoolReleasable.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/PoolReleasable.kt
@@ -1,0 +1,9 @@
+package com.ditchoom.buffer.pool
+
+/**
+ * Marker interface for objects that hold a reference to a pooled buffer.
+ * Calling [releaseToPool] decrements the parent's reference count.
+ */
+interface PoolReleasable {
+    fun releaseToPool()
+}

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/PooledBuffer.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/PooledBuffer.kt
@@ -1,0 +1,50 @@
+package com.ditchoom.buffer.pool
+
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+
+/**
+ * A buffer wrapper that returns its inner buffer to a pool when all references are released.
+ *
+ * Created by [BufferPool.acquire] to make pool-acquired buffers transparent.
+ * All buffer operations delegate to the inner [PlatformBuffer].
+ *
+ * Uses reference counting to track outstanding slices. The inner buffer is returned
+ * to the pool only when the chunk itself AND all slices created from it are released.
+ * This prevents the pool from reusing memory that is still referenced by slices.
+ */
+internal class PooledBuffer(
+    internal val inner: PlatformBuffer,
+    private val pool: BufferPool,
+) : PlatformBuffer by inner {
+    private var freed = false
+    private var refCount = 1 // 1 for the chunk reference in StreamProcessor
+
+    internal fun addRef() {
+        refCount++
+    }
+
+    internal fun releaseRef() {
+        if (--refCount == 0) {
+            pool.release(inner)
+        }
+    }
+
+    override fun freeNativeMemory() {
+        if (!freed) {
+            freed = true
+            releaseRef()
+        }
+    }
+
+    override fun slice(): ReadBuffer {
+        addRef()
+        return TrackedSlice(inner.slice(), this)
+    }
+
+    override fun unwrap(): PlatformBuffer = inner.unwrap()
+
+    override suspend fun close() {
+        freeNativeMemory()
+    }
+}

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/SingleThreadedBufferPool.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/SingleThreadedBufferPool.kt
@@ -2,12 +2,8 @@ package com.ditchoom.buffer.pool
 
 import com.ditchoom.buffer.AllocationZone
 import com.ditchoom.buffer.ByteOrder
-import com.ditchoom.buffer.Charset
-import com.ditchoom.buffer.ManagedMemoryAccess
-import com.ditchoom.buffer.NativeMemoryAccess
 import com.ditchoom.buffer.PlatformBuffer
-import com.ditchoom.buffer.ReadBuffer
-import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.ReadWriteBuffer
 import com.ditchoom.buffer.allocate
 
 /**
@@ -29,32 +25,40 @@ internal class SingleThreadedBufferPool(
     private var poolMisses = 0L
     private var peakPoolSize = 0
 
-    override fun acquire(minSize: Int): PooledBuffer {
+    override fun acquire(minSize: Int): ReadWriteBuffer {
         totalAllocations++
         val size = maxOf(minSize, defaultBufferSize)
 
         val buffer = pool.removeLastOrNull()
 
-        return if (buffer != null && buffer.capacity >= size) {
-            poolHits++
-            buffer.resetForWrite()
-            SimplePooledBuffer(buffer, this)
-        } else {
-            poolMisses++
-            val newBuffer = PlatformBuffer.allocate(size, allocationZone, byteOrder)
-            SimplePooledBuffer(newBuffer, this)
-        }
+        val raw =
+            if (buffer != null && buffer.capacity >= size) {
+                poolHits++
+                buffer.resetForWrite()
+                buffer
+            } else {
+                poolMisses++
+                PlatformBuffer.allocate(size, allocationZone, byteOrder)
+            }
+        return PooledBuffer(raw, this)
     }
 
-    override fun release(buffer: PooledBuffer) {
-        if (buffer !is SimplePooledBuffer) return
+    override fun release(buffer: ReadWriteBuffer) {
+        // Unwrap PooledBuffer to store the raw PlatformBuffer in the pool
+        val platformBuffer =
+            when (buffer) {
+                is PooledBuffer -> buffer.inner
+                is PlatformBuffer -> buffer
+                else -> return
+            }
 
         if (pool.size < maxPoolSize) {
-            buffer.inner.resetForWrite()
-            pool.addLast(buffer.inner)
+            pool.addLast(platformBuffer)
             if (pool.size > peakPoolSize) {
                 peakPoolSize = pool.size
             }
+        } else {
+            platformBuffer.freeNativeMemory()
         }
     }
 
@@ -68,170 +72,9 @@ internal class SingleThreadedBufferPool(
         )
 
     override fun clear() {
+        for (buffer in pool) {
+            buffer.freeNativeMemory()
+        }
         pool.clear()
     }
-}
-
-/**
- * Simple pooled buffer wrapper that delegates to the underlying PlatformBuffer.
- */
-internal class SimplePooledBuffer(
-    val inner: PlatformBuffer,
-    private val pool: BufferPool,
-) : PooledBuffer {
-    override val capacity: Int get() = inner.capacity
-    override val byteOrder: ByteOrder get() = inner.byteOrder
-
-    override fun release() = pool.release(this)
-
-    // Delegate memory access to inner buffer
-    override val nativeMemoryAccess: NativeMemoryAccess?
-        get() = inner as? NativeMemoryAccess
-
-    override val managedMemoryAccess: ManagedMemoryAccess?
-        get() = inner as? ManagedMemoryAccess
-
-    // Delegate ReadBuffer
-    override fun resetForRead() = inner.resetForRead()
-
-    override fun readByte(): Byte = inner.readByte()
-
-    override fun get(index: Int): Byte = inner.get(index)
-
-    override fun readByteArray(size: Int): ByteArray = inner.readByteArray(size)
-
-    override fun readShort(): Short = inner.readShort()
-
-    override fun getShort(index: Int): Short = inner.getShort(index)
-
-    override fun readInt(): Int = inner.readInt()
-
-    override fun getInt(index: Int): Int = inner.getInt(index)
-
-    override fun readLong(): Long = inner.readLong()
-
-    override fun getLong(index: Int): Long = inner.getLong(index)
-
-    override fun readFloat(): Float = inner.readFloat()
-
-    override fun getFloat(index: Int): Float = inner.getFloat(index)
-
-    override fun readDouble(): Double = inner.readDouble()
-
-    override fun getDouble(index: Int): Double = inner.getDouble(index)
-
-    override fun readString(
-        length: Int,
-        charset: Charset,
-    ): String = inner.readString(length, charset)
-
-    override fun slice(): ReadBuffer = inner.slice()
-
-    override fun limit(): Int = inner.limit()
-
-    override fun position(): Int = inner.position()
-
-    override fun position(newPosition: Int) = inner.position(newPosition)
-
-    override fun setLimit(limit: Int) = inner.setLimit(limit)
-
-    // Delegate WriteBuffer
-    override fun resetForWrite() = inner.resetForWrite()
-
-    override fun writeByte(byte: Byte): WriteBuffer {
-        inner.writeByte(byte)
-        return this
-    }
-
-    override fun set(
-        index: Int,
-        byte: Byte,
-    ): WriteBuffer {
-        inner.set(index, byte)
-        return this
-    }
-
-    override fun writeBytes(
-        bytes: ByteArray,
-        offset: Int,
-        length: Int,
-    ): WriteBuffer {
-        inner.writeBytes(bytes, offset, length)
-        return this
-    }
-
-    override fun writeShort(short: Short): WriteBuffer {
-        inner.writeShort(short)
-        return this
-    }
-
-    override fun set(
-        index: Int,
-        short: Short,
-    ): WriteBuffer {
-        inner.set(index, short)
-        return this
-    }
-
-    override fun writeInt(int: Int): WriteBuffer {
-        inner.writeInt(int)
-        return this
-    }
-
-    override fun set(
-        index: Int,
-        int: Int,
-    ): WriteBuffer {
-        inner.set(index, int)
-        return this
-    }
-
-    override fun writeLong(long: Long): WriteBuffer {
-        inner.writeLong(long)
-        return this
-    }
-
-    override fun set(
-        index: Int,
-        long: Long,
-    ): WriteBuffer {
-        inner.set(index, long)
-        return this
-    }
-
-    override fun writeFloat(float: Float): WriteBuffer {
-        inner.writeFloat(float)
-        return this
-    }
-
-    override fun set(
-        index: Int,
-        float: Float,
-    ): WriteBuffer {
-        inner.set(index, float)
-        return this
-    }
-
-    override fun writeDouble(double: Double): WriteBuffer {
-        inner.writeDouble(double)
-        return this
-    }
-
-    override fun set(
-        index: Int,
-        double: Double,
-    ): WriteBuffer {
-        inner.set(index, double)
-        return this
-    }
-
-    override fun writeString(
-        text: CharSequence,
-        charset: Charset,
-    ): WriteBuffer {
-        inner.writeString(text, charset)
-        return this
-    }
-
-    override fun write(buffer: ReadBuffer) = inner.write(buffer)
 }

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/TrackedSlice.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/TrackedSlice.kt
@@ -1,0 +1,28 @@
+package com.ditchoom.buffer.pool
+
+import com.ditchoom.buffer.ReadBuffer
+
+/**
+ * Read-only slice of a pooled buffer that tracks parent lifetime via reference counting.
+ * When released, decrements the parent's refCount. The parent buffer is returned to
+ * the pool only when all slices and the original chunk reference are released.
+ */
+internal class TrackedSlice(
+    internal val inner: ReadBuffer,
+    private val parent: PooledBuffer,
+) : ReadBuffer by inner,
+    PoolReleasable {
+    private var released = false
+
+    override fun releaseToPool() {
+        if (!released) {
+            released = true
+            parent.releaseRef()
+        }
+    }
+
+    override fun slice(): ReadBuffer {
+        parent.addRef()
+        return TrackedSlice(inner.slice(), parent)
+    }
+}

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/stream/BufferStream.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/stream/BufferStream.kt
@@ -1,8 +1,8 @@
 package com.ditchoom.buffer.stream
 
+import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.pool.BufferPool
-import com.ditchoom.buffer.pool.PooledBuffer
 
 /**
  * Represents a stream of buffer chunks for protocol parsing.
@@ -109,7 +109,7 @@ fun BufferStream.collectToBuffer(pool: BufferPool): ReadBuffer {
 interface StreamProcessor {
     /**
      * Appends a chunk to the processor.
-     * The processor takes ownership and will release PooledBuffers when consumed.
+     * The processor takes ownership and will free PlatformBuffers when consumed.
      */
     fun append(chunk: ReadBuffer)
 
@@ -519,8 +519,8 @@ internal class DefaultStreamProcessor(
     }
 
     private fun releaseIfPooled(buffer: ReadBuffer) {
-        if (buffer is PooledBuffer) {
-            buffer.release()
-        }
+        // Release consumed chunks. For PooledBuffer, freeNativeMemory() decrements
+        // refCount — the buffer is only returned to pool when all slices are also freed.
+        (buffer as? PlatformBuffer)?.freeNativeMemory()
     }
 }

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/stream/StreamProcessorBuilder.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/stream/StreamProcessorBuilder.kt
@@ -27,7 +27,7 @@ import com.ditchoom.buffer.pool.BufferPool
  * ```
  */
 class StreamProcessorBuilder(
-    private val pool: BufferPool,
+    val pool: BufferPool,
 ) {
     private val transforms = mutableListOf<TransformSpec>()
 

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/stream/SuspendingStreamProcessor.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/stream/SuspendingStreamProcessor.kt
@@ -22,7 +22,7 @@ import com.ditchoom.buffer.ReadBuffer
 interface SuspendingStreamProcessor {
     /**
      * Appends a chunk to the processor.
-     * The processor takes ownership and will release PooledBuffers when consumed.
+     * The processor takes ownership and will free PlatformBuffers when consumed.
      */
     suspend fun append(chunk: ReadBuffer)
 

--- a/buffer/src/commonTest/kotlin/com/ditchoom/buffer/BufferUtilsTests.kt
+++ b/buffer/src/commonTest/kotlin/com/ditchoom/buffer/BufferUtilsTests.kt
@@ -1,0 +1,39 @@
+package com.ditchoom.buffer
+
+import kotlin.test.Test
+
+class BufferUtilsTests {
+    @Test
+    fun freeIfNeededOnPlatformBuffer() {
+        val buffer = PlatformBuffer.allocate(64, AllocationZone.Direct)
+        buffer.writeInt(0x12345678)
+        // Should not crash
+        buffer.freeIfNeeded()
+    }
+
+    @Test
+    fun freeIfNeededOnHeapBuffer() {
+        val buffer = PlatformBuffer.allocate(64, AllocationZone.Heap)
+        buffer.writeInt(0x12345678)
+        // Should not crash (no-op or safe free)
+        buffer.freeIfNeeded()
+    }
+
+    @Test
+    fun freeAllOnMixedList() {
+        val buffers =
+            listOf(
+                PlatformBuffer.allocate(64, AllocationZone.Direct) as ReadBuffer,
+                PlatformBuffer.allocate(64, AllocationZone.Heap) as ReadBuffer,
+            )
+        // Should not crash
+        buffers.freeAll()
+    }
+
+    @Test
+    fun freeAllOnEmptyList() {
+        val buffers = emptyList<ReadBuffer>()
+        // Should not crash
+        buffers.freeAll()
+    }
+}


### PR DESCRIPTION
## Summary

- **PooledBuffer**: New `PlatformBuffer by inner` wrapper with automatic reference counting — buffers return to pool when refCount reaches 0
- **TrackedSlice**: Read-only slices that increment parent refCount, preventing pool buffers from being recycled while slices are in use
- **Pool simplification**: `SingleThreadedBufferPool` (~200→~80 LOC) and `LockFreeBufferPool` (~200→~100 LOC) rewritten around PooledBuffer
- **PooledBuffer transparency**: Platform-specific compression code (JVM, Apple, Linux) updated with `unwrap()` helpers so type checks work through the wrapper
- **BufferAllocator.FromPool**: Pool-backed allocation strategy for compression pipelines
- **BufferUtils**: `freeIfNeeded()` / `freeAll()` helpers for ergonomic buffer lifecycle

### Dependencies
- Requires PR #117 (compression improvements) to be merged first — this branch is based on `pr/compression`

## Test plan
- [ ] CI passes (build-linux, build-apple, validate-artifacts, docs)
- [ ] Pool lifecycle tests (acquire, release, reuse, clear, statistics)
- [ ] Pool transparency tests (PooledBuffer passes through all PlatformBuffer operations)
- [ ] TrackedSlice ref-counting tests
- [ ] Multi-threaded pool tests (LockFreeBufferPool concurrent access)
- [ ] BufferAllocator.FromPool tests with compression pipeline
- [ ] Existing compression tests still pass (flush, reset, windowBits)
- [ ] Validate against websocket repo: `publishToMavenLocal` → autobahn test suite