### PR TITLE
Optimize Apple StreamingStringDecoder with CoreFoundation APIs

### DIFF
--- a/buffer/build.gradle.kts
+++ b/buffer/build.gradle.kts
@@ -495,6 +495,13 @@ benchmark {
             iterationTimeUnit = "ms"
             include("BulkOperations")
         }
+        register("streaming") {
+            warmups = 3
+            iterations = 5
+            iterationTime = 1000
+            iterationTimeUnit = "ms"
+            include("StreamingStringDecoder")
+        }
         // Fast configuration for WASM - runs only key benchmarks to avoid long run times
         register("wasmFast") {
             warmups = 2

--- a/buffer/src/commonBenchmark/kotlin/com/ditchoom/buffer/benchmark/StreamingStringDecoderBenchmark.kt
+++ b/buffer/src/commonBenchmark/kotlin/com/ditchoom/buffer/benchmark/StreamingStringDecoderBenchmark.kt
@@ -1,0 +1,253 @@
+package com.ditchoom.buffer.benchmark
+
+import com.ditchoom.buffer.AllocationZone
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.StreamingStringDecoder
+import com.ditchoom.buffer.allocate
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.BenchmarkMode
+import kotlinx.benchmark.BenchmarkTimeUnit
+import kotlinx.benchmark.Measurement
+import kotlinx.benchmark.Mode
+import kotlinx.benchmark.OutputTimeUnit
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+import kotlinx.benchmark.Warmup
+
+/**
+ * Benchmarks for StreamingStringDecoder comparing platform implementations.
+ *
+ * Scenarios:
+ * 1. ASCII decoding — 64KB of pure ASCII text (Direct buffer)
+ * 2. Mixed UTF-8 decoding — 64KB of mixed ASCII + multibyte (CJK, accented)
+ * 3. Emoji-heavy decoding — 64KB with frequent 4-byte emoji sequences
+ * 4. Chunked streaming — 64KB ASCII split into 1KB chunks
+ * 5. Baseline: readString() — Same 64KB ASCII using buffer.readString() for comparison
+ *
+ * Bottleneck isolation:
+ * 6. Heap vs Direct — Tests if ByteArray copy from native memory is the bottleneck
+ * 7. Chunk size scaling — 256B/4KB/16KB chunks to measure per-call allocation overhead
+ * 8. Heap baseline readString — Confirms readString advantage is about the copy path
+ *
+ * Run with:
+ *   ./gradlew :buffer:jvmBenchmarkStreamingBenchmark
+ *   ./gradlew :buffer:macosArm64BenchmarkStreamingBenchmark
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(BenchmarkTimeUnit.SECONDS)
+open class StreamingStringDecoderBenchmark {
+    private val size64k = 64 * 1024
+    private val chunkSize = 1024
+
+    private lateinit var asciiBuffer: PlatformBuffer
+    private lateinit var asciiHeapBuffer: PlatformBuffer
+    private lateinit var mixedUtf8Buffer: PlatformBuffer
+    private lateinit var emojiBuffer: PlatformBuffer
+    private lateinit var asciiChunks: List<PlatformBuffer>
+    private lateinit var asciiChunks256: List<PlatformBuffer>
+    private lateinit var asciiChunks4k: List<PlatformBuffer>
+    private lateinit var asciiChunks16k: List<PlatformBuffer>
+
+    private lateinit var decoder: StreamingStringDecoder
+    private val destination = StringBuilder(size64k)
+
+    @Setup
+    fun setup() {
+        decoder = StreamingStringDecoder()
+
+        // ASCII buffer — repeating printable ASCII written directly
+        asciiBuffer = PlatformBuffer.allocate(size64k, AllocationZone.Direct)
+        for (i in 0 until size64k) {
+            asciiBuffer.writeByte((32 + (i % 95)).toByte())
+        }
+        asciiBuffer.resetForRead()
+
+        // ASCII Heap buffer — bulk copy from Direct buffer
+        asciiHeapBuffer = PlatformBuffer.allocate(size64k, AllocationZone.Heap)
+        asciiBuffer.position(0)
+        asciiHeapBuffer.write(asciiBuffer)
+        asciiHeapBuffer.resetForRead()
+        asciiBuffer.position(0)
+
+        // Mixed UTF-8 — alternating ASCII words and multibyte characters
+        val mixedPattern = "Hello wor\u00E9The quick\u4E16brown fox\u00FCjumps ove\u754C"
+        mixedUtf8Buffer = fillBufferWithPattern(mixedPattern, size64k)
+
+        // Emoji-heavy — ASCII with frequent 4-byte emoji sequences
+        val emojiPattern = "Hello \uD83D\uDE00World \uD83D\uDE80Test! \uD83C\uDF1F"
+        emojiBuffer = fillBufferWithPattern(emojiPattern, size64k)
+
+        // Chunked ASCII — various chunk sizes from the ASCII buffer
+        asciiChunks = buildChunks(asciiBuffer, chunkSize)
+        asciiChunks256 = buildChunks(asciiBuffer, 256)
+        asciiChunks4k = buildChunks(asciiBuffer, 4096)
+        asciiChunks16k = buildChunks(asciiBuffer, 16384)
+    }
+
+    @Benchmark
+    fun asciiDecode(): Int {
+        asciiBuffer.position(0)
+        destination.clear()
+        decoder.reset()
+        val chars = decoder.decode(asciiBuffer, destination)
+        decoder.finish(destination)
+        return chars
+    }
+
+    @Benchmark
+    fun mixedUtf8Decode(): Int {
+        mixedUtf8Buffer.position(0)
+        destination.clear()
+        decoder.reset()
+        val chars = decoder.decode(mixedUtf8Buffer, destination)
+        decoder.finish(destination)
+        return chars
+    }
+
+    @Benchmark
+    fun emojiDecode(): Int {
+        emojiBuffer.position(0)
+        destination.clear()
+        decoder.reset()
+        val chars = decoder.decode(emojiBuffer, destination)
+        decoder.finish(destination)
+        return chars
+    }
+
+    @Benchmark
+    fun chunkedStreamingAscii(): Int {
+        destination.clear()
+        decoder.reset()
+        var totalChars = 0
+        for (chunk in asciiChunks) {
+            chunk.position(0)
+            totalChars += decoder.decode(chunk, destination)
+        }
+        totalChars += decoder.finish(destination)
+        return totalChars
+    }
+
+    @Benchmark
+    fun baselineReadStringAscii(): Int {
+        asciiBuffer.position(0)
+        val str = asciiBuffer.readString(asciiBuffer.remaining(), Charset.UTF8)
+        return str.length
+    }
+
+    // --- Bottleneck isolation benchmarks ---
+
+    /** Heap buffer decode — if faster than Direct on Apple, the native->ByteArray copy is the bottleneck */
+    @Benchmark
+    fun asciiDecodeHeap(): Int {
+        asciiHeapBuffer.position(0)
+        destination.clear()
+        decoder.reset()
+        val chars = decoder.decode(asciiHeapBuffer, destination)
+        decoder.finish(destination)
+        return chars
+    }
+
+    /** Heap readString baseline — comparison point for Heap decode overhead */
+    @Benchmark
+    fun baselineReadStringAsciiHeap(): Int {
+        asciiHeapBuffer.position(0)
+        val str = asciiHeapBuffer.readString(asciiHeapBuffer.remaining(), Charset.UTF8)
+        return str.length
+    }
+
+    /** 256B chunks (256 calls) — high per-call overhead if allocations dominate */
+    @Benchmark
+    fun chunkedStreaming256b(): Int {
+        destination.clear()
+        decoder.reset()
+        var totalChars = 0
+        for (chunk in asciiChunks256) {
+            chunk.position(0)
+            totalChars += decoder.decode(chunk, destination)
+        }
+        totalChars += decoder.finish(destination)
+        return totalChars
+    }
+
+    /** 4KB chunks (16 calls) — moderate per-call overhead */
+    @Benchmark
+    fun chunkedStreaming4k(): Int {
+        destination.clear()
+        decoder.reset()
+        var totalChars = 0
+        for (chunk in asciiChunks4k) {
+            chunk.position(0)
+            totalChars += decoder.decode(chunk, destination)
+        }
+        totalChars += decoder.finish(destination)
+        return totalChars
+    }
+
+    /** 16KB chunks (4 calls) — low per-call overhead */
+    @Benchmark
+    fun chunkedStreaming16k(): Int {
+        destination.clear()
+        decoder.reset()
+        var totalChars = 0
+        for (chunk in asciiChunks16k) {
+            chunk.position(0)
+            totalChars += decoder.decode(chunk, destination)
+        }
+        totalChars += decoder.finish(destination)
+        return totalChars
+    }
+
+    companion object {
+        private fun buildChunks(
+            source: PlatformBuffer,
+            chunkSize: Int,
+        ): List<PlatformBuffer> {
+            val total = source.limit()
+            val savedLimit = source.limit()
+            return (0 until total step chunkSize)
+                .map { offset ->
+                    val len = minOf(chunkSize, total - offset)
+                    source.position(offset)
+                    source.setLimit(offset + len)
+                    val chunk = PlatformBuffer.allocate(len, AllocationZone.Direct)
+                    chunk.write(source)
+                    chunk.resetForRead()
+                    chunk
+                }.also {
+                    source.setLimit(savedLimit)
+                    source.position(0)
+                }
+        }
+
+        private fun fillBufferWithPattern(
+            pattern: String,
+            targetSize: Int,
+        ): PlatformBuffer {
+            // Encode pattern once into a temporary buffer to get exact byte length
+            val patternBuffer = PlatformBuffer.allocate(pattern.length * 4, AllocationZone.Direct)
+            patternBuffer.writeString(pattern, Charset.UTF8)
+            val patternByteLen = patternBuffer.position()
+            patternBuffer.resetForRead()
+
+            val buffer = PlatformBuffer.allocate(targetSize, AllocationZone.Direct)
+            var written = 0
+            while (written + patternByteLen <= targetSize) {
+                patternBuffer.position(0)
+                buffer.write(patternBuffer)
+                written += patternByteLen
+            }
+            // Fill remaining bytes with ASCII to stay on valid UTF-8 boundary
+            while (written < targetSize) {
+                buffer.writeByte(0x20) // space
+                written++
+            }
+            buffer.resetForRead()
+            return buffer
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Optimize `StreamingStringDecoder` on Apple targets by replacing the `CFBridgingRelease` → `NSString.toString()` path with direct CoreFoundation character extraction, eliminating intermediate String allocations for large inputs
- Add `StreamingStringDecoderBenchmark` and `streaming` benchmark configuration for targeted perf testing

## Changes

**`StreamingStringDecoder.apple.kt`** — Two-tier decoding strategy in `convertUtf8PtrToAppendable`:

- **Large strings (>512B):** `CFStringCreateWithBytesNoCopy` (zero-copy input, no byte copy into CFString) → `CFStringGetCharacters` (UTF-16 direct into reusable pinned `CharArray`) → `CFRelease` (no ARC bridge). Avoids intermediate Kotlin String allocation entirely.
- **Small strings (≤512B):** `CFStringCreateWithBytes` (copies + pre-processes into optimized internal format) → `CFBridgingRelease` → `toString()` → `append`. The pre-processed format makes the Kotlin runtime's `NSString→String` fast; at this size the copy cost is negligible and fewer CF calls wins.

Reusable per-instance state avoids per-call allocations:
- `charBuffer: CharArray` — grows as needed, never shrinks
- `cfRange: CFRange` — allocated once on native heap, freed in `close()`

## Benchmark Results (macOS ARM64, ops/sec, higher = better)

### Before (main) vs After (this PR)

| Benchmark | Before (main) | After | Change |
|-----------|--------------|-------|--------|
| asciiDecode (64KB) | 22,070 | **42,316** | **+92%** |
| asciiDecodeHeap (64KB) | 22,165 | **42,576** | **+92%** |
| chunkedStreaming16k | 22,201 | **41,438** | **+87%** |
| chunkedStreaming4k | 17,546 | **36,089** | **+106%** |
| chunkedStreamingAscii (1KB) | 16,760 | **24,136** | **+44%** |
| chunkedStreaming256b | 11,686 | **11,710** | **+0.2%** |
| mixedUtf8Decode | 5,275 | **5,513** | **+5%** |
| emojiDecode | 6,251 | **6,577** | **+5%** |

No regressions at any chunk size. The 256B case initially regressed 8% due to per-call CF overhead; fixed by using the `CFStringCreateWithBytes` + `toString()` fast path for small strings (≤512B).

### Comparison with simdutf (PR #124)

| Benchmark | Baseline (main) | CF-Optimized (this PR) | simdutf (#124) | CF vs simdutf gap |
|-----------|----------------|----------------------|---------|-------------------|
| asciiDecode (64KB) | 22,070 | 42,316 | **109,443** | 2.6x behind |
| asciiDecodeHeap (64KB) | 22,165 | 42,576 | **110,512** | 2.6x behind |
| chunkedStreaming16k | 22,201 | 41,438 | **119,652** | 2.9x behind |
| chunkedStreaming4k | 17,546 | 36,089 | **112,361** | 3.1x behind |
| chunkedStreamingAscii (1KB) | 16,760 | 24,136 | **85,862** | 3.6x behind |
| chunkedStreaming256b | 11,686 | 11,710 | **38,651** | 3.3x behind |
| mixedUtf8Decode | 5,275 | 5,513 | **17,778** | 3.2x behind |
| emojiDecode | 6,251 | 6,577 | **15,715** | 2.4x behind |

This PR closes ~half the gap from baseline to simdutf (ASCII went from 5x behind to 2.6x behind), but simdutf remains **2.4–3.6x faster** due to NEON SIMD instructions for UTF-8 validation and transcoding vs CoreFoundation's scalar code path.

## Test plan

- [x] `./gradlew :buffer:macosArm64Test` — all tests pass
- [x] `./gradlew :buffer:ktlintCheck` — style check passes
- [x] Benchmark before/after on macOS ARM64
- [ ] CI (macOS, JVM, JS, WASM, Linux targets)