### PR TITLE
Add FFM-backed PlatformBuffer for JVM 21+

### DIFF
--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -83,6 +83,11 @@ jobs:
           testDebugUnitTest testReleaseUnitTest
           --no-build-cache ${{ inputs.gradle-args }}
 
+      - name: Run JVM FFM tests (validates FfmBuffer path on Java 21+)
+        run: >-
+          ./gradlew :buffer:jvmFfmTest :buffer-compression:jvmFfmTest
+          --no-build-cache ${{ inputs.gradle-args }}
+
       - name: Run Linux x64 tests
         run: >-
           ./gradlew :buffer:linuxX64Test :buffer-compression:linuxX64Test :buffer-flow:linuxX64Test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,8 @@ src/
 
 | Platform | Heap (wrap/Heap zone) | Direct (allocate) | Shared Memory |
 |----------|----------------------|-------------------|---------------|
-| JVM | `HeapJvmBuffer` | `DirectJvmBuffer` | Falls back to Direct |
+| JVM < 21 | `HeapJvmBuffer` | `DirectJvmBuffer` | Falls back to Direct |
+| JVM 21+ | `HeapJvmBuffer` | `FfmBuffer` | Falls back to Direct |
 | Android | `HeapJvmBuffer` | `DirectJvmBuffer` | `ParcelableSharedMemoryBuffer` |
 | Apple | `ByteArrayBuffer` | `MutableDataBuffer` | Falls back to Direct |
 | JS | `JsBuffer` | `JsBuffer` | `JsBuffer` (SharedArrayBuffer) |
@@ -62,7 +63,7 @@ src/
 
 ### Memory Access Interfaces
 
-- `NativeMemoryAccess` - Direct native memory pointer (DirectJvmBuffer, MutableDataBuffer, LinearBuffer, JsBuffer, NativeBuffer)
+- `NativeMemoryAccess` - Direct native memory pointer (FfmBuffer, DirectJvmBuffer, MutableDataBuffer, LinearBuffer, JsBuffer, NativeBuffer)
 - `ManagedMemoryAccess` - Kotlin ByteArray backing (HeapJvmBuffer, ByteArrayBuffer, JsBuffer)
 - `SharedMemoryAccess` - Cross-process shared memory (ParcelableSharedMemoryBuffer, JsBuffer with SharedArrayBuffer)
 
@@ -274,13 +275,63 @@ PlatformBuffer.wrap(byteArray)
 
 ## Platform Notes
 
-- **JVM/Android:** Direct ByteBuffers (`DirectJvmBuffer`) used by default; `HeapJvmBuffer` for `wrap()` and `Heap` zone
+- **JVM 21+:** Direct buffers use `FfmBuffer` (FFM Arena-backed) for deterministic memory management; `HeapJvmBuffer` for `wrap()` and `Heap` zone
+- **JVM < 21/Android:** Direct ByteBuffers (`DirectJvmBuffer`) used by default; `HeapJvmBuffer` for `wrap()` and `Heap` zone
 - **Android SharedMemory:** Use `AllocationZone.SharedMemory` for zero-copy IPC via Parcelable (API 27+)
 - **Apple:** `MutableDataBuffer` wraps NSMutableData (native memory); `wrap(ByteArray)` returns `ByteArrayBuffer`
 - **Apple NSData interop:** Use `PlatformBuffer.wrap(nsData)` or `PlatformBuffer.wrap(nsMutableData)` for zero-copy Apple API interop
 - **JS SharedArrayBuffer:** Requires CORS headers (`Cross-Origin-Opener-Policy`, `Cross-Origin-Embedder-Policy`)
 - **WASM:** `LinearBuffer` (Direct) uses native WASM memory for JS interop; `ByteArrayBuffer` (Heap) for compute workloads
 - **Linux:** `NativeBuffer` (Direct) uses malloc/free for zero-copy io_uring I/O; `ByteArrayBuffer` (Heap) for managed memory
+
+## Buffer Lifecycle
+
+Direct/native buffers on some platforms use native memory that requires explicit cleanup. On platforms where cleanup is required, failing to free buffers will leak native memory.
+
+### Cleanup by Platform
+
+| Platform | Direct buffer cleanup |
+|----------|----------------------|
+| JVM 9-20 | **Best-effort** — `Unsafe.invokeCleaner` (falls back to GC) |
+| JVM 21+  | **Must free** — FFM Arena-backed, not GC'd |
+| Android  | GC-managed (no action needed) |
+| Apple    | ARC-managed (no action needed) |
+| Linux    | **Must free** — malloc-backed |
+| WASM     | **Must free** — linear memory |
+| JS       | GC-managed (no action needed) |
+
+### Recommended Patterns
+
+```kotlin
+// 1. use block (recommended for one-off buffers)
+PlatformBuffer.allocate(1024, AllocationZone.Direct).use { buffer ->
+    buffer.writeInt(42)
+}
+
+// 2. Pool (recommended for repeated allocations)
+withPool { pool ->
+    pool.withBuffer(1024) { buffer ->
+        buffer.writeInt(42)
+    }
+}
+
+// 3. Explicit cleanup (when scope-based patterns don't fit)
+val buffer = PlatformBuffer.allocate(1024, AllocationZone.Direct)
+try {
+    buffer.writeInt(42)
+} finally {
+    buffer.freeNativeMemory()
+}
+```
+
+### FFM Interop (JVM 21+)
+
+On JVM 21+, direct buffers are backed by FFM `Arena`/`MemorySegment`. Use `asMemorySegment()` for FFM Panama downcalls:
+
+```kotlin
+val segment = buffer.asMemorySegment() ?: error("No native memory")
+val result = nativeFunctionHandle.invokeExact(segment, buffer.remaining()) as Int
+```
 
 ## Benchmarking
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,7 +276,9 @@ PlatformBuffer.wrap(byteArray)
 
 ## Platform Notes
 
-- **JVM 21+:** Direct buffers use `FfmBuffer` (FFM Arena-backed) for deterministic memory management; `HeapJvmBuffer` for `wrap()` and `Heap` zone
+- **JVM module name:** `Automatic-Module-Name` is `com.ditchoom.buffer`
+- **JVM 21+:** Direct buffers use `FfmBuffer` (FFM Arena-backed) for deterministic memory management; `HeapJvmBuffer` for `wrap()` and `Heap` zone. Requires `--enable-native-access=com.ditchoom.buffer` for FFM `reinterpret()`
+- **JVM 9-20:** `--add-opens=java.base/java.nio=com.ditchoom.buffer` recommended for reflection-based `nativeAddress` access
 - **JVM < 21/Android:** Direct ByteBuffers (`DirectJvmBuffer`) used by default; `HeapJvmBuffer` for `wrap()` and `Heap` zone
 - **Android SharedMemory:** Use `AllocationZone.SharedMemory` for zero-copy IPC via Parcelable (API 27+)
 - **Apple:** `MutableDataBuffer` wraps NSMutableData (native memory); `wrap(ByteArray)` returns `ByteArrayBuffer`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ src/
 ### Memory Access Interfaces
 
 - `NativeMemoryAccess` - Direct native memory pointer (FfmBuffer, DirectJvmBuffer, MutableDataBuffer, LinearBuffer, JsBuffer, NativeBuffer)
-- `ManagedMemoryAccess` - Kotlin ByteArray backing (HeapJvmBuffer, ByteArrayBuffer, JsBuffer)
+- `ManagedMemoryAccess` - Kotlin ByteArray backing (HeapJvmBuffer, ByteArrayBuffer, JsBuffer, Android DirectJvmBuffer)
 - `SharedMemoryAccess` - Cross-process shared memory (ParcelableSharedMemoryBuffer, JsBuffer with SharedArrayBuffer)
 
 ### Native Data Conversions
@@ -109,6 +109,7 @@ val nativeBuffer: NativeBuffer = buffer.toNativeData().nativeBuffer
 **Zero-copy vs Copy:**
 - Zero-copy when source already matches target type (e.g., direct buffer → direct ByteBuffer)
 - Copies when conversion is needed (e.g., heap buffer → direct ByteBuffer)
+- **Android special case:** `DirectJvmBuffer` implements both `NativeMemoryAccess` and `ManagedMemoryAccess` — the native address and backing `byte[]` are the same non-movable memory, so `toByteArray()` and `toNativeData()` are both zero-copy
 
 **Platform wrapper contents:**
 
@@ -294,7 +295,7 @@ Direct/native buffers on some platforms use native memory that requires explicit
 |----------|----------------------|
 | JVM 9-20 | **Best-effort** — `Unsafe.invokeCleaner` (falls back to GC) |
 | JVM 21+  | **Must free** — FFM Arena-backed, not GC'd |
-| Android  | GC-managed (no action needed) |
+| Android  | GC-managed (no action needed) — `DirectByteBuffer` uses `VMRuntime.newNonMovableArray()`, not `Unsafe.allocateMemory()`; `Unsafe.invokeCleaner` unavailable |
 | Apple    | ARC-managed (no action needed) |
 | Linux    | **Must free** — malloc-backed |
 | WASM     | **Must free** — linear memory |

--- a/buffer-compression/build.gradle.kts
+++ b/buffer-compression/build.gradle.kts
@@ -321,6 +321,8 @@ tasks.withType<Test>().configureEach {
         jvmArgs("-ea")
     }
 }
+
+
 ktlint {
     verbose.set(true)
     outputToConsole.set(true)

--- a/buffer-compression/build.gradle.kts
+++ b/buffer-compression/build.gradle.kts
@@ -270,6 +270,57 @@ mavenPublishing {
     }
 }
 
+// Split publishing metadata fix (see buffer/build.gradle.kts for details)
+afterEvaluate {
+    if (isRunningOnGithub) {
+        if (HostManager.hostIsLinux) {
+            tasks.named("generateMetadataFileForKotlinMultiplatformPublication") {
+                doLast {
+                    val moduleFile = outputs.files.singleFile
+                    injectAppleVariantsIntoModuleMetadata(moduleFile, project.version.toString(), "buffer-compression")
+                }
+            }
+        }
+        if (HostManager.hostIsMac) {
+            tasks
+                .matching {
+                    it.name.startsWith("publishKotlinMultiplatformPublication")
+                }.configureEach { enabled = false }
+        }
+    }
+}
+
+// jvmFfmTest: runs ALL JVM tests with buffer's java22 classes first on classpath.
+// This makes PlatformBuffer.allocate(Direct) return FfmBuffer, exercising the FFM path
+// through all compression tests.
+// Configured in afterEvaluate so jvmTest's classpath is fully resolved by all plugins.
+tasks.register<Test>("jvmFfmTest") {
+    description = "Runs JVM tests with FFM-backed BufferFactory (Java 22+)"
+    group = "verification"
+}
+
+afterEvaluate {
+    tasks.named<Test>("jvmFfmTest") {
+        val jvmTestTask = tasks.named<Test>("jvmTest").get()
+        // Depend on test class compilation, not on jvmTest execution
+        dependsOn("compileTestKotlinJvm", ":buffer:compileJava22KotlinJvm")
+        testClassesDirs = jvmTestTask.testClassesDirs
+        val bufferJava22Classes =
+            files(
+                project(":buffer")
+                    .layout
+                    .buildDirectory
+                    .dir("classes/kotlin/jvm/java22"),
+            )
+        classpath = bufferJava22Classes + jvmTestTask.classpath
+    }
+}
+
+tasks.withType<Test>().configureEach {
+    if (!name.contains("benchmark", ignoreCase = true)) {
+        jvmArgs("-ea")
+    }
+}
 ktlint {
     verbose.set(true)
     outputToConsole.set(true)

--- a/buffer-compression/build.gradle.kts
+++ b/buffer-compression/build.gradle.kts
@@ -270,32 +270,12 @@ mavenPublishing {
     }
 }
 
