### PR TITLE
Docs: prefer BufferFactory, add zero-copy RIFF codec example

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,6 +335,7 @@ data class MyMessage(
 
 - **Use `slice()` or `readBytes()`** instead of `readByteArray()` + `wrap()` for zero-copy views
 - **Use `toNativeData()`/`toMutableNativeData()`** for platform interop instead of converting to ByteArray first
+- **Use `BufferFactory.wrapNativeAddress()`** to write directly into externally-owned memory (HardwareBuffer, mmap, Skia surface) instead of copying through an intermediate buffer
 - **Use `writeString()` directly** instead of `payload.encodeToByteArray()` + `writeBytes()`
 - **Use `BufferPool`** in hot paths to reuse buffers instead of allocating per request
 - **Accept `ReadBuffer`/`WriteBuffer`** in function signatures, not `ByteArray`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,14 +274,96 @@ All new buffer-consuming code must be tested with wrapper types (see `WrapperTra
 
 ### Factory Pattern
 
-Buffers are created via factories:
+**Always use `BufferFactory` to create buffers** — never use `PlatformBuffer.allocate()` or `PlatformBuffer.wrap()` directly:
 ```kotlin
 BufferFactory.Default.allocate(size)                    // Native memory (platform-optimal)
+BufferFactory.Default.wrap(byteArray)                   // Wrap existing ByteArray (zero-copy)
 BufferFactory.managed().allocate(size)                  // Heap memory (ByteArray-backed)
 BufferFactory.shared().allocate(size)                   // Shared memory (Android IPC)
 BufferFactory.deterministic().allocate(size)             // Explicit cleanup via .use {}
-PlatformBuffer.allocate(size)                           // Shorthand for Default
-PlatformBuffer.wrap(byteArray)                          // Wrap existing ByteArray
+```
+
+Library code should accept `BufferFactory` as a parameter so callers control allocation:
+```kotlin
+class MyProtocol(private val factory: BufferFactory = BufferFactory.Default) {
+    fun encode(data: MyData): PlatformBuffer {
+        val buffer = factory.allocate(data.sizeOf())
+        // ...
+    }
+}
+```
+
+## Best Practices for Using This Library
+
+### Always Use `BufferFactory`, Not `PlatformBuffer`
+
+`BufferFactory` is the correct entry point for all buffer creation. Do NOT use `PlatformBuffer.allocate()` or `PlatformBuffer.wrap()` — these are legacy shortcuts that bypass factory composition (pooling, monitoring, deterministic cleanup).
+
+```kotlin
+// CORRECT
+val buffer = BufferFactory.Default.allocate(1024)
+val wrapped = BufferFactory.Default.wrap(byteArray)
+
+// WRONG — do not use these
+val buffer = PlatformBuffer.allocate(1024)
+val wrapped = PlatformBuffer.wrap(byteArray)
+```
+
+### Use Protocol Codecs for Structured Data
+
+For any structured binary data, use `buffer-codec` with `@ProtocolMessage` annotations instead of hand-writing `readInt()`/`writeInt()` sequences. Hand-written encode/decode is error-prone and doesn't guarantee round-trip correctness.
+
+```kotlin
+// WRONG — manual field-by-field serialization
+fun encode(buffer: WriteBuffer, msg: MyMessage) {
+    buffer.writeInt(msg.id)
+    buffer.writeShort(msg.type)
+    buffer.writeLengthPrefixedUtf8String(msg.payload)
+}
+
+// CORRECT — annotated data class, codec is generated
+@ProtocolMessage
+data class MyMessage(
+    val id: Int,
+    val type: Short,
+    @LengthPrefixed val payload: String,
+)
+// MyMessageCodec.encode(buffer, msg) — generated, type-safe, batch-optimized
+```
+
+### Avoid Unnecessary Memory Copies
+
+- **Use `slice()` or `readBytes()`** instead of `readByteArray()` + `wrap()` for zero-copy views
+- **Use `toNativeData()`/`toMutableNativeData()`** for platform interop instead of converting to ByteArray first
+- **Use `writeString()` directly** instead of `payload.encodeToByteArray()` + `writeBytes()`
+- **Use `BufferPool`** in hot paths to reuse buffers instead of allocating per request
+- **Accept `ReadBuffer`/`WriteBuffer`** in function signatures, not `ByteArray`
+
+```kotlin
+// WRONG — unnecessary copies
+val bytes = buffer.readByteArray(length)  // copy to ByteArray
+val newBuffer = BufferFactory.Default.wrap(bytes)  // wrap again
+processBytes(bytes)  // works on ByteArray instead of buffer
+
+// CORRECT — zero-copy
+val slice = buffer.readBytes(length)  // zero-copy slice
+processBuffer(slice)  // works directly on buffer
+```
+
+### Accept Factory as a Parameter in Library Code
+
+Library code should accept `BufferFactory` as a constructor parameter so callers control allocation strategy:
+
+```kotlin
+class ProtocolConnection(
+    private val factory: BufferFactory = BufferFactory.Default,
+) {
+    fun send(packet: Packet) {
+        factory.allocate(packet.sizeOf()).use { buffer ->
+            packet.writeTo(buffer)
+        }
+    }
+}
 ```
 
 ## Platform Notes
@@ -289,7 +371,7 @@ PlatformBuffer.wrap(byteArray)                          // Wrap existing ByteArr
 - **JVM/Android:** Direct ByteBuffers (`DirectJvmBuffer`) used by default; `HeapJvmBuffer` for `wrap()` and `BufferFactory.managed()`
 - **Android SharedMemory:** Use `BufferFactory.shared()` for zero-copy IPC via Parcelable (API 27+)
 - **Apple:** `MutableDataBuffer` wraps NSMutableData (native memory); `wrap(ByteArray)` returns `ByteArrayBuffer`
-- **Apple NSData interop:** Use `PlatformBuffer.wrap(nsData)` or `PlatformBuffer.wrap(nsMutableData)` for zero-copy Apple API interop
+- **Apple NSData interop:** Use `BufferFactory.Default.wrap(nsData)` or `BufferFactory.Default.wrap(nsMutableData)` for zero-copy Apple API interop
 - **JS SharedArrayBuffer:** Requires CORS headers (`Cross-Origin-Opener-Policy`, `Cross-Origin-Embedder-Policy`)
 - **WASM:** `LinearBuffer` (Direct) uses native WASM memory for JS interop; `ByteArrayBuffer` (Heap) for compute workloads
 - **Linux:** `NativeBuffer` (Direct) uses malloc/free for zero-copy io_uring I/O; `ByteArrayBuffer` (Heap) for managed memory

--- a/MODULE.md
+++ b/MODULE.md
@@ -8,7 +8,7 @@ Core buffer interfaces and implementations:
 - `PlatformBuffer` - Main buffer interface combining read/write operations
 - `ReadBuffer` - Read operations (relative and absolute)
 - `WriteBuffer` - Write operations (relative and absolute)
-- `AllocationZone` - Memory allocation strategy
+- `BufferFactory` - Memory allocation strategy: `Default` (native), `managed()` (heap), `shared()` (IPC), `deterministic()` (explicit cleanup)
 
 ## Package com.ditchoom.buffer.pool
 

--- a/Readme.md
+++ b/Readme.md
@@ -61,7 +61,7 @@ Find the latest version on [Maven Central](https://central.sonatype.com/artifact
 
 ```kotlin
 // Works identically on JVM, Android, iOS, macOS, Linux, JS, WASM
-val buffer = PlatformBuffer.allocate(1024)
+val buffer = BufferFactory.Default.allocate(1024)
 buffer.writeInt(42)
 buffer.writeString("Hello!")
 buffer.resetForRead()
@@ -70,9 +70,11 @@ val number = buffer.readInt()     // 42
 val text = buffer.readString(6)   // "Hello!"
 ```
 
-## Protocol Codecs
+> **Tip:** Always use `BufferFactory` to allocate buffers — not `PlatformBuffer.allocate()`. Factories compose with pooling, deterministic cleanup, and custom allocation strategies. For structured binary data, use [Protocol Codecs](#protocol-codecs--stop-hand-writing-parsers) instead of manual read/write sequences.
 
-Define a data class, annotate it, and the codec writes itself:
+## Protocol Codecs — Stop Hand-Writing Parsers
+
+For structured data, **always use `buffer-codec`** instead of manual `readInt()`/`writeInt()` sequences. Hand-written encode/decode is error-prone (field order mismatches, type mismatches) and doesn't guarantee round-trip correctness. Define a data class, annotate it, and the codec writes itself:
 
 ```kotlin
 @ProtocolMessage

--- a/docs/docs/platforms/apple.md
+++ b/docs/docs/platforms/apple.md
@@ -34,7 +34,7 @@ When exposing to Swift code:
 
 ```swift
 // In Swift
-let buffer = PlatformBuffer.companion.allocate(size: 1024)
+let buffer = BufferFactory.Default.allocate(size: 1024)
 buffer.writeInt(value: 42)
 buffer.resetForRead()
 let value = buffer.readInt()

--- a/docs/docs/recipes/protocol-codecs.md
+++ b/docs/docs/recipes/protocol-codecs.md
@@ -672,7 +672,38 @@ object RiffImageDecoder {
 
 **What's zero-copy here:** `readBytes()` returns a `ReadBuffer` slice that shares the same underlying native memory as the original buffer. No pixel data is copied during parsing. The headers are tiny (28 bytes total) and parsed by the generated codec — only the multi-megabyte pixel payload gets the zero-copy treatment.
 
+### Render in Compose Multiplatform (Skia)
+
+Use `nativeAddress` to create a Skia `Pixmap` that wraps the buffer's memory directly — no copy:
+
+```kotlin
+@Composable
+fun RiffBitmap(buffer: ReadBuffer, modifier: Modifier = Modifier) {
+    // Hold a reference to the decoded image so the backing buffer stays alive
+    val (imageBitmap, imageRef) = remember(buffer) {
+        val img = RiffImageDecoder.decode(buffer)
+        val w = img.metadata.width.toInt()
+        val h = img.metadata.height.toInt()
+
+        val nma = img.pixelData.nativeMemoryAccess
+            ?: error("Use BufferFactory.Default for zero-copy Skia rendering")
+
+        val info = ImageInfo(w, h, ColorType.RGBA_8888, ColorAlphaType.PREMUL)
+        // Zero-copy: Pixmap wraps the buffer's native memory directly
+        val pixmap = Pixmap(info, nma.nativeAddress, info.minRowBytes)
+        Image.makeFromPixmap(pixmap).toComposeImageBitmap() to img
+    }
+    Image(bitmap = imageBitmap, contentDescription = null, modifier = modifier)
+}
+```
+
+:::warning Buffer Lifetime
+`Pixmap` does not own the memory — it borrows the buffer's native address. The original buffer (or pool) must stay alive while the image is in use. In the example above, `imageRef` keeps the `RiffImage` (and its backing `ReadBuffer` slice) alive alongside the `ImageBitmap` inside `remember`.
+:::
+
 ### Render in Jetpack Compose (Android)
+
+For basic Android rendering, `toNativeData().byteBuffer` avoids an intermediate `ByteArray`:
 
 ```kotlin
 @Composable
@@ -685,29 +716,57 @@ fun RiffBitmap(buffer: ReadBuffer, modifier: Modifier = Modifier) {
         // toNativeData() is zero-copy when the source is already a Direct buffer
         val byteBuffer = img.pixelData.toNativeData().byteBuffer
         val bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
-        bitmap.copyPixelsFromBuffer(byteBuffer)
+        bitmap.copyPixelsFromBuffer(byteBuffer)  // 1 copy: DirectByteBuffer → Bitmap
         bitmap.asImageBitmap()
     }
     Image(bitmap = imageBitmap, contentDescription = null, modifier = modifier)
 }
 ```
 
-### Render in Compose Multiplatform (Skia)
+### Android GPU-Optimal: HardwareBuffer (API 26+)
+
+For the fastest path to the GPU, lock a `HardwareBuffer` and blit from the buffer's `nativeAddress` directly into GPU-accessible memory — one DMA-capable copy, no intermediate `Bitmap`:
 
 ```kotlin
 @Composable
-fun RiffBitmap(buffer: ReadBuffer, modifier: Modifier = Modifier) {
+fun RiffBitmapHw(buffer: ReadBuffer, modifier: Modifier = Modifier) {
     val imageBitmap = remember(buffer) {
         val img = RiffImageDecoder.decode(buffer)
         val w = img.metadata.width.toInt()
         val h = img.metadata.height.toInt()
 
-        val info = ImageInfo(w, h, ColorType.RGBA_8888, ColorAlphaType.PREMUL)
-        // toByteArray() copies once — Skia's makeRaster needs managed memory
-        val skiaImage = Image.makeRaster(info, img.pixelData.toByteArray(), info.minRowBytes)
-        skiaImage.toComposeImageBitmap()
+        val nma = img.pixelData.nativeMemoryAccess
+            ?: error("Use BufferFactory.Default for zero-copy HardwareBuffer rendering")
+
+        val hwBuffer = HardwareBuffer.create(
+            w, h, HardwareBuffer.RGBA_8888, 1,
+            HardwareBuffer.USAGE_GPU_SAMPLED_IMAGE or HardwareBuffer.USAGE_CPU_WRITE_OFTEN,
+        )
+        // 1 copy: buffer native address → GPU-mapped memory (via JNI)
+        NativeRenderer.blitToHardwareBuffer(nma.nativeAddress, nma.nativeSize, hwBuffer)
+
+        Bitmap.wrapHardwareBuffer(hwBuffer, ColorSpace.get(ColorSpace.Named.SRGB))!!
+            .asImageBitmap()
     }
     Image(bitmap = imageBitmap, contentDescription = null, modifier = modifier)
+}
+```
+
+The JNI helper locks the `HardwareBuffer` for CPU write and does a single `memcpy`:
+
+```c
+#include <android/hardware_buffer_jni.h>
+#include <string.h>
+
+JNIEXPORT void JNICALL
+Java_com_example_NativeRenderer_blitToHardwareBuffer(
+        JNIEnv *env, jclass clazz,
+        jlong src_addr, jlong src_size, jobject hw_buffer) {
+    AHardwareBuffer *ahb = AHardwareBuffer_fromHardwareBuffer(env, hw_buffer);
+    void *dst = NULL;
+    AHardwareBuffer_lock(ahb, AHARDWAREBUFFER_USAGE_CPU_WRITE_OFTEN, -1, NULL, &dst);
+    memcpy(dst, (void *)src_addr, (size_t)src_size);
+    AHardwareBuffer_unlock(ahb, NULL);
 }
 ```
 
@@ -743,14 +802,14 @@ fun encodeRiffImage(metadata: ImageMetadata, pixels: ReadBuffer): PlatformBuffer
 
 ### Copy Budget
 
-| Step | Android (Direct) | Skia |
-|------|------------------|------|
-| Parse headers (codec) | Zero-copy (reads in place) | Zero-copy |
-| Extract pixel slice (`readBytes`) | Zero-copy (same memory) | Zero-copy |
-| Handoff to renderer | Zero-copy (`toNativeData().byteBuffer`) | 1 copy (`toByteArray()`) |
-| **Total copies of pixel data** | **0** | **1** |
+| Step | Skia (`Pixmap`) | Android (`HardwareBuffer`) | Android (basic) | Naive (`ByteArray`) |
+|------|-----------------|---------------------------|-----------------|---------------------|
+| Parse headers (codec) | Zero-copy | Zero-copy | Zero-copy | Zero-copy |
+| Extract pixels (`readBytes`) | Zero-copy | Zero-copy | Zero-copy | 1 copy (`readByteArray`) |
+| Handoff to renderer | Zero-copy (`nativeAddress`) | 1 copy (→ GPU memory) | 1 copy (`copyPixelsFromBuffer`) | 1 copy (`wrap` + `copyPixels`) |
+| **Total copies of pixel data** | **0** | **1 (directly to GPU)** | **1** | **2** |
 
-Without the buffer library, the typical approach — `readByteArray()` → `ByteArray` → `ByteBuffer.wrap()` → `Bitmap` — copies pixel data **twice**.
+The Skia `Pixmap` path achieves **zero copies** — the GPU reads from the buffer's native memory at draw time. The `HardwareBuffer` path copies once but lands pixels directly in GPU-accessible memory, skipping the CPU-side `Bitmap` entirely.
 
 ---
 

--- a/docs/docs/recipes/protocol-codecs.md
+++ b/docs/docs/recipes/protocol-codecs.md
@@ -701,9 +701,9 @@ fun RiffBitmap(buffer: ReadBuffer, modifier: Modifier = Modifier) {
 `Pixmap` does not own the memory — it borrows the buffer's native address. The original buffer (or pool) must stay alive while the image is in use. In the example above, `imageRef` keeps the `RiffImage` (and its backing `ReadBuffer` slice) alive alongside the `ImageBitmap` inside `remember`.
 :::
 
-### Render in Jetpack Compose (Android)
+### Android: Decompress Directly into HardwareBuffer (API 26+)
 
-For basic Android rendering, `toNativeData().byteBuffer` avoids an intermediate `ByteArray`:
+For the fastest path to the GPU, lock a `HardwareBuffer`, wrap the locked pointer with `BufferFactory.wrapNativeAddress`, and decompress directly into GPU-accessible memory — zero intermediate buffers:
 
 ```kotlin
 @Composable
@@ -712,38 +712,26 @@ fun RiffBitmap(buffer: ReadBuffer, modifier: Modifier = Modifier) {
         val img = RiffImageDecoder.decode(buffer)
         val w = img.metadata.width.toInt()
         val h = img.metadata.height.toInt()
-
-        // toNativeData() is zero-copy when the source is already a Direct buffer
-        val byteBuffer = img.pixelData.toNativeData().byteBuffer
-        val bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
-        bitmap.copyPixelsFromBuffer(byteBuffer)  // 1 copy: DirectByteBuffer → Bitmap
-        bitmap.asImageBitmap()
-    }
-    Image(bitmap = imageBitmap, contentDescription = null, modifier = modifier)
-}
-```
-
-### Android GPU-Optimal: HardwareBuffer (API 26+)
-
-For the fastest path to the GPU, lock a `HardwareBuffer` and blit from the buffer's `nativeAddress` directly into GPU-accessible memory — one DMA-capable copy, no intermediate `Bitmap`:
-
-```kotlin
-@Composable
-fun RiffBitmapHw(buffer: ReadBuffer, modifier: Modifier = Modifier) {
-    val imageBitmap = remember(buffer) {
-        val img = RiffImageDecoder.decode(buffer)
-        val w = img.metadata.width.toInt()
-        val h = img.metadata.height.toInt()
-
-        val nma = img.pixelData.nativeMemoryAccess
-            ?: error("Use BufferFactory.Default for zero-copy HardwareBuffer rendering")
+        val pixelSize = w * h * 4
 
         val hwBuffer = HardwareBuffer.create(
             w, h, HardwareBuffer.RGBA_8888, 1,
             HardwareBuffer.USAGE_GPU_SAMPLED_IMAGE or HardwareBuffer.USAGE_CPU_WRITE_OFTEN,
         )
-        // 1 copy: buffer native address → GPU-mapped memory (via JNI)
-        NativeRenderer.blitToHardwareBuffer(nma.nativeAddress, nma.nativeSize, hwBuffer)
+
+        // Lock HardwareBuffer → get GPU-mapped memory address (JNI)
+        val gpuAddr = NativeRenderer.lockHardwareBuffer(hwBuffer)
+
+        // Wrap the GPU memory as a PlatformBuffer — zero-copy, non-owning
+        val dst = BufferFactory.wrapNativeAddress(gpuAddr, pixelSize)
+
+        // Decompress directly from source buffer into GPU memory
+        StreamingDecompressor.create(CompressionAlgorithm.Raw).use(
+            onOutput = { chunk -> dst.write(chunk) }
+        ) { decompress -> decompress(img.pixelData) }
+
+        // Unlock → pixels are in GPU memory, ready to render
+        NativeRenderer.unlockHardwareBuffer(hwBuffer)
 
         Bitmap.wrapHardwareBuffer(hwBuffer, ColorSpace.get(ColorSpace.Named.SRGB))!!
             .asImageBitmap()
@@ -752,20 +740,22 @@ fun RiffBitmapHw(buffer: ReadBuffer, modifier: Modifier = Modifier) {
 }
 ```
 
-The JNI helper locks the `HardwareBuffer` for CPU write and does a single `memcpy`:
+The JNI helper is just lock/unlock — two small functions:
 
 ```c
 #include <android/hardware_buffer_jni.h>
-#include <string.h>
 
-JNIEXPORT void JNICALL
-Java_com_example_NativeRenderer_blitToHardwareBuffer(
-        JNIEnv *env, jclass clazz,
-        jlong src_addr, jlong src_size, jobject hw_buffer) {
+JNIEXPORT jlong JNICALL
+Java_com_example_NativeRenderer_lockHardwareBuffer(JNIEnv *env, jclass clazz, jobject hw_buffer) {
     AHardwareBuffer *ahb = AHardwareBuffer_fromHardwareBuffer(env, hw_buffer);
     void *dst = NULL;
     AHardwareBuffer_lock(ahb, AHARDWAREBUFFER_USAGE_CPU_WRITE_OFTEN, -1, NULL, &dst);
-    memcpy(dst, (void *)src_addr, (size_t)src_size);
+    return (jlong)dst;
+}
+
+JNIEXPORT void JNICALL
+Java_com_example_NativeRenderer_unlockHardwareBuffer(JNIEnv *env, jclass clazz, jobject hw_buffer) {
+    AHardwareBuffer *ahb = AHardwareBuffer_fromHardwareBuffer(env, hw_buffer);
     AHardwareBuffer_unlock(ahb, NULL);
 }
 ```
@@ -802,14 +792,15 @@ fun encodeRiffImage(metadata: ImageMetadata, pixels: ReadBuffer): PlatformBuffer
 
 ### Copy Budget
 
-| Step | Skia (`Pixmap`) | Android (`HardwareBuffer`) | Android (basic) | Naive (`ByteArray`) |
-|------|-----------------|---------------------------|-----------------|---------------------|
-| Parse headers (codec) | Zero-copy | Zero-copy | Zero-copy | Zero-copy |
-| Extract pixels (`readBytes`) | Zero-copy | Zero-copy | Zero-copy | 1 copy (`readByteArray`) |
-| Handoff to renderer | Zero-copy (`nativeAddress`) | 1 copy (→ GPU memory) | 1 copy (`copyPixelsFromBuffer`) | 1 copy (`wrap` + `copyPixels`) |
-| **Total copies of pixel data** | **0** | **1 (directly to GPU)** | **1** | **2** |
+| Step | Skia (`Pixmap`) | Android (`HardwareBuffer` + `wrapNativeAddress`) | Naive (`ByteArray`) |
+|------|-----------------|--------------------------------------------------|---------------------|
+| Parse headers (codec) | Zero-copy | Zero-copy | Zero-copy |
+| Extract compressed data (`readBytes`) | Zero-copy (slice) | Zero-copy (slice) | 1 copy (`readByteArray`) |
+| Decompress | → Direct buffer | → GPU memory (`wrapNativeAddress`) | → `ByteArray` |
+| Render | Zero-copy (`Pixmap` borrows memory) | Zero-copy (GPU reads `HardwareBuffer`) | 1 copy (`wrap` + `copyPixels`) |
+| **Intermediate copies** | **0** | **0** | **2** |
 
-The Skia `Pixmap` path achieves **zero copies** — the GPU reads from the buffer's native memory at draw time. The `HardwareBuffer` path copies once but lands pixels directly in GPU-accessible memory, skipping the CPU-side `Bitmap` entirely.
+Both the Skia and HardwareBuffer paths achieve **zero intermediate copies** of pixel data. Decompressed pixels exist in exactly one place — either the Skia-wrapped Direct buffer or the GPU-mapped HardwareBuffer memory. `BufferFactory.wrapNativeAddress` is what makes the HardwareBuffer path possible from pure Kotlin.
 
 ---
 

--- a/docs/docs/recipes/protocol-codecs.md
+++ b/docs/docs/recipes/protocol-codecs.md
@@ -583,6 +583,177 @@ withPool { pool ->
 }
 ```
 
+## Real-World Example: Zero-Copy RIFF Image Decoder
+
+This example decodes a custom RIFF-like image container and renders the bitmap in Jetpack Compose — without copying pixel data during parsing.
+
+### Wire Format
+
+```
+┌────────────────────────────┐
+│ FileHeader    (12 bytes)   │  magic("RIFF") + fileSize + format("IMG ")
+├────────────────────────────┤
+│ ChunkHeader   (8 bytes)    │  chunkId("meta") + chunkSize
+│ ImageMetadata (variable)   │  width, height, depth, title
+├────────────────────────────┤
+│ ChunkHeader   (8 bytes)    │  chunkId("pxls") + chunkSize
+│ Raw pixel data             │  ← zero-copy slice, never copied during parse
+└────────────────────────────┘
+```
+
+### Define the Codec Types
+
+Use `@ProtocolMessage` for all structured headers. The binary pixel payload is **not** a codec field — it's extracted manually with `readBytes()` for zero-copy.
+
+```kotlin
+@ProtocolMessage
+data class FileHeader(
+    val magic: Int,       // "RIFF" = 0x52494646
+    val fileSize: UInt,   // total size after this field
+    val format: Int,      // "IMG " = 0x494D4720
+)
+
+@ProtocolMessage
+data class ChunkHeader(
+    val chunkId: Int,     // 4-byte ASCII chunk ID
+    val chunkSize: UInt,  // byte count of chunk data
+)
+
+@ProtocolMessage
+data class ImageMetadata(
+    val width: UInt,
+    val height: UInt,
+    val colorDepth: UShort,              // bits per pixel (32 = ARGB_8888)
+    @LengthPrefixed val title: String,
+)
+```
+
+:::tip Why not put pixel data in the codec?
+`@ProtocolMessage` fields must be primitives, strings, or codec-composed types — not raw byte blobs. For binary payloads:
+
+- **Hybrid (shown here)**: codec for headers, manual `readBytes()` for the blob — simplest approach
+- **Custom SPI annotation**: create a `@BinarySlice("sizeField")` annotation with a `CodecFieldProvider` that generates `readBytes()` calls — fully codec-managed, reusable across protocols (see [Custom Annotations (SPI)](#custom-annotations-spi))
+- **`@Payload` type parameter**: for payloads that have their own structure and codec, not for raw bytes
+:::
+
+### Decode with Zero-Copy Pixel Extraction
+
+```kotlin
+data class RiffImage(
+    val metadata: ImageMetadata,
+    val pixelData: ReadBuffer,  // zero-copy slice of the original buffer
+)
+
+object RiffImageDecoder {
+    private const val MAGIC_RIFF = 0x52494646  // "RIFF"
+    private const val FORMAT_IMG = 0x494D4720  // "IMG "
+    private const val CHUNK_META = 0x6D657461  // "meta"
+    private const val CHUNK_PXLS = 0x70786C73  // "pxls"
+
+    fun decode(buffer: ReadBuffer): RiffImage {
+        // Generated codecs parse the structured headers — type-safe, batch-optimized
+        val header = FileHeaderCodec.decode(buffer)
+        require(header.magic == MAGIC_RIFF && header.format == FORMAT_IMG)
+
+        val metaChunk = ChunkHeaderCodec.decode(buffer)
+        require(metaChunk.chunkId == CHUNK_META)
+        val metadata = ImageMetadataCodec.decode(buffer)
+
+        val pxlsChunk = ChunkHeaderCodec.decode(buffer)
+        require(pxlsChunk.chunkId == CHUNK_PXLS)
+
+        // Zero-copy: readBytes() returns a slice backed by the same memory
+        val pixelData = buffer.readBytes(pxlsChunk.chunkSize.toInt())
+
+        return RiffImage(metadata, pixelData)
+    }
+}
+```
+
+**What's zero-copy here:** `readBytes()` returns a `ReadBuffer` slice that shares the same underlying native memory as the original buffer. No pixel data is copied during parsing. The headers are tiny (28 bytes total) and parsed by the generated codec — only the multi-megabyte pixel payload gets the zero-copy treatment.
+
+### Render in Jetpack Compose (Android)
+
+```kotlin
+@Composable
+fun RiffBitmap(buffer: ReadBuffer, modifier: Modifier = Modifier) {
+    val imageBitmap = remember(buffer) {
+        val img = RiffImageDecoder.decode(buffer)
+        val w = img.metadata.width.toInt()
+        val h = img.metadata.height.toInt()
+
+        // toNativeData() is zero-copy when the source is already a Direct buffer
+        val byteBuffer = img.pixelData.toNativeData().byteBuffer
+        val bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+        bitmap.copyPixelsFromBuffer(byteBuffer)
+        bitmap.asImageBitmap()
+    }
+    Image(bitmap = imageBitmap, contentDescription = null, modifier = modifier)
+}
+```
+
+### Render in Compose Multiplatform (Skia)
+
+```kotlin
+@Composable
+fun RiffBitmap(buffer: ReadBuffer, modifier: Modifier = Modifier) {
+    val imageBitmap = remember(buffer) {
+        val img = RiffImageDecoder.decode(buffer)
+        val w = img.metadata.width.toInt()
+        val h = img.metadata.height.toInt()
+
+        val info = ImageInfo(w, h, ColorType.RGBA_8888, ColorAlphaType.PREMUL)
+        // toByteArray() copies once — Skia's makeRaster needs managed memory
+        val skiaImage = Image.makeRaster(info, img.pixelData.toByteArray(), info.minRowBytes)
+        skiaImage.toComposeImageBitmap()
+    }
+    Image(bitmap = imageBitmap, contentDescription = null, modifier = modifier)
+}
+```
+
+### Writing the Container
+
+```kotlin
+fun encodeRiffImage(metadata: ImageMetadata, pixels: ReadBuffer): PlatformBuffer {
+    val metadataSize = ImageMetadataCodec.sizeOf(metadata)!!
+    val pixelSize = pixels.remaining()
+    val totalSize = 4 + 8 + metadataSize + 8 + pixelSize  // format + 2 chunk headers + data
+
+    val buffer = BufferFactory.Default.allocate(12 + totalSize)
+
+    // File header
+    FileHeaderCodec.encode(buffer, FileHeader(
+        magic = 0x52494646,
+        fileSize = totalSize.toUInt(),
+        format = 0x494D4720,
+    ))
+
+    // Metadata chunk
+    ChunkHeaderCodec.encode(buffer, ChunkHeader(0x6D657461, metadataSize.toUInt()))
+    ImageMetadataCodec.encode(buffer, metadata)
+
+    // Pixel data chunk — bulk copy from source buffer
+    ChunkHeaderCodec.encode(buffer, ChunkHeader(0x70786C73, pixelSize.toUInt()))
+    buffer.write(pixels)
+
+    buffer.resetForRead()
+    return buffer
+}
+```
+
+### Copy Budget
+
+| Step | Android (Direct) | Skia |
+|------|------------------|------|
+| Parse headers (codec) | Zero-copy (reads in place) | Zero-copy |
+| Extract pixel slice (`readBytes`) | Zero-copy (same memory) | Zero-copy |
+| Handoff to renderer | Zero-copy (`toNativeData().byteBuffer`) | 1 copy (`toByteArray()`) |
+| **Total copies of pixel data** | **0** | **1** |
+
+Without the buffer library, the typical approach — `readByteArray()` → `ByteArray` → `ByteBuffer.wrap()` → `Bitmap` — copies pixel data **twice**.
+
+---
+
 ## Extension Functions Reference
 
 | Function | Description |

--- a/docs/docs/recipes/protocol-codecs.md
+++ b/docs/docs/recipes/protocol-codecs.md
@@ -133,9 +133,9 @@ DeviceReportCodec.testRoundTrip(report, expectedBytes = wireBytes)
 
 ## Annotation Reference
 
-### `@LengthPrefixed` — Length-Prefixed Strings
+### `@LengthPrefixed` — Length-Prefixed Data
 
-Reads/writes a string with a byte-length prefix. Default is 2-byte big-endian.
+Reads/writes a length prefix followed by that many bytes. Works on both `String` fields and `@Payload` type parameters. Default is 2-byte big-endian prefix.
 
 ```kotlin
 @ProtocolMessage
@@ -144,11 +144,19 @@ data class GreetingMessage(
     @LengthPrefixed(LengthPrefix.Byte) val nickname: String,   // 1-byte prefix (max 255 bytes)
     @LengthPrefixed(LengthPrefix.Int) val bio: String,         // 4-byte prefix
 )
+
+// Also works with @Payload — the codec reads the prefix, then passes
+// that many bytes to the caller's decode lambda
+@ProtocolMessage
+data class TlvMessage<@Payload P>(
+    val tag: UByte,
+    @LengthPrefixed val value: P,  // 2-byte length prefix + payload bytes
+)
 ```
 
 ### `@RemainingBytes` — Consume Remaining Bytes
 
-Reads all remaining bytes as a UTF-8 string. Must be the last constructor parameter.
+Reads all remaining bytes as a UTF-8 string (or passes them to a `@Payload` decode lambda). Must be the last constructor parameter.
 
 ```kotlin
 @ProtocolMessage
@@ -156,11 +164,18 @@ data class LogEntry(
     val level: UByte,
     @RemainingBytes val message: String,  // reads everything after level byte
 )
+
+// With @Payload — all remaining bytes are passed to the decode lambda
+@ProtocolMessage
+data class RawPacket<@Payload P>(
+    val header: UInt,
+    @RemainingBytes val body: P,
+)
 ```
 
 ### `@LengthFrom("field")` — Length from Preceding Field
 
-The string's byte length is determined by a preceding numeric field instead of a prefix in the wire format.
+The byte length is determined by a preceding numeric field instead of a prefix in the wire format. Works on both `String` fields and `@Payload` type parameters.
 
 ```kotlin
 @ProtocolMessage
@@ -168,6 +183,15 @@ data class NamedRecord(
     val nameLength: UShort,
     @LengthFrom("nameLength") val name: String,  // reads nameLength bytes as UTF-8
     val value: Int,
+)
+
+// With @Payload — reads bitmapLength bytes and passes to decode lambda
+@ProtocolMessage
+data class ImageFrame<@Payload P>(
+    val width: UShort,
+    val height: UShort,
+    val bitmapLength: Int,
+    @LengthFrom("bitmapLength") val bitmap: P,
 )
 ```
 

--- a/docs/docs/recipes/protocol-codecs.md
+++ b/docs/docs/recipes/protocol-codecs.md
@@ -209,6 +209,45 @@ data class CompactHeader(
 
 Only applies to integer types. Not allowed on `Float`, `Double`, or `Boolean`.
 
+### `@UseCodec(codec)` — Custom Codec Reference
+
+Delegates field encoding/decoding to an existing `Codec` object, without needing an SPI module. The referenced codec must be a Kotlin `object` implementing `Codec<T>`.
+
+**Without a length annotation** — the codec reads directly from the buffer:
+
+```kotlin
+object RgbCodec : Codec<Rgb> {
+    override fun decode(buffer: ReadBuffer) = Rgb(
+        buffer.readUnsignedByte(), buffer.readUnsignedByte(), buffer.readUnsignedByte()
+    )
+    override fun encode(buffer: WriteBuffer, value: Rgb) {
+        buffer.writeUByte(value.r); buffer.writeUByte(value.g); buffer.writeUByte(value.b)
+    }
+    override fun sizeOf(value: Rgb) = 3
+}
+
+@ProtocolMessage
+data class ColoredPoint(
+    val x: Int,
+    val y: Int,
+    @UseCodec(RgbCodec::class) val color: Rgb,
+)
+// Generated: val color = RgbCodec.decode(buffer)
+```
+
+**With a length annotation** — the codec receives a size-limited slice:
+
+```kotlin
+@ProtocolMessage
+data class ImageFrame(
+    val bitmapLength: Int,
+    @UseCodec(PngBitmapCodec::class) @LengthFrom("bitmapLength") val bitmap: ImageBitmap,
+)
+// Generated: val bitmap = PngBitmapCodec.decode(buffer.readBytes(bitmapLength))
+```
+
+Composes with `@LengthPrefixed`, `@RemainingBytes`, and `@LengthFrom`. This replaces the SPI `CodecFieldProvider` approach for most use cases — no extra Gradle module, no META-INF/services, no ServiceLoader.
+
 ### `@WhenTrue("expression")` — Conditional Fields
 
 A field that is only present on the wire when a preceding Boolean field is `true`. The annotated field must be nullable with a default of `null`.


### PR DESCRIPTION
## Summary

- Updated all docs to recommend `BufferFactory` over `PlatformBuffer.allocate()`/`wrap()`
- Added "Best Practices" section to CLAUDE.md: factory-based allocation, codec usage, zero-copy patterns
- Added real-world RIFF image decoder example to protocol codecs guide showing codec headers + zero-copy pixel extraction into Skia Pixmap and Android HardwareBuffer

## Why

AI tools consuming this library were defaulting to `PlatformBuffer.allocate()` and hand-writing `readInt()`/`writeInt()` sequences instead of using `BufferFactory` and `buffer-codec`.

## Test plan

- [ ] Docs-only change — CI should auto-skip release
- [ ] Verify rendered markdown on GitHub