### PR TITLE
Docs: prefer BufferFactory over PlatformBuffer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,14 +274,96 @@ All new buffer-consuming code must be tested with wrapper types (see `WrapperTra
 
 ### Factory Pattern
 
-Buffers are created via factories:
+**Always use `BufferFactory` to create buffers** — never use `PlatformBuffer.allocate()` or `PlatformBuffer.wrap()` directly:
 ```kotlin
 BufferFactory.Default.allocate(size)                    // Native memory (platform-optimal)
+BufferFactory.Default.wrap(byteArray)                   // Wrap existing ByteArray (zero-copy)
 BufferFactory.managed().allocate(size)                  // Heap memory (ByteArray-backed)
 BufferFactory.shared().allocate(size)                   // Shared memory (Android IPC)
 BufferFactory.deterministic().allocate(size)             // Explicit cleanup via .use {}
-PlatformBuffer.allocate(size)                           // Shorthand for Default
-PlatformBuffer.wrap(byteArray)                          // Wrap existing ByteArray
+```
+
+Library code should accept `BufferFactory` as a parameter so callers control allocation:
+```kotlin
+class MyProtocol(private val factory: BufferFactory = BufferFactory.Default) {
+    fun encode(data: MyData): PlatformBuffer {
+        val buffer = factory.allocate(data.sizeOf())
+        // ...
+    }
+}
+```
+
+## Best Practices for Using This Library
+
+### Always Use `BufferFactory`, Not `PlatformBuffer`
+
+`BufferFactory` is the correct entry point for all buffer creation. Do NOT use `PlatformBuffer.allocate()` or `PlatformBuffer.wrap()` — these are legacy shortcuts that bypass factory composition (pooling, monitoring, deterministic cleanup).
+
+```kotlin
+// CORRECT
+val buffer = BufferFactory.Default.allocate(1024)
+val wrapped = BufferFactory.Default.wrap(byteArray)
+
+// WRONG — do not use these
+val buffer = PlatformBuffer.allocate(1024)
+val wrapped = PlatformBuffer.wrap(byteArray)
+```
+
+### Use Protocol Codecs for Structured Data
+
+For any structured binary data, use `buffer-codec` with `@ProtocolMessage` annotations instead of hand-writing `readInt()`/`writeInt()` sequences. Hand-written encode/decode is error-prone and doesn't guarantee round-trip correctness.
+
+```kotlin
+// WRONG — manual field-by-field serialization
+fun encode(buffer: WriteBuffer, msg: MyMessage) {
+    buffer.writeInt(msg.id)
+    buffer.writeShort(msg.type)
+    buffer.writeLengthPrefixedUtf8String(msg.payload)
+}
+
+// CORRECT — annotated data class, codec is generated
+@ProtocolMessage
+data class MyMessage(
+    val id: Int,
+    val type: Short,
+    @LengthPrefixed val payload: String,
+)
+// MyMessageCodec.encode(buffer, msg) — generated, type-safe, batch-optimized
+```
+
+### Avoid Unnecessary Memory Copies
+
+- **Use `slice()` or `readBytes()`** instead of `readByteArray()` + `wrap()` for zero-copy views
+- **Use `toNativeData()`/`toMutableNativeData()`** for platform interop instead of converting to ByteArray first
+- **Use `writeString()` directly** instead of `payload.encodeToByteArray()` + `writeBytes()`
+- **Use `BufferPool`** in hot paths to reuse buffers instead of allocating per request
+- **Accept `ReadBuffer`/`WriteBuffer`** in function signatures, not `ByteArray`
+
+```kotlin
+// WRONG — unnecessary copies
+val bytes = buffer.readByteArray(length)  // copy to ByteArray
+val newBuffer = BufferFactory.Default.wrap(bytes)  // wrap again
+processBytes(bytes)  // works on ByteArray instead of buffer
+
+// CORRECT — zero-copy
+val slice = buffer.readBytes(length)  // zero-copy slice
+processBuffer(slice)  // works directly on buffer
+```
+
+### Accept Factory as a Parameter in Library Code
+
+Library code should accept `BufferFactory` as a constructor parameter so callers control allocation strategy:
+
+```kotlin
+class ProtocolConnection(
+    private val factory: BufferFactory = BufferFactory.Default,
+) {
+    fun send(packet: Packet) {
+        factory.allocate(packet.sizeOf()).use { buffer ->
+            packet.writeTo(buffer)
+        }
+    }
+}
 ```
 
 ## Platform Notes
@@ -289,7 +371,7 @@ PlatformBuffer.wrap(byteArray)                          // Wrap existing ByteArr
 - **JVM/Android:** Direct ByteBuffers (`DirectJvmBuffer`) used by default; `HeapJvmBuffer` for `wrap()` and `BufferFactory.managed()`
 - **Android SharedMemory:** Use `BufferFactory.shared()` for zero-copy IPC via Parcelable (API 27+)
 - **Apple:** `MutableDataBuffer` wraps NSMutableData (native memory); `wrap(ByteArray)` returns `ByteArrayBuffer`
-- **Apple NSData interop:** Use `PlatformBuffer.wrap(nsData)` or `PlatformBuffer.wrap(nsMutableData)` for zero-copy Apple API interop
+- **Apple NSData interop:** Use `BufferFactory.Default.wrap(nsData)` or `BufferFactory.Default.wrap(nsMutableData)` for zero-copy Apple API interop
 - **JS SharedArrayBuffer:** Requires CORS headers (`Cross-Origin-Opener-Policy`, `Cross-Origin-Embedder-Policy`)
 - **WASM:** `LinearBuffer` (Direct) uses native WASM memory for JS interop; `ByteArrayBuffer` (Heap) for compute workloads
 - **Linux:** `NativeBuffer` (Direct) uses malloc/free for zero-copy io_uring I/O; `ByteArrayBuffer` (Heap) for managed memory

--- a/MODULE.md
+++ b/MODULE.md
@@ -8,7 +8,7 @@ Core buffer interfaces and implementations:
 - `PlatformBuffer` - Main buffer interface combining read/write operations
 - `ReadBuffer` - Read operations (relative and absolute)
 - `WriteBuffer` - Write operations (relative and absolute)
-- `AllocationZone` - Memory allocation strategy
+- `BufferFactory` - Memory allocation strategy: `Default` (native), `managed()` (heap), `shared()` (IPC), `deterministic()` (explicit cleanup)
 
 ## Package com.ditchoom.buffer.pool
 

--- a/Readme.md
+++ b/Readme.md
@@ -61,7 +61,7 @@ Find the latest version on [Maven Central](https://central.sonatype.com/artifact
 
 ```kotlin
 // Works identically on JVM, Android, iOS, macOS, Linux, JS, WASM
-val buffer = PlatformBuffer.allocate(1024)
+val buffer = BufferFactory.Default.allocate(1024)
 buffer.writeInt(42)
 buffer.writeString("Hello!")
 buffer.resetForRead()
@@ -70,9 +70,11 @@ val number = buffer.readInt()     // 42
 val text = buffer.readString(6)   // "Hello!"
 ```
 
-## Protocol Codecs
+> **Tip:** Always use `BufferFactory` to allocate buffers — not `PlatformBuffer.allocate()`. Factories compose with pooling, deterministic cleanup, and custom allocation strategies. For structured binary data, use [Protocol Codecs](#protocol-codecs--stop-hand-writing-parsers) instead of manual read/write sequences.
 
-Define a data class, annotate it, and the codec writes itself:
+## Protocol Codecs — Stop Hand-Writing Parsers
+
+For structured data, **always use `buffer-codec`** instead of manual `readInt()`/`writeInt()` sequences. Hand-written encode/decode is error-prone (field order mismatches, type mismatches) and doesn't guarantee round-trip correctness. Define a data class, annotate it, and the codec writes itself:
 
 ```kotlin
 @ProtocolMessage

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecGenerator.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecGenerator.kt
@@ -27,7 +27,8 @@ class CodecGenerator(
     ) {
         val className = classDeclaration.simpleName.asString()
         val packageName = classDeclaration.packageName.asString()
-        val codecName = "${className}Codec"
+        val codecName = classDeclaration.codecName()
+        val classTypeName = classDeclaration.toPoetClassName()
         val containingFile = classDeclaration.containingFile
 
         val dependencies =
@@ -39,9 +40,9 @@ class CodecGenerator(
 
         val fileSpec =
             if (hasPayload) {
-                buildPayloadCodecFile(packageName, className, codecName, fields, batches)
+                buildPayloadCodecFile(packageName, classTypeName, codecName, fields, batches)
             } else {
-                buildCodecFile(packageName, className, codecName, fields, batches)
+                buildCodecFile(packageName, classTypeName, codecName, fields, batches)
             }
 
         fileSpec.writeTo(codeGenerator, dependencies)
@@ -51,13 +52,11 @@ class CodecGenerator(
 
     private fun buildCodecFile(
         packageName: String,
-        className: String,
+        classTypeName: ClassName,
         codecName: String,
         fields: List<FieldInfo>,
         batches: List<CodegenItem>,
     ): FileSpec {
-        val classTypeName = ClassName(packageName, className)
-
         // Build decode function body
         val decodeBody = CodeBlock.builder()
         var batchIndex = 0
@@ -73,7 +72,7 @@ class CodecGenerator(
             }
         }
         val fieldNames = fields.joinToString(", ") { it.name }
-        decodeBody.addStatement("return %L(%L)", className, fieldNames)
+        decodeBody.addStatement("return %T(%L)", classTypeName, fieldNames)
 
         val decodeFun =
             FunSpec
@@ -124,16 +123,17 @@ class CodecGenerator(
 
     private fun buildPayloadCodecFile(
         packageName: String,
-        className: String,
+        classTypeName: ClassName,
         codecName: String,
         fields: List<FieldInfo>,
         batches: List<CodegenItem>,
     ): FileSpec {
+        val className = classTypeName.simpleName
         val payloadFields = fields.filter { it.strategy is FieldReadStrategy.PayloadField }
         val payloadTypeParams =
             payloadFields.map { (it.strategy as FieldReadStrategy.PayloadField).typeParamName }.distinct()
         val typeParamList = payloadTypeParams.joinToString(", ")
-        val contextName = "${className}Context"
+        val contextName = "${classTypeName.simpleNames.joinToString("")}Context"
         val typeVariables = payloadTypeParams.map { TypeVariableName(it) }
 
         // Build decode function
@@ -163,7 +163,7 @@ class CodecGenerator(
             decodeBuilder.addParameter("decode${capitalizeFirst(pf.name)}", paramLambdaType)
         }
 
-        val returnType = ClassName(packageName, className).parameterizedBy(typeVariables)
+        val returnType = classTypeName.parameterizedBy(typeVariables)
         decodeBuilder.returns(returnType)
 
         val decodeBody = CodeBlock.builder()
@@ -222,7 +222,7 @@ class CodecGenerator(
 
         // Phase 4: return constructor call
         val fieldNames = fields.joinToString(", ") { it.name }
-        decodeBody.addStatement("return %L(%L)", className, fieldNames)
+        decodeBody.addStatement("return %T(%L)", classTypeName, fieldNames)
 
         decodeBuilder.addCode(decodeBody.build())
 

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/FieldAnalyzer.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/FieldAnalyzer.kt
@@ -502,7 +502,7 @@ class FieldAnalyzer(
                 it.qualifiedName() == "com.ditchoom.buffer.codec.annotations.ProtocolMessage"
             }
         if (hasProtocolMessage) {
-            val codecName = "${typeDecl.simpleName.asString()}Codec"
+            val codecName = typeDecl.codecName()
             return FieldReadStrategy.NestedMessageField(codecName)
         }
 
@@ -601,7 +601,7 @@ class FieldAnalyzer(
         val annotations = param.annotations.toList()
         val lk = resolveLengthKind(param, annotations, fieldName, "List") ?: return null
 
-        val codecName = "${elementDecl.simpleName.asString()}Codec"
+        val codecName = elementDecl.codecName()
         return FieldReadStrategy.CollectionField(lk, codecName)
     }
 

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/PayloadContextGenerator.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/PayloadContextGenerator.kt
@@ -22,9 +22,8 @@ class PayloadContextGenerator(
         classDeclaration: KSClassDeclaration,
         fields: List<FieldInfo>,
     ) {
-        val className = classDeclaration.simpleName.asString()
         val packageName = classDeclaration.packageName.asString()
-        val contextName = "${className}Context"
+        val contextName = "${classDeclaration.enclosingSimpleNames().joinToString("")}Context"
 
         val nonPayloadFields = fields.filter { it.strategy !is FieldReadStrategy.PayloadField }
         if (nonPayloadFields.isEmpty()) return

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/PayloadEmitter.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/PayloadEmitter.kt
@@ -132,5 +132,3 @@ internal fun addPayloadEncodeBody(
         }
     }
 }
-
-internal fun capitalizeFirst(s: String): String = s.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/ProtocolMessageProcessor.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/ProtocolMessageProcessor.kt
@@ -95,10 +95,8 @@ class ProtocolMessageProcessor(
             return
         }
 
-        val generator = SealedDispatchGenerator(codeGenerator, logger)
-        generator.generate(classDeclaration, sealedSubclasses)
-
-        // Auto-generate codecs for sealed variants (they inherit @ProtocolMessage from the sealed parent)
+        // Phase 1: Analyze and generate sub-codecs, collecting payload metadata
+        val variantPayloadInfos = mutableListOf<SealedVariantPayloadInfo>()
         for (subclass in sealedSubclasses) {
             val qualifiedName = subclass.qualifiedName?.asString() ?: continue
             if (qualifiedName in processed) continue
@@ -123,7 +121,34 @@ class ProtocolMessageProcessor(
                 )
                 continue
             }
-            processDataClass(subclass, resolver)
+
+            // Analyze fields to detect @Payload
+            val fieldAnalyzer = FieldAnalyzer(logger, customProviders)
+            val fields = fieldAnalyzer.analyze(subclass) ?: continue
+
+            val payloadFields = fields.filter { it.strategy is FieldReadStrategy.PayloadField }
+            val payloadInfos =
+                payloadFields.map { field ->
+                    val strategy = field.strategy as FieldReadStrategy.PayloadField
+                    PayloadFieldInfo(
+                        fieldName = field.name,
+                        typeParamName = strategy.typeParamName,
+                        contextClassName = "${subclass.enclosingSimpleNames().joinToString("")}Context",
+                    )
+                }
+            variantPayloadInfos.add(SealedVariantPayloadInfo(subclass, payloadInfos))
+
+            // Generate the sub-codec
+            val batches = BatchOptimizer().optimize(fields)
+            val hasPayload = payloadFields.isNotEmpty()
+            CodecGenerator(codeGenerator, logger).generate(subclass, fields, batches, hasPayload)
+            if (hasPayload) {
+                PayloadContextGenerator(codeGenerator, logger).generate(subclass, fields)
+            }
         }
+
+        // Phase 2: Generate the dispatch codec with payload awareness
+        val generator = SealedDispatchGenerator(codeGenerator, logger)
+        generator.generate(classDeclaration, sealedSubclasses, variantPayloadInfos)
     }
 }

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/ProtocolMessageProcessor.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/ProtocolMessageProcessor.kt
@@ -35,7 +35,7 @@ class ProtocolMessageProcessor(
             processed.add(qualifiedName)
 
             when {
-                Modifier.SEALED in symbol.modifiers -> processSealedInterface(symbol)
+                Modifier.SEALED in symbol.modifiers -> processSealedInterface(symbol, resolver)
                 else -> {
                     val constructor = symbol.primaryConstructor
                     if (constructor == null) {
@@ -81,7 +81,10 @@ class ProtocolMessageProcessor(
         }
     }
 
-    private fun processSealedInterface(classDeclaration: KSClassDeclaration) {
+    private fun processSealedInterface(
+        classDeclaration: KSClassDeclaration,
+        resolver: Resolver,
+    ) {
         val sealedSubclasses = classDeclaration.getSealedSubclasses().toList()
         if (sealedSubclasses.isEmpty()) {
             logger.error(
@@ -94,5 +97,33 @@ class ProtocolMessageProcessor(
 
         val generator = SealedDispatchGenerator(codeGenerator, logger)
         generator.generate(classDeclaration, sealedSubclasses)
+
+        // Auto-generate codecs for sealed variants (they inherit @ProtocolMessage from the sealed parent)
+        for (subclass in sealedSubclasses) {
+            val qualifiedName = subclass.qualifiedName?.asString() ?: continue
+            if (qualifiedName in processed) continue
+            processed.add(qualifiedName)
+
+            val constructor = subclass.primaryConstructor
+            if (constructor == null) {
+                logger.error(
+                    "Sealed variant '${subclass.simpleName.asString()}' of " +
+                        "'${classDeclaration.simpleName.asString()}' must have a primary constructor " +
+                        "with val parameters.",
+                    subclass,
+                )
+                continue
+            }
+            if (constructor.parameters.isEmpty()) {
+                logger.error(
+                    "Sealed variant '${subclass.simpleName.asString()}' of " +
+                        "'${classDeclaration.simpleName.asString()}' must have at least one val parameter " +
+                        "in its primary constructor.",
+                    subclass,
+                )
+                continue
+            }
+            processDataClass(subclass, resolver)
+        }
     }
 }

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/SealedDispatchGenerator.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/SealedDispatchGenerator.kt
@@ -81,8 +81,8 @@ class SealedDispatchGenerator(
                 .addStatement("val type = buffer.readByte().toInt() and 0xFF")
                 .beginControlFlow("return when (type)")
         for ((value, subclass) in variants) {
-            val subName = subclass.simpleName.asString()
-            decodeBody.addStatement("$value -> ${subName}Codec.decode(buffer)")
+            val subCodecName = subclass.codecName()
+            decodeBody.addStatement("$value -> $subCodecName.decode(buffer)")
         }
         decodeBody
             .addStatement("else -> throw IllegalArgumentException(%P)", "Unknown packet type: \$type")
@@ -100,10 +100,11 @@ class SealedDispatchGenerator(
         // Build encode function
         val encodeBody = CodeBlock.builder().beginControlFlow("when (value)")
         for ((value, subclass) in variants) {
-            val subName = subclass.simpleName.asString()
-            encodeBody.beginControlFlow("is $subName ->")
+            val subTypeName = subclass.toPoetClassName()
+            val subCodecName = subclass.codecName()
+            encodeBody.beginControlFlow("is %T ->", subTypeName)
             encodeBody.addStatement("buffer.writeByte($value.toByte())")
-            encodeBody.addStatement("${subName}Codec.encode(buffer, value)")
+            encodeBody.addStatement("$subCodecName.encode(buffer, value)")
             encodeBody.endControlFlow()
         }
         encodeBody.endControlFlow()

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/SealedDispatchGenerator.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/SealedDispatchGenerator.kt
@@ -9,8 +9,12 @@ import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.LambdaTypeName
+import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.STAR
 import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.TypeVariableName
 import com.squareup.kotlinpoet.ksp.writeTo
 
 class SealedDispatchGenerator(
@@ -20,6 +24,7 @@ class SealedDispatchGenerator(
     fun generate(
         sealedInterface: KSClassDeclaration,
         subclasses: List<KSClassDeclaration>,
+        variantPayloadInfos: List<SealedVariantPayloadInfo> = emptyList(),
     ) {
         val interfaceName = sealedInterface.simpleName.asString()
         val packageName = sealedInterface.packageName.asString()
@@ -74,15 +79,44 @@ class SealedDispatchGenerator(
             }
         val dependencies = Dependencies(aggregating = true, sources = sourceFiles.toTypedArray())
 
-        // Build decode function
+        val hasAnyPayload = variantPayloadInfos.any { it.payloadFields.isNotEmpty() }
+
+        val (decodeFun, encodeFun, implementsCodec) =
+            if (hasAnyPayload) {
+                buildPayloadDispatch(packageName, interfaceTypeName, variants, variantPayloadInfos)
+            } else {
+                buildSimpleDispatch(interfaceTypeName, variants)
+            }
+
+        val objectBuilder = TypeSpec.objectBuilder(codecName)
+        if (implementsCodec) {
+            objectBuilder.addSuperinterface(CODEC.parameterizedBy(interfaceTypeName))
+        }
+        objectBuilder.addFunction(decodeFun)
+        objectBuilder.addFunction(encodeFun)
+
+        val fileSpec =
+            FileSpec
+                .builder(packageName, codecName)
+                .addType(objectBuilder.build())
+                .build()
+
+        fileSpec.writeTo(codeGenerator, dependencies)
+    }
+
+    /** No payload variants — generates a standard Codec<T> implementation. */
+    private fun buildSimpleDispatch(
+        interfaceTypeName: ClassName,
+        variants: List<Pair<Int, KSClassDeclaration>>,
+    ): Triple<FunSpec, FunSpec, Boolean> {
+        // Decode
         val decodeBody =
             CodeBlock
                 .builder()
                 .addStatement("val type = buffer.readByte().toInt() and 0xFF")
                 .beginControlFlow("return when (type)")
         for ((value, subclass) in variants) {
-            val subCodecName = subclass.codecName()
-            decodeBody.addStatement("$value -> $subCodecName.decode(buffer)")
+            decodeBody.addStatement("$value -> ${subclass.codecName()}.decode(buffer)")
         }
         decodeBody
             .addStatement("else -> throw IllegalArgumentException(%P)", "Unknown packet type: \$type")
@@ -97,14 +131,12 @@ class SealedDispatchGenerator(
                 .addCode(decodeBody.build())
                 .build()
 
-        // Build encode function
+        // Encode
         val encodeBody = CodeBlock.builder().beginControlFlow("when (value)")
         for ((value, subclass) in variants) {
-            val subTypeName = subclass.toPoetClassName()
-            val subCodecName = subclass.codecName()
-            encodeBody.beginControlFlow("is %T ->", subTypeName)
+            encodeBody.beginControlFlow("is %T ->", subclass.toPoetClassName())
             encodeBody.addStatement("buffer.writeByte($value.toByte())")
-            encodeBody.addStatement("$subCodecName.encode(buffer, value)")
+            encodeBody.addStatement("${subclass.codecName()}.encode(buffer, value)")
             encodeBody.endControlFlow()
         }
         encodeBody.endControlFlow()
@@ -118,20 +150,149 @@ class SealedDispatchGenerator(
                 .addCode(encodeBody.build())
                 .build()
 
-        val objectSpec =
-            TypeSpec
-                .objectBuilder(codecName)
-                .addSuperinterface(CODEC.parameterizedBy(interfaceTypeName))
-                .addFunction(decodeFun)
-                .addFunction(encodeFun)
-                .build()
+        return Triple(decodeFun, encodeFun, true)
+    }
 
-        val fileSpec =
-            FileSpec
-                .builder(packageName, codecName)
-                .addType(objectSpec)
-                .build()
+    /**
+     * Some variants have @Payload — generates a dispatch with type params and lambda forwarding.
+     * Cannot implement Codec<T> because decode/encode need extra lambda parameters.
+     */
+    private fun buildPayloadDispatch(
+        packageName: String,
+        interfaceTypeName: ClassName,
+        variants: List<Pair<Int, KSClassDeclaration>>,
+        variantPayloadInfos: List<SealedVariantPayloadInfo>,
+    ): Triple<FunSpec, FunSpec, Boolean> {
+        // Collect all distinct type params from all payload variants
+        val allTypeParams =
+            variantPayloadInfos
+                .flatMap { it.payloadFields }
+                .map { it.typeParamName }
+                .distinct()
+        val typeVariables = allTypeParams.map { TypeVariableName(it) }
 
-        fileSpec.writeTo(codeGenerator, dependencies)
+        // Build payload info lookup
+        val payloadBySubclass =
+            variantPayloadInfos.associateBy { it.subclass.qualifiedName?.asString() }
+
+        // ── Decode ──
+        val decodeBuilder =
+            FunSpec
+                .builder("decode")
+                .addParameter("buffer", READ_BUFFER)
+                .returns(interfaceTypeName)
+
+        for (tv in typeVariables) {
+            decodeBuilder.addTypeVariable(tv)
+        }
+
+        // Add lambda params for each payload field in each payload variant
+        for (info in variantPayloadInfos) {
+            for (pf in info.payloadFields) {
+                val variantName = info.subclass.simpleName.asString()
+                val paramName = "decode${variantName}${capitalizeFirst(pf.fieldName)}"
+                val tpName = TypeVariableName(pf.typeParamName)
+                val contextType = ClassName(packageName, pf.contextClassName)
+                val lambdaType =
+                    LambdaTypeName.get(
+                        receiver = contextType,
+                        parameters = listOf(ParameterSpec.unnamed(PAYLOAD_READER)),
+                        returnType = tpName,
+                    )
+                decodeBuilder.addParameter(paramName, lambdaType)
+            }
+        }
+
+        val decodeBody =
+            CodeBlock
+                .builder()
+                .addStatement("val type = buffer.readByte().toInt() and 0xFF")
+                .beginControlFlow("return when (type)")
+
+        for ((value, subclass) in variants) {
+            val info = payloadBySubclass[subclass.qualifiedName?.asString()]
+            val subCodecName = subclass.codecName()
+            if (info != null && info.payloadFields.isNotEmpty()) {
+                val lambdaArgs =
+                    info.payloadFields.joinToString(", ") { pf ->
+                        "decode${subclass.simpleName.asString()}${capitalizeFirst(pf.fieldName)}"
+                    }
+                decodeBody.addStatement("$value -> $subCodecName.decode(buffer, $lambdaArgs)")
+            } else {
+                decodeBody.addStatement("$value -> $subCodecName.decode(buffer)")
+            }
+        }
+        decodeBody
+            .addStatement("else -> throw IllegalArgumentException(%P)", "Unknown packet type: \$type")
+            .endControlFlow()
+
+        decodeBuilder.addCode(decodeBody.build())
+
+        // ── Encode ──
+        val encodeBuilder =
+            FunSpec
+                .builder("encode")
+                .addParameter("buffer", WRITE_BUFFER)
+                .addParameter("value", interfaceTypeName)
+
+        for (tv in typeVariables) {
+            encodeBuilder.addTypeVariable(tv)
+        }
+
+        // Add encode lambda params
+        for (info in variantPayloadInfos) {
+            for (pf in info.payloadFields) {
+                val variantName = info.subclass.simpleName.asString()
+                val paramName = "encode${variantName}${capitalizeFirst(pf.fieldName)}"
+                val tpName = TypeVariableName(pf.typeParamName)
+                val encodeLambdaType =
+                    LambdaTypeName.get(
+                        parameters =
+                            listOf(
+                                ParameterSpec.unnamed(WRITE_BUFFER),
+                                ParameterSpec.unnamed(tpName),
+                            ),
+                        returnType = UNIT,
+                    )
+                encodeBuilder.addParameter(paramName, encodeLambdaType)
+            }
+        }
+
+        val encodeBody = CodeBlock.builder().beginControlFlow("when (value)")
+        for ((value, subclass) in variants) {
+            val info = payloadBySubclass[subclass.qualifiedName?.asString()]
+            val subTypeName = subclass.toPoetClassName()
+            val subCodecName = subclass.codecName()
+
+            if (info != null && info.payloadFields.isNotEmpty()) {
+                // Star-projected match for generic variant
+                val starType = subTypeName.parameterizedBy(info.payloadFields.map { STAR })
+                encodeBody.beginControlFlow("is %T ->", starType)
+                encodeBody.addStatement("buffer.writeByte($value.toByte())")
+                // Unchecked cast to typed variant
+                val castTypeParams = info.payloadFields.map { TypeVariableName(it.typeParamName) }
+                val castType = subTypeName.parameterizedBy(castTypeParams)
+                val lambdaArgs =
+                    info.payloadFields.joinToString(", ") { pf ->
+                        "encode${subclass.simpleName.asString()}${capitalizeFirst(pf.fieldName)}"
+                    }
+                encodeBody.addStatement(
+                    "@Suppress(\"UNCHECKED_CAST\") $subCodecName.encode(buffer, value as %T, $lambdaArgs)",
+                    castType,
+                )
+                encodeBody.endControlFlow()
+            } else {
+                // Non-payload variant: simple dispatch
+                encodeBody.beginControlFlow("is %T ->", subTypeName)
+                encodeBody.addStatement("buffer.writeByte($value.toByte())")
+                encodeBody.addStatement("$subCodecName.encode(buffer, value)")
+                encodeBody.endControlFlow()
+            }
+        }
+        encodeBody.endControlFlow()
+
+        encodeBuilder.addCode(encodeBody.build())
+
+        return Triple(decodeBuilder.build(), encodeBuilder.build(), false)
     }
 }

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/StringUtils.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/StringUtils.kt
@@ -46,3 +46,16 @@ internal fun KSClassDeclaration.toPoetClassName(): ClassName {
     val names = enclosingSimpleNames()
     return ClassName(packageName.asString(), *names.toTypedArray())
 }
+
+/** Payload metadata for a sealed interface variant. */
+data class SealedVariantPayloadInfo(
+    val subclass: KSClassDeclaration,
+    val payloadFields: List<PayloadFieldInfo>,
+)
+
+/** A single @Payload field within a sealed variant. */
+data class PayloadFieldInfo(
+    val fieldName: String,
+    val typeParamName: String,
+    val contextClassName: String,
+)

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/StringUtils.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/StringUtils.kt
@@ -1,0 +1,48 @@
+package com.ditchoom.buffer.codec.processor
+
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.squareup.kotlinpoet.ClassName
+
+internal fun capitalizeFirst(s: String): String = s.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }
+
+/**
+ * Prepends "value." to the first path segment of a condition expression,
+ * so that generated code references the constructor parameter.
+ * E.g. "flags.willFlag" → "value.flags.willFlag", "enabled" → "value.enabled"
+ */
+internal fun conditionToValueExpr(expression: String): String = expression.replace(Regex("^([^.]+)"), "value.$1")
+
+/**
+ * Returns the codec object name for this class, handling nested classes.
+ *
+ * Top-level: `MqttPacketConnect` → `MqttPacketConnectCodec`
+ * Nested:    `AnimChunk.Header`  → `AnimChunkHeaderCodec`
+ */
+internal fun KSClassDeclaration.codecName(): String = enclosingSimpleNames().joinToString("") + "Codec"
+
+/**
+ * Returns the simple name chain from the outermost enclosing class to this class.
+ *
+ * Top-level: `MqttPacketConnect` → `["MqttPacketConnect"]`
+ * Nested:    `AnimChunk.Header`  → `["AnimChunk", "Header"]`
+ */
+internal fun KSClassDeclaration.enclosingSimpleNames(): List<String> {
+    val names = mutableListOf<String>()
+    var current: KSClassDeclaration? = this
+    while (current != null) {
+        names.add(0, current.simpleName.asString())
+        current = current.parentDeclaration as? KSClassDeclaration
+    }
+    return names
+}
+
+/**
+ * Returns a KotlinPoet [ClassName] that correctly handles nested classes.
+ *
+ * Top-level: `ClassName("com.example", "MqttPacketConnect")`
+ * Nested:    `ClassName("com.example", "AnimChunk", "Header")`
+ */
+internal fun KSClassDeclaration.toPoetClassName(): ClassName {
+    val names = enclosingSimpleNames()
+    return ClassName(packageName.asString(), *names.toTypedArray())
+}

--- a/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/AnimChunks.kt
+++ b/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/AnimChunks.kt
@@ -1,0 +1,55 @@
+package com.ditchoom.buffer.codec.test.protocols
+
+import com.ditchoom.buffer.codec.annotations.LengthPrefixed
+import com.ditchoom.buffer.codec.annotations.PacketType
+import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+import com.ditchoom.buffer.codec.annotations.WireBytes
+import kotlin.jvm.JvmInline
+
+@JvmInline
+value class ImageSize(
+    val packed: UInt,
+) {
+    val width: UShort get() = (packed shr 16).toUShort()
+    val height: UShort get() = packed.toUShort()
+
+    companion object {
+        fun of(
+            width: UShort,
+            height: UShort,
+        ): ImageSize = ImageSize((width.toUInt() shl 16) or height.toUInt())
+    }
+}
+
+/**
+ * Sealed interface with nested @PacketType variants — tests that the KSP processor
+ * auto-generates sub-codecs for nested classes and uses qualified names in the dispatch.
+ *
+ * Validates three fixes:
+ * 1. Sub-codecs (AnimChunkHeaderCodec, etc.) are generated for nested variants
+ * 2. Dispatch uses qualified names (is AnimChunk.Header, not is Header)
+ * 3. Codec names are flattened (AnimChunkHeaderCodec, not HeaderCodec)
+ */
+@ProtocolMessage
+sealed interface AnimChunk {
+    @PacketType(0x01)
+    data class Header(
+        val magic: Int,
+        val version: UByte,
+        @WireBytes(3) val frameCount: UInt,
+    ) : AnimChunk
+
+    @PacketType(0x02)
+    data class FrameInfo(
+        @WireBytes(3) val index: UInt,
+        val size: ImageSize,
+        val bitmapOffset: Int,
+        val bitmapLength: Int,
+    ) : AnimChunk
+
+    @PacketType(0x03)
+    data class Metadata(
+        @LengthPrefixed val name: String,
+        @LengthPrefixed val author: String,
+    ) : AnimChunk
+}

--- a/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/AnimChunks.kt
+++ b/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/AnimChunks.kt
@@ -1,7 +1,9 @@
 package com.ditchoom.buffer.codec.test.protocols
 
+import com.ditchoom.buffer.codec.annotations.LengthFrom
 import com.ditchoom.buffer.codec.annotations.LengthPrefixed
 import com.ditchoom.buffer.codec.annotations.PacketType
+import com.ditchoom.buffer.codec.annotations.Payload
 import com.ditchoom.buffer.codec.annotations.ProtocolMessage
 import com.ditchoom.buffer.codec.annotations.WireBytes
 import kotlin.jvm.JvmInline
@@ -22,13 +24,11 @@ value class ImageSize(
 }
 
 /**
- * Sealed interface with nested @PacketType variants — tests that the KSP processor
- * auto-generates sub-codecs for nested classes and uses qualified names in the dispatch.
- *
- * Validates three fixes:
- * 1. Sub-codecs (AnimChunkHeaderCodec, etc.) are generated for nested variants
- * 2. Dispatch uses qualified names (is AnimChunk.Header, not is Header)
- * 3. Codec names are flattened (AnimChunkHeaderCodec, not HeaderCodec)
+ * Sealed interface with nested @PacketType variants — tests:
+ * 1. Sub-codecs generated for nested classes (AnimChunkHeaderCodec, etc.)
+ * 2. Qualified names in dispatch (is AnimChunk.Header, not is Header)
+ * 3. Flattened codec names (AnimChunkHeaderCodec, not HeaderCodec)
+ * 4. Mixed payload/non-payload variants in sealed dispatch
  */
 @ProtocolMessage
 sealed interface AnimChunk {
@@ -40,11 +40,11 @@ sealed interface AnimChunk {
     ) : AnimChunk
 
     @PacketType(0x02)
-    data class FrameInfo(
+    data class ImageFrame<@Payload P>(
         @WireBytes(3) val index: UInt,
         val size: ImageSize,
-        val bitmapOffset: Int,
         val bitmapLength: Int,
+        @LengthFrom("bitmapLength") val bitmap: P,
     ) : AnimChunk
 
     @PacketType(0x03)

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/AnimChunkRoundTripTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/AnimChunkRoundTripTest.kt
@@ -5,8 +5,8 @@ import com.ditchoom.buffer.ByteOrder
 import com.ditchoom.buffer.Default
 import com.ditchoom.buffer.codec.test.protocols.AnimChunk
 import com.ditchoom.buffer.codec.test.protocols.AnimChunkCodec
-import com.ditchoom.buffer.codec.test.protocols.AnimChunkFrameInfoCodec
 import com.ditchoom.buffer.codec.test.protocols.AnimChunkHeaderCodec
+import com.ditchoom.buffer.codec.test.protocols.AnimChunkImageFrameCodec
 import com.ditchoom.buffer.codec.test.protocols.AnimChunkMetadataCodec
 import com.ditchoom.buffer.codec.test.protocols.ImageSize
 import com.ditchoom.buffer.codec.testRoundTrip
@@ -16,11 +16,11 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 /**
- * Tests for nested sealed interface @PacketType codecs.
- * Validates that the KSP processor:
- * 1. Generates sub-codecs for nested variants (AnimChunkHeaderCodec, etc.)
- * 2. Uses qualified names in the dispatch (is AnimChunk.Header, not is Header)
- * 3. Flattens codec names (AnimChunkHeaderCodec, not HeaderCodec)
+ * Tests for nested sealed interface @PacketType codecs, including:
+ * - Sub-codec generation for nested classes
+ * - Qualified names in dispatch
+ * - Flattened codec names
+ * - Mixed payload/non-payload variant dispatch
  */
 class AnimChunkRoundTripTest {
     // ========== Individual variant codecs ==========
@@ -64,18 +64,29 @@ class AnimChunkRoundTripTest {
     }
 
     @Test
-    fun frameInfoRoundTrip() {
+    fun imageFrameRoundTripWithPayload() {
         val original =
-            AnimChunk.FrameInfo(
+            AnimChunk.ImageFrame(
                 index = 0u,
                 size = ImageSize.of(1920u.toUShort(), 1080u.toUShort()),
-                bitmapOffset = 1024,
-                bitmapLength = 8294400,
+                bitmapLength = 5,
+                bitmap = "hello",
             )
-        val decoded = AnimChunkFrameInfoCodec.testRoundTrip(original)
-        assertEquals(original, decoded)
-        assertEquals(1920u.toUShort(), decoded.size.width)
-        assertEquals(1080u.toUShort(), decoded.size.height)
+        val buffer = BufferFactory.Default.allocate(256, ByteOrder.BIG_ENDIAN)
+        AnimChunkImageFrameCodec.encode(
+            buffer,
+            original,
+            encodeBitmap = { buf, s -> buf.writeString(s) },
+        )
+        buffer.resetForRead()
+        val decoded =
+            AnimChunkImageFrameCodec.decode<String>(
+                buffer,
+                decodeBitmap = { pr -> pr.readString(pr.remaining()) },
+            )
+        assertEquals(original.index, decoded.index)
+        assertEquals(original.size, decoded.size)
+        assertEquals(original.bitmap, decoded.bitmap)
     }
 
     @Test
@@ -96,7 +107,7 @@ class AnimChunkRoundTripTest {
         assertEquals(480u.toUShort(), size.height)
     }
 
-    // ========== Sealed dispatch codec ==========
+    // ========== Sealed dispatch codec (mixed payload/non-payload) ==========
 
     @Test
     fun sealedDispatchHeader() {
@@ -106,23 +117,45 @@ class AnimChunkRoundTripTest {
                 version = 1u,
                 frameCount = 24u,
             )
-        val decoded = AnimChunkCodec.testRoundTrip(original)
+        val buffer = BufferFactory.Default.allocate(256, ByteOrder.BIG_ENDIAN)
+        AnimChunkCodec.encode<String>(
+            buffer,
+            original,
+            encodeImageFrameBitmap = { buf, s -> buf.writeString(s) },
+        )
+        buffer.resetForRead()
+        val decoded =
+            AnimChunkCodec.decode<String>(
+                buffer,
+                decodeImageFrameBitmap = { pr -> pr.readString(pr.remaining()) },
+            )
         assertTrue(decoded is AnimChunk.Header)
         assertEquals(original, decoded)
     }
 
     @Test
-    fun sealedDispatchFrameInfo() {
+    fun sealedDispatchImageFrame() {
         val original: AnimChunk =
-            AnimChunk.FrameInfo(
+            AnimChunk.ImageFrame(
                 index = 5u,
                 size = ImageSize.of(320u.toUShort(), 240u.toUShort()),
-                bitmapOffset = 0,
-                bitmapLength = 307200,
+                bitmapLength = 11,
+                bitmap = "hello world",
             )
-        val decoded = AnimChunkCodec.testRoundTrip(original)
-        assertTrue(decoded is AnimChunk.FrameInfo)
-        assertEquals(original, decoded)
+        val buffer = BufferFactory.Default.allocate(256, ByteOrder.BIG_ENDIAN)
+        AnimChunkCodec.encode<String>(
+            buffer,
+            original,
+            encodeImageFrameBitmap = { buf, s -> buf.writeString(s) },
+        )
+        buffer.resetForRead()
+        val decoded =
+            AnimChunkCodec.decode<String>(
+                buffer,
+                decodeImageFrameBitmap = { pr -> pr.readString(pr.remaining()) },
+            )
+        assertTrue(decoded is AnimChunk.ImageFrame<*>)
+        assertEquals("hello world", (decoded as AnimChunk.ImageFrame<*>).bitmap)
     }
 
     @Test
@@ -132,7 +165,18 @@ class AnimChunkRoundTripTest {
                 name = "bounce",
                 author = "Bob",
             )
-        val decoded = AnimChunkCodec.testRoundTrip(original)
+        val buffer = BufferFactory.Default.allocate(256, ByteOrder.BIG_ENDIAN)
+        AnimChunkCodec.encode<String>(
+            buffer,
+            original,
+            encodeImageFrameBitmap = { buf, s -> buf.writeString(s) },
+        )
+        buffer.resetForRead()
+        val decoded =
+            AnimChunkCodec.decode<String>(
+                buffer,
+                decodeImageFrameBitmap = { pr -> pr.readString(pr.remaining()) },
+            )
         assertTrue(decoded is AnimChunk.Metadata)
         assertEquals(original, decoded)
     }
@@ -143,7 +187,10 @@ class AnimChunkRoundTripTest {
         buffer.writeByte(0xFF.toByte())
         buffer.resetForRead()
         assertFailsWith<IllegalArgumentException> {
-            AnimChunkCodec.decode(buffer)
+            AnimChunkCodec.decode<String>(
+                buffer,
+                decodeImageFrameBitmap = { pr -> pr.readString(pr.remaining()) },
+            )
         }
     }
 }

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/AnimChunkRoundTripTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/AnimChunkRoundTripTest.kt
@@ -1,0 +1,149 @@
+package com.ditchoom.buffer.codec.test
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.codec.test.protocols.AnimChunk
+import com.ditchoom.buffer.codec.test.protocols.AnimChunkCodec
+import com.ditchoom.buffer.codec.test.protocols.AnimChunkFrameInfoCodec
+import com.ditchoom.buffer.codec.test.protocols.AnimChunkHeaderCodec
+import com.ditchoom.buffer.codec.test.protocols.AnimChunkMetadataCodec
+import com.ditchoom.buffer.codec.test.protocols.ImageSize
+import com.ditchoom.buffer.codec.testRoundTrip
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Tests for nested sealed interface @PacketType codecs.
+ * Validates that the KSP processor:
+ * 1. Generates sub-codecs for nested variants (AnimChunkHeaderCodec, etc.)
+ * 2. Uses qualified names in the dispatch (is AnimChunk.Header, not is Header)
+ * 3. Flattens codec names (AnimChunkHeaderCodec, not HeaderCodec)
+ */
+class AnimChunkRoundTripTest {
+    // ========== Individual variant codecs ==========
+
+    @Test
+    fun headerRoundTrip() {
+        val original =
+            AnimChunk.Header(
+                magic = 0x414E494D, // "ANIM"
+                version = 1u,
+                frameCount = 120u,
+            )
+        val decoded = AnimChunkHeaderCodec.testRoundTrip(original)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun headerExactBytes() {
+        val original =
+            AnimChunk.Header(
+                magic = 0x414E494D,
+                version = 2u,
+                frameCount = 0x030201u,
+            )
+        val decoded =
+            AnimChunkHeaderCodec.testRoundTrip(
+                original,
+                expectedBytes =
+                    byteArrayOf(
+                        0x41,
+                        0x4E,
+                        0x49,
+                        0x4D, // magic
+                        0x02, // version
+                        0x03,
+                        0x02,
+                        0x01, // frameCount (3 bytes)
+                    ),
+            )
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun frameInfoRoundTrip() {
+        val original =
+            AnimChunk.FrameInfo(
+                index = 0u,
+                size = ImageSize.of(1920u.toUShort(), 1080u.toUShort()),
+                bitmapOffset = 1024,
+                bitmapLength = 8294400,
+            )
+        val decoded = AnimChunkFrameInfoCodec.testRoundTrip(original)
+        assertEquals(original, decoded)
+        assertEquals(1920u.toUShort(), decoded.size.width)
+        assertEquals(1080u.toUShort(), decoded.size.height)
+    }
+
+    @Test
+    fun metadataRoundTrip() {
+        val original =
+            AnimChunk.Metadata(
+                name = "walk_cycle",
+                author = "Alice",
+            )
+        val decoded = AnimChunkMetadataCodec.testRoundTrip(original)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun imageSizeValueClass() {
+        val size = ImageSize.of(640u.toUShort(), 480u.toUShort())
+        assertEquals(640u.toUShort(), size.width)
+        assertEquals(480u.toUShort(), size.height)
+    }
+
+    // ========== Sealed dispatch codec ==========
+
+    @Test
+    fun sealedDispatchHeader() {
+        val original: AnimChunk =
+            AnimChunk.Header(
+                magic = 0x414E494D,
+                version = 1u,
+                frameCount = 24u,
+            )
+        val decoded = AnimChunkCodec.testRoundTrip(original)
+        assertTrue(decoded is AnimChunk.Header)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun sealedDispatchFrameInfo() {
+        val original: AnimChunk =
+            AnimChunk.FrameInfo(
+                index = 5u,
+                size = ImageSize.of(320u.toUShort(), 240u.toUShort()),
+                bitmapOffset = 0,
+                bitmapLength = 307200,
+            )
+        val decoded = AnimChunkCodec.testRoundTrip(original)
+        assertTrue(decoded is AnimChunk.FrameInfo)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun sealedDispatchMetadata() {
+        val original: AnimChunk =
+            AnimChunk.Metadata(
+                name = "bounce",
+                author = "Bob",
+            )
+        val decoded = AnimChunkCodec.testRoundTrip(original)
+        assertTrue(decoded is AnimChunk.Metadata)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun sealedDispatchUnknownTypeThrows() {
+        val buffer = BufferFactory.Default.allocate(16, ByteOrder.BIG_ENDIAN)
+        buffer.writeByte(0xFF.toByte())
+        buffer.resetForRead()
+        assertFailsWith<IllegalArgumentException> {
+            AnimChunkCodec.decode(buffer)
+        }
+    }
+}

--- a/buffer/src/androidMain/kotlin/com/ditchoom/buffer/BufferFactory.kt
+++ b/buffer/src/androidMain/kotlin/com/ditchoom/buffer/BufferFactory.kt
@@ -102,3 +102,17 @@ actual fun PlatformBuffer.Companion.allocateShared(
     size: Int,
     byteOrder: ByteOrder,
 ): PlatformBuffer = BufferFactory.shared().allocate(size, byteOrder)
+
+actual fun PlatformBuffer.Companion.wrapNativeAddress(
+    address: Long,
+    size: Int,
+    byteOrder: ByteOrder,
+): PlatformBuffer {
+    val byteBuffer =
+        UnsafeMemory.tryWrapAsDirectByteBuffer(address, size)
+            ?: throw UnsupportedOperationException(
+                "Cannot wrap native address: DirectByteBuffer reflection is not available on this Android version.",
+            )
+    byteBuffer.order(byteOrder.toJava())
+    return DirectJvmBuffer(byteBuffer)
+}

--- a/buffer/src/appleMain/kotlin/com/ditchoom/buffer/BufferFactory.kt
+++ b/buffer/src/appleMain/kotlin/com/ditchoom/buffer/BufferFactory.kt
@@ -125,3 +125,22 @@ actual fun PlatformBuffer.Companion.allocateShared(
     size: Int,
     byteOrder: ByteOrder,
 ): PlatformBuffer = BufferFactory.Default.allocate(size, byteOrder)
+
+@OptIn(UnsafeNumber::class)
+actual fun PlatformBuffer.Companion.wrapNativeAddress(
+    address: Long,
+    size: Int,
+    byteOrder: ByteOrder,
+): PlatformBuffer {
+    val ptr =
+        address.toCPointer<kotlinx.cinterop.ByteVar>()
+            ?: throw IllegalArgumentException("Cannot wrap null address (0)")
+    // bytesNoCopy + freeWhenDone=false: wraps existing memory without ownership
+    val data =
+        NSMutableData.create(
+            bytesNoCopy = ptr,
+            length = size.convert(),
+            freeWhenDone = false,
+        ) ?: throw IllegalStateException("Failed to create NSMutableData wrapping address $address")
+    return MutableDataBuffer(data, byteOrder)
+}

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/NativeMemoryAccess.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/NativeMemoryAccess.kt
@@ -255,6 +255,52 @@ expect fun PlatformBuffer.Companion.allocateShared(
     byteOrder: ByteOrder = ByteOrder.BIG_ENDIAN,
 ): PlatformBuffer
 
+/**
+ * Wraps an externally-owned native memory address as a readable/writable [PlatformBuffer].
+ *
+ * The returned buffer does **not** own the memory — the caller must ensure the memory
+ * remains valid for the buffer's lifetime. No cleanup is performed on GC or close.
+ *
+ * The returned buffer implements [NativeMemoryAccess] with the given [address] and [size].
+ *
+ * Use this to write directly into memory owned by another system (e.g., a locked
+ * Android HardwareBuffer, an mmap region, a Skia surface, or an io_uring buffer):
+ *
+ * ```kotlin
+ * val gpuAddr = lockHardwareBuffer(hwBuffer)
+ * val dst = PlatformBuffer.wrapNativeAddress(gpuAddr, pixelSize)
+ * decompressor.decompress(compressedSlice).forEach { dst.write(it) }
+ * unlockHardwareBuffer(hwBuffer)
+ * ```
+ *
+ * Platform behavior:
+ * - **JVM 21+**: FFM `MemorySegment.ofAddress()` → DirectByteBuffer
+ * - **JVM < 21 / Android**: Unsafe reflection to create DirectByteBuffer
+ * - **Apple**: `NSMutableData(bytesNoCopy:freeWhenDone:false)` — zero-copy, non-owning
+ * - **Linux**: `NativeBuffer` wrapping a `CPointer` — non-owning
+ * - **WASM**: [address] is a linear memory offset → `LinearBuffer`
+ * - **JS**: Throws [UnsupportedOperationException] (no raw pointer concept)
+ *
+ * @param address The native memory address (or WASM linear memory offset) to wrap
+ * @param size The size of the memory region in bytes
+ * @param byteOrder The byte order for multi-byte operations
+ * @return A [PlatformBuffer] backed by the given native memory
+ */
+expect fun PlatformBuffer.Companion.wrapNativeAddress(
+    address: Long,
+    size: Int,
+    byteOrder: ByteOrder = ByteOrder.BIG_ENDIAN,
+): PlatformBuffer
+
+/**
+ * Convenience extension on [BufferFactory.Companion] for [PlatformBuffer.Companion.wrapNativeAddress].
+ */
+fun BufferFactory.Companion.wrapNativeAddress(
+    address: Long,
+    size: Int,
+    byteOrder: ByteOrder = ByteOrder.BIG_ENDIAN,
+): PlatformBuffer = PlatformBuffer.wrapNativeAddress(address, size, byteOrder)
+
 // =============================================================================
 // Accessing Platform-Specific Native Buffer Objects
 // =============================================================================

--- a/buffer/src/commonTest/kotlin/com/ditchoom/buffer/WrapNativeAddressTest.kt
+++ b/buffer/src/commonTest/kotlin/com/ditchoom/buffer/WrapNativeAddressTest.kt
@@ -1,0 +1,89 @@
+package com.ditchoom.buffer
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class WrapNativeAddressTest {
+    @Test
+    fun wrapNativeAddressReadsThroughOriginal() {
+        // Allocate a real buffer and get its native address
+        val original = BufferFactory.Default.allocate(64)
+        original.writeInt(0x12345678)
+        original.writeInt(0xABCDEF00.toInt())
+        original.resetForRead()
+
+        val nma = original.nativeMemoryAccess ?: return // skip on platforms without native access
+
+        // Wrap the same memory via nativeAddress
+        val wrapped = PlatformBuffer.wrapNativeAddress(nma.nativeAddress, 64)
+        assertEquals(0x12345678, wrapped.readInt())
+        assertEquals(0xABCDEF00.toInt(), wrapped.readInt())
+    }
+
+    @Test
+    fun wrapNativeAddressWritesThroughToOriginal() {
+        val original = BufferFactory.Default.allocate(64)
+        val nma = original.nativeMemoryAccess ?: return
+
+        // Write through the wrapped buffer
+        val wrapped = PlatformBuffer.wrapNativeAddress(nma.nativeAddress, 64)
+        wrapped.writeInt(42)
+        wrapped.writeShort(1000.toShort())
+
+        // Read through the original using absolute reads (position-independent)
+        // since the two buffers share memory but not position/limit state
+        assertEquals(42, original.getInt(0))
+        assertEquals(1000.toShort(), original.getShort(4))
+    }
+
+    @Test
+    fun wrappedBufferHasNativeMemoryAccess() {
+        val original = BufferFactory.Default.allocate(32)
+        val nma = original.nativeMemoryAccess ?: return
+
+        val wrapped = PlatformBuffer.wrapNativeAddress(nma.nativeAddress, 32)
+        val wrappedNma = wrapped.nativeMemoryAccess
+        assertNotNull(wrappedNma)
+        assertEquals(nma.nativeAddress, wrappedNma.nativeAddress)
+    }
+
+    @Test
+    fun wrappedBufferRespectsSize() {
+        val original = BufferFactory.Default.allocate(128)
+        val nma = original.nativeMemoryAccess ?: return
+
+        // Wrap only 16 bytes
+        val wrapped = PlatformBuffer.wrapNativeAddress(nma.nativeAddress, 16)
+        assertEquals(16, wrapped.capacity)
+        assertEquals(16, wrapped.remaining())
+    }
+
+    @Test
+    fun wrappedBufferRespectsOffset() {
+        val original = BufferFactory.Default.allocate(64)
+        original.writeInt(0x11111111)
+        original.writeInt(0x22222222)
+        original.writeInt(0x33333333)
+        original.resetForRead()
+
+        val nma = original.nativeMemoryAccess ?: return
+
+        // Wrap starting at offset 4 (second int)
+        val wrapped = PlatformBuffer.wrapNativeAddress(nma.nativeAddress + 4, 8)
+        assertEquals(0x22222222, wrapped.readInt())
+        assertEquals(0x33333333, wrapped.readInt())
+    }
+
+    @Test
+    fun bufferFactoryConvenienceWorks() {
+        val original = BufferFactory.Default.allocate(32)
+        val nma = original.nativeMemoryAccess ?: return
+
+        // Use the BufferFactory.Companion convenience
+        val wrapped = BufferFactory.wrapNativeAddress(nma.nativeAddress, 32)
+        assertTrue(wrapped is PlatformBuffer)
+        assertEquals(32, wrapped.capacity)
+    }
+}

--- a/buffer/src/jsMain/kotlin/com/ditchoom/buffer/BufferFactory.kt
+++ b/buffer/src/jsMain/kotlin/com/ditchoom/buffer/BufferFactory.kt
@@ -86,3 +86,39 @@ actual fun PlatformBuffer.Companion.allocateShared(
     size: Int,
     byteOrder: ByteOrder,
 ): PlatformBuffer = BufferFactory.shared().allocate(size, byteOrder)
+
+actual fun PlatformBuffer.Companion.wrapNativeAddress(
+    address: Long,
+    size: Int,
+    byteOrder: ByteOrder,
+): PlatformBuffer =
+    throw UnsupportedOperationException(
+        "wrapNativeAddress(Long) is not supported on JavaScript — JS has no global memory address space. " +
+            "Use PlatformBuffer.wrap(Int8Array) or PlatformBuffer.wrap(ArrayBuffer) instead.",
+    )
+
+/**
+ * Wraps an existing [Int8Array] as a [PlatformBuffer] (zero-copy).
+ *
+ * The buffer shares memory with the original typed array — modifications
+ * to one are visible in the other. The buffer does not own the memory.
+ *
+ * This is the JS equivalent of [wrapNativeAddress] on other platforms.
+ */
+fun PlatformBuffer.Companion.wrap(
+    int8Array: Int8Array,
+    byteOrder: ByteOrder = ByteOrder.BIG_ENDIAN,
+): PlatformBuffer = JsBuffer(int8Array, byteOrder)
+
+/**
+ * Wraps an existing [ArrayBuffer] as a [PlatformBuffer] (zero-copy).
+ *
+ * Creates an [Int8Array] view over the entire ArrayBuffer. The buffer shares
+ * memory with the original ArrayBuffer — modifications are visible in both.
+ *
+ * This is the JS equivalent of [wrapNativeAddress] on other platforms.
+ */
+fun PlatformBuffer.Companion.wrap(
+    arrayBuffer: ArrayBuffer,
+    byteOrder: ByteOrder = ByteOrder.BIG_ENDIAN,
+): PlatformBuffer = JsBuffer(Int8Array(arrayBuffer), byteOrder)

--- a/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/BufferFactory.kt
+++ b/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/BufferFactory.kt
@@ -98,6 +98,18 @@ fun PlatformBuffer.Companion.allocateShared(
     byteOrder: ByteOrder = ByteOrder.BIG_ENDIAN,
 ): PlatformBuffer = BufferFactory.Default.allocate(size, byteOrder)
 
+fun PlatformBuffer.Companion.wrapNativeAddress(
+    address: Long,
+    size: Int,
+    byteOrder: ByteOrder = ByteOrder.BIG_ENDIAN,
+): PlatformBuffer {
+    // MemorySegment.ofAddress creates a global-scope segment (no Arena = no ownership).
+    // reinterpret extends it to the given size. The buffer does NOT own this memory.
+    val segment = MemorySegment.ofAddress(address).reinterpret(size.toLong())
+    val byteBuffer = segment.asByteBuffer().order(byteOrder.toJavaByteOrder())
+    return FfmAutoBuffer(segment, byteBuffer)
+}
+
 /**
  * Creates a GC-managed FFM buffer using [Arena.ofAuto].
  *

--- a/buffer/src/jvmMain/kotlin/com/ditchoom/buffer/BufferFactory.kt
+++ b/buffer/src/jvmMain/kotlin/com/ditchoom/buffer/BufferFactory.kt
@@ -88,3 +88,42 @@ actual fun PlatformBuffer.Companion.allocateShared(
     size: Int,
     byteOrder: ByteOrder,
 ): PlatformBuffer = BufferFactory.Default.allocate(size, byteOrder)
+
+actual fun PlatformBuffer.Companion.wrapNativeAddress(
+    address: Long,
+    size: Int,
+    byteOrder: ByteOrder,
+): PlatformBuffer {
+    // Try FFM first (JVM 21+ at runtime, even if compiled against jvmMain)
+    tryWrapViaFfm(address, size, byteOrder)?.let { return it }
+
+    // Fall back to Unsafe DirectByteBuffer reflection
+    val byteBuffer =
+        UnsafeMemory.tryWrapAsDirectByteBuffer(address, size)
+            ?: throw UnsupportedOperationException(
+                "Cannot wrap native address: neither FFM (JVM 21+) nor DirectByteBuffer reflection is available.",
+            )
+    byteBuffer.order(byteOrder.toJava())
+    return DirectJvmBuffer(byteBuffer)
+}
+
+/** Attempt to wrap via FFM (available on JVM 21+ at runtime). Returns null if FFM is not available. */
+private fun tryWrapViaFfm(
+    address: Long,
+    size: Int,
+    byteOrder: ByteOrder,
+): PlatformBuffer? =
+    try {
+        val memorySegmentClass = Class.forName("java.lang.foreign.MemorySegment")
+        val ofAddress = memorySegmentClass.getMethod("ofAddress", Long::class.javaPrimitiveType)
+        val reinterpret = memorySegmentClass.getMethod("reinterpret", Long::class.javaPrimitiveType)
+        val asByteBuffer = memorySegmentClass.getMethod("asByteBuffer")
+
+        val zeroSegment = ofAddress.invoke(null, address)
+        val segment = reinterpret.invoke(zeroSegment, size.toLong())
+        val byteBuffer = asByteBuffer.invoke(segment) as ByteBuffer
+        byteBuffer.order(byteOrder.toJava())
+        DirectJvmBuffer(byteBuffer)
+    } catch (_: Exception) {
+        null
+    }

--- a/buffer/src/linuxMain/kotlin/com/ditchoom/buffer/BufferFactory.kt
+++ b/buffer/src/linuxMain/kotlin/com/ditchoom/buffer/BufferFactory.kt
@@ -64,3 +64,9 @@ actual fun PlatformBuffer.Companion.allocateShared(
     size: Int,
     byteOrder: ByteOrder,
 ): PlatformBuffer = NativeBuffer.allocate(size, byteOrder)
+
+actual fun PlatformBuffer.Companion.wrapNativeAddress(
+    address: Long,
+    size: Int,
+    byteOrder: ByteOrder,
+): PlatformBuffer = NativeBuffer.wrapExternal(address, size, byteOrder)

--- a/buffer/src/linuxMain/kotlin/com/ditchoom/buffer/NativeBuffer.kt
+++ b/buffer/src/linuxMain/kotlin/com/ditchoom/buffer/NativeBuffer.kt
@@ -58,6 +58,7 @@ class NativeBuffer private constructor(
     private val ptr: CPointer<ByteVar>,
     override val capacity: Int,
     override val byteOrder: ByteOrder,
+    private val ownsMemory: Boolean = true,
 ) : PlatformBuffer,
     NativeMemoryAccess,
     CloseableBuffer {
@@ -83,6 +84,21 @@ class NativeBuffer private constructor(
                 malloc(size.convert())?.reinterpret<ByteVar>()
                     ?: throw OutOfMemoryError("Failed to allocate $size bytes")
             return NativeBuffer(ptr, size, byteOrder)
+        }
+
+        /**
+         * Wraps an externally-owned native address as a [NativeBuffer] without taking ownership.
+         * The caller is responsible for the memory lifetime — [freeNativeMemory] will NOT call free().
+         */
+        fun wrapExternal(
+            address: Long,
+            size: Int,
+            byteOrder: ByteOrder = ByteOrder.BIG_ENDIAN,
+        ): NativeBuffer {
+            val ptr =
+                address.toCPointer<ByteVar>()
+                    ?: throw IllegalArgumentException("Cannot wrap null address (0)")
+            return NativeBuffer(ptr, size, byteOrder, ownsMemory = false)
         }
     }
 
@@ -551,7 +567,9 @@ class NativeBuffer private constructor(
     override fun freeNativeMemory() {
         if (!closed) {
             closed = true
-            free(ptr)
+            if (ownsMemory) {
+                free(ptr)
+            }
         }
     }
 

--- a/buffer/src/wasmJsMain/kotlin/com/ditchoom/buffer/BufferFactory.wasmJs.kt
+++ b/buffer/src/wasmJsMain/kotlin/com/ditchoom/buffer/BufferFactory.wasmJs.kt
@@ -61,3 +61,14 @@ actual fun PlatformBuffer.Companion.allocateShared(
     size: Int,
     byteOrder: ByteOrder,
 ): PlatformBuffer = BufferFactory.Default.allocate(size, byteOrder)
+
+actual fun PlatformBuffer.Companion.wrapNativeAddress(
+    address: Long,
+    size: Int,
+    byteOrder: ByteOrder,
+): PlatformBuffer {
+    require(address >= 0 && address <= Int.MAX_VALUE) {
+        "WASM linear memory address must fit in Int range, got $address"
+    }
+    return LinearBuffer(address.toInt(), size, byteOrder)
+}

--- a/docs/docs/platforms/apple.md
+++ b/docs/docs/platforms/apple.md
@@ -34,7 +34,7 @@ When exposing to Swift code:
 
 ```swift
 // In Swift
-let buffer = PlatformBuffer.companion.allocate(size: 1024)
+let buffer = BufferFactory.Default.allocate(size: 1024)
 buffer.writeInt(value: 42)
 buffer.resetForRead()
 let value = buffer.readInt()

--- a/docs/docs/recipes/protocol-codecs.md
+++ b/docs/docs/recipes/protocol-codecs.md
@@ -672,7 +672,38 @@ object RiffImageDecoder {
 
 **What's zero-copy here:** `readBytes()` returns a `ReadBuffer` slice that shares the same underlying native memory as the original buffer. No pixel data is copied during parsing. The headers are tiny (28 bytes total) and parsed by the generated codec — only the multi-megabyte pixel payload gets the zero-copy treatment.
 
+### Render in Compose Multiplatform (Skia)
+
+Use `nativeAddress` to create a Skia `Pixmap` that wraps the buffer's memory directly — no copy:
+
+```kotlin
+@Composable
+fun RiffBitmap(buffer: ReadBuffer, modifier: Modifier = Modifier) {
+    // Hold a reference to the decoded image so the backing buffer stays alive
+    val (imageBitmap, imageRef) = remember(buffer) {
+        val img = RiffImageDecoder.decode(buffer)
+        val w = img.metadata.width.toInt()
+        val h = img.metadata.height.toInt()
+
+        val nma = img.pixelData.nativeMemoryAccess
+            ?: error("Use BufferFactory.Default for zero-copy Skia rendering")
+
+        val info = ImageInfo(w, h, ColorType.RGBA_8888, ColorAlphaType.PREMUL)
+        // Zero-copy: Pixmap wraps the buffer's native memory directly
+        val pixmap = Pixmap(info, nma.nativeAddress, info.minRowBytes)
+        Image.makeFromPixmap(pixmap).toComposeImageBitmap() to img
+    }
+    Image(bitmap = imageBitmap, contentDescription = null, modifier = modifier)
+}
+```
+
+:::warning Buffer Lifetime
+`Pixmap` does not own the memory — it borrows the buffer's native address. The original buffer (or pool) must stay alive while the image is in use. In the example above, `imageRef` keeps the `RiffImage` (and its backing `ReadBuffer` slice) alive alongside the `ImageBitmap` inside `remember`.
+:::
+
 ### Render in Jetpack Compose (Android)
+
+For basic Android rendering, `toNativeData().byteBuffer` avoids an intermediate `ByteArray`:
 
 ```kotlin
 @Composable
@@ -685,29 +716,57 @@ fun RiffBitmap(buffer: ReadBuffer, modifier: Modifier = Modifier) {
         // toNativeData() is zero-copy when the source is already a Direct buffer
         val byteBuffer = img.pixelData.toNativeData().byteBuffer
         val bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
-        bitmap.copyPixelsFromBuffer(byteBuffer)
+        bitmap.copyPixelsFromBuffer(byteBuffer)  // 1 copy: DirectByteBuffer → Bitmap
         bitmap.asImageBitmap()
     }
     Image(bitmap = imageBitmap, contentDescription = null, modifier = modifier)
 }
 ```
 
-### Render in Compose Multiplatform (Skia)
+### Android GPU-Optimal: HardwareBuffer (API 26+)
+
+For the fastest path to the GPU, lock a `HardwareBuffer` and blit from the buffer's `nativeAddress` directly into GPU-accessible memory — one DMA-capable copy, no intermediate `Bitmap`:
 
 ```kotlin
 @Composable
-fun RiffBitmap(buffer: ReadBuffer, modifier: Modifier = Modifier) {
+fun RiffBitmapHw(buffer: ReadBuffer, modifier: Modifier = Modifier) {
     val imageBitmap = remember(buffer) {
         val img = RiffImageDecoder.decode(buffer)
         val w = img.metadata.width.toInt()
         val h = img.metadata.height.toInt()
 
-        val info = ImageInfo(w, h, ColorType.RGBA_8888, ColorAlphaType.PREMUL)
-        // toByteArray() copies once — Skia's makeRaster needs managed memory
-        val skiaImage = Image.makeRaster(info, img.pixelData.toByteArray(), info.minRowBytes)
-        skiaImage.toComposeImageBitmap()
+        val nma = img.pixelData.nativeMemoryAccess
+            ?: error("Use BufferFactory.Default for zero-copy HardwareBuffer rendering")
+
+        val hwBuffer = HardwareBuffer.create(
+            w, h, HardwareBuffer.RGBA_8888, 1,
+            HardwareBuffer.USAGE_GPU_SAMPLED_IMAGE or HardwareBuffer.USAGE_CPU_WRITE_OFTEN,
+        )
+        // 1 copy: buffer native address → GPU-mapped memory (via JNI)
+        NativeRenderer.blitToHardwareBuffer(nma.nativeAddress, nma.nativeSize, hwBuffer)
+
+        Bitmap.wrapHardwareBuffer(hwBuffer, ColorSpace.get(ColorSpace.Named.SRGB))!!
+            .asImageBitmap()
     }
     Image(bitmap = imageBitmap, contentDescription = null, modifier = modifier)
+}
+```
+
+The JNI helper locks the `HardwareBuffer` for CPU write and does a single `memcpy`:
+
+```c
+#include <android/hardware_buffer_jni.h>
+#include <string.h>
+
+JNIEXPORT void JNICALL
+Java_com_example_NativeRenderer_blitToHardwareBuffer(
+        JNIEnv *env, jclass clazz,
+        jlong src_addr, jlong src_size, jobject hw_buffer) {
+    AHardwareBuffer *ahb = AHardwareBuffer_fromHardwareBuffer(env, hw_buffer);
+    void *dst = NULL;
+    AHardwareBuffer_lock(ahb, AHARDWAREBUFFER_USAGE_CPU_WRITE_OFTEN, -1, NULL, &dst);
+    memcpy(dst, (void *)src_addr, (size_t)src_size);
+    AHardwareBuffer_unlock(ahb, NULL);
 }
 ```
 
@@ -743,14 +802,14 @@ fun encodeRiffImage(metadata: ImageMetadata, pixels: ReadBuffer): PlatformBuffer
 
 ### Copy Budget
 
-| Step | Android (Direct) | Skia |
-|------|------------------|------|
-| Parse headers (codec) | Zero-copy (reads in place) | Zero-copy |
-| Extract pixel slice (`readBytes`) | Zero-copy (same memory) | Zero-copy |
-| Handoff to renderer | Zero-copy (`toNativeData().byteBuffer`) | 1 copy (`toByteArray()`) |
-| **Total copies of pixel data** | **0** | **1** |
+| Step | Skia (`Pixmap`) | Android (`HardwareBuffer`) | Android (basic) | Naive (`ByteArray`) |
+|------|-----------------|---------------------------|-----------------|---------------------|
+| Parse headers (codec) | Zero-copy | Zero-copy | Zero-copy | Zero-copy |
+| Extract pixels (`readBytes`) | Zero-copy | Zero-copy | Zero-copy | 1 copy (`readByteArray`) |
+| Handoff to renderer | Zero-copy (`nativeAddress`) | 1 copy (→ GPU memory) | 1 copy (`copyPixelsFromBuffer`) | 1 copy (`wrap` + `copyPixels`) |
+| **Total copies of pixel data** | **0** | **1 (directly to GPU)** | **1** | **2** |
 
-Without the buffer library, the typical approach — `readByteArray()` → `ByteArray` → `ByteBuffer.wrap()` → `Bitmap` — copies pixel data **twice**.
+The Skia `Pixmap` path achieves **zero copies** — the GPU reads from the buffer's native memory at draw time. The `HardwareBuffer` path copies once but lands pixels directly in GPU-accessible memory, skipping the CPU-side `Bitmap` entirely.
 
 ---
 

--- a/docs/docs/recipes/protocol-codecs.md
+++ b/docs/docs/recipes/protocol-codecs.md
@@ -583,6 +583,177 @@ withPool { pool ->
 }
 ```
 
+## Real-World Example: Zero-Copy RIFF Image Decoder
+
+This example decodes a custom RIFF-like image container and renders the bitmap in Jetpack Compose — without copying pixel data during parsing.
+
+### Wire Format
+
+```
+┌────────────────────────────┐
+│ FileHeader    (12 bytes)   │  magic("RIFF") + fileSize + format("IMG ")
+├────────────────────────────┤
+│ ChunkHeader   (8 bytes)    │  chunkId("meta") + chunkSize
+│ ImageMetadata (variable)   │  width, height, depth, title
+├────────────────────────────┤
+│ ChunkHeader   (8 bytes)    │  chunkId("pxls") + chunkSize
+│ Raw pixel data             │  ← zero-copy slice, never copied during parse
+└────────────────────────────┘
+```
+
+### Define the Codec Types
+
+Use `@ProtocolMessage` for all structured headers. The binary pixel payload is **not** a codec field — it's extracted manually with `readBytes()` for zero-copy.
+
+```kotlin
+@ProtocolMessage
+data class FileHeader(
+    val magic: Int,       // "RIFF" = 0x52494646
+    val fileSize: UInt,   // total size after this field
+    val format: Int,      // "IMG " = 0x494D4720
+)
+
+@ProtocolMessage
+data class ChunkHeader(
+    val chunkId: Int,     // 4-byte ASCII chunk ID
+    val chunkSize: UInt,  // byte count of chunk data
+)
+
+@ProtocolMessage
+data class ImageMetadata(
+    val width: UInt,
+    val height: UInt,
+    val colorDepth: UShort,              // bits per pixel (32 = ARGB_8888)
+    @LengthPrefixed val title: String,
+)
+```
+
+:::tip Why not put pixel data in the codec?
+`@ProtocolMessage` fields must be primitives, strings, or codec-composed types — not raw byte blobs. For binary payloads:
+
+- **Hybrid (shown here)**: codec for headers, manual `readBytes()` for the blob — simplest approach
+- **Custom SPI annotation**: create a `@BinarySlice("sizeField")` annotation with a `CodecFieldProvider` that generates `readBytes()` calls — fully codec-managed, reusable across protocols (see [Custom Annotations (SPI)](#custom-annotations-spi))
+- **`@Payload` type parameter**: for payloads that have their own structure and codec, not for raw bytes
+:::
+
+### Decode with Zero-Copy Pixel Extraction
+
+```kotlin
+data class RiffImage(
+    val metadata: ImageMetadata,
+    val pixelData: ReadBuffer,  // zero-copy slice of the original buffer
+)
+
+object RiffImageDecoder {
+    private const val MAGIC_RIFF = 0x52494646  // "RIFF"
+    private const val FORMAT_IMG = 0x494D4720  // "IMG "
+    private const val CHUNK_META = 0x6D657461  // "meta"
+    private const val CHUNK_PXLS = 0x70786C73  // "pxls"
+
+    fun decode(buffer: ReadBuffer): RiffImage {
+        // Generated codecs parse the structured headers — type-safe, batch-optimized
+        val header = FileHeaderCodec.decode(buffer)
+        require(header.magic == MAGIC_RIFF && header.format == FORMAT_IMG)
+
+        val metaChunk = ChunkHeaderCodec.decode(buffer)
+        require(metaChunk.chunkId == CHUNK_META)
+        val metadata = ImageMetadataCodec.decode(buffer)
+
+        val pxlsChunk = ChunkHeaderCodec.decode(buffer)
+        require(pxlsChunk.chunkId == CHUNK_PXLS)
+
+        // Zero-copy: readBytes() returns a slice backed by the same memory
+        val pixelData = buffer.readBytes(pxlsChunk.chunkSize.toInt())
+
+        return RiffImage(metadata, pixelData)
+    }
+}
+```
+
+**What's zero-copy here:** `readBytes()` returns a `ReadBuffer` slice that shares the same underlying native memory as the original buffer. No pixel data is copied during parsing. The headers are tiny (28 bytes total) and parsed by the generated codec — only the multi-megabyte pixel payload gets the zero-copy treatment.
+
+### Render in Jetpack Compose (Android)
+
+```kotlin
+@Composable
+fun RiffBitmap(buffer: ReadBuffer, modifier: Modifier = Modifier) {
+    val imageBitmap = remember(buffer) {
+        val img = RiffImageDecoder.decode(buffer)
+        val w = img.metadata.width.toInt()
+        val h = img.metadata.height.toInt()
+
+        // toNativeData() is zero-copy when the source is already a Direct buffer
+        val byteBuffer = img.pixelData.toNativeData().byteBuffer
+        val bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+        bitmap.copyPixelsFromBuffer(byteBuffer)
+        bitmap.asImageBitmap()
+    }
+    Image(bitmap = imageBitmap, contentDescription = null, modifier = modifier)
+}
+```
+
+### Render in Compose Multiplatform (Skia)
+
+```kotlin
+@Composable
+fun RiffBitmap(buffer: ReadBuffer, modifier: Modifier = Modifier) {
+    val imageBitmap = remember(buffer) {
+        val img = RiffImageDecoder.decode(buffer)
+        val w = img.metadata.width.toInt()
+        val h = img.metadata.height.toInt()
+
+        val info = ImageInfo(w, h, ColorType.RGBA_8888, ColorAlphaType.PREMUL)
+        // toByteArray() copies once — Skia's makeRaster needs managed memory
+        val skiaImage = Image.makeRaster(info, img.pixelData.toByteArray(), info.minRowBytes)
+        skiaImage.toComposeImageBitmap()
+    }
+    Image(bitmap = imageBitmap, contentDescription = null, modifier = modifier)
+}
+```
+
+### Writing the Container
+
+```kotlin
+fun encodeRiffImage(metadata: ImageMetadata, pixels: ReadBuffer): PlatformBuffer {
+    val metadataSize = ImageMetadataCodec.sizeOf(metadata)!!
+    val pixelSize = pixels.remaining()
+    val totalSize = 4 + 8 + metadataSize + 8 + pixelSize  // format + 2 chunk headers + data
+
+    val buffer = BufferFactory.Default.allocate(12 + totalSize)
+
+    // File header
+    FileHeaderCodec.encode(buffer, FileHeader(
+        magic = 0x52494646,
+        fileSize = totalSize.toUInt(),
+        format = 0x494D4720,
+    ))
+
+    // Metadata chunk
+    ChunkHeaderCodec.encode(buffer, ChunkHeader(0x6D657461, metadataSize.toUInt()))
+    ImageMetadataCodec.encode(buffer, metadata)
+
+    // Pixel data chunk — bulk copy from source buffer
+    ChunkHeaderCodec.encode(buffer, ChunkHeader(0x70786C73, pixelSize.toUInt()))
+    buffer.write(pixels)
+
+    buffer.resetForRead()
+    return buffer
+}
+```
+
+### Copy Budget
+
+| Step | Android (Direct) | Skia |
+|------|------------------|------|
+| Parse headers (codec) | Zero-copy (reads in place) | Zero-copy |
+| Extract pixel slice (`readBytes`) | Zero-copy (same memory) | Zero-copy |
+| Handoff to renderer | Zero-copy (`toNativeData().byteBuffer`) | 1 copy (`toByteArray()`) |
+| **Total copies of pixel data** | **0** | **1** |
+
+Without the buffer library, the typical approach — `readByteArray()` → `ByteArray` → `ByteBuffer.wrap()` → `Bitmap` — copies pixel data **twice**.
+
+---
+
 ## Extension Functions Reference
 
 | Function | Description |


### PR DESCRIPTION
## Summary

- Updated all documentation to recommend `BufferFactory` over `PlatformBuffer.allocate()`/`PlatformBuffer.wrap()`
- Added "Best Practices" section to CLAUDE.md covering: factory-based allocation, protocol codecs for structured data, zero-copy patterns, and accepting factory as a parameter
- Updated Readme quick example and added tip callout steering users toward BufferFactory and codecs
- Updated MODULE.md to reference `BufferFactory` instead of legacy `AllocationZone`
- Updated Apple docs Swift interop example to use `BufferFactory`

## Why

AI tools consuming this library were defaulting to `PlatformBuffer.allocate()` and hand-writing `readInt()`/`writeInt()` sequences instead of using `BufferFactory` and `buffer-codec`. This causes unnecessary memory copies and misses factory composition (pooling, deterministic cleanup).

## Test plan

- [ ] Docs-only change — no code modified, CI should auto-skip release
- [ ] Verify rendered markdown on GitHub looks correct