-// Split publishing metadata fix (see buffer/build.gradle.kts for details)
-afterEvaluate {
-    if (isRunningOnGithub) {
-        if (HostManager.hostIsLinux) {
-            tasks.named("generateMetadataFileForKotlinMultiplatformPublication") {
-                doLast {
-                    val moduleFile = outputs.files.singleFile
-                    injectAppleVariantsIntoModuleMetadata(moduleFile, project.version.toString(), "buffer-compression")
-                }
-            }
-        }
-        if (HostManager.hostIsMac) {
-            tasks
-                .matching {
-                    it.name.startsWith("publishKotlinMultiplatformPublication")
-                }.configureEach { enabled = false }
-        }
-    }
-}
-
-// jvmFfmTest: runs ALL JVM tests with buffer's java22 classes first on classpath.
+// jvmFfmTest: runs ALL JVM tests with buffer's java21 classes first on classpath.
 // This makes PlatformBuffer.allocate(Direct) return FfmBuffer, exercising the FFM path
 // through all compression tests.
 // Configured in afterEvaluate so jvmTest's classpath is fully resolved by all plugins.
 tasks.register<Test>("jvmFfmTest") {
-    description = "Runs JVM tests with FFM-backed BufferFactory (Java 22+)"
+    description = "Runs JVM tests with FFM-backed BufferFactory (Java 21+)"
     group = "verification"
 }
 
