### PR TITLE
ci: fix release gate on large PRs + add manual release trigger

### DIFF
--- a/.github/workflows/merged.yaml
+++ b/.github/workflows/merged.yaml
@@ -49,8 +49,13 @@ jobs:
             exit 0
           fi
 
-          # Check if only non-code files changed
-          changed_files=$(gh pr diff ${{ github.event.pull_request.number }} --name-only)
+          # Check if only non-code files changed.
+          # Use the paginated "list PR files" API rather than `gh pr diff`: the
+          # latter hits the .diff endpoint, which GitHub caps at 300 files and
+          # returns HTTP 406 for larger PRs.
+          changed_files=$(gh api --paginate \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[].path')
           for file in $changed_files; do
             case "$file" in
               .github/*|*.md|.gitignore|.editorconfig|CLAUDE.md|LICENSE|*.txt)

--- a/.github/workflows/merged.yaml
+++ b/.github/workflows/merged.yaml
@@ -4,6 +4,24 @@ on:
     branches: [ main ]
     types:
       - closed
+  workflow_dispatch:
+    inputs:
+      version-bump:
+        description: "Version bump"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
+      flow:
+        description: "Release flow"
+        type: choice
+        options:
+          - release
+          - draft
+          - dry-run
+        default: release
 
 permissions:
   contents: write
@@ -15,7 +33,7 @@ concurrency:
 jobs:
   check-release:
     name: Check if release is needed
-    if: github.event.pull_request.merged == true
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     outputs:
       flow: ${{ steps.check.outputs.flow }}
@@ -29,6 +47,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Manual dispatch has no PR to inspect — take flow and version
+          # bump straight from the workflow inputs.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            case "${{ inputs.version-bump }}" in
+              major) echo "gradle-args=-PincrementMajor=true" >> $GITHUB_OUTPUT ;;
+              minor) echo "gradle-args=-PincrementMinor=true" >> $GITHUB_OUTPUT ;;
+              *)     echo "gradle-args=" >> $GITHUB_OUTPUT ;;
+            esac
+            echo "flow=${{ inputs.flow }}" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           gradle_args=""
           if ${{ contains(github.event.pull_request.labels.*.name, 'major') }}; then
             gradle_args="-PincrementMajor=true"
@@ -117,8 +147,8 @@ jobs:
         if: needs.check-release.outputs.flow == 'draft' && needs.publish.result == 'success'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_TITLE: ${{ github.event.pull_request.title || 'Manual release' }}
+          PR_URL: ${{ github.event.pull_request.html_url || format('{0}/{1}', github.server_url, github.repository) }}
         run: |
           version="${{ needs.build-linux.outputs.version }}"
           deployment_id="${{ needs.publish.outputs.deployment-id }}"
@@ -148,8 +178,8 @@ jobs:
         if: needs.check-release.outputs.flow == 'release' && needs.publish.result == 'success'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_TITLE: ${{ github.event.pull_request.title || 'Manual release' }}
+          PR_URL: ${{ github.event.pull_request.html_url || format('{0}/{1}', github.server_url, github.repository) }}
         run: |
           version="${{ needs.build-linux.outputs.version }}"
           tag="v${version}"


### PR DESCRIPTION
## Problem

Merging #149 ran the `merged.yaml` "Build Test and Deploy" workflow ([run 26290119989](https://github.com/DitchOoM/buffer/actions/runs/26290119989)), which **failed** — so 5.0.0 never built or published. Only the docs deploy succeeded.

It failed at the first gate job, "Determine release flow". That step decides whether a merged PR changed code (vs docs-only) by listing the PR's files:

```bash
changed_files=$(gh pr diff ${{ github.event.pull_request.number }} --name-only)
```

`gh pr diff` uses GitHub's `.diff` endpoint, which is hard-capped at 300 files:

```
HTTP 406: Sorry, the diff exceeded the maximum number of files (300).
PullRequest.diff too_large
##[error]Process completed with exit code 1.
```

PR #149 changed more than 300 files. Under `bash -e`, the failed command aborted the step before it could emit `flow=release`, so `build-linux` / `build-apple` / `validate` / `publish` were all skipped.

## Changes

**1. Fix the file-list call.** Switch to the paginated *list pull request files* API (`gh api --paginate .../pulls/N/files`), which has no file-count limit. No behavior change for normal-sized PRs.

**2. Add a `workflow_dispatch` release trigger.** The pipeline previously only fired on PR merge — there was no way to re-run a release after a failed run, since GitHub re-runs pin to the original (broken) workflow file. The new trigger takes explicit `version-bump` (patch/minor/major) and `flow` (release/draft/dry-run) inputs. The `check-release` gate short-circuits on `workflow_dispatch` — no PR to inspect — and the `finalize` job's release notes fall back to a generic title + repo URL when PR context is absent.

## Note

This PR only touches `.github/workflows/merged.yaml`. When it merges, the release gate's `.github/*` path match sets `flow=skip`, so merging it does **not** cut a release.