### PR TITLE
Support @ProtocolMessage on data object, nested length annotations, and @RemainingBytes trailer

### DIFF
--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecGenerator.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecGenerator.kt
@@ -3,6 +3,7 @@ package com.ditchoom.buffer.codec.processor
 import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.Dependencies
 import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
@@ -38,11 +39,12 @@ class CodecGenerator(
                 Dependencies(aggregating = false)
             }
 
+        val isObject = classDeclaration.classKind == ClassKind.OBJECT
         val fileSpec =
             if (hasPayload) {
                 buildPayloadCodecFile(packageName, classTypeName, codecName, fields, batches)
             } else {
-                buildCodecFile(packageName, classTypeName, codecName, fields, batches)
+                buildCodecFile(packageName, classTypeName, codecName, fields, batches, isObject)
             }
 
         fileSpec.writeTo(codeGenerator, dependencies)
@@ -56,6 +58,7 @@ class CodecGenerator(
         codecName: String,
         fields: List<FieldInfo>,
         batches: List<CodegenItem>,
+        isObject: Boolean = false,
     ): FileSpec {
         val objectBuilder =
             TypeSpec
@@ -76,8 +79,12 @@ class CodecGenerator(
                 }
             }
         }
-        val fieldNames = fields.joinToString(", ") { it.name }
-        decodeBody.addStatement("return %T(%L)", classTypeName, fieldNames)
+        if (isObject) {
+            decodeBody.addStatement("return %T", classTypeName)
+        } else {
+            val fieldNames = fields.joinToString(", ") { it.name }
+            decodeBody.addStatement("return %T(%L)", classTypeName, fieldNames)
+        }
 
         objectBuilder.addFunction(
             FunSpec

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/FieldAnalyzer.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/FieldAnalyzer.kt
@@ -49,7 +49,14 @@ sealed class LengthKind {
         val prefix: String,
     ) : LengthKind()
 
-    data object Remaining : LengthKind()
+    /**
+     * Consume remaining bytes for this field, reserving [trailingBytes] at the end for fields
+     * that follow. The processor sets [trailingBytes] automatically when fixed-size trailing
+     * fields follow a @RemainingBytes field; users don't specify it directly.
+     */
+    data class Remaining(
+        val trailingBytes: Int = 0,
+    ) : LengthKind()
 
     data class FromField(
         val field: String,
@@ -171,7 +178,9 @@ sealed class FieldReadStrategy {
         val prefix: String,
     ) : FieldReadStrategy()
 
-    data object RemainingBytesStringField : FieldReadStrategy()
+    data class RemainingBytesStringField(
+        val trailingBytes: Int = 0,
+    ) : FieldReadStrategy()
 
     data class LengthFromStringField(
         val field: String,
@@ -185,6 +194,17 @@ sealed class FieldReadStrategy {
 
     data class NestedMessageField(
         val codecName: String,
+    ) : FieldReadStrategy()
+
+    /**
+     * Nested @ProtocolMessage field bounded by a length annotation. Decoding slices the buffer
+     * to the length before invoking the nested codec, so a variable-size payload can be wrapped
+     * inside a framed region that also carries trailing fields (e.g., checksum) in a separate
+     * @ProtocolMessage wrapper.
+     */
+    data class NestedMessageWithLengthField(
+        val codecName: String,
+        val lengthKind: LengthKind,
     ) : FieldReadStrategy()
 
     data class PayloadField(
@@ -340,7 +360,8 @@ class FieldAnalyzer(
             fields.filter {
                 it.strategy is FieldReadStrategy.RemainingBytesStringField ||
                     (it.strategy is FieldReadStrategy.PayloadField && it.strategy.lengthKind is LengthKind.Remaining) ||
-                    (it.strategy is FieldReadStrategy.CollectionField && it.strategy.lengthKind is LengthKind.Remaining)
+                    (it.strategy is FieldReadStrategy.CollectionField && it.strategy.lengthKind is LengthKind.Remaining) ||
+                    (it.strategy is FieldReadStrategy.NestedMessageWithLengthField && it.strategy.lengthKind is LengthKind.Remaining)
             }
         if (remainingBytesFields.size > 1) {
             val names = remainingBytesFields.joinToString(", ") { "'${it.name}'" }
@@ -356,14 +377,39 @@ class FieldAnalyzer(
         if (remainingBytesFields.size == 1) {
             val rbField = remainingBytesFields.first()
             if (rbField != nonConditionalFields.lastOrNull()) {
-                val lastField = nonConditionalFields.lastOrNull()?.name ?: "the last field"
-                logger.error(
-                    "@RemainingBytes on '${rbField.name}' is invalid — it must be the last non-conditional field. " +
-                        "Currently '$lastField' comes after it. " +
-                        "Move '${rbField.name}' to the end, or use @LengthPrefixed instead.",
-                    rbField.parameter,
-                )
-                return null
+                // Allow trailing fields if each has a fixed wire size. Sum the trailer and
+                // rewrite the @RemainingBytes strategy to reserve those bytes on decode.
+                val rbIndex = fields.indexOf(rbField)
+                val trailingFields = fields.subList(rbIndex + 1, fields.size)
+                var trailingSize = 0
+                for (t in trailingFields) {
+                    if (t.condition != null) {
+                        logger.error(
+                            "@RemainingBytes on '${rbField.name}' is followed by conditional field '${t.name}'. " +
+                                "Conditional fields have variable wire size — they cannot be reserved automatically. " +
+                                "Move '${t.name}' before the @RemainingBytes field, " +
+                                "or wrap the payload in a length-prefixed @ProtocolMessage.",
+                            rbField.parameter,
+                        )
+                        return null
+                    }
+                    val size = fixedWireSize(t.strategy)
+                    if (size == null) {
+                        logger.error(
+                            "@RemainingBytes on '${rbField.name}' is followed by '${t.name}', which has a variable " +
+                                "wire size. Only fields with a fixed wire size (primitives, value classes wrapping " +
+                                "primitives, fixed custom fields) may follow @RemainingBytes. " +
+                                "Move '${t.name}' before the @RemainingBytes field, " +
+                                "or wrap the payload in a length-prefixed @ProtocolMessage.",
+                            rbField.parameter,
+                        )
+                        return null
+                    }
+                    trailingSize += size
+                }
+                val updated = rewriteRemainingStrategy(rbField.strategy, trailingSize)
+                val idx = fields.indexOf(rbField)
+                fields[idx] = rbField.copy(strategy = updated)
             }
         }
 
@@ -378,6 +424,10 @@ class FieldAnalyzer(
                         if (lk is LengthKind.FromField) lk.field else null
                     }
                     is FieldReadStrategy.CollectionField -> {
+                        val lk = strategy.lengthKind
+                        if (lk is LengthKind.FromField) lk.field else null
+                    }
+                    is FieldReadStrategy.NestedMessageWithLengthField -> {
                         val lk = strategy.lengthKind
                         if (lk is LengthKind.FromField) lk.field else null
                     }
@@ -464,6 +514,38 @@ class FieldAnalyzer(
 
     private fun isNumericStrategy(strategy: FieldReadStrategy): Boolean =
         strategy is FieldReadStrategy.PrimitiveField && strategy.primitive.isNumeric
+
+    /**
+     * Returns the fixed wire size in bytes, or null if the strategy's size is not statically
+     * known. Used to validate trailing fields after a @RemainingBytes field and sum the
+     * reservation.
+     */
+    private fun fixedWireSize(strategy: FieldReadStrategy): Int? =
+        when (strategy) {
+            is FieldReadStrategy.PrimitiveField -> strategy.wireBytes
+            is FieldReadStrategy.ValueClassField -> fixedWireSize(strategy.innerStrategy)
+            is FieldReadStrategy.Custom ->
+                strategy.descriptor.fixedSize.takeIf { it >= 0 }
+            else -> null
+        }
+
+    private fun rewriteRemainingStrategy(
+        strategy: FieldReadStrategy,
+        trailingBytes: Int,
+    ): FieldReadStrategy =
+        when (strategy) {
+            is FieldReadStrategy.RemainingBytesStringField ->
+                FieldReadStrategy.RemainingBytesStringField(trailingBytes)
+            is FieldReadStrategy.PayloadField ->
+                strategy.copy(lengthKind = LengthKind.Remaining(trailingBytes))
+            is FieldReadStrategy.CollectionField ->
+                strategy.copy(lengthKind = LengthKind.Remaining(trailingBytes))
+            is FieldReadStrategy.NestedMessageWithLengthField ->
+                strategy.copy(lengthKind = LengthKind.Remaining(trailingBytes))
+            is FieldReadStrategy.UseCodecField ->
+                strategy.copy(lengthKind = LengthKind.Remaining(trailingBytes))
+            else -> strategy
+        }
 
     private fun extractCondition(param: KSValueParameter): FieldCondition? {
         for (annotation in param.annotations) {
@@ -601,7 +683,7 @@ class FieldAnalyzer(
                 ?: return null
         return when (lk) {
             is LengthKind.Prefixed -> FieldReadStrategy.LengthPrefixedStringField(lk.prefix)
-            is LengthKind.Remaining -> FieldReadStrategy.RemainingBytesStringField
+            is LengthKind.Remaining -> FieldReadStrategy.RemainingBytesStringField()
             is LengthKind.FromField -> FieldReadStrategy.LengthFromStringField(lk.field)
         }
     }
@@ -672,11 +754,43 @@ class FieldAnalyzer(
             val qualifiedName = typeDecl.qualifiedName?.asString()
             val dispatchInfo = currentDispatchOnInfo
             if (dispatchInfo != null && qualifiedName != null && qualifiedName == dispatchInfo.typeName) {
+                // Reject length annotations on discriminator fields — they don't consume wire bytes here.
+                val annotations = param.annotations.toList()
+                val lengthAnn =
+                    annotations.find {
+                        val fqn = it.qualifiedName()
+                        fqn == "com.ditchoom.buffer.codec.annotations.LengthFrom" ||
+                            fqn == "com.ditchoom.buffer.codec.annotations.LengthPrefixed" ||
+                            fqn == "com.ditchoom.buffer.codec.annotations.RemainingBytes"
+                    }
+                if (lengthAnn != null) {
+                    val annShort = lengthAnn.qualifiedName()?.substringAfterLast(".") ?: "length annotation"
+                    logger.error(
+                        "@$annShort is not valid on field '$fieldName': this field is the @DispatchOn " +
+                            "discriminator and is populated from decode context, not read from the wire.",
+                        param,
+                    )
+                    return null
+                }
                 return FieldReadStrategy.DiscriminatorField(
                     codecName,
                     dispatchInfo.sealedPackage,
                     dispatchInfo.sealedCodecSimpleName,
                 )
+            }
+
+            // If a length annotation is present, bound the nested decode to that byte count.
+            val annotations = param.annotations.toList()
+            val hasLengthAnnotation =
+                annotations.any {
+                    val fqn = it.qualifiedName()
+                    fqn == "com.ditchoom.buffer.codec.annotations.LengthFrom" ||
+                        fqn == "com.ditchoom.buffer.codec.annotations.LengthPrefixed" ||
+                        fqn == "com.ditchoom.buffer.codec.annotations.RemainingBytes"
+                }
+            if (hasLengthAnnotation) {
+                val lk = resolveLengthKind(param, annotations, fieldName, "Nested @ProtocolMessage") ?: return null
+                return FieldReadStrategy.NestedMessageWithLengthField(codecName, lk)
             }
             return FieldReadStrategy.NestedMessageField(codecName)
         }
@@ -863,7 +977,7 @@ class FieldAnalyzer(
         }
 
         if (remainingBytes != null) {
-            return LengthKind.Remaining
+            return LengthKind.Remaining()
         }
 
         if (lengthFrom != null) {

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/FieldCodeEmitter.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/FieldCodeEmitter.kt
@@ -45,7 +45,12 @@ internal fun readExpression(
                 "run { val _len = $lenExpr; buffer.readString(_len) }"
             }
         }
-        is FieldReadStrategy.RemainingBytesStringField -> "buffer.readString(buffer.remaining())"
+        is FieldReadStrategy.RemainingBytesStringField ->
+            if (strategy.trailingBytes > 0) {
+                "buffer.readString(buffer.remaining() - ${strategy.trailingBytes})"
+            } else {
+                "buffer.readString(buffer.remaining())"
+            }
         is FieldReadStrategy.LengthFromStringField -> "buffer.readString(${strategy.field}.toInt())"
         is FieldReadStrategy.ValueClassField -> {
             val inner = readExpression(strategy.innerStrategy, withContext, byteOrderOverride)
@@ -55,6 +60,7 @@ internal fun readExpression(
             val ctxArg = if (withContext) ", context" else ""
             "${strategy.codecName}.decode(buffer$ctxArg)"
         }
+        is FieldReadStrategy.NestedMessageWithLengthField -> readNestedWithLengthExpression(strategy, withContext)
         is FieldReadStrategy.UseCodecField -> readUseCodecExpression(strategy, withContext)
         is FieldReadStrategy.CollectionField -> readCollectionExpression(strategy, withContext)
         is FieldReadStrategy.DiscriminatorField -> {
@@ -124,6 +130,8 @@ internal fun writeExpression(
             val ctxArg = if (withContext) ", context" else ""
             "${strategy.codecName}.encode(buffer, $valueExpr$ctxArg)"
         }
+        is FieldReadStrategy.NestedMessageWithLengthField ->
+            writeNestedWithLengthExpression(strategy, valueExpr, withContext)
         is FieldReadStrategy.UseCodecField -> writeUseCodecExpression(strategy, valueExpr, withContext)
         is FieldReadStrategy.CollectionField -> writeCollectionExpression(strategy, valueExpr, withContext)
         is FieldReadStrategy.DiscriminatorField -> {
@@ -149,8 +157,10 @@ private fun readCollectionExpression(
     return when (val lk = strategy.lengthKind) {
         is LengthKind.FromField ->
             "buildList { repeat(${lk.field}.toInt()) { add($codecName.decode(buffer$ctxArg)) } }"
-        is LengthKind.Remaining ->
-            "buildList { while (buffer.remaining() > 0) { add($codecName.decode(buffer$ctxArg)) } }"
+        is LengthKind.Remaining -> {
+            val threshold = lk.trailingBytes
+            "buildList { while (buffer.remaining() > $threshold) { add($codecName.decode(buffer$ctxArg)) } }"
+        }
         is LengthKind.Prefixed -> {
             val cfg = prefixConfig(lk.prefix)
             "run { val _n = ${cfg.readExpr}; buildList { repeat(_n) { add($codecName.decode(buffer$ctxArg)) } } }"
@@ -189,10 +199,54 @@ private fun readUseCodecExpression(
             val lenExpr = prefixConfig(lk.prefix).readExpr
             "run { val _len = $lenExpr; $codec.decode(buffer.readBytes(_len)$ctxArg) }"
         }
-        is LengthKind.Remaining ->
-            "$codec.decode(buffer.readBytes(buffer.remaining())$ctxArg)"
+        is LengthKind.Remaining -> {
+            val bound = if (lk.trailingBytes > 0) "buffer.remaining() - ${lk.trailingBytes}" else "buffer.remaining()"
+            "$codec.decode(buffer.readBytes($bound)$ctxArg)"
+        }
         is LengthKind.FromField ->
             "$codec.decode(buffer.readBytes(${lk.field}.toInt())$ctxArg)"
+    }
+}
+
+private fun readNestedWithLengthExpression(
+    strategy: FieldReadStrategy.NestedMessageWithLengthField,
+    withContext: Boolean = false,
+): String {
+    val codec = strategy.codecName
+    val ctxArg = if (withContext) ", context" else ""
+    return when (val lk = strategy.lengthKind) {
+        is LengthKind.Prefixed -> {
+            val lenExpr = prefixConfig(lk.prefix).readExpr
+            "run { val _len = $lenExpr; $codec.decode(buffer.readBytes(_len)$ctxArg) }"
+        }
+        is LengthKind.Remaining -> {
+            val bound = if (lk.trailingBytes > 0) "buffer.remaining() - ${lk.trailingBytes}" else "buffer.remaining()"
+            "$codec.decode(buffer.readBytes($bound)$ctxArg)"
+        }
+        is LengthKind.FromField ->
+            "$codec.decode(buffer.readBytes(${lk.field}.toInt())$ctxArg)"
+    }
+}
+
+private fun writeNestedWithLengthExpression(
+    strategy: FieldReadStrategy.NestedMessageWithLengthField,
+    valueExpr: String,
+    withContext: Boolean = false,
+): String {
+    val codec = strategy.codecName
+    val ctxArg = if (withContext) ", context" else ""
+    return when (val lk = strategy.lengthKind) {
+        is LengthKind.Prefixed -> {
+            val cfg = prefixConfig(lk.prefix)
+            "run { val _pos = buffer.position(); ${cfg.writePlaceholder}; " +
+                "$codec.encode(buffer, $valueExpr$ctxArg); " +
+                "val _end = buffer.position(); val _len = _end - _pos - ${cfg.byteCount}; " +
+                "buffer.position(_pos); ${cfg.writeExpr("_len")}; buffer.position(_end) }"
+        }
+        is LengthKind.Remaining,
+        is LengthKind.FromField,
+        ->
+            "$codec.encode(buffer, $valueExpr$ctxArg)"
     }
 }
 

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/PayloadEmitter.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/PayloadEmitter.kt
@@ -82,7 +82,11 @@ internal fun addPayloadRawReadBody(
             code.addStatement("buffer.readBytes(_len)")
         }
         is LengthKind.Remaining -> {
-            code.addStatement("buffer.readBytes(buffer.remaining())")
+            if (lk.trailingBytes > 0) {
+                code.addStatement("buffer.readBytes(buffer.remaining() - %L)", lk.trailingBytes)
+            } else {
+                code.addStatement("buffer.readBytes(buffer.remaining())")
+            }
         }
         is LengthKind.FromField -> {
             code.addStatement("buffer.readBytes(%L.toInt())", lk.field)

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/PeekFrameSizeEmitter.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/PeekFrameSizeEmitter.kt
@@ -32,6 +32,8 @@ internal object PeekFrameSizeEmitter {
                     lengthFromTargets.add(strategy.lengthKind.field)
                 strategy is FieldReadStrategy.UseCodecField && strategy.lengthKind is LengthKind.FromField ->
                     lengthFromTargets.add(strategy.lengthKind.field)
+                strategy is FieldReadStrategy.NestedMessageWithLengthField && strategy.lengthKind is LengthKind.FromField ->
+                    lengthFromTargets.add(strategy.lengthKind.field)
             }
             if (field.condition is FieldCondition.WhenTrue) {
                 val expr = (field.condition as FieldCondition.WhenTrue).expression
@@ -208,6 +210,27 @@ internal object PeekFrameSizeEmitter {
                 steps.add(PeekStep.FlushFixed(accum))
                 accum = 0
                 steps.add(PeekStep.DelegateNested(strategy.codecName))
+            }
+
+            strategy is FieldReadStrategy.NestedMessageWithLengthField -> {
+                when (val lk = strategy.lengthKind) {
+                    is LengthKind.Prefixed -> {
+                        steps.add(PeekStep.FlushFixed(accum))
+                        accum = 0
+                        val prefixBytes = prefixByteCount(lk.prefix)
+                        val varName = "_${field.name}Len"
+                        steps.add(PeekStep.PeekPrefix(varName, prefixBytes))
+                        accum += prefixBytes
+                        steps.add(PeekStep.AddVariable(varName))
+                    }
+                    is LengthKind.FromField -> {
+                        steps.add(PeekStep.FlushFixed(accum))
+                        accum = 0
+                        val varName = capturedLengths[lk.field] ?: return null
+                        steps.add(PeekStep.AddVariable(varName))
+                    }
+                    is LengthKind.Remaining -> return null
+                }
             }
 
             strategy is FieldReadStrategy.RemainingBytesStringField -> return null

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/ProtocolMessageProcessor.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/ProtocolMessageProcessor.kt
@@ -5,6 +5,7 @@ import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSType
@@ -37,6 +38,7 @@ class ProtocolMessageProcessor(
 
             when {
                 Modifier.SEALED in symbol.modifiers -> processSealedInterface(symbol, resolver)
+                symbol.classKind == ClassKind.OBJECT -> processObject(symbol)
                 else -> {
                     val constructor = symbol.primaryConstructor
                     if (constructor == null) {
@@ -49,7 +51,8 @@ class ProtocolMessageProcessor(
                     } else if (constructor.parameters.isEmpty()) {
                         logger.error(
                             "@ProtocolMessage class '${symbol.simpleName.asString()}' must have at least one val parameter " +
-                                "in its primary constructor.",
+                                "in its primary constructor. For a type-only message (no wire bytes), declare it as " +
+                                "'object ${symbol.simpleName.asString()}' or 'data object ${symbol.simpleName.asString()}' instead.",
                             symbol,
                         )
                     } else {
@@ -80,6 +83,37 @@ class ProtocolMessageProcessor(
         if (hasPayload) {
             PayloadContextGenerator(codeGenerator, logger).generate(classDeclaration, fields)
         }
+    }
+
+    /**
+     * Generates a codec for a `@ProtocolMessage` `object` (or `data object`).
+     * Wire format is zero bytes — decode returns the singleton, encode writes nothing,
+     * sizeOf is 0. Type-only sealed variants (e.g., protocol commands with no payload)
+     * are the primary use case.
+     */
+    private fun processObject(classDeclaration: KSClassDeclaration) {
+        if (classDeclaration.typeParameters.isNotEmpty()) {
+            logger.error(
+                "@ProtocolMessage object '${classDeclaration.simpleName.asString()}' cannot have type parameters. " +
+                    "If you need @Payload, use a data class instead.",
+                classDeclaration,
+            )
+            return
+        }
+        val dispatchOnAnnotation =
+            classDeclaration.annotations.find {
+                it.qualifiedName() == "com.ditchoom.buffer.codec.annotations.DispatchOn"
+            }
+        if (dispatchOnAnnotation != null) {
+            logger.error(
+                "@DispatchOn is not valid on an object. @DispatchOn annotates a sealed interface that holds " +
+                    "variants distinguished by a discriminator.",
+                classDeclaration,
+            )
+            return
+        }
+        val generator = CodecGenerator(codeGenerator, logger)
+        generator.generate(classDeclaration, fields = emptyList(), batches = emptyList(), hasPayload = false)
     }
 
     private fun processSealedInterface(
@@ -119,29 +153,40 @@ class ProtocolMessageProcessor(
             if (qualifiedName in processed) continue
             processed.add(qualifiedName)
 
-            val constructor = subclass.primaryConstructor
-            if (constructor == null) {
-                logger.error(
-                    "Sealed variant '${subclass.simpleName.asString()}' of " +
-                        "'${classDeclaration.simpleName.asString()}' must have a primary constructor " +
-                        "with val parameters.",
-                    subclass,
-                )
-                continue
-            }
-            if (constructor.parameters.isEmpty()) {
-                logger.error(
-                    "Sealed variant '${subclass.simpleName.asString()}' of " +
-                        "'${classDeclaration.simpleName.asString()}' must have at least one val parameter " +
-                        "in its primary constructor.",
-                    subclass,
-                )
-                continue
+            val isObjectVariant = subclass.classKind == ClassKind.OBJECT
+            if (!isObjectVariant) {
+                val constructor = subclass.primaryConstructor
+                if (constructor == null) {
+                    logger.error(
+                        "Sealed variant '${subclass.simpleName.asString()}' of " +
+                            "'${classDeclaration.simpleName.asString()}' must have a primary constructor " +
+                            "with val parameters.",
+                        subclass,
+                    )
+                    continue
+                }
+                if (constructor.parameters.isEmpty()) {
+                    logger.error(
+                        "Sealed variant '${subclass.simpleName.asString()}' of " +
+                            "'${classDeclaration.simpleName.asString()}' must have at least one val parameter " +
+                            "in its primary constructor. For a type-only variant (no payload), " +
+                            "declare it as 'object ${subclass.simpleName.asString()}' or " +
+                            "'data object ${subclass.simpleName.asString()}'.",
+                        subclass,
+                    )
+                    continue
+                }
             }
 
-            // Analyze fields to detect @Payload and discriminator fields
-            val fieldAnalyzer = FieldAnalyzer(logger, customProviders)
-            val fields = fieldAnalyzer.analyze(subclass, dispatchOnInfo, sealedWireOrder) ?: continue
+            // Analyze fields to detect @Payload and discriminator fields.
+            // Object variants skip analysis (no constructor params) and produce an empty field list.
+            val fields =
+                if (isObjectVariant) {
+                    emptyList()
+                } else {
+                    val fieldAnalyzer = FieldAnalyzer(logger, customProviders)
+                    fieldAnalyzer.analyze(subclass, dispatchOnInfo, sealedWireOrder) ?: continue
+                }
 
             if (fields.any { it.strategy is FieldReadStrategy.DiscriminatorField }) {
                 anyVariantHasDiscriminatorField = true

--- a/buffer-codec-processor/src/test/kotlin/com/ditchoom/buffer/codec/processor/DataClassCodegenTest.kt
+++ b/buffer-codec-processor/src/test/kotlin/com/ditchoom/buffer/codec/processor/DataClassCodegenTest.kt
@@ -175,7 +175,9 @@ class DataClassCodegenTest {
     }
 
     @Test
-    fun `remaining bytes on non-last field causes error`() {
+    fun `remaining bytes followed by fixed-size trailer auto-reserves bytes`() {
+        // @RemainingBytes is no longer required to be the last field when the trailing fields have
+        // a fixed wire size. The processor infers the trailer size and emits a reservation.
         val source =
             SourceFile.kotlin(
                 "Test.kt",
@@ -185,14 +187,33 @@ class DataClassCodegenTest {
             import com.ditchoom.buffer.codec.annotations.RemainingBytes
 
             @ProtocolMessage
-            data class BadMsg(@RemainingBytes val data: String, val id: UByte)
+            data class TrailerMsg(@RemainingBytes val data: String, val crc: UByte)
+            """,
+            )
+        val result = compileWithKsp(source)
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, "Compilation failed:\n${result.messages}")
+    }
+
+    @Test
+    fun `remaining bytes followed by variable-size trailer causes error`() {
+        val source =
+            SourceFile.kotlin(
+                "Test.kt",
+                """
+            package test
+            import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+            import com.ditchoom.buffer.codec.annotations.RemainingBytes
+            import com.ditchoom.buffer.codec.annotations.LengthPrefixed
+
+            @ProtocolMessage
+            data class BadMsg(@RemainingBytes val data: String, @LengthPrefixed val trailer: String)
             """,
             )
         val result = compileWithKsp(source)
         val hasError =
             result.exitCode == KotlinCompilation.ExitCode.COMPILATION_ERROR ||
-                result.messages.contains("@RemainingBytes can only be used on the last")
-        assertTrue(hasError, "Expected error for @RemainingBytes on non-last field but got: ${result.exitCode}\n${result.messages}")
+                result.messages.contains("variable wire size", ignoreCase = true)
+        assertTrue(hasError, "Expected error for variable-size trailer but got: ${result.exitCode}\n${result.messages}")
     }
 
     @Test

--- a/buffer-codec-processor/src/test/kotlin/com/ditchoom/buffer/codec/processor/DataObjectCodegenTest.kt
+++ b/buffer-codec-processor/src/test/kotlin/com/ditchoom/buffer/codec/processor/DataObjectCodegenTest.kt
@@ -1,0 +1,131 @@
+package com.ditchoom.buffer.codec.processor
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DataObjectCodegenTest {
+    @Test
+    fun `data object standalone compiles and emits zero-byte codec`() {
+        val source =
+            SourceFile.kotlin(
+                "Test.kt",
+                """
+            package test
+            import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+
+            @ProtocolMessage
+            data object Heartbeat
+            """,
+            )
+        val result = compileWithKsp(source)
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, "Compilation failed:\n${result.messages}")
+    }
+
+    @Test
+    fun `plain object standalone compiles`() {
+        val source =
+            SourceFile.kotlin(
+                "Test.kt",
+                """
+            package test
+            import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+
+            @ProtocolMessage
+            object Ack
+            """,
+            )
+        val result = compileWithKsp(source)
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, "Compilation failed:\n${result.messages}")
+    }
+
+    @Test
+    fun `sealed variant as data object compiles`() {
+        val source =
+            SourceFile.kotlin(
+                "Test.kt",
+                """
+            package test
+            import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+            import com.ditchoom.buffer.codec.annotations.PacketType
+
+            @ProtocolMessage
+            sealed interface Command {
+                @PacketType(0x01) @ProtocolMessage
+                data class SetValue(val value: UByte) : Command
+
+                @PacketType(0x02) @ProtocolMessage
+                data object Ping : Command
+
+                @PacketType(0x03) @ProtocolMessage
+                object Reset : Command
+            }
+            """,
+            )
+        val result = compileWithKsp(source)
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, "Compilation failed:\n${result.messages}")
+    }
+
+    @Test
+    fun `data object with DispatchOn on sealed parent compiles`() {
+        val source =
+            SourceFile.kotlin(
+                "Test.kt",
+                """
+            package test
+            import com.ditchoom.buffer.codec.annotations.*
+
+            @JvmInline
+            @ProtocolMessage
+            value class Header(val raw: UByte) {
+                @DispatchValue
+                val packetType: Int get() = raw.toInt() and 0x0F
+            }
+
+            @DispatchOn(Header::class)
+            @ProtocolMessage
+            sealed interface Frame {
+                @PacketType(value = 1, wire = 0x01)
+                @ProtocolMessage
+                data class WithValue(val header: Header, val value: UByte) : Frame
+
+                @PacketType(value = 2, wire = 0x02)
+                @ProtocolMessage
+                data object Empty : Frame
+            }
+            """,
+            )
+        val result = compileWithKsp(source)
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, "Compilation failed:\n${result.messages}")
+    }
+
+    @Test
+    fun `object with DispatchOn annotation rejected`() {
+        val source =
+            SourceFile.kotlin(
+                "Test.kt",
+                """
+            package test
+            import com.ditchoom.buffer.codec.annotations.*
+
+            @JvmInline
+            @ProtocolMessage
+            value class H(val raw: UByte) {
+                @DispatchValue
+                val packetType: Int get() = raw.toInt() and 0x0F
+            }
+
+            @DispatchOn(H::class)
+            @ProtocolMessage
+            object Bad
+            """,
+            )
+        val result = compileWithKsp(source)
+        val hasError =
+            result.exitCode == KotlinCompilation.ExitCode.COMPILATION_ERROR ||
+                result.messages.contains("@DispatchOn is not valid on an object", ignoreCase = true)
+        assertTrue(hasError, "Expected rejection but got: ${result.exitCode}\n${result.messages}")
+    }
+}

--- a/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/CommandPayloadProtocol.kt
+++ b/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/CommandPayloadProtocol.kt
@@ -1,0 +1,61 @@
+package com.ditchoom.buffer.codec.test.protocols
+
+import com.ditchoom.buffer.codec.annotations.Endianness
+import com.ditchoom.buffer.codec.annotations.PacketType
+import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+
+/**
+ * Protocol using `data object` and `object` sealed variants for type-only commands
+ * (e.g., ping, reset) alongside normal data-class variants with payload.
+ */
+@ProtocolMessage(wireOrder = Endianness.Little)
+sealed interface CommandPayload {
+    @PacketType(0x22)
+    @ProtocolMessage
+    data class SetRgbState(
+        val r: UByte,
+        val g: UByte,
+        val b: UByte,
+    ) : CommandPayload
+
+    @PacketType(0x23)
+    @ProtocolMessage
+    data object GetRgbState : CommandPayload
+
+    @PacketType(0x24)
+    @ProtocolMessage
+    object ResetDevice : CommandPayload
+}
+
+/**
+ * A data class whose nested `@ProtocolMessage` field is a sealed interface that
+ * contains `data object` variants — exercises nested decode/encode of the singleton
+ * variants, not just compile-time acceptance.
+ */
+@ProtocolMessage(wireOrder = Endianness.Little)
+data class DeviceState(
+    val deviceId: UByte,
+    val connection: ConnectionStatus,
+)
+
+/** A state-machine-style sealed interface with mixed data class / data object variants. */
+@ProtocolMessage(wireOrder = Endianness.Little)
+sealed interface ConnectionStatus {
+    @PacketType(0x00)
+    @ProtocolMessage
+    data object Disconnected : ConnectionStatus
+
+    @PacketType(0x01)
+    @ProtocolMessage
+    data class Connecting(
+        val attempt: UByte,
+    ) : ConnectionStatus
+
+    @PacketType(0x02)
+    @ProtocolMessage
+    data object Connected : ConnectionStatus
+
+    @PacketType(0x03)
+    @ProtocolMessage
+    data object Failed : ConnectionStatus
+}

--- a/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/FramedCommandProtocol.kt
+++ b/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/FramedCommandProtocol.kt
@@ -1,0 +1,46 @@
+package com.ditchoom.buffer.codec.test.protocols
+
+import com.ditchoom.buffer.codec.annotations.Endianness
+import com.ditchoom.buffer.codec.annotations.LengthFrom
+import com.ditchoom.buffer.codec.annotations.LengthPrefix
+import com.ditchoom.buffer.codec.annotations.LengthPrefixed
+import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+import com.ditchoom.buffer.codec.annotations.RemainingBytes
+
+/**
+ * Wire: [payload variant][checksum:2]
+ * The wrapper holds a variable-size payload (sealed @ProtocolMessage) plus a trailing checksum.
+ * When used as a nested field bounded by an outer length, the whole block decodes within that
+ * length region and the checksum is recovered from the tail.
+ */
+@ProtocolMessage(wireOrder = Endianness.Little)
+data class PayloadWithChecksum(
+    val payload: CommandPayload,
+    val checksum: UShort,
+)
+
+/**
+ * Wire: [counter:2][length:2][body:length bytes]
+ * `length` covers the whole `body` (payload + checksum). Users compute `length = body.sizeOf()`
+ * before building a `FramedCommand`.
+ */
+@ProtocolMessage(wireOrder = Endianness.Little)
+data class FramedCommand(
+    val counter: UShort,
+    val length: UShort,
+    @LengthFrom("length") val body: PayloadWithChecksum,
+)
+
+/** Length-prefixed variant: a 2-byte prefix written before the nested body. */
+@ProtocolMessage(wireOrder = Endianness.Little)
+data class LengthPrefixedCommand(
+    val counter: UShort,
+    @LengthPrefixed(LengthPrefix.Short) val body: PayloadWithChecksum,
+)
+
+/** Remaining-bytes variant: nested body consumes everything left in the buffer. */
+@ProtocolMessage(wireOrder = Endianness.Little)
+data class RemainingBytesCommand(
+    val counter: UShort,
+    @RemainingBytes val body: PayloadWithChecksum,
+)

--- a/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/TrailingChecksumProtocol.kt
+++ b/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/TrailingChecksumProtocol.kt
@@ -1,0 +1,39 @@
+package com.ditchoom.buffer.codec.test.protocols
+
+import com.ditchoom.buffer.codec.annotations.Endianness
+import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+import com.ditchoom.buffer.codec.annotations.RemainingBytes
+
+/**
+ * Wire: [id:1][data:remaining-1][checksum:1]
+ * The processor auto-reserves 1 byte from the remaining buffer for the trailing `checksum`.
+ */
+@ProtocolMessage(wireOrder = Endianness.Little)
+data class DataPacketByteTrailer(
+    val id: UByte,
+    @RemainingBytes val data: String,
+    val checksum: UByte,
+)
+
+/**
+ * Wire: [version:1][data:remaining-4][crc:4]
+ * Larger fixed-size trailer to prove the reservation handles multi-byte primitives.
+ */
+@ProtocolMessage(wireOrder = Endianness.Little)
+data class DataPacketCrcTrailer(
+    val version: UByte,
+    @RemainingBytes val data: String,
+    val crc: UInt,
+)
+
+/**
+ * Wire: [id:1][data:remaining-3][flags:1][seq:2]
+ * Multiple trailing primitives — processor sums them into the reservation.
+ */
+@ProtocolMessage(wireOrder = Endianness.Little)
+data class DataPacketMultiTrailer(
+    val id: UByte,
+    @RemainingBytes val data: String,
+    val flags: UByte,
+    val seq: UShort,
+)

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/CommandPayloadRoundTripTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/CommandPayloadRoundTripTest.kt
@@ -1,0 +1,94 @@
+package com.ditchoom.buffer.codec.test
+
+import com.ditchoom.buffer.codec.test.protocols.CommandPayload
+import com.ditchoom.buffer.codec.test.protocols.CommandPayloadCodec
+import com.ditchoom.buffer.codec.test.protocols.ConnectionStatus
+import com.ditchoom.buffer.codec.test.protocols.DeviceState
+import com.ditchoom.buffer.codec.test.protocols.DeviceStateCodec
+import com.ditchoom.buffer.codec.testRoundTrip
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class CommandPayloadRoundTripTest {
+    @Test
+    fun setRgbStateRoundTrips() {
+        val original: CommandPayload = CommandPayload.SetRgbState(r = 1u, g = 2u, b = 3u)
+        val decoded = CommandPayloadCodec.testRoundTrip(original)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun setRgbStateEncodesExactBytes() {
+        val original: CommandPayload = CommandPayload.SetRgbState(r = 0x10u, g = 0x20u, b = 0x30u)
+        val decoded =
+            CommandPayloadCodec.testRoundTrip(
+                original,
+                expectedBytes = byteArrayOf(0x22, 0x10, 0x20, 0x30),
+            )
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun getRgbStateDataObjectRoundTrips() {
+        val original: CommandPayload = CommandPayload.GetRgbState
+        val decoded =
+            CommandPayloadCodec.testRoundTrip(
+                original,
+                expectedBytes = byteArrayOf(0x23),
+            )
+        assertSame(CommandPayload.GetRgbState, decoded, "data object should round-trip to the singleton")
+    }
+
+    @Test
+    fun resetDevicePlainObjectRoundTrips() {
+        val original: CommandPayload = CommandPayload.ResetDevice
+        val decoded =
+            CommandPayloadCodec.testRoundTrip(
+                original,
+                expectedBytes = byteArrayOf(0x24),
+            )
+        assertSame(CommandPayload.ResetDevice, decoded, "plain object should round-trip to the singleton")
+    }
+
+    // ── Nested data-object states via an outer data class ──
+
+    @Test
+    fun deviceStateDisconnectedRoundTrips() {
+        val original = DeviceState(deviceId = 7u, connection = ConnectionStatus.Disconnected)
+        val decoded =
+            DeviceStateCodec.testRoundTrip(
+                original,
+                expectedBytes = byteArrayOf(0x07, 0x00),
+            )
+        assertEquals(original.deviceId, decoded.deviceId)
+        assertSame(ConnectionStatus.Disconnected, decoded.connection)
+    }
+
+    @Test
+    fun deviceStateConnectingRoundTrips() {
+        val original = DeviceState(deviceId = 7u, connection = ConnectionStatus.Connecting(attempt = 3u))
+        val decoded =
+            DeviceStateCodec.testRoundTrip(
+                original,
+                expectedBytes = byteArrayOf(0x07, 0x01, 0x03),
+            )
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun deviceStateConnectedRoundTrips() {
+        val original = DeviceState(deviceId = 42u, connection = ConnectionStatus.Connected)
+        val decoded = DeviceStateCodec.testRoundTrip(original)
+        assertTrue(decoded.connection is ConnectionStatus.Connected)
+        assertSame(ConnectionStatus.Connected, decoded.connection)
+    }
+
+    @Test
+    fun deviceStateFailedRoundTrips() {
+        val original = DeviceState(deviceId = 9u, connection = ConnectionStatus.Failed)
+        val decoded = DeviceStateCodec.testRoundTrip(original)
+        assertSame(ConnectionStatus.Failed, decoded.connection)
+    }
+}

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/FramedCommandRoundTripTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/FramedCommandRoundTripTest.kt
@@ -1,0 +1,109 @@
+package com.ditchoom.buffer.codec.test
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.test.protocols.CommandPayload
+import com.ditchoom.buffer.codec.test.protocols.FramedCommand
+import com.ditchoom.buffer.codec.test.protocols.FramedCommandCodec
+import com.ditchoom.buffer.codec.test.protocols.LengthPrefixedCommand
+import com.ditchoom.buffer.codec.test.protocols.LengthPrefixedCommandCodec
+import com.ditchoom.buffer.codec.test.protocols.PayloadWithChecksum
+import com.ditchoom.buffer.codec.test.protocols.PayloadWithChecksumCodec
+import com.ditchoom.buffer.codec.test.protocols.RemainingBytesCommand
+import com.ditchoom.buffer.codec.test.protocols.RemainingBytesCommandCodec
+import com.ditchoom.buffer.codec.testRoundTrip
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+/**
+ * Tests for length annotations on nested `@ProtocolMessage` fields (issue #151 Change 2a).
+ *
+ * The wire shape is `[outer header][body:length bytes]` where `body` is a `@ProtocolMessage`
+ * data class that wraps a variable-size payload plus a trailing checksum. The user computes
+ * `length` from `body`'s actual wire size on encode; the processor emits a sliced decode.
+ */
+class FramedCommandRoundTripTest {
+    // Payload type byte (1) + variant body (0 or 3) + trailing UShort checksum (2)
+    private fun bodyWireBytes(payload: CommandPayload): Int =
+        1 +
+            when (payload) {
+                is CommandPayload.SetRgbState -> 3
+                CommandPayload.GetRgbState, CommandPayload.ResetDevice -> 0
+            } + 2
+
+    @Test
+    fun framedCommandWithSetRgbRoundTrips() {
+        val payload = CommandPayload.SetRgbState(r = 1u, g = 2u, b = 3u)
+        val body = PayloadWithChecksum(payload = payload, checksum = 0xBEEFu)
+        val bodyLen = bodyWireBytes(payload)
+        val original = FramedCommand(counter = 42u, length = bodyLen.toUShort(), body = body)
+        val decoded = FramedCommandCodec.testRoundTrip(original)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun framedCommandWithGetRgbDataObjectRoundTrips() {
+        val payload = CommandPayload.GetRgbState
+        val body = PayloadWithChecksum(payload = payload, checksum = 0x1234u)
+        val bodyLen = bodyWireBytes(payload)
+        val original = FramedCommand(counter = 7u, length = bodyLen.toUShort(), body = body)
+        val decoded = FramedCommandCodec.testRoundTrip(original)
+        assertSame(CommandPayload.GetRgbState, decoded.body.payload)
+        assertEquals(0x1234u.toUShort(), decoded.body.checksum)
+    }
+
+    @Test
+    fun framedCommandBodyStopsAtLengthBoundary() {
+        // Append extra junk after the frame and verify the decoder does NOT consume it.
+        val payload = CommandPayload.GetRgbState
+        val body = PayloadWithChecksum(payload = payload, checksum = 0xABCDu)
+        val bodyLen = bodyWireBytes(payload)
+        val original = FramedCommand(counter = 99u, length = bodyLen.toUShort(), body = body)
+
+        val buffer = BufferFactory.Default.allocate(64, ByteOrder.LITTLE_ENDIAN)
+        FramedCommandCodec.encode(buffer, original, EncodeContext.Empty)
+        // Inject 3 junk bytes after the frame — decoding body via @LengthFrom should ignore them.
+        buffer.writeByte(0xDE.toByte())
+        buffer.writeByte(0xAD.toByte())
+        buffer.writeByte(0xBE.toByte())
+        val framePlusJunkEnd = buffer.position()
+        buffer.setLimit(framePlusJunkEnd)
+        buffer.position(0)
+
+        val decoded = FramedCommandCodec.decode(buffer, DecodeContext.Empty)
+        assertEquals(original, decoded)
+        // After decode, the 3 junk bytes must remain.
+        assertEquals(3, buffer.remaining())
+    }
+
+    @Test
+    fun lengthPrefixedCommandRoundTrips() {
+        val payload = CommandPayload.SetRgbState(r = 0x10u, g = 0x20u, b = 0x30u)
+        val body = PayloadWithChecksum(payload = payload, checksum = 0xCAFEu)
+        val original = LengthPrefixedCommand(counter = 5u, body = body)
+        val decoded = LengthPrefixedCommandCodec.testRoundTrip(original)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun remainingBytesCommandRoundTrips() {
+        val payload = CommandPayload.SetRgbState(r = 0xAAu, g = 0xBBu, b = 0xCCu)
+        val body = PayloadWithChecksum(payload = payload, checksum = 0x4321u)
+        val original = RemainingBytesCommand(counter = 13u, body = body)
+        val decoded = RemainingBytesCommandCodec.testRoundTrip(original)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun payloadWithChecksumRoundTripsStandalone() {
+        // Nested wrapper still works as a top-level message (no outer length).
+        val original = PayloadWithChecksum(payload = CommandPayload.ResetDevice, checksum = 0x55AAu)
+        val decoded = PayloadWithChecksumCodec.testRoundTrip(original)
+        assertSame(CommandPayload.ResetDevice, decoded.payload)
+        assertEquals(0x55AAu.toUShort(), decoded.checksum)
+    }
+}

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/TrailingChecksumRoundTripTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/TrailingChecksumRoundTripTest.kt
@@ -1,0 +1,56 @@
+package com.ditchoom.buffer.codec.test
+
+import com.ditchoom.buffer.codec.test.protocols.DataPacketByteTrailer
+import com.ditchoom.buffer.codec.test.protocols.DataPacketByteTrailerCodec
+import com.ditchoom.buffer.codec.test.protocols.DataPacketCrcTrailer
+import com.ditchoom.buffer.codec.test.protocols.DataPacketCrcTrailerCodec
+import com.ditchoom.buffer.codec.test.protocols.DataPacketMultiTrailer
+import com.ditchoom.buffer.codec.test.protocols.DataPacketMultiTrailerCodec
+import com.ditchoom.buffer.codec.testRoundTrip
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests for issue #151 Change 2b: fields after `@RemainingBytes` with fixed wire size
+ * are auto-reserved by the processor. No annotation parameters — inference is structural.
+ */
+class TrailingChecksumRoundTripTest {
+    @Test
+    fun byteTrailerRoundTrips() {
+        val original = DataPacketByteTrailer(id = 0x07u, data = "hello world", checksum = 0xABu)
+        val decoded = DataPacketByteTrailerCodec.testRoundTrip(original)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun byteTrailerEmptyDataRoundTrips() {
+        val original = DataPacketByteTrailer(id = 0x01u, data = "", checksum = 0xFFu)
+        val decoded = DataPacketByteTrailerCodec.testRoundTrip(original)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun crcTrailerRoundTrips() {
+        val original =
+            DataPacketCrcTrailer(
+                version = 0x02u,
+                data = "payload-bytes-here",
+                crc = 0xDEADBEEFu,
+            )
+        val decoded = DataPacketCrcTrailerCodec.testRoundTrip(original)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun multiTrailerRoundTrips() {
+        val original =
+            DataPacketMultiTrailer(
+                id = 0x42u,
+                data = "arbitrary variable data",
+                flags = 0x10u,
+                seq = 0x1234u,
+            )
+        val decoded = DataPacketMultiTrailerCodec.testRoundTrip(original)
+        assertEquals(original, decoded)
+    }
+}

--- a/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/annotations/Annotations.kt
+++ b/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/annotations/Annotations.kt
@@ -245,7 +245,13 @@ annotation class WhenTrue(
 /**
  * Delegates field decoding/encoding to an existing [Codec][com.ditchoom.buffer.codec.Codec] object.
  *
- * Use this instead of writing a full SPI module when you need a custom field type.
+ * **Use this only for custom, hand-written codecs** (for example, variable-byte-integer encoders
+ * or image-bitmap parsers). If the field's type is itself annotated with [@ProtocolMessage],
+ * declare the field with that type directly instead — the processor generates the codec by
+ * convention and wires it up automatically, including sealed dispatch and forward references
+ * to codecs generated in the same compilation round. `@UseCodec` cannot forward-reference a
+ * KSP-generated codec class.
+ *
  * The referenced [codec] must be a Kotlin `object` implementing `Codec<T>`.
  *
  * **Without a length annotation** — the codec reads directly from the buffer:
@@ -265,6 +271,16 @@ annotation class WhenTrue(
  *     @UseCodec(PngBitmapCodec::class) @LengthFrom("bitmapLength") val bitmap: ImageBitmap,
  * )
  * // Generated: val _slice = buffer.readBytes(bitmapLength); val bitmap = PngBitmapCodec.decode(_slice)
+ * ```
+ *
+ * **For nested @ProtocolMessage types, skip @UseCodec entirely.** Length annotations attach
+ * directly to the nested field:
+ * ```kotlin
+ * @ProtocolMessage
+ * data class Frame(
+ *     val length: UShort,
+ *     @LengthFrom("length") val body: BodyMessage,  // BodyMessage has @ProtocolMessage — no @UseCodec
+ * )
  * ```
  *
  * Composes with [@LengthPrefixed], [@RemainingBytes], and [@LengthFrom].


### PR DESCRIPTION
Closes #150 and #151. Refs #152.

## Summary

- **#150 — `@ProtocolMessage` on `data object` / `object`**: zero-field type-only messages (sealed variants for ping/reset/ack, state-machine states, etc.) are now valid. Decode returns the singleton, encode writes nothing, `sizeOf` is `0`. No change to existing `data class` paths.

- **#151 part 1 — length annotations on nested `@ProtocolMessage` fields**: `@LengthFrom` / `@LengthPrefixed` / `@RemainingBytes` can now attach directly to a field whose type is itself `@ProtocolMessage`. Enables framing where a length covers *payload + trailer* by wrapping them in a `@ProtocolMessage`. Rejects length annotations on `@DispatchOn` discriminator fields with a clear error.

- **#151 part 2 — `@RemainingBytes` with fixed-size trailer**: `@RemainingBytes` no longer has to be the last field. Trailing fields with a fixed wire size (primitives, value-class-wrapped primitives, fixed custom fields) are auto-reserved, so the `@RemainingBytes` field stops short of them. Variable-size trailers (length-prefixed strings, lists, `@WhenTrue`) are rejected with a field-specific error. **No new annotation parameters** — the reservation is inferred structurally.

- **#152 — `@UseCodec` KDoc**: updated to clarify `@UseCodec` is for hand-written codecs only and cannot forward-reference a codec generated in the same KSP round. Users should declare nested `@ProtocolMessage` fields directly.

## Examples

**#150**
```kotlin
@ProtocolMessage
sealed interface CommandPayload {
    @PacketType(0x22) @ProtocolMessage
    data class SetRgbState(val r: UByte, val g: UByte, val b: UByte) : CommandPayload

    @PacketType(0x23) @ProtocolMessage
    data object GetRgbState : CommandPayload
}
```

**#151 part 1 — length covers payload + trailer**
```kotlin
@ProtocolMessage data class PayloadWithChecksum(val payload: CommandPayload, val checksum: UShort)

@ProtocolMessage
data class FramedCommand(
    val counter: UShort,
    val length: UShort,
    @LengthFrom("length") val body: PayloadWithChecksum,
)
```

**#151 part 2 — trailing checksum after `@RemainingBytes`**
```kotlin
@ProtocolMessage
data class DataPacket<@Payload P>(
    @RemainingBytes val payload: P,   // reads buffer.remaining() - 1
    val checksum: UByte,
)
```

## Test plan

- [x] `DataObjectCodegenTest` — 5 new unit tests for `data object` / plain `object` support, including `@DispatchOn` rejection on objects.
- [x] `CommandPayloadRoundTripTest` — round-trips `SetRgbState` (4 bytes) and `GetRgbState` / `ResetDevice` (1 byte each), asserts singleton identity. Covers nested state-machine states (`DeviceState` + `ConnectionStatus` with mixed `data class` / `data object` variants).
- [x] `FramedCommandRoundTripTest` — covers `@LengthFrom`, `@LengthPrefixed`, and `@RemainingBytes` on nested `@ProtocolMessage` fields. Includes a boundary test that appends junk after the frame and asserts decode stops exactly at `length`.
- [x] `TrailingChecksumRoundTripTest` — 1-byte trailer, 4-byte CRC trailer, and multi-field trailer round-trips.
- [x] Negative test in `DataClassCodegenTest` — variable-size trailing field after `@RemainingBytes` produces a compile error.
- [x] Full `:buffer-codec-processor:test` + `:buffer-codec-test:jvmTest` + `ktlintCheck` green locally on JDK 21.