@@ -303,25 +283,28 @@ afterEvaluate {
     tasks.named<Test>("jvmFfmTest") {
         val jvmTestTask = tasks.named<Test>("jvmTest").get()
         // Depend on test class compilation, not on jvmTest execution
-        dependsOn("compileTestKotlinJvm", ":buffer:compileJava22KotlinJvm")
+        dependsOn("compileTestKotlinJvm", ":buffer:compileJava21KotlinJvm")
         testClassesDirs = jvmTestTask.testClassesDirs
-        val bufferJava22Classes =
+        val bufferJava21Classes =
             files(
                 project(":buffer")
                     .layout
                     .buildDirectory
-                    .dir("classes/kotlin/jvm/java22"),
+                    .dir("classes/kotlin/jvm/java21"),
             )
-        classpath = bufferJava22Classes + jvmTestTask.classpath
+        classpath = bufferJava21Classes + jvmTestTask.classpath
     }
 }
 
 tasks.withType<Test>().configureEach {
-    if (!name.contains("benchmark", ignoreCase = true)) {
+    val isBenchmark = name.contains("benchmark", ignoreCase = true)
+    jvmArgs(
+        "--enable-native-access=ALL-UNNAMED",
+    )
+    if (!isBenchmark) {
         jvmArgs("-ea")
     }
 }
-
 
 ktlint {
     verbose.set(true)

--- a/buffer/build.gradle.kts
+++ b/buffer/build.gradle.kts
@@ -540,6 +540,46 @@ tasks.named<Jar>("jvmJar") {
     }
 }
 
+// Add Java 21 compilation output to JVM test classpath so FfmBufferTest can reference FfmBuffer directly
+kotlin
+    .jvm()
+    .compilations
+    .getByName("test") {
+        val java21Output =
+            kotlin
+                .jvm()
+                .compilations["java21"]
+                .output
+                .classesDirs
+        compileDependencyFiles += java21Output
+        runtimeDependencyFiles += java21Output
+    }
+
+// jvmFfmTest: runs ALL JVM tests with java21 classes first on classpath.
+// This makes BufferFactoryJvm from jvm21Main shadow jvmMain's version,
+// so PlatformBuffer.allocate(Direct) returns FfmBuffer instead of DirectJvmBuffer.
+// Configured in afterEvaluate so jvmTest's classpath is fully resolved by all plugins.
+tasks.register<Test>("jvmFfmTest") {
+    description = "Runs JVM tests with FFM-backed BufferFactory (Java 21+)"
+    group = "verification"
+}
+
+afterEvaluate {
+    tasks.named<Test>("jvmFfmTest") {
+        val jvmTestTask = tasks.named<Test>("jvmTest").get()
+        // Depend on test class compilation, not on jvmTest execution
+        dependsOn("compileTestKotlinJvm", "transformJvmTestAtomicfu", "compileJava21KotlinJvm")
+        testClassesDirs = jvmTestTask.testClassesDirs
+        val java21Output =
+            kotlin
+                .jvm()
+                .compilations["java21"]
+                .output
+                .classesDirs
+        classpath = java21Output + jvmTestTask.classpath
+    }
+}
+
 ktlint {
     verbose.set(true)
     outputToConsole.set(true)
@@ -643,9 +683,13 @@ tasks.matching { it.name == "testBenchmarkUnitTest" }.configureEach {
 // - java.nio: DirectBufferAddressHelper accesses Buffer.address field
 // - jdk.internal.misc: UnsafeMemory accesses sun.misc.Unsafe
 tasks.withType<Test>().configureEach {
+    val isBenchmark = name.contains("benchmark", ignoreCase = true)
     jvmArgs(
         "--add-opens=java.base/java.nio=ALL-UNNAMED",
     )
+    if (!isBenchmark) {
+        jvmArgs("-ea")
+    }
 }
 
 dokka {

--- a/buffer/build.gradle.kts
+++ b/buffer/build.gradle.kts
@@ -516,7 +516,10 @@ benchmark {
 // Configure multi-release JAR for Java 11+ and Java 21+ optimizations
 tasks.named<Jar>("jvmJar") {
     manifest {
-        attributes("Multi-Release" to "true")
+        attributes(
+            "Multi-Release" to "true",
+            "Automatic-Module-Name" to "com.ditchoom.buffer",
+        )
     }
     // Include Java 11 classes in META-INF/versions/11/
     into("META-INF/versions/11") {
@@ -679,13 +682,15 @@ tasks.matching { it.name == "testBenchmarkUnitTest" }.configureEach {
     enabled = false
 }
 
-// Allow reflective access to internal JDK fields:
-// - java.nio: DirectBufferAddressHelper accesses Buffer.address field
-// - jdk.internal.misc: UnsafeMemory accesses sun.misc.Unsafe
+// JVM flags for test tasks:
+// - --add-opens java.nio: DirectBufferAddressHelper accesses Buffer.address field via reflection
+// - --enable-native-access: FFM reinterpret() is a restricted method (warnings on JDK 22+, error on JDK 24+)
+// Tests run from the classpath (unnamed module), so ALL-UNNAMED is required.
 tasks.withType<Test>().configureEach {
     val isBenchmark = name.contains("benchmark", ignoreCase = true)
     jvmArgs(
         "--add-opens=java.base/java.nio=ALL-UNNAMED",
+        "--enable-native-access=ALL-UNNAMED",
     )
     if (!isBenchmark) {
         jvmArgs("-ea")

--- a/buffer/src/androidMain/kotlin/com/ditchoom/buffer/DirectJvmBuffer.kt
+++ b/buffer/src/androidMain/kotlin/com/ditchoom/buffer/DirectJvmBuffer.kt
@@ -1,21 +1,30 @@
 package com.ditchoom.buffer
 
+import java.nio.Buffer
 import java.nio.ByteBuffer
 
 /**
- * JVM buffer backed by a direct ByteBuffer with native memory access support.
+ * Android buffer backed by a direct ByteBuffer with both native and managed memory access.
  *
- * This class provides access to the native memory address for use with:
- * - Java NIO channels
- * - JNI/FFI native code
- * - Memory-mapped files
+ * On Android, [ByteBuffer.allocateDirect] allocates a non-movable byte array via
+ * [dalvik.system.VMRuntime.newNonMovableArray][https://cs.android.com/android/platform/superproject/+/android-16.0.0_r2:libcore/ojluni/src/main/java/java/nio/DirectByteBuffer.java;l=73].
+ * The native address and the backing `byte[]` point to the **same memory**, so this class
+ * implements both [NativeMemoryAccess] and [ManagedMemoryAccess] — zero-copy in either
+ * direction.
+ *
+ * This differs from JVM where direct buffers use off-heap memory (`Unsafe.allocateMemory`)
+ * with no backing array. On Android, "direct" means "pinned/non-movable" rather than
+ * "off-heap," which is why APIs like JNI, Camera2, and MediaCodec require direct buffers:
+ * the GC guarantees it will never relocate the underlying array, so native code can safely
+ * hold a raw pointer.
  *
  * On Android 33+, uses MethodHandle for faster address lookup.
  */
 class DirectJvmBuffer(
     byteBuffer: ByteBuffer,
 ) : JvmBuffer(byteBuffer),
-    NativeMemoryAccess {
+    NativeMemoryAccess,
+    ManagedMemoryAccess {
     init {
         require(byteBuffer.isDirect) { "DirectJvmBuffer requires a direct ByteBuffer" }
     }
@@ -30,6 +39,16 @@ class DirectJvmBuffer(
      * The size of the native memory region in bytes.
      */
     override val nativeSize: Long get() = capacity.toLong()
+
+    /**
+     * The backing non-movable byte array. On Android, this is the same memory as [nativeAddress].
+     */
+    override val backingArray: ByteArray get() = byteBuffer.array()
+
+    /**
+     * The offset within [backingArray] where buffer data begins (alignment padding).
+     */
+    override val arrayOffset: Int get() = (byteBuffer as Buffer).arrayOffset()
 
     override fun slice() = DirectJvmBuffer(byteBuffer.slice())
 }

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/BufferFactory.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/BufferFactory.kt
@@ -2,6 +2,14 @@ package com.ditchoom.buffer
 
 import kotlin.math.roundToInt
 
+/**
+ * Allocates a new buffer of the given [size] with the specified [zone] and [byteOrder].
+ *
+ * **Important:** Buffers allocated with [AllocationZone.Direct] on some platforms
+ * (Linux, WASM, JVM 21+) use native memory that requires explicit cleanup.
+ * Prefer `withBuffer`, [com.ditchoom.buffer.pool.BufferPool], or `use` blocks
+ * to ensure proper lifecycle management.
+ */
 expect fun PlatformBuffer.Companion.allocate(
     size: Int,
     zone: AllocationZone = AllocationZone.Heap,

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/PlatformBuffer.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/PlatformBuffer.kt
@@ -18,7 +18,7 @@ interface PlatformBuffer :
      * |----------|----------------------|
      * | JVM 9-20 | **Best-effort** — `Unsafe.invokeCleaner` (falls back to GC) |
      * | JVM 21+  | **Must free** — Arena-backed, not GC'd |
-     * | Android  | GC-managed (no action needed) |
+     * | Android  | GC-managed (no action needed) — backed by `VMRuntime.newNonMovableArray()`, `invokeCleaner` unavailable |
      * | Apple    | ARC-managed (no action needed) |
      * | Linux    | **Must free** — malloc-backed |
      * | WASM     | **Must free** — linear memory |

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/PlatformBuffer.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/PlatformBuffer.kt
@@ -6,7 +6,25 @@ interface PlatformBuffer :
     Parcelable {
     /**
      * Frees native memory resources without requiring suspend context.
-     * No-op on JVM/JS where GC handles cleanup. On Linux, frees the underlying malloc'd memory.
+     *
+     * **Lifecycle responsibility:** Buffers allocated with [AllocationZone.Direct] or
+     * [AllocationZone.SharedMemory] may use native memory that is NOT garbage-collected
+     * on all platforms. Callers must ensure cleanup via one of:
+     * - [use] block (recommended): `buffer.use { ... }`
+     * - [com.ditchoom.buffer.pool.BufferPool] / `withBuffer`: pool manages lifecycle automatically
+     * - Explicit call to [freeNativeMemory] or [close]
+     *
+     * | Platform | Direct buffer cleanup |
+     * |----------|----------------------|
+     * | JVM 9-20 | **Best-effort** — `Unsafe.invokeCleaner` (falls back to GC) |
+     * | JVM 21+  | **Must free** — Arena-backed, not GC'd |
+     * | Android  | GC-managed (no action needed) |
+     * | Apple    | ARC-managed (no action needed) |
+     * | Linux    | **Must free** — malloc-backed |
+     * | WASM     | **Must free** — linear memory |
+     * | JS       | GC-managed (no action needed) |
+     *
+     * Calling this on a freed buffer is safe (idempotent).
      * For pool-acquired buffers, returns the buffer to its pool instead of freeing.
      */
     fun freeNativeMemory() {}

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/SuspendCloseable.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/SuspendCloseable.kt
@@ -3,3 +3,24 @@ package com.ditchoom.buffer
 interface SuspendCloseable {
     suspend fun close()
 }
+
+/**
+ * Executes the given [block] on this buffer and then frees native memory in a finally block.
+ *
+ * This is the recommended pattern for one-off buffer usage:
+ * ```kotlin
+ * PlatformBuffer.allocate(1024, AllocationZone.Direct).use { buffer ->
+ *     buffer.writeInt(42)
+ * }
+ * ```
+ *
+ * Calls [PlatformBuffer.freeNativeMemory] (non-suspend) rather than [SuspendCloseable.close],
+ * so it can be used in any context without requiring a coroutine scope.
+ */
+inline fun <T : PlatformBuffer, R> T.use(block: (T) -> R): R {
+    try {
+        return block(this)
+    } finally {
+        freeNativeMemory()
+    }
+}

--- a/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/BufferFactory.kt
+++ b/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/BufferFactory.kt
@@ -1,0 +1,101 @@
+@file:JvmName("BufferFactoryJvm")
+@file:Suppress("unused") // Loaded at runtime via multi-release JAR
+
+package com.ditchoom.buffer
+
+import java.lang.foreign.Arena
+import java.lang.foreign.MemorySegment
+import java.nio.ByteBuffer
+
+/**
+ * FFM-backed buffer factory for Java 21+.
+ *
+ * Shadows the jvmMain BufferFactory via multi-release JAR. Routes [AllocationZone.Direct]
+ * and [AllocationZone.SharedMemory] to [FfmBuffer] for deterministic memory management.
+ * Heap allocation still uses [HeapJvmBuffer].
+ */
+fun PlatformBuffer.Companion.allocate(
+    size: Int,
+    zone: AllocationZone = AllocationZone.Heap,
+    byteOrder: ByteOrder = ByteOrder.BIG_ENDIAN,
+): PlatformBuffer {
+    val byteOrderNative =
+        when (byteOrder) {
+            ByteOrder.BIG_ENDIAN -> java.nio.ByteOrder.BIG_ENDIAN
+            ByteOrder.LITTLE_ENDIAN -> java.nio.ByteOrder.LITTLE_ENDIAN
+        }
+    return when (zone) {
+        AllocationZone.Heap -> HeapJvmBuffer(ByteBuffer.allocate(size).order(byteOrderNative))
+        AllocationZone.SharedMemory,
+        AllocationZone.Direct,
+        -> allocateFfmBuffer(size, byteOrder)
+    }
+}
+
+fun PlatformBuffer.Companion.wrap(
+    array: ByteArray,
+    byteOrder: ByteOrder = ByteOrder.BIG_ENDIAN,
+): PlatformBuffer {
+    val byteOrderNative =
+        when (byteOrder) {
+            ByteOrder.BIG_ENDIAN -> java.nio.ByteOrder.BIG_ENDIAN
+            ByteOrder.LITTLE_ENDIAN -> java.nio.ByteOrder.LITTLE_ENDIAN
+        }
+    return HeapJvmBuffer(ByteBuffer.wrap(array).order(byteOrderNative))
+}
+
+/**
+ * Allocates a buffer with guaranteed native memory access ([FfmBuffer]).
+ * Uses FFM Arena for deterministic memory management.
+ */
+fun PlatformBuffer.Companion.allocateNative(
+    size: Int,
+    byteOrder: ByteOrder = ByteOrder.BIG_ENDIAN,
+): PlatformBuffer = allocateFfmBuffer(size, byteOrder)
+
+/**
+ * Allocates a buffer with shared memory support.
+ * On JVM, falls back to FFM-backed direct allocation (no cross-process shared memory).
+ */
+fun PlatformBuffer.Companion.allocateShared(
+    size: Int,
+    byteOrder: ByteOrder = ByteOrder.BIG_ENDIAN,
+): PlatformBuffer = allocate(size, AllocationZone.Direct, byteOrder)
+
+/**
+ * Internal factory that creates an FFM-backed buffer.
+ *
+ * Uses [Arena.ofShared] for memory ownership — deterministic free from any thread via
+ * [FfmBuffer.freeNativeMemory]. The ByteBuffer view is created from a global-scope
+ * reinterpretation of the segment address so it is compatible with all JDK APIs
+ * (Deflater, Inflater, CRC32, NIO channels). The JDK rejects ByteBuffers from closeable
+ * shared sessions, but global-scope ByteBuffers are treated as regular direct ByteBuffers.
+ *
+ * Lifecycle safety is provided by the pool ([BufferPool] tracks references and only frees
+ * when buffers are unreferenced) or by the caller for standalone allocations.
+ *
+ * @param size Buffer size in bytes.
+ * @param byteOrder Byte order for multi-byte operations.
+ */
+internal fun allocateFfmBuffer(
+    size: Int,
+    byteOrder: ByteOrder,
+): FfmBuffer {
+    val arena = Arena.ofShared()
+    val segment = arena.allocate(size.toLong())
+    val byteOrderNative =
+        when (byteOrder) {
+            ByteOrder.BIG_ENDIAN -> java.nio.ByteOrder.BIG_ENDIAN
+            ByteOrder.LITTLE_ENDIAN -> java.nio.ByteOrder.LITTLE_ENDIAN
+        }
+    // Create ByteBuffer from a global-scope view of the same native memory.
+    // This ensures the ByteBuffer is NOT tied to the Arena's closeable shared session,
+    // which JDK APIs (Deflater.deflate, Inflater.inflate, CRC32.update) reject.
+    // Memory ownership remains with the shared Arena — freeNativeMemory() closes it.
+    val globalView =
+        MemorySegment
+            .ofAddress(segment.address())
+            .reinterpret(size.toLong())
+    val byteBuffer = globalView.asByteBuffer().order(byteOrderNative)
+    return FfmBuffer(arena, segment, byteBuffer)
+}

--- a/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/FfmBuffer.kt
+++ b/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/FfmBuffer.kt
@@ -1,0 +1,107 @@
+@file:Suppress("unused") // Loaded at runtime via multi-release JAR
+
+package com.ditchoom.buffer
+
+import java.lang.foreign.Arena
+import java.lang.foreign.MemorySegment
+import java.nio.ByteBuffer
+
+/**
+ * FFM-backed PlatformBuffer for Java 21+.
+ *
+ * Uses [Arena.ofShared] for deterministic native memory management. When [freeNativeMemory]
+ * is called, the Arena is closed and the native memory is freed immediately from any thread —
+ * no GC/Cleaner dependency.
+ *
+ * The ByteBuffer view is created from a global-scope reinterpretation of the segment address,
+ * making it compatible with all JDK APIs (Deflater, Inflater, CRC32, NIO). The shared Arena
+ * still owns the memory; the global-scope ByteBuffer is just a view.
+ *
+ * This transparently replaces [DirectJvmBuffer] on JVM 21+ via the multi-release JAR.
+ * All buffer operations are inherited from [BaseJvmBuffer] via the ByteBuffer view.
+ *
+ * @param arena The shared FFM Arena that owns the native memory. Closed by [freeNativeMemory].
+ * @param segment The MemorySegment backing this buffer (shared Arena scope).
+ * @param byteBuffer A global-scope ByteBuffer view for JDK API compatibility.
+ */
+class FfmBuffer(
+    private val arena: Arena,
+    val segment: MemorySegment,
+    byteBuffer: ByteBuffer,
+) : BaseJvmBuffer(byteBuffer),
+    NativeMemoryAccess {
+    /**
+     * The native memory address of the FFM MemorySegment.
+     * With assertions enabled, throws if the buffer has been freed.
+     */
+    override val nativeAddress: Long
+        get() {
+            assertAlive()
+            return segment.address()
+        }
+
+    /**
+     * The size of the native memory region in bytes.
+     * With assertions enabled, throws if the buffer has been freed.
+     */
+    override val nativeSize: Long
+        get() {
+            assertAlive()
+            return segment.byteSize()
+        }
+
+    private fun assertAlive() {
+        assert(arena.scope().isAlive) { "FfmBuffer used after freeNativeMemory()" }
+    }
+
+    /**
+     * Frees the native memory by closing the Arena and invalidating the ByteBuffer view.
+     *
+     * After this call, the ByteBuffer's limit is set to 0, causing any subsequent
+     * read/write operation to throw [java.nio.BufferUnderflowException] or
+     * [java.nio.BufferOverflowException]. With assertions enabled (`-ea`),
+     * lifecycle methods ([resetForRead], [resetForWrite], [slice]) will throw
+     * [AssertionError] before the ByteBuffer check.
+     *
+     * This method is idempotent — calling it multiple times is safe.
+     *
+     * **Note:** Slices created before this call retain their own ByteBuffer position/limit
+     * state and will NOT be invalidated. Slices must not outlive the parent FfmBuffer.
+     */
+    override fun freeNativeMemory() {
+        if (arena.scope().isAlive) {
+            arena.close()
+            // Invalidate the ByteBuffer view so any subsequent access throws
+            // BufferUnderflowException/BufferOverflowException instead of
+            // silently accessing freed native memory.
+            val buf = byteBuffer as java.nio.Buffer
+            buf.position(0)
+            buf.limit(0)
+        }
+    }
+
+    override suspend fun close() {
+        freeNativeMemory()
+    }
+
+    override fun resetForRead() {
+        assertAlive()
+        super.resetForRead()
+    }
+
+    override fun resetForWrite() {
+        assertAlive()
+        super.resetForWrite()
+    }
+
+    /**
+     * Returns a [DirectJvmBuffer] slice that shares the parent's native memory.
+     *
+     * The slice does NOT own the Arena and will not close it — this prevents
+     * use-after-free when the slice outlives the parent in pool scenarios.
+     */
+    override fun slice(): PlatformBuffer {
+        assertAlive()
+        return DirectJvmBuffer(byteBuffer.slice())
+    }
+}

--- a/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/FfmBuffer.kt
+++ b/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/FfmBuffer.kt
@@ -65,8 +65,9 @@ class FfmBuffer(
      *
      * This method is idempotent — calling it multiple times is safe.
      *
-     * **Note:** Slices created before this call retain their own ByteBuffer position/limit
-     * state and will NOT be invalidated. Slices must not outlive the parent FfmBuffer.
+     * **Note:** Slices ([FfmSliceBuffer]) created from this buffer are derived from the
+     * arena-scoped segment. After this call, any access to the slice's ByteBuffer throws
+     * [IllegalStateException] ("Already closed") — providing automatic use-after-free safety.
      */
     override fun freeNativeMemory() {
         if (arena.scope().isAlive) {
@@ -95,13 +96,14 @@ class FfmBuffer(
     }
 
     /**
-     * Returns a [DirectJvmBuffer] slice that shares the parent's native memory.
-     *
-     * The slice does NOT own the Arena and will not close it — this prevents
-     * use-after-free when the slice outlives the parent in pool scenarios.
+     * Returns an [FfmSliceBuffer] slice whose ByteBuffer is derived from the arena-scoped
+     * segment. When the parent Arena is closed, the JDK automatically invalidates the
+     * slice's ByteBuffer — any access throws [IllegalStateException].
      */
     override fun slice(): PlatformBuffer {
         assertAlive()
-        return DirectJvmBuffer(byteBuffer.slice())
+        val slicedSegment = segment.asSlice(position().toLong(), remaining().toLong())
+        val sliceByteBuffer = slicedSegment.asByteBuffer().order(byteBuffer.order())
+        return FfmSliceBuffer(slicedSegment, sliceByteBuffer)
     }
 }

--- a/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/FfmBufferScope.kt
+++ b/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/FfmBufferScope.kt
@@ -101,21 +101,21 @@ class FfmScopedBuffer(
     override fun readByte(): Byte = segment.get(ValueLayout.JAVA_BYTE, positionValue++.toLong())
 
     override fun readShort(): Short {
-        val layout = ValueLayout.JAVA_SHORT.withOrder(javaByteOrder())
+        val layout = ValueLayout.JAVA_SHORT_UNALIGNED.withOrder(javaByteOrder())
         val value = segment.get(layout, positionValue.toLong())
         positionValue += 2
         return value
     }
 
     override fun readInt(): Int {
-        val layout = ValueLayout.JAVA_INT.withOrder(javaByteOrder())
+        val layout = ValueLayout.JAVA_INT_UNALIGNED.withOrder(javaByteOrder())
         val value = segment.get(layout, positionValue.toLong())
         positionValue += 4
         return value
     }
 
     override fun readLong(): Long {
-        val layout = ValueLayout.JAVA_LONG.withOrder(javaByteOrder())
+        val layout = ValueLayout.JAVA_LONG_UNALIGNED.withOrder(javaByteOrder())
         val value = segment.get(layout, positionValue.toLong())
         positionValue += 8
         return value
@@ -125,17 +125,17 @@ class FfmScopedBuffer(
     override fun get(index: Int): Byte = segment.get(ValueLayout.JAVA_BYTE, index.toLong())
 
     override fun getShort(index: Int): Short {
-        val layout = ValueLayout.JAVA_SHORT.withOrder(javaByteOrder())
+        val layout = ValueLayout.JAVA_SHORT_UNALIGNED.withOrder(javaByteOrder())
         return segment.get(layout, index.toLong())
     }
 
     override fun getInt(index: Int): Int {
-        val layout = ValueLayout.JAVA_INT.withOrder(javaByteOrder())
+        val layout = ValueLayout.JAVA_INT_UNALIGNED.withOrder(javaByteOrder())
         return segment.get(layout, index.toLong())
     }
 
     override fun getLong(index: Int): Long {
-        val layout = ValueLayout.JAVA_LONG.withOrder(javaByteOrder())
+        val layout = ValueLayout.JAVA_LONG_UNALIGNED.withOrder(javaByteOrder())
         return segment.get(layout, index.toLong())
     }
 
@@ -146,21 +146,21 @@ class FfmScopedBuffer(
     }
 
     override fun writeShort(short: Short): WriteBuffer {
-        val layout = ValueLayout.JAVA_SHORT.withOrder(javaByteOrder())
+        val layout = ValueLayout.JAVA_SHORT_UNALIGNED.withOrder(javaByteOrder())
         segment.set(layout, positionValue.toLong(), short)
         positionValue += 2
         return this
     }
 
     override fun writeInt(int: Int): WriteBuffer {
-        val layout = ValueLayout.JAVA_INT.withOrder(javaByteOrder())
+        val layout = ValueLayout.JAVA_INT_UNALIGNED.withOrder(javaByteOrder())
         segment.set(layout, positionValue.toLong(), int)
         positionValue += 4
         return this
     }
 
     override fun writeLong(long: Long): WriteBuffer {
-        val layout = ValueLayout.JAVA_LONG.withOrder(javaByteOrder())
+        val layout = ValueLayout.JAVA_LONG_UNALIGNED.withOrder(javaByteOrder())
         segment.set(layout, positionValue.toLong(), long)
         positionValue += 8
         return this
@@ -179,7 +179,7 @@ class FfmScopedBuffer(
         index: Int,
         short: Short,
     ): WriteBuffer {
-        val layout = ValueLayout.JAVA_SHORT.withOrder(javaByteOrder())
+        val layout = ValueLayout.JAVA_SHORT_UNALIGNED.withOrder(javaByteOrder())
         segment.set(layout, index.toLong(), short)
         return this
     }
@@ -188,7 +188,7 @@ class FfmScopedBuffer(
         index: Int,
         int: Int,
     ): WriteBuffer {
-        val layout = ValueLayout.JAVA_INT.withOrder(javaByteOrder())
+        val layout = ValueLayout.JAVA_INT_UNALIGNED.withOrder(javaByteOrder())
         segment.set(layout, index.toLong(), int)
         return this
     }
@@ -197,7 +197,7 @@ class FfmScopedBuffer(
         index: Int,
         long: Long,
     ): WriteBuffer {
-        val layout = ValueLayout.JAVA_LONG.withOrder(javaByteOrder())
+        val layout = ValueLayout.JAVA_LONG_UNALIGNED.withOrder(javaByteOrder())
         segment.set(layout, index.toLong(), long)
         return this
     }

--- a/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/FfmInterop.kt
+++ b/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/FfmInterop.kt
@@ -29,6 +29,7 @@ fun ReadBuffer.asMemorySegment(): MemorySegment? {
     val unwrapped = unwrapFully()
     return when (unwrapped) {
         is FfmBuffer -> unwrapped.segment.asSlice(unwrapped.position().toLong(), unwrapped.remaining().toLong())
+        is FfmSliceBuffer -> unwrapped.segment.asSlice(unwrapped.position().toLong(), unwrapped.remaining().toLong())
         is BaseJvmBuffer ->
             if (unwrapped.byteBuffer.isDirect) {
                 MemorySegment

--- a/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/FfmInterop.kt
+++ b/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/FfmInterop.kt
@@ -1,0 +1,42 @@
+@file:Suppress("unused") // Loaded at runtime via multi-release JAR
+
+package com.ditchoom.buffer
+
+import java.lang.foreign.MemorySegment
+
+/**
+ * Returns a [MemorySegment] view of this buffer's remaining bytes for use with
+ * Java FFM (Foreign Function & Memory) API Panama downcalls.
+ *
+ * The returned segment covers [ReadBuffer.position] to [ReadBuffer.limit].
+ *
+ * **Zero-copy path:**
+ * - [FfmBuffer]: Returns a slice of the owned MemorySegment (scoped to the Arena's lifetime).
+ * - [DirectJvmBuffer] / other direct [BaseJvmBuffer]: Creates a MemorySegment from the
+ *   direct ByteBuffer's native address.
+ *
+ * **Returns null:**
+ * - Heap-backed buffers (no native address to wrap).
+ * - Non-JVM buffer types.
+ *
+ * Example usage with FFM Panama downcall:
+ * ```kotlin
+ * val segment = buffer.asMemorySegment() ?: error("Buffer has no native memory")
+ * val result = nativeFunctionHandle.invokeExact(segment, buffer.remaining()) as Int
+ * ```
+ */
+fun ReadBuffer.asMemorySegment(): MemorySegment? {
+    val unwrapped = unwrapFully()
+    return when (unwrapped) {
+        is FfmBuffer -> unwrapped.segment.asSlice(unwrapped.position().toLong(), unwrapped.remaining().toLong())
+        is BaseJvmBuffer ->
+            if (unwrapped.byteBuffer.isDirect) {
+                MemorySegment
+                    .ofBuffer(unwrapped.byteBuffer)
+                    .asSlice(unwrapped.position().toLong(), unwrapped.remaining().toLong())
+            } else {
+                null
+            }
+        else -> null
+    }
+}

--- a/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/FfmSliceBuffer.kt
+++ b/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/FfmSliceBuffer.kt
@@ -1,0 +1,52 @@
+@file:Suppress("unused") // Loaded at runtime via multi-release JAR
+
+package com.ditchoom.buffer
+
+import java.lang.foreign.MemorySegment
+import java.nio.ByteBuffer
+
+/**
+ * Arena-scoped slice of an [FfmBuffer].
+ *
+ * The [byteBuffer] is derived from [segment]`.asByteBuffer()`, which binds it to the
+ * parent Arena's scope. When the parent calls `arena.close()`, the JDK automatically
+ * invalidates ALL ByteBuffers derived from that Arena — any access throws
+ * [IllegalStateException] ("Already closed"). This gives zero-overhead use-after-free
+ * safety without any manual checking.
+ *
+ * Unlike [FfmBuffer], this class does **not** own the Arena and [freeNativeMemory] is a
+ * no-op. The parent [FfmBuffer] is solely responsible for closing the Arena.
+ *
+ * @param segment Arena-scoped MemorySegment (not global-scope).
+ * @param byteBuffer ByteBuffer derived from [segment]`.asByteBuffer()`.
+ */
+class FfmSliceBuffer(
+    val segment: MemorySegment,
+    byteBuffer: ByteBuffer,
+) : BaseJvmBuffer(byteBuffer),
+    NativeMemoryAccess {
+    override val nativeAddress: Long
+        get() {
+            checkAlive()
+            return segment.address()
+        }
+
+    override val nativeSize: Long
+        get() {
+            checkAlive()
+            return segment.byteSize()
+        }
+
+    private fun checkAlive() {
+        check(segment.scope().isAlive) { "FfmSliceBuffer used after parent Arena closed" }
+    }
+
+    /** No-op — this slice does not own the Arena. */
+    override fun freeNativeMemory() {}
+
+    override fun slice(): PlatformBuffer {
+        val sliced = segment.asSlice(position().toLong(), remaining().toLong())
+        val bb = sliced.asByteBuffer().order(byteBuffer.order())
+        return FfmSliceBuffer(sliced, bb)
+    }
+}

--- a/buffer/src/jvmMain/kotlin/com/ditchoom/buffer/DirectJvmBuffer.kt
+++ b/buffer/src/jvmMain/kotlin/com/ditchoom/buffer/DirectJvmBuffer.kt
@@ -30,5 +30,41 @@ class DirectJvmBuffer(
      */
     override val nativeSize: Long get() = capacity.toLong()
 
+    /**
+     * Frees native memory by invoking the direct ByteBuffer's Cleaner via
+     * `sun.misc.Unsafe.invokeCleaner()` (JDK 9+).
+     *
+     * This is best-effort: silently fails on sliced buffers, already-cleaned
+     * buffers, JDK 8, or if reflection is blocked. Idempotent.
+     */
+    override fun freeNativeMemory() {
+        invokeCleaner?.let { cleaner ->
+            try {
+                cleaner.invoke(unsafeInstance, byteBuffer)
+            } catch (_: Exception) {
+                // Silently fail: sliced buffer, already cleaned, or unsupported JDK
+            }
+        }
+    }
+
     override fun slice() = DirectJvmBuffer(byteBuffer.slice())
+
+    companion object {
+        // Resolved once per process. null = not available (JDK 8 or restricted access)
+        private val unsafeInstance: Any? =
+            try {
+                val field = sun.misc.Unsafe::class.java.getDeclaredField("theUnsafe")
+                field.isAccessible = true
+                field.get(null)
+            } catch (_: Exception) {
+                null
+            }
+
+        private val invokeCleaner: java.lang.reflect.Method? =
+            try {
+                sun.misc.Unsafe::class.java.getMethod("invokeCleaner", java.nio.ByteBuffer::class.java)
+            } catch (_: Exception) {
+                null
+            }
+    }
 }

--- a/buffer/src/jvmTest/kotlin/com/ditchoom/buffer/FfmBufferTest.kt
+++ b/buffer/src/jvmTest/kotlin/com/ditchoom/buffer/FfmBufferTest.kt
@@ -193,21 +193,105 @@ class FfmBufferTest {
     }
 
     @Test
-    fun `slice after parent free - slice retains own state`() {
-        // Slices created BEFORE free retain their own ByteBuffer position/limit
-        // and will NOT be invalidated. This is documented behavior — slices
-        // must not outlive the parent FfmBuffer.
+    fun `slice after parent free throws IllegalStateException`() {
+        // FfmSliceBuffer's ByteBuffer is derived from the arena-scoped segment.
+        // After arena.close(), the JDK invalidates it automatically.
         val buffer = createFfmBuffer(64)
         buffer.writeInt(0x12345678)
         buffer.resetForRead()
         val slice = buffer.slice()
         buffer.freeNativeMemory()
-        // The slice's ByteBuffer has its own position/limit state,
-        // so it doesn't throw. However, the underlying native memory
-        // is freed — the slice is reading freed memory (undefined behavior).
-        // This test documents the limitation; users must ensure slices
-        // do not outlive the parent.
-        assertIs<DirectJvmBuffer>(slice)
+        assertIs<FfmSliceBuffer>(slice)
+        assertFailsWith<IllegalStateException> { slice.readInt() }
+    }
+
+    @Test
+    fun `slice of slice throws after parent free`() {
+        val buffer = createFfmBuffer(64)
+        buffer.writeLong(0x123456789ABCDEF0L)
+        buffer.resetForRead()
+        val slice1 = buffer.slice()
+        val slice2 = slice1.slice()
+        buffer.freeNativeMemory()
+        assertFailsWith<IllegalStateException> { slice1.readLong() }
+        assertFailsWith<IllegalStateException> { slice2.readLong() }
+    }
+
+    @Test
+    fun `FfmSliceBuffer nativeAddress throws after parent free`() {
+        val buffer = createFfmBuffer(64)
+        buffer.writeInt(42)
+        buffer.resetForRead()
+        val slice = buffer.slice() as FfmSliceBuffer
+        buffer.freeNativeMemory()
+        assertFailsWith<IllegalStateException> { slice.nativeAddress }
+    }
+
+    @Test
+    fun `FfmSliceBuffer nativeSize throws after parent free`() {
+        val buffer = createFfmBuffer(64)
+        buffer.writeInt(42)
+        buffer.resetForRead()
+        val slice = buffer.slice() as FfmSliceBuffer
+        buffer.freeNativeMemory()
+        assertFailsWith<IllegalStateException> { slice.nativeSize }
+    }
+
+    @Test
+    fun `slice write after parent free throws IllegalStateException`() {
+        val buffer = createFfmBuffer(64)
+        // Don't resetForRead — slice needs remaining capacity to attempt a write
+        val slice = buffer.slice()
+        buffer.freeNativeMemory()
+        assertFailsWith<IllegalStateException> { slice.writeInt(42) }
+    }
+
+    @Test
+    fun `slice created from dead FfmSliceBuffer cannot read`() {
+        // Creating a slice view from a dead buffer may succeed (JDK doesn't check
+        // scope during view creation), but any memory access on the result throws.
+        val buffer = createFfmBuffer(64)
+        buffer.writeInt(0x12345678)
+        buffer.resetForRead()
+        val slice = buffer.slice()
+        buffer.freeNativeMemory()
+        val subSlice = slice.slice() // view creation may succeed
+        assertFailsWith<IllegalStateException> { subSlice.readInt() }
+    }
+
+    @Test
+    fun `FfmSliceBuffer implements NativeMemoryAccess`() =
+        createFfmBuffer(64).use { buffer ->
+            buffer.writeInt(0x12345678)
+            buffer.resetForRead()
+            val slice = buffer.slice()
+            assertIs<NativeMemoryAccess>(slice)
+            assertNotNull(slice.nativeMemoryAccess)
+            Unit
+        }
+
+    @Test
+    fun `slice preserves little-endian byte order`() =
+        createFfmBuffer(64, ByteOrder.LITTLE_ENDIAN).use { buffer ->
+            buffer.writeInt(0x01020304)
+            buffer.resetForRead()
+            val slice = buffer.slice()
+            assertEquals(0x01020304, slice.readInt())
+            // Verify the raw first byte is LE layout (0x04, not 0x01)
+            slice.position(0)
+            assertEquals(0x04.toByte(), slice.readByte())
+        }
+
+    @Test
+    fun `multiple independent slices all invalidated after parent free`() {
+        val buffer = createFfmBuffer(64)
+        repeat(16) { buffer.writeInt(it) }
+        buffer.resetForRead()
+        val slices = (0 until 4).map { buffer.slice() }
+        buffer.freeNativeMemory()
+        slices.forEach { slice ->
+            assertFailsWith<IllegalStateException> { slice.readInt() }
+        }
     }
 
     // ============================================================================
@@ -259,12 +343,12 @@ class FfmBufferTest {
     // ============================================================================
 
     @Test
-    fun `slice returns DirectJvmBuffer not FfmBuffer`() =
+    fun `slice returns FfmSliceBuffer not FfmBuffer`() =
         createFfmBuffer(64).use { buffer ->
             buffer.writeInt(0x12345678)
             buffer.resetForRead()
             val slice = buffer.slice()
-            assertIs<DirectJvmBuffer>(slice)
+            assertIs<FfmSliceBuffer>(slice)
             Unit
         }
 
@@ -274,7 +358,7 @@ class FfmBufferTest {
             buffer.writeInt(0x12345678)
             buffer.resetForRead()
             val slice = buffer.slice()
-            slice.freeNativeMemory() // no-op on DirectJvmBuffer
+            slice.freeNativeMemory() // no-op on FfmSliceBuffer
             assertTrue(buffer.segment.scope().isAlive, "Parent Arena should still be alive")
             buffer.position(0)
             assertEquals(0x12345678, buffer.readInt())
@@ -437,6 +521,18 @@ class FfmBufferTest {
         assertNotNull(segment)
         assertEquals(buffer.remaining().toLong(), segment.byteSize())
     }
+
+    @Test
+    fun `asMemorySegment returns valid segment for FfmSliceBuffer`() =
+        createFfmBuffer(64).use { buffer ->
+            buffer.writeInt(0x12345678)
+            buffer.writeLong(0x123456789ABCDEF0L)
+            buffer.resetForRead()
+            val slice = buffer.slice()
+            val segment = slice.asMemorySegment()
+            assertNotNull(segment)
+            assertEquals(slice.remaining().toLong(), segment.byteSize())
+        }
 
     @Test
     fun `asMemorySegment reflects position and limit`() =

--- a/buffer/src/jvmTest/kotlin/com/ditchoom/buffer/FfmBufferTest.kt
+++ b/buffer/src/jvmTest/kotlin/com/ditchoom/buffer/FfmBufferTest.kt
@@ -1,0 +1,453 @@
+package com.ditchoom.buffer
+
+import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.buffer.pool.withBuffer
+import com.ditchoom.buffer.pool.withPool
+import java.lang.foreign.Arena
+import java.lang.foreign.MemorySegment
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for FfmBuffer — FFM Arena-backed PlatformBuffer on JVM 21+.
+ *
+ * FfmBuffer is in the jvm21Main compilation, added to jvmTest compile classpath
+ * so we can reference it directly. These tests verify FfmBuffer behavior independently.
+ *
+ * The transparent upgrade (BufferFactory routing allocate(Direct) → FfmBuffer) is tested
+ * by the jvmFfmTest Gradle task, which runs ALL common tests with java21 classes first
+ * on the classpath, making PlatformBuffer.allocate(Direct) return FfmBuffer.
+ */
+class FfmBufferTest {
+    private fun createFfmBuffer(
+        size: Int,
+        byteOrder: ByteOrder = ByteOrder.BIG_ENDIAN,
+    ): FfmBuffer {
+        val arena = Arena.ofShared()
+        val segment = arena.allocate(size.toLong())
+        val javaByteOrder =
+            when (byteOrder) {
+                ByteOrder.BIG_ENDIAN -> java.nio.ByteOrder.BIG_ENDIAN
+                ByteOrder.LITTLE_ENDIAN -> java.nio.ByteOrder.LITTLE_ENDIAN
+            }
+        // Match the factory: global-scope ByteBuffer for JDK API compatibility
+        val globalView =
+            MemorySegment
+                .ofAddress(segment.address())
+                .reinterpret(size.toLong())
+        val byteBuffer = globalView.asByteBuffer().order(javaByteOrder)
+        return FfmBuffer(arena, segment, byteBuffer)
+    }
+
+    // ============================================================================
+    // Type & Interface Tests
+    // ============================================================================
+
+    @Test
+    fun `FfmBuffer is a PlatformBuffer`() =
+        createFfmBuffer(64).use { buffer ->
+            assertIs<PlatformBuffer>(buffer)
+            Unit
+        }
+
+    @Test
+    fun `FfmBuffer implements NativeMemoryAccess`() =
+        createFfmBuffer(64).use { buffer ->
+            assertIs<NativeMemoryAccess>(buffer)
+            assertNotNull(buffer.nativeMemoryAccess)
+            Unit
+        }
+
+    @Test
+    fun `nativeAddress returns valid non-zero address`() =
+        createFfmBuffer(1024).use { buffer ->
+            assertTrue(buffer.nativeAddress != 0L)
+        }
+
+    @Test
+    fun `nativeSize matches allocated size`() =
+        createFfmBuffer(1024).use { buffer ->
+            assertEquals(1024L, buffer.nativeSize)
+        }
+
+    // ============================================================================
+    // Deterministic Memory Management Tests
+    // ============================================================================
+
+    @Test
+    fun `freeNativeMemory closes Arena`() {
+        val buffer = createFfmBuffer(1024)
+        assertTrue(buffer.segment.scope().isAlive)
+        buffer.freeNativeMemory()
+        assertFalse(buffer.segment.scope().isAlive)
+    }
+
+    @Test
+    fun `freeNativeMemory is idempotent`() {
+        val buffer = createFfmBuffer(1024)
+        buffer.freeNativeMemory()
+        buffer.freeNativeMemory() // Should not throw
+        assertFalse(buffer.segment.scope().isAlive)
+    }
+
+    @Test
+    fun `close frees native memory`() {
+        val buffer = createFfmBuffer(1024)
+        kotlinx.coroutines.runBlocking { buffer.close() }
+        assertFalse(buffer.segment.scope().isAlive)
+    }
+
+    @Test
+    fun `arena is not alive after free`() {
+        val buffer = createFfmBuffer(1024)
+        buffer.freeNativeMemory()
+        assertFalse(buffer.segment.scope().isAlive)
+    }
+
+    @Test
+    fun `use block frees memory`() {
+        val buffer = createFfmBuffer(64)
+        val segment = buffer.segment
+        buffer.use {
+            it.writeInt(42)
+            it.resetForRead()
+            assertEquals(42, it.readInt())
+        }
+        assertFalse(segment.scope().isAlive)
+    }
+
+    @Test
+    fun `readInt after free throws`() {
+        val buffer = createFfmBuffer(64)
+        buffer.writeInt(42)
+        buffer.resetForRead()
+        buffer.freeNativeMemory()
+        assertFailsWith<java.nio.BufferUnderflowException> { buffer.readInt() }
+    }
+
+    @Test
+    fun `writeInt after free throws`() {
+        val buffer = createFfmBuffer(64)
+        buffer.freeNativeMemory()
+        assertFailsWith<java.nio.BufferOverflowException> { buffer.writeInt(42) }
+    }
+
+    @Test
+    fun `resetForRead after free throws with assertions`() {
+        val buffer = createFfmBuffer(64)
+        buffer.writeInt(42)
+        buffer.freeNativeMemory()
+        assertFailsWith<AssertionError> { buffer.resetForRead() }
+    }
+
+    @Test
+    fun `resetForWrite after free throws with assertions`() {
+        val buffer = createFfmBuffer(64)
+        buffer.freeNativeMemory()
+        assertFailsWith<AssertionError> { buffer.resetForWrite() }
+    }
+
+    @Test
+    fun `nativeAddress after free throws with assertions`() {
+        val buffer = createFfmBuffer(64)
+        buffer.freeNativeMemory()
+        assertFailsWith<AssertionError> { buffer.nativeAddress }
+    }
+
+    @Test
+    fun `absolute get after free throws`() {
+        val buffer = createFfmBuffer(64)
+        buffer.writeInt(42)
+        buffer.freeNativeMemory()
+        assertFailsWith<IndexOutOfBoundsException> { buffer.get(0) }
+    }
+
+    @Test
+    fun `use block frees memory on exception`() {
+        val buffer = createFfmBuffer(64)
+        val segment = buffer.segment
+        assertFailsWith<RuntimeException> {
+            buffer.use {
+                it.writeInt(42)
+                throw RuntimeException("test error")
+            }
+        }
+        assertFalse(segment.scope().isAlive, "Buffer should be freed even after exception")
+    }
+
+    @Test
+    fun `use block tolerates freeNativeMemory inside block`() {
+        val buffer = createFfmBuffer(64)
+        val segment = buffer.segment
+        buffer.use {
+            it.writeInt(42)
+            it.freeNativeMemory() // explicit free inside use
+        } // use calls freeNativeMemory again — idempotent
+        assertFalse(segment.scope().isAlive)
+    }
+
+    @Test
+    fun `slice after parent free - slice retains own state`() {
+        // Slices created BEFORE free retain their own ByteBuffer position/limit
+        // and will NOT be invalidated. This is documented behavior — slices
+        // must not outlive the parent FfmBuffer.
+        val buffer = createFfmBuffer(64)
+        buffer.writeInt(0x12345678)
+        buffer.resetForRead()
+        val slice = buffer.slice()
+        buffer.freeNativeMemory()
+        // The slice's ByteBuffer has its own position/limit state,
+        // so it doesn't throw. However, the underlying native memory
+        // is freed — the slice is reading freed memory (undefined behavior).
+        // This test documents the limitation; users must ensure slices
+        // do not outlive the parent.
+        assertIs<DirectJvmBuffer>(slice)
+    }
+
+    // ============================================================================
+    // Buffer Operations Tests
+    // ============================================================================
+
+    @Test
+    fun `basic read write operations work`() =
+        createFfmBuffer(64).use { buffer ->
+            buffer.writeInt(0x12345678)
+            buffer.writeLong(0x123456789ABCDEF0L)
+            buffer.writeShort(0x1234.toShort())
+            buffer.writeByte(0x42)
+            buffer.resetForRead()
+            assertEquals(0x12345678, buffer.readInt())
+            assertEquals(0x123456789ABCDEF0L, buffer.readLong())
+            assertEquals(0x1234.toShort(), buffer.readShort())
+            assertEquals(0x42.toByte(), buffer.readByte())
+        }
+
+    @Test
+    fun `string operations work`() =
+        createFfmBuffer(256).use { buffer ->
+            val text = "Hello, FFM Buffer!"
+            buffer.writeString(text, Charset.UTF8)
+            buffer.resetForRead()
+            val result = buffer.readString(buffer.remaining(), Charset.UTF8)
+            assertEquals(text, result)
+        }
+
+    @Test
+    fun `byte order is respected`() {
+        createFfmBuffer(8, ByteOrder.BIG_ENDIAN).use { bufferBE ->
+            createFfmBuffer(8, ByteOrder.LITTLE_ENDIAN).use { bufferLE ->
+                bufferBE.writeInt(0x01020304)
+                bufferLE.writeInt(0x01020304)
+                bufferBE.resetForRead()
+                bufferLE.resetForRead()
+                val beByte = bufferBE.readByte()
+                bufferLE.position(0)
+                val leByte = bufferLE.readByte()
+                assertNotEquals(beByte, leByte, "Byte order should affect raw byte layout")
+            }
+        }
+    }
+
+    // ============================================================================
+    // Slice Tests
+    // ============================================================================
+
+    @Test
+    fun `slice returns DirectJvmBuffer not FfmBuffer`() =
+        createFfmBuffer(64).use { buffer ->
+            buffer.writeInt(0x12345678)
+            buffer.resetForRead()
+            val slice = buffer.slice()
+            assertIs<DirectJvmBuffer>(slice)
+            Unit
+        }
+
+    @Test
+    fun `slice does not close parent Arena`() =
+        createFfmBuffer(64).use { buffer ->
+            buffer.writeInt(0x12345678)
+            buffer.resetForRead()
+            val slice = buffer.slice()
+            slice.freeNativeMemory() // no-op on DirectJvmBuffer
+            assertTrue(buffer.segment.scope().isAlive, "Parent Arena should still be alive")
+            buffer.position(0)
+            assertEquals(0x12345678, buffer.readInt())
+        }
+
+    @Test
+    fun `slice shares parent data`() =
+        createFfmBuffer(64).use { buffer ->
+            buffer.writeInt(0x12345678)
+            buffer.resetForRead()
+            val slice = buffer.slice()
+            assertEquals(0x12345678, slice.readInt())
+        }
+
+    // ============================================================================
+    // NativeData Conversion Tests
+    // ============================================================================
+
+    @Test
+    fun `toNativeData zero-copy returns direct ByteBuffer`() =
+        createFfmBuffer(64).use { buffer ->
+            buffer.writeInt(0x12345678)
+            buffer.resetForRead()
+            val nativeData = buffer.toNativeData()
+            assertTrue(nativeData.byteBuffer.isDirect)
+            assertEquals(0x12345678, nativeData.byteBuffer.getInt())
+        }
+
+    @Test
+    fun `toByteArray copies correctly`() =
+        createFfmBuffer(4).use { buffer ->
+            buffer.writeByte(1)
+            buffer.writeByte(2)
+            buffer.writeByte(3)
+            buffer.writeByte(4)
+            buffer.resetForRead()
+            val array = buffer.toByteArray()
+            assertEquals(4, array.size)
+            assertEquals(1.toByte(), array[0])
+            assertEquals(4.toByte(), array[3])
+        }
+
+    // ============================================================================
+    // Pool Integration Tests
+    // ============================================================================
+
+    @Test
+    fun `pool clear frees FfmBuffer memory`() {
+        val pool = BufferPool(defaultBufferSize = 1024, maxPoolSize = 4)
+        val buffers = (1..4).map { pool.acquire(512) }
+        buffers.forEach { pool.release(it) }
+        pool.clear()
+    }
+
+    @Test
+    fun `pool overflow frees FfmBuffer memory`() =
+        withPool(defaultBufferSize = 1024, maxPoolSize = 2) { pool ->
+            val buffers = (1..5).map { pool.acquire(512) }
+            buffers.forEach { pool.release(it) }
+            assertTrue(pool.stats().currentPoolSize <= 2)
+        }
+
+    @Test
+    fun `pool withBuffer works`() =
+        withPool(defaultBufferSize = 1024) { pool ->
+            pool.withBuffer(512) { buffer ->
+                buffer.writeInt(42)
+                buffer.resetForRead()
+                assertEquals(42, buffer.readInt())
+            }
+        }
+
+    // ============================================================================
+    // Cross-Buffer Interop Tests
+    // ============================================================================
+
+    @Test
+    fun `write FfmBuffer to HeapJvmBuffer`() =
+        createFfmBuffer(64).use { ffm ->
+            ffm.writeInt(0x12345678)
+            ffm.writeLong(0x1234567890ABCDEFL)
+            ffm.resetForRead()
+
+            val heap = PlatformBuffer.allocate(64, AllocationZone.Heap)
+            heap.write(ffm)
+            heap.resetForRead()
+
+            assertEquals(0x12345678, heap.readInt())
+            assertEquals(0x1234567890ABCDEFL, heap.readLong())
+        }
+
+    @Test
+    fun `write HeapJvmBuffer to FfmBuffer`() =
+        createFfmBuffer(64).use { ffm ->
+            val heap = PlatformBuffer.allocate(64, AllocationZone.Heap)
+            heap.writeInt(0x12345678)
+            heap.resetForRead()
+
+            ffm.write(heap)
+            ffm.resetForRead()
+
+            assertEquals(0x12345678, ffm.readInt())
+        }
+
+    @Test
+    fun `write FfmBuffer to DirectJvmBuffer`() =
+        createFfmBuffer(64).use { ffm ->
+            ffm.writeInt(0x12345678)
+            ffm.resetForRead()
+
+            val direct = DirectJvmBuffer(java.nio.ByteBuffer.allocateDirect(64))
+            direct.write(ffm)
+            direct.resetForRead()
+
+            assertEquals(0x12345678, direct.readInt())
+        }
+
+    @Test
+    fun `contentEquals between FfmBuffer and HeapJvmBuffer`() =
+        createFfmBuffer(64).use { ffm ->
+            val heap = PlatformBuffer.allocate(64, AllocationZone.Heap)
+            repeat(64) {
+                ffm.writeByte(it.toByte())
+                heap.writeByte(it.toByte())
+            }
+            ffm.resetForRead()
+            heap.resetForRead()
+            assertTrue(ffm.contentEquals(heap))
+        }
+
+    // ============================================================================
+    // FFM Interop Extension Tests
+    // ============================================================================
+
+    @Test
+    fun `asMemorySegment returns valid segment for FfmBuffer`() =
+        createFfmBuffer(64).use { buffer ->
+            buffer.writeInt(0x12345678)
+            buffer.resetForRead()
+
+            val segment = buffer.asMemorySegment()
+            assertNotNull(segment)
+            assertEquals(buffer.remaining().toLong(), segment.byteSize())
+        }
+
+    @Test
+    fun `asMemorySegment returns null for heap buffer`() {
+        val buffer = PlatformBuffer.allocate(64, AllocationZone.Heap)
+        val segment = buffer.asMemorySegment()
+        assertEquals(null, segment)
+    }
+
+    @Test
+    fun `asMemorySegment returns valid segment for DirectJvmBuffer`() {
+        val buffer = DirectJvmBuffer(java.nio.ByteBuffer.allocateDirect(64))
+        buffer.writeInt(0x12345678)
+        buffer.resetForRead()
+
+        val segment = buffer.asMemorySegment()
+        assertNotNull(segment)
+        assertEquals(buffer.remaining().toLong(), segment.byteSize())
+    }
+
+    @Test
+    fun `asMemorySegment reflects position and limit`() =
+        createFfmBuffer(64).use { buffer ->
+            repeat(64) { buffer.writeByte(it.toByte()) }
+            buffer.resetForRead()
+            buffer.position(10)
+            buffer.setLimit(50)
+
+            val segment = buffer.asMemorySegment()
+            assertNotNull(segment)
+            assertEquals(40L, segment.byteSize())
+        }
+}

--- a/docs/docs/core-concepts/allocation-zones.md
+++ b/docs/docs/core-concepts/allocation-zones.md
@@ -58,8 +58,9 @@ val buffer = PlatformBuffer.allocate(1024, AllocationZone.Direct)
 **Platform behavior:**
 | Platform | Implementation |
 |----------|---------------|
-| JVM | [`DirectByteBuffer`](https://docs.oracle.com/javase/8/docs/api/java/nio/ByteBuffer.html#allocateDirect-int-) |
-| Android | [`DirectByteBuffer`](https://developer.android.com/reference/java/nio/ByteBuffer#allocateDirect(int)) |
+| JVM 21+ | `FfmBuffer` (FFM Arena — deterministic free) |
+| JVM < 21 | `DirectByteBuffer` (best-effort free via `Unsafe.invokeCleaner`) |
+| Android | `DirectByteBuffer` (GC-managed) |
 | iOS/macOS | [`NSMutableData`](https://developer.apple.com/documentation/foundation/nsmutabledata) |
 | JavaScript | [`Int8Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int8Array) |
 | WASM | `LinearBuffer` (native WASM memory) |

--- a/docs/docs/core-concepts/allocation-zones.md
+++ b/docs/docs/core-concepts/allocation-zones.md
@@ -58,9 +58,9 @@ val buffer = PlatformBuffer.allocate(1024, AllocationZone.Direct)
 **Platform behavior:**
 | Platform | Implementation |
 |----------|---------------|
-| JVM 21+ | `FfmBuffer` (FFM Arena — deterministic free) |
-| JVM < 21 | `DirectByteBuffer` (best-effort free via `Unsafe.invokeCleaner`) |
-| Android | `DirectByteBuffer` (GC-managed) |
+| JVM 21+ | [`FfmBuffer`](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/foreign/Arena.html) (FFM Arena — deterministic free) |
+| JVM < 21 | [`DirectByteBuffer`](https://docs.oracle.com/javase/8/docs/api/java/nio/ByteBuffer.html#allocateDirect-int-) (best-effort free via `Unsafe.invokeCleaner`) |
+| Android | [`DirectByteBuffer`](https://developer.android.com/reference/java/nio/ByteBuffer#allocateDirect(int)) (GC-managed) |
 | iOS/macOS | [`NSMutableData`](https://developer.apple.com/documentation/foundation/nsmutabledata) |
 | JavaScript | [`Int8Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int8Array) |
 | WASM | `LinearBuffer` (native WASM memory) |

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -46,6 +46,16 @@ kotlin {
 }
 ```
 
+## JVM Configuration
+
+On JDK 21+, Direct and SharedMemory buffers use the FFM API which requires native access to be enabled:
+
+```
+--enable-native-access=com.ditchoom.buffer
+```
+
+See [JVM Platform — JVM Flags](./platforms/jvm#jvm-flags) for details on all JDK versions.
+
 ## Your First Buffer
 
 ### Allocating a Buffer

--- a/docs/docs/platforms/android.md
+++ b/docs/docs/platforms/android.md
@@ -68,12 +68,54 @@ val buffer = PlatformBuffer.allocate(1024, AllocationZone.SharedMemory)
 
 ### Memory Lifecycle
 
-Android's `DirectJvmBuffer` is GC-managed — no explicit cleanup needed. Calling `freeNativeMemory()` on an Android `DirectJvmBuffer` is a no-op. For deterministic native memory management on Android, use `withScope {}` (backed by `UnsafeBufferScope`).
+Android's `DirectJvmBuffer` is GC-managed — no explicit cleanup needed. Calling
+`freeNativeMemory()` on an Android `DirectJvmBuffer` is a no-op.
 
-### Direct Buffers
+Unlike the JVM (which allocates direct buffers with `Unsafe.allocateMemory()` and can
+free them early via `Unsafe.invokeCleaner()`), Android's `DirectByteBuffer` is backed by
+a non-movable byte array allocated through
+[`VMRuntime.newNonMovableArray()`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r2:libcore/ojluni/src/main/java/java/nio/DirectByteBuffer.java;l=73).
+This memory is owned by the GC — there is no public API to free it deterministically.
+The [`MemoryRef.free()`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r2:libcore/ojluni/src/main/java/java/nio/DirectByteBuffer.java;l=90)
+method simply nulls the backing array reference and lets the GC reclaim it. The Android
+source itself
+[notes](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r2:libcore/ojluni/src/main/java/java/nio/DirectByteBuffer.java;l=103):
+*"Only have references to java objects, no need for a cleaner since the GC will do all
+the work."* This has not changed from API 28 through API 36.
+
+While Android does expose
+[`Unsafe.freeMemory(long)`](https://developer.android.com/reference/sun/misc/Unsafe#freeMemory(long)),
+it can only free memory allocated via `Unsafe.allocateMemory()` — not `DirectByteBuffer`
+memory from `VMRuntime.newNonMovableArray()`. Android does **not** expose
+`Unsafe.invokeCleaner(ByteBuffer)` (a JDK 9+ addition).
+
+For deterministic native memory management on Android, use `withScope {}` (backed by
+`UnsafeBufferScope`, which allocates via `Unsafe.allocateMemory()` /
+`Unsafe.freeMemory()` — a separate allocation path from `ByteBuffer.allocateDirect()`).
+
+### Zero-Copy Direct Buffers
+
+On Android, `DirectByteBuffer` is backed by a non-movable `byte[]` — the native address
+and the backing array point to the **same memory**. Android's own
+[source confirms](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r2:libcore/ojluni/src/main/java/java/nio/ByteBuffer.java;l=1160):
+*"isDirect() doesn't imply !hasArray(), ByteBuffer.allocateDirect allocated buffer will
+have a backing, non-gc-movable byte array."*
+
+This means `DirectJvmBuffer` on Android implements **both** `NativeMemoryAccess` and
+`ManagedMemoryAccess` — conversions like `toByteArray()` and `toNativeData()` are
+zero-copy when the buffer is already direct.
+
+This differs from the JVM, where direct buffers are off-heap (`hasArray() = false`) and
+any conversion to `ByteArray` requires a copy.
+
+**Why do JNI/Camera2/MediaCodec require direct buffers?**
+
+"Direct" on Android means **pinned/non-movable**, not off-heap. A regular `byte[]` can
+be relocated by the GC at any time. Native code (camera HAL, video codecs, OpenGL) needs
+a stable pointer that won't move mid-operation, which only `newNonMovableArray` guarantees.
 
 ```kotlin
-// Large buffers should use Direct to avoid GC
+// Large buffers should use Direct to avoid GC pressure from relocation
 val videoFrame = PlatformBuffer.allocate(
     size = 1920 * 1080 * 4,  // 8MB RGBA
     zone = AllocationZone.Direct

--- a/docs/docs/platforms/android.md
+++ b/docs/docs/platforms/android.md
@@ -66,6 +66,10 @@ val buffer = PlatformBuffer.allocate(1024, AllocationZone.SharedMemory)
 
 ## Memory Considerations
 
+### Memory Lifecycle
+
+Android's `DirectJvmBuffer` is GC-managed — no explicit cleanup needed. Calling `freeNativeMemory()` on an Android `DirectJvmBuffer` is a no-op. For deterministic native memory management on Android, use `withScope {}` (backed by `UnsafeBufferScope`).
+
 ### Direct Buffers
 
 ```kotlin

--- a/docs/docs/platforms/jvm.md
+++ b/docs/docs/platforms/jvm.md
@@ -9,11 +9,11 @@ Buffer on JVM wraps `java.nio.ByteBuffer` for optimal performance.
 
 ## Implementation
 
-| Zone | JVM Type |
-|------|----------|
-| `Heap` | `HeapByteBuffer` |
-| `Direct` | `DirectByteBuffer` |
-| `SharedMemory` | Falls back to `Direct` |
+| Zone | JVM < 21 | JVM 21+ |
+|------|----------|---------|
+| `Heap` | `HeapJvmBuffer` | `HeapJvmBuffer` |
+| `Direct` | `DirectJvmBuffer` | `FfmBuffer` (FFM Arena) |
+| `SharedMemory` | Falls back to Direct | Falls back to Direct |
 
 ## Direct vs Heap Buffers
 
@@ -115,9 +115,64 @@ All conversion functions operate on remaining bytes (position to limit) and do *
 
 See [Platform Interop](../recipes/platform-interop) for more details.
 
+## Memory Management
+
+Direct buffer memory cleanup varies by JVM version:
+
+| JVM Version | Cleanup Behavior |
+|-------------|-----------------|
+| JVM 21+ | `FfmBuffer` uses FFM `Arena.ofShared()` — deterministic free via `freeNativeMemory()` |
+| JVM 9-20 | `DirectJvmBuffer` uses `Unsafe.invokeCleaner()` — best-effort deterministic free (falls back to GC) |
+| JVM 8 | GC-only (no deterministic free) |
+
+Recommended patterns:
+
+```kotlin
+// 1. use block (recommended)
+PlatformBuffer.allocate(1024, AllocationZone.Direct).use { buffer ->
+    buffer.writeInt(42)
+}
+
+// 2. Pool (recommended for repeated allocations)
+withPool { pool ->
+    pool.withBuffer(1024) { buffer ->
+        buffer.writeInt(42)
+    }
+}
+
+// 3. Explicit cleanup
+val buffer = PlatformBuffer.allocate(1024, AllocationZone.Direct)
+try {
+    buffer.writeInt(42)
+} finally {
+    buffer.freeNativeMemory()
+}
+```
+
+## FFM Interop (JVM 21+)
+
+On JVM 21+, direct buffers are backed by FFM `Arena`/`MemorySegment`. Use `asMemorySegment()` for Panama downcalls:
+
+```kotlin
+val segment = buffer.asMemorySegment() ?: error("No native memory")
+val result = nativeFunctionHandle.invokeExact(segment, buffer.remaining()) as Int
+```
+
+## Native Memory Access
+
+Direct buffers expose `nativeAddress` and `nativeSize` for JNI/FFI interop:
+
+```kotlin
+val buffer = PlatformBuffer.allocate(1024, AllocationZone.Direct)
+val address = (buffer as NativeMemoryAccess).nativeAddress
+val size = buffer.nativeSize
+// Pass address and size to JNI/FFI functions
+```
+
 ## Best Practices
 
 1. **Use Direct for I/O** - network sockets, file channels
 2. **Use Heap for parsing** - or pool Direct buffers
 3. **Pool Direct buffers** - allocation is expensive
 4. **Watch off-heap memory** - not tracked by `-Xmx`
+5. **Call `freeNativeMemory()`** - or use `use {}` blocks to free direct buffers deterministically

--- a/docs/docs/platforms/jvm.md
+++ b/docs/docs/platforms/jvm.md
@@ -15,6 +15,56 @@ Buffer on JVM wraps `java.nio.ByteBuffer` for optimal performance.
 | `Direct` | `DirectJvmBuffer` | `FfmBuffer` (FFM Arena) |
 | `SharedMemory` | Falls back to Direct | Falls back to Direct |
 
+## JVM Flags
+
+The library's `Automatic-Module-Name` is `com.ditchoom.buffer`. This lets you grant permissions to the library specifically instead of using `ALL-UNNAMED`.
+
+### JDK 21+ (FFM)
+
+Direct and SharedMemory buffers use the FFM API (`MemorySegment.reinterpret()`), which is a restricted method. You must enable native access:
+
+```
+--enable-native-access=com.ditchoom.buffer
+```
+
+Without this flag, JDK 22-23 print warnings and JDK 24+ throws `IllegalCallerException`.
+
+### JDK 9-20 (Reflection)
+
+`nativeAddress` access uses reflection into `java.nio.Buffer.address`. This is recommended but not strictly required (the library falls back gracefully):
+
+```
+--add-opens=java.base/java.nio=com.ditchoom.buffer
+```
+
+### JDK 8
+
+No flags needed (no module system).
+
+### Gradle Configuration
+
+```kotlin
+// build.gradle.kts
+tasks.withType<JavaExec>().configureEach {
+    jvmArgs(
+        "--enable-native-access=com.ditchoom.buffer",
+        "--add-opens=java.base/java.nio=com.ditchoom.buffer",
+    )
+}
+
+// For test tasks
+tasks.withType<Test>().configureEach {
+    jvmArgs(
+        "--enable-native-access=com.ditchoom.buffer",
+        "--add-opens=java.base/java.nio=com.ditchoom.buffer",
+    )
+}
+```
+
+:::note Classpath Usage
+If you run the library from the classpath (unnamed module) rather than the module path, use `ALL-UNNAMED` instead of `com.ditchoom.buffer`.
+:::
+
 ## Direct vs Heap Buffers
 
 ### Direct Buffers (Default)


### PR DESCRIPTION
## Slice Use-After-Free Protection (JVM 21+)

Previously, slicing an `FfmBuffer` and then freeing the parent produced **silent data corruption** — the slice kept reading freed memory with no exception:

```kotlin
val buffer = PlatformBuffer.allocate(1024, AllocationZone.Direct)
buffer.writeInt(0x12345678)
buffer.resetForRead()

val slice = buffer.slice()
buffer.freeNativeMemory()

val value = slice.readInt() // ⚠️ Returns garbage — no error, no crash
```

Now, slices are automatically invalidated when the parent is freed:

```kotlin
val buffer = PlatformBuffer.allocate(1024, AllocationZone.Direct)
buffer.writeInt(0x12345678)
buffer.resetForRead()

val slice = buffer.slice()
buffer.freeNativeMemory()

slice.readInt() // ✅ throws IllegalStateException("Already closed")
```

This works because `FfmSliceBuffer` derives its ByteBuffer from the FFM arena-scoped segment rather than a detached global-scope view. When the arena closes, the JDK invalidates all derived ByteBuffers automatically — zero runtime overhead, the safety check is inside every JDK ByteBuffer operation.

Nested slices are also protected — a slice of a slice is invalidated when the root buffer is freed. Pooled buffers (`PooledBuffer`/`TrackedSlice`) are unaffected since they use ref-counting.

---

## What's in this PR

**Deterministic native memory on JVM 21+**
- `FfmBuffer` — Direct buffers backed by FFM `Arena`/`MemorySegment` instead of `DirectByteBuffer`. Native memory is freed immediately on `freeNativeMemory()` or `.use {}`, no GC dependency.
- `FfmSliceBuffer` — Arena-scoped slices with automatic use-after-free protection (described above).
- `asMemorySegment()` — Zero-copy FFM interop extension for Panama downcalls.
- Transparent upgrade via multi-release JAR — existing code gets `FfmBuffer` automatically on JVM 21+, no API changes needed.

**Lifecycle safety across JVM versions**
- `PlatformBuffer.use {}` — Inline RAII extension that calls `freeNativeMemory()` in a finally block.
- `DirectJvmBuffer.freeNativeMemory()` — Best-effort cleanup via `Unsafe.invokeCleaner()` on JVM 9-20.
- ByteBuffer invalidation after arena close prevents silent reads of freed memory.

**Android memory model documentation**
- Documents that Android `DirectByteBuffer` uses `VMRuntime.newNonMovableArray()` (pinned Java heap), not `Unsafe.allocateMemory()`.
- `DirectJvmBuffer` on Android now implements `ManagedMemoryAccess` since the backing `byte[]` is accessible.

**Named module + `--enable-native-access`**
- `Automatic-Module-Name: com.ditchoom.buffer` in JAR manifest — lets users grant `--enable-native-access=com.ditchoom.buffer` instead of the security anti-pattern `ALL-UNNAMED`.
- `--enable-native-access=ALL-UNNAMED` added to test JVM args (FFM `reinterpret()` is restricted; warnings on JDK 22+, fatal on JDK 24+).
- JVM flags documentation in `docs/docs/platforms/jvm.md` and getting-started guide.

**Testing**
- 46 dedicated `FfmBuffer`/`FfmSliceBuffer` tests.
- `jvmFfmTest` Gradle task runs all common tests with `FfmBuffer` as the Direct allocator.

## Test plan

- [x] `./gradlew :buffer:jvmTest --tests "com.ditchoom.buffer.FfmBufferTest"` — 46 tests
- [x] `./gradlew :buffer:jvmFfmTest` — all common tests with FfmBuffer
- [x] `./gradlew :buffer-compression:jvmFfmTest` — compression with FfmBuffer
- [x] `./gradlew :buffer:ktlintCheck` — code style
- [x] JAR manifest verified: `Automatic-Module-Name: com.ditchoom.buffer`
- [x] CI Build and Test
- [x] CI Android Emulator Integration Test