### PR TITLE
Restore nested-codec name flattening (fix #156)

### DIFF
--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
@@ -205,7 +205,7 @@ internal class CodecEmitter(
                 packageName = symbol.packageName.asString(),
                 messageClassName = classNameOf(symbol),
                 ownerSimpleName = ownerSimpleName,
-                codecSimpleName = "${ownerSimpleName}Codec",
+                codecSimpleName = symbol.flattenedCodecName(),
                 fields = emptyList(),
                 isSingletonObject = true,
                 singletonDispatchDiscriminator = detectSealedDispatchOnParentDiscriminator(symbol),
@@ -332,7 +332,7 @@ internal class CodecEmitter(
             packageName = pkg,
             messageClassName = classNameOf(symbol),
             ownerSimpleName = ownerSimpleName,
-            codecSimpleName = "${ownerSimpleName}Codec",
+            codecSimpleName = symbol.flattenedCodecName(),
             fields = fields,
             payloadTypeParameter = payloadTypeParameter,
             framedBy = detectFramedBy(symbol),
@@ -724,7 +724,7 @@ internal class CodecEmitter(
                 name = name,
                 ownerSimpleName = ownerSimpleName,
                 messageType = classNameOf(decl),
-                codecType = ClassName(decl.packageName.asString(), "${decl.simpleName.asString()}Codec"),
+                codecType = ClassName(decl.packageName.asString(), decl.flattenedCodecName()),
                 prefixWidth = prefixWidth,
                 prefixWireOrder = messageWireOrder,
             )
@@ -998,7 +998,7 @@ internal class CodecEmitter(
             elementCodecClassName =
                 ClassName(
                     elementDecl.packageName.asString(),
-                    "${elementDecl.simpleName.asString()}Codec",
+                    elementDecl.flattenedCodecName(),
                 ),
         )
     }
@@ -1061,7 +1061,7 @@ internal class CodecEmitter(
             codecType =
                 ClassName(
                     decl.packageName.asString(),
-                    "${decl.simpleName.asString()}Codec",
+                    decl.flattenedCodecName(),
                 ),
         )
     }
@@ -1122,7 +1122,7 @@ internal class CodecEmitter(
             elementCodecClassName =
                 ClassName(
                     elementDecl.packageName.asString(),
-                    "${elementDecl.simpleName.asString()}Codec",
+                    elementDecl.flattenedCodecName(),
                 ),
             elementIsBackPatch = detectElementBackPatch(elementDecl),
         )
@@ -1173,7 +1173,7 @@ internal class CodecEmitter(
             codecType =
                 ClassName(
                     decl.packageName.asString(),
-                    "${decl.simpleName.asString()}Codec",
+                    decl.flattenedCodecName(),
                 ),
         )
     }
@@ -1375,7 +1375,7 @@ internal class CodecEmitter(
             elementCodecClassName =
                 ClassName(
                     elementDecl.packageName.asString(),
-                    "${elementDecl.simpleName.asString()}Codec",
+                    elementDecl.flattenedCodecName(),
                 ),
             elementIsBackPatch = detectElementBackPatch(elementDecl),
         )
@@ -1904,7 +1904,7 @@ internal class CodecEmitter(
             codecType =
                 ClassName(
                     decl.packageName.asString(),
-                    "${decl.simpleName.asString()}Codec",
+                    decl.flattenedCodecName(),
                 ),
         )
     }
@@ -5823,7 +5823,7 @@ internal class CodecEmitter(
                     codecClassName =
                         ClassName(
                             sub.packageName.asString(),
-                            "${sub.simpleName.asString()}Codec",
+                            sub.flattenedCodecName(),
                         ),
                     packetTypeValue = rawValue,
                     wireSize = variantWireSize,
@@ -5839,7 +5839,7 @@ internal class CodecEmitter(
             packageName = pkg,
             parentClassName = ClassName(pkg, parentSimpleName),
             parentSimpleName = parentSimpleName,
-            codecSimpleName = "${parentSimpleName}Codec",
+            codecSimpleName = symbol.flattenedCodecName(),
             variants = variants,
         )
     }
@@ -5984,7 +5984,7 @@ internal class CodecEmitter(
                     codecClassName =
                         ClassName(
                             sub.packageName.asString(),
-                            "${variantSimpleName}Codec",
+                            sub.flattenedCodecName(),
                         ),
                     dispatchValue = rawValue,
                     genericInstanceFieldName = genericInstanceFieldName,
@@ -6004,12 +6004,12 @@ internal class CodecEmitter(
             packageName = pkg,
             parentClassName = ClassName(pkg, parentSimpleName),
             parentSimpleName = parentSimpleName,
-            codecSimpleName = "${parentSimpleName}Codec",
+            codecSimpleName = symbol.flattenedCodecName(),
             discriminatorClassName = classNameOf(discriminatorDecl),
             discriminatorCodecClassName =
                 ClassName(
                     discriminatorDecl.packageName.asString(),
-                    "${discriminatorDecl.simpleName.asString()}Codec",
+                    discriminatorDecl.flattenedCodecName(),
                 ),
             discriminatorInnerKind = innerKind,
             discriminatorInnerWireOrder = discriminatorWireOrder,

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/StringUtils.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/StringUtils.kt
@@ -1,0 +1,23 @@
+package com.ditchoom.buffer.codec.processor
+
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+
+/**
+ * Flattens the enclosing-type chain into a codec object name so that
+ * two same-named nested classes in the same package don't collide at
+ * KSP file write time (issue #156).
+ *
+ * Top-level: `MqttPacketConnect` → `MqttPacketConnectCodec`
+ * Nested:    `MqttPacket.SubAck` → `MqttPacketSubAckCodec`
+ */
+internal fun KSClassDeclaration.flattenedCodecName(): String = enclosingSimpleNames().joinToString("") + "Codec"
+
+internal fun KSClassDeclaration.enclosingSimpleNames(): List<String> {
+    val names = mutableListOf<String>()
+    var current: KSClassDeclaration? = this
+    while (current != null) {
+        names.add(0, current.simpleName.asString())
+        current = current.parentDeclaration as? KSClassDeclaration
+    }
+    return names
+}

--- a/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/Issue156NestedNameProtocol.kt
+++ b/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/Issue156NestedNameProtocol.kt
@@ -1,0 +1,36 @@
+package com.ditchoom.buffer.codec.test.protocols
+
+import com.ditchoom.buffer.codec.annotations.Endianness
+import com.ditchoom.buffer.codec.annotations.PacketType
+import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+
+/**
+ * Regression fixture for issue #156 — two sealed interfaces in the same
+ * package each carry a nested `data class LedStateSet`. Pre-fix, both
+ * resolved to `LedStateSetCodec` and KSP threw `FileAlreadyExistsException`
+ * at the second file write. Post-fix, generated codec names flatten across
+ * the enclosing-type chain: `Issue156CommandLedStateSetCodec` and
+ * `Issue156ResponseLedStateSetCodec`.
+ *
+ * Names are prefixed with `Issue156` because this file shares a package
+ * with `CommandPayloadProtocol.kt`, which already owns `CommandPayload`.
+ */
+@ProtocolMessage(wireOrder = Endianness.Little)
+sealed interface Issue156Command {
+    @PacketType(0x20)
+    @ProtocolMessage
+    data class LedStateSet(
+        val ledId: UByte,
+        val duty: UShort,
+    ) : Issue156Command
+}
+
+@ProtocolMessage(wireOrder = Endianness.Little)
+sealed interface Issue156Response {
+    @PacketType(0x20)
+    @ProtocolMessage
+    data class LedStateSet(
+        val ledId: UByte,
+        val duty: UShort,
+    ) : Issue156Response
+}

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/Issue156NestedNameTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/Issue156NestedNameTest.kt
@@ -1,0 +1,52 @@
+package com.ditchoom.buffer.codec.test.protocols
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+/**
+ * Regression for issue #156 — generated codec names must flatten across
+ * the enclosing-type chain so that same-named nested data classes do not
+ * collide on the KSP `createNewFile` write path.
+ *
+ * The fact that this test class compiles is the primary assertion: pre-fix,
+ * KSP threw `FileAlreadyExistsException` and the whole test source set
+ * failed to build. The round-trip and distinctness checks lock in the
+ * dispatcher-side fix (the sealed parent dispatcher must reference variant
+ * codecs by their flattened names, not their simple names).
+ */
+class Issue156NestedNameTest {
+    @Test
+    fun commandLedStateSetRoundTrips() {
+        val original: Issue156Command = Issue156Command.LedStateSet(ledId = 0x05u, duty = 750u)
+        val buf = BufferFactory.Default.allocate(64)
+        Issue156CommandCodec.encode(buf, original, EncodeContext.Empty)
+        buf.resetForRead()
+        val decoded = Issue156CommandCodec.decode(buf, DecodeContext.Empty)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun responseLedStateSetRoundTrips() {
+        val original: Issue156Response = Issue156Response.LedStateSet(ledId = 0x05u, duty = 750u)
+        val buf = BufferFactory.Default.allocate(64)
+        Issue156ResponseCodec.encode(buf, original, EncodeContext.Empty)
+        buf.resetForRead()
+        val decoded = Issue156ResponseCodec.decode(buf, DecodeContext.Empty)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun nestedVariantCodecsAreDistinctObjects() {
+        // If flattening regressed, the test source set would fail to compile
+        // (one of these identifiers would not exist). Asserting distinct
+        // class names also guards against an accidental aliasing fix.
+        val cmd = Issue156CommandLedStateSetCodec::class.simpleName
+        val resp = Issue156ResponseLedStateSetCodec::class.simpleName
+        assertNotEquals(cmd, resp)
+    }
+}

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttConnAckCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttConnAckCodecTest.kt
@@ -19,7 +19,7 @@ import kotlin.test.assertFailsWith
  * MQTT v3.1.1 §3.2 CONNACK packet.
  * Fixed-shape 4-byte ack: header `0x20` + remainingLength=2 +
  * connectAckFlags (UByte; bit 0 carries Session Present per §3.2.2.1)
- * + returnCode (UByte per §3.2.2.3). Drives `ConnAckCodec`.
+ * + returnCode (UByte per §3.2.2.3). Drives `MqttPacketConnAckCodec`.
  */
 class MqttConnAckCodecTest {
     @Test
@@ -52,7 +52,7 @@ class MqttConnAckCodecTest {
     fun decodesFromSpecBytes() {
         val wire = byteArrayOf(0x20, 0x02, 0x01, 0x00)
         val buf = bigEndianBufferOf(wire)
-        val decoded = ConnAckCodec.decode(buf, DecodeContext.Empty)
+        val decoded = MqttPacketConnAckCodec.decode(buf, DecodeContext.Empty)
         assertEquals(MqttFixedHeader(0x20u), decoded.header)
         assertEquals(0x01u.toUByte(), decoded.connectAckFlags, "session-present bit")
         assertEquals(0x00u.toUByte(), decoded.returnCode, "accepted")
@@ -72,7 +72,7 @@ class MqttConnAckCodecTest {
                 0xAD.toByte(),
             )
         val buf = bigEndianBufferOf(wire)
-        ConnAckCodec.decode(buf, DecodeContext.Empty)
+        MqttPacketConnAckCodec.decode(buf, DecodeContext.Empty)
         assertEquals(4, buf.position(), "decode advanced exactly through CONNACK")
         assertEquals(4, buf.remaining(), "trailing 4 bytes left in buffer for next packet")
     }
@@ -86,7 +86,7 @@ class MqttConnAckCodecTest {
         buf.writeByte(0x00)
         buf.resetForRead()
         val originalLimit = buf.limit()
-        ConnAckCodec.decode(buf, DecodeContext.Empty)
+        MqttPacketConnAckCodec.decode(buf, DecodeContext.Empty)
         assertEquals(originalLimit, buf.limit(), "decode restored the outer limit")
     }
 
@@ -99,7 +99,7 @@ class MqttConnAckCodecTest {
                 returnCode = 0x05u,
             )
         val buf = encode(original)
-        assertEquals(original, ConnAckCodec.decode(buf, DecodeContext.Empty))
+        assertEquals(original, MqttPacketConnAckCodec.decode(buf, DecodeContext.Empty))
     }
 
     @Test
@@ -116,7 +116,7 @@ class MqttConnAckCodecTest {
         val buf = bigEndianBufferOf(wire)
         val ex =
             assertFailsWith<DecodeException> {
-                ConnAckCodec.decode(buf, DecodeContext.Empty)
+                MqttPacketConnAckCodec.decode(buf, DecodeContext.Empty)
             }
         assertEquals("MqttRemainingLength", ex.fieldPath)
     }
@@ -138,7 +138,7 @@ class MqttConnAckCodecTest {
                 stream.append(one)
                 assertEquals(
                     PeekResult.NeedsMoreData,
-                    ConnAckCodec.peekFrameSize(stream),
+                    MqttPacketConnAckCodec.peekFrameSize(stream),
                     "after ${i + 1} bytes",
                 )
             }
@@ -146,7 +146,7 @@ class MqttConnAckCodecTest {
             last.writeByte(encoded.readByte())
             last.resetForRead()
             stream.append(last)
-            assertEquals(PeekResult.Complete(totalBytes), ConnAckCodec.peekFrameSize(stream))
+            assertEquals(PeekResult.Complete(totalBytes), MqttPacketConnAckCodec.peekFrameSize(stream))
         } finally {
             stream.release()
             pool.clear()
@@ -169,5 +169,6 @@ class MqttConnAckCodecTest {
             .also { it.writeBytes(wire) }
             .also { it.resetForRead() }
 
-    private fun encode(value: MqttPacket.ConnAck): ReadBuffer = ConnAckCodec.encode(value, EncodeContext.Empty, BufferFactory.Default)
+    private fun encode(value: MqttPacket.ConnAck): ReadBuffer =
+        MqttPacketConnAckCodec.encode(value, EncodeContext.Empty, BufferFactory.Default)
 }

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttConnectCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttConnectCodecTest.kt
@@ -32,7 +32,7 @@ import kotlin.test.assertNull
  *     path (header byte + var-int + value covers the full message).
  *
  * Folded onto the `MqttPacket.Connect` sealed
- * variant. Drives `ConnectCodec` (the per-variant codec object emitted
+ * variant. Drives `MqttPacketConnectCodec` (the per-variant codec object emitted
  * by the dispatcher) per the brief's option 1: same byte
  * exact assertions, same var-int boundary coverage, same drip-fed
  * peekFrameSize coverage. The standalone `MqttConnect` data class +
@@ -192,7 +192,7 @@ class MqttConnectCodecTest {
                 password = BinaryData("secret".encodeToByteArray()),
             )
         val buf = encode(msg)
-        val decoded = ConnectCodec.decode(buf, DecodeContext.Empty)
+        val decoded = MqttPacketConnectCodec.decode(buf, DecodeContext.Empty)
         assertEquals(msg.clientId, decoded.clientId)
         assertEquals(msg.willTopic, decoded.willTopic)
         assertContentEquals(msg.willPayload!!.bytes, decoded.willPayload!!.bytes)
@@ -238,7 +238,7 @@ class MqttConnectCodecTest {
             )
         val buf = BufferFactory.Default.allocate(wire.size).also { it.writeBytes(wire) }
         buf.resetForRead()
-        val decoded = ConnectCodec.decode(buf, DecodeContext.Empty)
+        val decoded = MqttPacketConnectCodec.decode(buf, DecodeContext.Empty)
         assertEquals("test", decoded.clientId)
         assertNull(decoded.willTopic, "willPresent bit not set → willTopic should be null")
         assertNull(decoded.willPayload, "willPresent bit not set → willPayload should be null")
@@ -275,7 +275,7 @@ class MqttConnectCodecTest {
             )
         val buf = BufferFactory.Default.allocate(wire.size).also { it.writeBytes(wire) }
         buf.resetForRead()
-        val decoded = ConnectCodec.decode(buf, DecodeContext.Empty)
+        val decoded = MqttPacketConnectCodec.decode(buf, DecodeContext.Empty)
         assertEquals("abc", decoded.clientId)
         assertEquals(2, buf.remaining(), "trailing 2 bytes (next packet) left in buffer")
     }
@@ -301,7 +301,7 @@ class MqttConnectCodecTest {
 
         val stream = StreamProcessor.create(pool, ByteOrder.BIG_ENDIAN)
         try {
-            assertEquals(PeekResult.NeedsMoreData, ConnectCodec.peekFrameSize(stream))
+            assertEquals(PeekResult.NeedsMoreData, MqttPacketConnectCodec.peekFrameSize(stream))
 
             for (i in 0 until totalBytes - 1) {
                 val one = BufferFactory.Default.allocate(1)
@@ -310,7 +310,7 @@ class MqttConnectCodecTest {
                 stream.append(one)
                 assertEquals(
                     PeekResult.NeedsMoreData,
-                    ConnectCodec.peekFrameSize(stream),
+                    MqttPacketConnectCodec.peekFrameSize(stream),
                     "after ${i + 1} bytes",
                 )
             }
@@ -318,11 +318,11 @@ class MqttConnectCodecTest {
             last.writeByte(encoded.readByte())
             last.resetForRead()
             stream.append(last)
-            assertEquals(PeekResult.Complete(totalBytes), ConnectCodec.peekFrameSize(stream))
+            assertEquals(PeekResult.Complete(totalBytes), MqttPacketConnectCodec.peekFrameSize(stream))
 
             val decoded =
                 stream.readBufferScoped(totalBytes) {
-                    ConnectCodec.decode(this, DecodeContext.Empty)
+                    MqttPacketConnectCodec.decode(this, DecodeContext.Empty)
                 }
             assertConnectEquals(original, decoded)
             assertEquals(0, stream.available(), "stream should be drained")
@@ -360,7 +360,7 @@ class MqttConnectCodecTest {
                     it.resetForRead()
                 },
             )
-            assertEquals(PeekResult.Complete(expectedTotal), ConnectCodec.peekFrameSize(stream))
+            assertEquals(PeekResult.Complete(expectedTotal), MqttPacketConnectCodec.peekFrameSize(stream))
         } finally {
             stream.release()
             pool.clear()
@@ -378,7 +378,7 @@ class MqttConnectCodecTest {
 
         val readBuf = BufferFactory.Default.allocate(expected.size).also { it.writeBytes(expected) }
         readBuf.resetForRead()
-        val decoded = ConnectCodec.decode(readBuf, DecodeContext.Empty)
+        val decoded = MqttPacketConnectCodec.decode(readBuf, DecodeContext.Empty)
         assertConnectEquals(original, decoded)
     }
 
@@ -405,5 +405,6 @@ class MqttConnectCodecTest {
         assertEquals(original.password?.bytes?.toList(), decoded.password?.bytes?.toList())
     }
 
-    private fun encode(value: MqttPacket.Connect): ReadBuffer = ConnectCodec.encode(value, EncodeContext.Empty, BufferFactory.Default)
+    private fun encode(value: MqttPacket.Connect): ReadBuffer =
+        MqttPacketConnectCodec.encode(value, EncodeContext.Empty, BufferFactory.Default)
 }

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketCodecTest.kt
@@ -604,7 +604,7 @@ class MqttPacketCodecTest {
     @Test
     fun roundTripsPublishVariantThroughVariantPartial() {
         // Direct Partial flow for the variant codec: the consumer
-        // decodes headers via PublishCodec.partial<P>(...), inspects
+        // decodes headers via MqttPacketPublishCodec.partial<P>(...), inspects
         // the topic, then completes with the payload codec selected
         // at the call site. Verifies the Partial machinery
         // composes with 's @RemainingLength outer-limit
@@ -623,7 +623,7 @@ class MqttPacketCodecTest {
         // Skip the discriminator route — exercise Partial directly on
         // the variant codec (the code path that emits the outer-limit
         // capture).
-        val partial = PublishCodec.partial<JpegImage>(buf, DecodeContext.Empty)
+        val partial = MqttPacketPublishCodec.partial<JpegImage>(buf, DecodeContext.Empty)
         assertEquals("a/b", partial.topic)
         val full = partial.complete(JpegImageCodec)
         assertEquals(original, full)

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPubAckCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPubAckCodecTest.kt
@@ -18,7 +18,7 @@ import kotlin.test.assertFailsWith
 /**
  * MQTT v3.1.1 §3.4 PUBACK packet.
  * Fixed-shape 4-byte ack: header `0x40` + remainingLength=2 +
- * packetIdentifier (UShort BE). Drives the per-variant `PubAckCodec`
+ * packetIdentifier (UShort BE). Drives the per-variant `MqttPacketPubAckCodec`
  * object emitted by the dispatcher (option 1 from the brief).
  */
 class MqttPubAckCodecTest {
@@ -37,7 +37,7 @@ class MqttPubAckCodecTest {
     fun decodesFromSpecBytes() {
         val wire = byteArrayOf(0x40, 0x02, 0x12, 0x34)
         val buf = bigEndianBufferOf(wire)
-        val decoded = PubAckCodec.decode(buf, DecodeContext.Empty)
+        val decoded = MqttPacketPubAckCodec.decode(buf, DecodeContext.Empty)
         assertEquals(MqttFixedHeader(0x40u), decoded.header)
         assertEquals(0x1234u.toUShort(), decoded.packetIdentifier)
     }
@@ -57,7 +57,7 @@ class MqttPubAckCodecTest {
                 0xAD.toByte(),
             )
         val buf = bigEndianBufferOf(wire)
-        PubAckCodec.decode(buf, DecodeContext.Empty)
+        MqttPacketPubAckCodec.decode(buf, DecodeContext.Empty)
         assertEquals(4, buf.position(), "decode advanced exactly through PUBACK")
         assertEquals(4, buf.remaining(), "trailing 4 bytes left in buffer for next packet")
     }
@@ -70,7 +70,7 @@ class MqttPubAckCodecTest {
         buf.writeShort(0x0001.toShort())
         buf.resetForRead()
         val originalLimit = buf.limit()
-        PubAckCodec.decode(buf, DecodeContext.Empty)
+        MqttPacketPubAckCodec.decode(buf, DecodeContext.Empty)
         assertEquals(originalLimit, buf.limit(), "decode restored the outer limit")
     }
 
@@ -82,7 +82,7 @@ class MqttPubAckCodecTest {
                 packetIdentifier = 0xCAFEu,
             )
         val buf = encode(original)
-        assertEquals(original, PubAckCodec.decode(buf, DecodeContext.Empty))
+        assertEquals(original, MqttPacketPubAckCodec.decode(buf, DecodeContext.Empty))
     }
 
     @Test
@@ -100,7 +100,7 @@ class MqttPubAckCodecTest {
         val buf = bigEndianBufferOf(wire)
         val ex =
             assertFailsWith<DecodeException> {
-                PubAckCodec.decode(buf, DecodeContext.Empty)
+                MqttPacketPubAckCodec.decode(buf, DecodeContext.Empty)
             }
         assertEquals("MqttRemainingLength", ex.fieldPath)
     }
@@ -122,7 +122,7 @@ class MqttPubAckCodecTest {
                 stream.append(one)
                 assertEquals(
                     PeekResult.NeedsMoreData,
-                    PubAckCodec.peekFrameSize(stream),
+                    MqttPacketPubAckCodec.peekFrameSize(stream),
                     "after ${i + 1} bytes",
                 )
             }
@@ -130,7 +130,7 @@ class MqttPubAckCodecTest {
             last.writeByte(encoded.readByte())
             last.resetForRead()
             stream.append(last)
-            assertEquals(PeekResult.Complete(totalBytes), PubAckCodec.peekFrameSize(stream))
+            assertEquals(PeekResult.Complete(totalBytes), MqttPacketPubAckCodec.peekFrameSize(stream))
         } finally {
             stream.release()
             pool.clear()
@@ -153,5 +153,6 @@ class MqttPubAckCodecTest {
             .also { it.writeBytes(wire) }
             .also { it.resetForRead() }
 
-    private fun encode(value: MqttPacket.PubAck): ReadBuffer = PubAckCodec.encode(value, EncodeContext.Empty, BufferFactory.Default)
+    private fun encode(value: MqttPacket.PubAck): ReadBuffer =
+        MqttPacketPubAckCodec.encode(value, EncodeContext.Empty, BufferFactory.Default)
 }

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPubCompCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPubCompCodecTest.kt
@@ -18,7 +18,7 @@ import kotlin.test.assertFailsWith
 /**
  * MQTT v3.1.1 §3.7 PUBCOMP packet.
  * Fixed-shape 4-byte ack: header `0x70` + remainingLength=2 +
- * packetIdentifier (UShort BE). Drives `PubCompCodec`.
+ * packetIdentifier (UShort BE). Drives `MqttPacketPubCompCodec`.
  */
 class MqttPubCompCodecTest {
     @Test
@@ -36,7 +36,7 @@ class MqttPubCompCodecTest {
     fun decodesFromSpecBytes() {
         val wire = byteArrayOf(0x70, 0x02, 0x12, 0x34)
         val buf = bigEndianBufferOf(wire)
-        val decoded = PubCompCodec.decode(buf, DecodeContext.Empty)
+        val decoded = MqttPacketPubCompCodec.decode(buf, DecodeContext.Empty)
         assertEquals(MqttFixedHeader(0x70u), decoded.header)
         assertEquals(0x1234u.toUShort(), decoded.packetIdentifier)
     }
@@ -55,7 +55,7 @@ class MqttPubCompCodecTest {
                 0xAD.toByte(),
             )
         val buf = bigEndianBufferOf(wire)
-        PubCompCodec.decode(buf, DecodeContext.Empty)
+        MqttPacketPubCompCodec.decode(buf, DecodeContext.Empty)
         assertEquals(4, buf.position(), "decode advanced exactly through PUBCOMP")
         assertEquals(4, buf.remaining(), "trailing 4 bytes left in buffer for next packet")
     }
@@ -68,7 +68,7 @@ class MqttPubCompCodecTest {
         buf.writeShort(0x0001.toShort())
         buf.resetForRead()
         val originalLimit = buf.limit()
-        PubCompCodec.decode(buf, DecodeContext.Empty)
+        MqttPacketPubCompCodec.decode(buf, DecodeContext.Empty)
         assertEquals(originalLimit, buf.limit(), "decode restored the outer limit")
     }
 
@@ -80,7 +80,7 @@ class MqttPubCompCodecTest {
                 packetIdentifier = 0xCAFEu,
             )
         val buf = encode(original)
-        assertEquals(original, PubCompCodec.decode(buf, DecodeContext.Empty))
+        assertEquals(original, MqttPacketPubCompCodec.decode(buf, DecodeContext.Empty))
     }
 
     @Test
@@ -97,7 +97,7 @@ class MqttPubCompCodecTest {
         val buf = bigEndianBufferOf(wire)
         val ex =
             assertFailsWith<DecodeException> {
-                PubCompCodec.decode(buf, DecodeContext.Empty)
+                MqttPacketPubCompCodec.decode(buf, DecodeContext.Empty)
             }
         assertEquals("MqttRemainingLength", ex.fieldPath)
     }
@@ -119,7 +119,7 @@ class MqttPubCompCodecTest {
                 stream.append(one)
                 assertEquals(
                     PeekResult.NeedsMoreData,
-                    PubCompCodec.peekFrameSize(stream),
+                    MqttPacketPubCompCodec.peekFrameSize(stream),
                     "after ${i + 1} bytes",
                 )
             }
@@ -127,7 +127,7 @@ class MqttPubCompCodecTest {
             last.writeByte(encoded.readByte())
             last.resetForRead()
             stream.append(last)
-            assertEquals(PeekResult.Complete(totalBytes), PubCompCodec.peekFrameSize(stream))
+            assertEquals(PeekResult.Complete(totalBytes), MqttPacketPubCompCodec.peekFrameSize(stream))
         } finally {
             stream.release()
             pool.clear()
@@ -150,5 +150,6 @@ class MqttPubCompCodecTest {
             .also { it.writeBytes(wire) }
             .also { it.resetForRead() }
 
-    private fun encode(value: MqttPacket.PubComp): ReadBuffer = PubCompCodec.encode(value, EncodeContext.Empty, BufferFactory.Default)
+    private fun encode(value: MqttPacket.PubComp): ReadBuffer =
+        MqttPacketPubCompCodec.encode(value, EncodeContext.Empty, BufferFactory.Default)
 }

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPubRecCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPubRecCodecTest.kt
@@ -18,7 +18,7 @@ import kotlin.test.assertFailsWith
 /**
  * MQTT v3.1.1 §3.5 PUBREC packet.
  * Fixed-shape 4-byte ack: header `0x50` + remainingLength=2 +
- * packetIdentifier (UShort BE). Drives `PubRecCodec`.
+ * packetIdentifier (UShort BE). Drives `MqttPacketPubRecCodec`.
  */
 class MqttPubRecCodecTest {
     @Test
@@ -36,7 +36,7 @@ class MqttPubRecCodecTest {
     fun decodesFromSpecBytes() {
         val wire = byteArrayOf(0x50, 0x02, 0x12, 0x34)
         val buf = bigEndianBufferOf(wire)
-        val decoded = PubRecCodec.decode(buf, DecodeContext.Empty)
+        val decoded = MqttPacketPubRecCodec.decode(buf, DecodeContext.Empty)
         assertEquals(MqttFixedHeader(0x50u), decoded.header)
         assertEquals(0x1234u.toUShort(), decoded.packetIdentifier)
     }
@@ -55,7 +55,7 @@ class MqttPubRecCodecTest {
                 0xAD.toByte(),
             )
         val buf = bigEndianBufferOf(wire)
-        PubRecCodec.decode(buf, DecodeContext.Empty)
+        MqttPacketPubRecCodec.decode(buf, DecodeContext.Empty)
         assertEquals(4, buf.position(), "decode advanced exactly through PUBREC")
         assertEquals(4, buf.remaining(), "trailing 4 bytes left in buffer for next packet")
     }
@@ -68,7 +68,7 @@ class MqttPubRecCodecTest {
         buf.writeShort(0x0001.toShort())
         buf.resetForRead()
         val originalLimit = buf.limit()
-        PubRecCodec.decode(buf, DecodeContext.Empty)
+        MqttPacketPubRecCodec.decode(buf, DecodeContext.Empty)
         assertEquals(originalLimit, buf.limit(), "decode restored the outer limit")
     }
 
@@ -80,7 +80,7 @@ class MqttPubRecCodecTest {
                 packetIdentifier = 0xCAFEu,
             )
         val buf = encode(original)
-        assertEquals(original, PubRecCodec.decode(buf, DecodeContext.Empty))
+        assertEquals(original, MqttPacketPubRecCodec.decode(buf, DecodeContext.Empty))
     }
 
     @Test
@@ -97,7 +97,7 @@ class MqttPubRecCodecTest {
         val buf = bigEndianBufferOf(wire)
         val ex =
             assertFailsWith<DecodeException> {
-                PubRecCodec.decode(buf, DecodeContext.Empty)
+                MqttPacketPubRecCodec.decode(buf, DecodeContext.Empty)
             }
         assertEquals("MqttRemainingLength", ex.fieldPath)
     }
@@ -119,7 +119,7 @@ class MqttPubRecCodecTest {
                 stream.append(one)
                 assertEquals(
                     PeekResult.NeedsMoreData,
-                    PubRecCodec.peekFrameSize(stream),
+                    MqttPacketPubRecCodec.peekFrameSize(stream),
                     "after ${i + 1} bytes",
                 )
             }
@@ -127,7 +127,7 @@ class MqttPubRecCodecTest {
             last.writeByte(encoded.readByte())
             last.resetForRead()
             stream.append(last)
-            assertEquals(PeekResult.Complete(totalBytes), PubRecCodec.peekFrameSize(stream))
+            assertEquals(PeekResult.Complete(totalBytes), MqttPacketPubRecCodec.peekFrameSize(stream))
         } finally {
             stream.release()
             pool.clear()
@@ -150,5 +150,6 @@ class MqttPubRecCodecTest {
             .also { it.writeBytes(wire) }
             .also { it.resetForRead() }
 
-    private fun encode(value: MqttPacket.PubRec): ReadBuffer = PubRecCodec.encode(value, EncodeContext.Empty, BufferFactory.Default)
+    private fun encode(value: MqttPacket.PubRec): ReadBuffer =
+        MqttPacketPubRecCodec.encode(value, EncodeContext.Empty, BufferFactory.Default)
 }

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPubRelCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPubRelCodecTest.kt
@@ -46,7 +46,7 @@ class MqttPubRelCodecTest {
     fun decodesFromSpecBytes() {
         val wire = byteArrayOf(0x62, 0x02, 0x12, 0x34)
         val buf = bigEndianBufferOf(wire)
-        val decoded = PubRelCodec.decode(buf, DecodeContext.Empty)
+        val decoded = MqttPacketPubRelCodec.decode(buf, DecodeContext.Empty)
         assertEquals(MqttFixedHeader(0x62u), decoded.header)
         assertEquals(0x1234u.toUShort(), decoded.packetIdentifier)
     }
@@ -65,7 +65,7 @@ class MqttPubRelCodecTest {
                 0xAD.toByte(),
             )
         val buf = bigEndianBufferOf(wire)
-        PubRelCodec.decode(buf, DecodeContext.Empty)
+        MqttPacketPubRelCodec.decode(buf, DecodeContext.Empty)
         assertEquals(4, buf.position(), "decode advanced exactly through PUBREL")
         assertEquals(4, buf.remaining(), "trailing 4 bytes left in buffer for next packet")
     }
@@ -78,7 +78,7 @@ class MqttPubRelCodecTest {
         buf.writeShort(0x0001.toShort())
         buf.resetForRead()
         val originalLimit = buf.limit()
-        PubRelCodec.decode(buf, DecodeContext.Empty)
+        MqttPacketPubRelCodec.decode(buf, DecodeContext.Empty)
         assertEquals(originalLimit, buf.limit(), "decode restored the outer limit")
     }
 
@@ -90,7 +90,7 @@ class MqttPubRelCodecTest {
                 packetIdentifier = 0xCAFEu,
             )
         val buf = encode(original)
-        assertEquals(original, PubRelCodec.decode(buf, DecodeContext.Empty))
+        assertEquals(original, MqttPacketPubRelCodec.decode(buf, DecodeContext.Empty))
     }
 
     @Test
@@ -107,7 +107,7 @@ class MqttPubRelCodecTest {
         val buf = bigEndianBufferOf(wire)
         val ex =
             assertFailsWith<DecodeException> {
-                PubRelCodec.decode(buf, DecodeContext.Empty)
+                MqttPacketPubRelCodec.decode(buf, DecodeContext.Empty)
             }
         assertEquals("MqttRemainingLength", ex.fieldPath)
     }
@@ -129,7 +129,7 @@ class MqttPubRelCodecTest {
                 stream.append(one)
                 assertEquals(
                     PeekResult.NeedsMoreData,
-                    PubRelCodec.peekFrameSize(stream),
+                    MqttPacketPubRelCodec.peekFrameSize(stream),
                     "after ${i + 1} bytes",
                 )
             }
@@ -137,7 +137,7 @@ class MqttPubRelCodecTest {
             last.writeByte(encoded.readByte())
             last.resetForRead()
             stream.append(last)
-            assertEquals(PeekResult.Complete(totalBytes), PubRelCodec.peekFrameSize(stream))
+            assertEquals(PeekResult.Complete(totalBytes), MqttPacketPubRelCodec.peekFrameSize(stream))
         } finally {
             stream.release()
             pool.clear()
@@ -160,5 +160,6 @@ class MqttPubRelCodecTest {
             .also { it.writeBytes(wire) }
             .also { it.resetForRead() }
 
-    private fun encode(value: MqttPacket.PubRel): ReadBuffer = PubRelCodec.encode(value, EncodeContext.Empty, BufferFactory.Default)
+    private fun encode(value: MqttPacket.PubRel): ReadBuffer =
+        MqttPacketPubRelCodec.encode(value, EncodeContext.Empty, BufferFactory.Default)
 }

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttSubAckCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttSubAckCodecTest.kt
@@ -9,11 +9,11 @@ import com.ditchoom.buffer.codec.DecodeException
 import com.ditchoom.buffer.codec.EncodeContext
 import com.ditchoom.buffer.codec.PeekResult
 import com.ditchoom.buffer.codec.WireSize
-import com.ditchoom.buffer.codec.test.protocols.mqtt.suback.FailureCodec
 import com.ditchoom.buffer.codec.test.protocols.mqtt.suback.MqttV3SubAckReturnCode
-import com.ditchoom.buffer.codec.test.protocols.mqtt.suback.SuccessMaximumQoS0Codec
-import com.ditchoom.buffer.codec.test.protocols.mqtt.suback.SuccessMaximumQoS1Codec
-import com.ditchoom.buffer.codec.test.protocols.mqtt.suback.SuccessMaximumQoS2Codec
+import com.ditchoom.buffer.codec.test.protocols.mqtt.suback.MqttV3SubAckReturnCodeFailureCodec
+import com.ditchoom.buffer.codec.test.protocols.mqtt.suback.MqttV3SubAckReturnCodeSuccessMaximumQoS0Codec
+import com.ditchoom.buffer.codec.test.protocols.mqtt.suback.MqttV3SubAckReturnCodeSuccessMaximumQoS1Codec
+import com.ditchoom.buffer.codec.test.protocols.mqtt.suback.MqttV3SubAckReturnCodeSuccessMaximumQoS2Codec
 import com.ditchoom.buffer.pool.BufferPool
 import com.ditchoom.buffer.stream.StreamProcessor
 import kotlin.test.Test
@@ -32,7 +32,7 @@ import kotlin.test.assertFailsWith
  * transitions and the 0/max boundaries.
  *
  * Folded onto the `MqttPacket.SubAck` sealed
- * variant. Drives `SubAckCodec` (the per-variant codec object emitted
+ * variant. Drives `MqttPacketSubAckCodec` (the per-variant codec object emitted
  * by the dispatcher) per the brief's option 1: same byte
  * exact assertions, same Partial / Aggregator / peekFrameSize
  * coverage, with the per-variant codec reachable directly. The
@@ -91,7 +91,7 @@ class MqttSubAckCodecTest {
     fun decodesSingleReturnCodeFromSpecBytes() {
         val wire = byteArrayOf(0x90.toByte(), 0x03, 0x00, 0x01, 0x00)
         val buf = bigEndianBufferOf(wire)
-        val decoded = SubAckCodec.decode(buf, DecodeContext.Empty)
+        val decoded = MqttPacketSubAckCodec.decode(buf, DecodeContext.Empty)
         assertEquals(MqttFixedHeader(0x90u), decoded.header)
         assertEquals(1u.toUShort(), decoded.packetIdentifier)
         assertEquals(listOf(MqttV3SubAckReturnCode.SuccessMaximumQoS0), decoded.returnCodes)
@@ -116,7 +116,7 @@ class MqttSubAckCodecTest {
                 0xAD.toByte(),
             )
         val buf = bigEndianBufferOf(wire)
-        val decoded = SubAckCodec.decode(buf, DecodeContext.Empty)
+        val decoded = MqttPacketSubAckCodec.decode(buf, DecodeContext.Empty)
         assertEquals(1, decoded.returnCodes.size, "decode bounded by remainingLength, not buffer remaining")
         assertEquals(5, buf.position(), "decode advanced exactly through SUBACK")
         assertEquals(4, buf.remaining(), "trailing 4 bytes left in buffer for next packet")
@@ -133,7 +133,7 @@ class MqttSubAckCodecTest {
         buf.writeByte(0x00.toByte())
         buf.resetForRead()
         val originalLimit = buf.limit()
-        SubAckCodec.decode(buf, DecodeContext.Empty)
+        MqttPacketSubAckCodec.decode(buf, DecodeContext.Empty)
         assertEquals(originalLimit, buf.limit(), "decode restored the outer limit")
     }
 
@@ -151,7 +151,7 @@ class MqttSubAckCodecTest {
                     ),
             )
         val buf = encode(original)
-        assertEquals(original, SubAckCodec.decode(buf, DecodeContext.Empty))
+        assertEquals(original, MqttPacketSubAckCodec.decode(buf, DecodeContext.Empty))
     }
 
     @Test
@@ -219,7 +219,7 @@ class MqttSubAckCodecTest {
         for (rl in listOf(127u, 128u, 16_383u, 16_384u)) {
             val msg = makeAckWithRemainingLength(rl)
             val buf = encode(msg)
-            val decoded = SubAckCodec.decode(buf, DecodeContext.Empty)
+            val decoded = MqttPacketSubAckCodec.decode(buf, DecodeContext.Empty)
             assertEquals(msg, decoded, "full round-trip remainingLength=$rl")
         }
     }
@@ -239,7 +239,7 @@ class MqttSubAckCodecTest {
         val buf = bigEndianBufferOf(wire)
         val ex =
             assertFailsWith<DecodeException> {
-                SubAckCodec.decode(buf, DecodeContext.Empty)
+                MqttPacketSubAckCodec.decode(buf, DecodeContext.Empty)
             }
         // FieldPath is now controlled by the codec
         // (`MqttRemainingLengthCodec.decode`'s own throw site); the
@@ -275,7 +275,7 @@ class MqttSubAckCodecTest {
                 stream.append(one)
                 assertEquals(
                     PeekResult.NeedsMoreData,
-                    SubAckCodec.peekFrameSize(stream),
+                    MqttPacketSubAckCodec.peekFrameSize(stream),
                     "after ${i + 1} bytes",
                 )
             }
@@ -283,7 +283,7 @@ class MqttSubAckCodecTest {
             last.writeByte(encoded.readByte())
             last.resetForRead()
             stream.append(last)
-            assertEquals(PeekResult.Complete(totalBytes), SubAckCodec.peekFrameSize(stream))
+            assertEquals(PeekResult.Complete(totalBytes), MqttPacketSubAckCodec.peekFrameSize(stream))
         } finally {
             stream.release()
             pool.clear()
@@ -307,7 +307,7 @@ class MqttSubAckCodecTest {
             b1.writeByte(encoded.readByte())
             b1.resetForRead()
             stream.append(b1)
-            assertEquals(PeekResult.NeedsMoreData, SubAckCodec.peekFrameSize(stream))
+            assertEquals(PeekResult.NeedsMoreData, MqttPacketSubAckCodec.peekFrameSize(stream))
 
             // Second byte is the first var-int byte (continuation bit set since 200 > 127).
             val b2 = BufferFactory.Default.allocate(1)
@@ -316,7 +316,7 @@ class MqttSubAckCodecTest {
             stream.append(b2)
             assertEquals(
                 PeekResult.NeedsMoreData,
-                SubAckCodec.peekFrameSize(stream),
+                MqttPacketSubAckCodec.peekFrameSize(stream),
                 "var-int continuation bit set, need second byte",
             )
 
@@ -327,7 +327,7 @@ class MqttSubAckCodecTest {
             stream.append(b3)
             assertEquals(
                 PeekResult.NeedsMoreData,
-                SubAckCodec.peekFrameSize(stream),
+                MqttPacketSubAckCodec.peekFrameSize(stream),
                 "var-int complete but still need 200 body bytes",
             )
 
@@ -337,13 +337,13 @@ class MqttSubAckCodecTest {
                 one.writeByte(encoded.readByte())
                 one.resetForRead()
                 stream.append(one)
-                assertEquals(PeekResult.NeedsMoreData, SubAckCodec.peekFrameSize(stream))
+                assertEquals(PeekResult.NeedsMoreData, MqttPacketSubAckCodec.peekFrameSize(stream))
             }
             val last = BufferFactory.Default.allocate(1)
             last.writeByte(encoded.readByte())
             last.resetForRead()
             stream.append(last)
-            assertEquals(PeekResult.Complete(totalBytes), SubAckCodec.peekFrameSize(stream))
+            assertEquals(PeekResult.Complete(totalBytes), MqttPacketSubAckCodec.peekFrameSize(stream))
         } finally {
             stream.release()
             pool.clear()
@@ -380,25 +380,25 @@ class MqttSubAckCodecTest {
                 VariantCase(
                     "SuccessMaximumQoS0",
                     MqttV3SubAckReturnCode.SuccessMaximumQoS0,
-                    SuccessMaximumQoS0Codec as com.ditchoom.buffer.codec.Codec<MqttV3SubAckReturnCode>,
+                    MqttV3SubAckReturnCodeSuccessMaximumQoS0Codec as com.ditchoom.buffer.codec.Codec<MqttV3SubAckReturnCode>,
                     0x00.toByte(),
                 ),
                 VariantCase(
                     "SuccessMaximumQoS1",
                     MqttV3SubAckReturnCode.SuccessMaximumQoS1,
-                    SuccessMaximumQoS1Codec as com.ditchoom.buffer.codec.Codec<MqttV3SubAckReturnCode>,
+                    MqttV3SubAckReturnCodeSuccessMaximumQoS1Codec as com.ditchoom.buffer.codec.Codec<MqttV3SubAckReturnCode>,
                     0x01.toByte(),
                 ),
                 VariantCase(
                     "SuccessMaximumQoS2",
                     MqttV3SubAckReturnCode.SuccessMaximumQoS2,
-                    SuccessMaximumQoS2Codec as com.ditchoom.buffer.codec.Codec<MqttV3SubAckReturnCode>,
+                    MqttV3SubAckReturnCodeSuccessMaximumQoS2Codec as com.ditchoom.buffer.codec.Codec<MqttV3SubAckReturnCode>,
                     0x02.toByte(),
                 ),
                 VariantCase(
                     "Failure",
                     MqttV3SubAckReturnCode.Failure,
-                    FailureCodec as com.ditchoom.buffer.codec.Codec<MqttV3SubAckReturnCode>,
+                    MqttV3SubAckReturnCodeFailureCodec as com.ditchoom.buffer.codec.Codec<MqttV3SubAckReturnCode>,
                     0x80.toByte(),
                 ),
             )
@@ -474,5 +474,6 @@ class MqttSubAckCodecTest {
             .also { it.writeBytes(wire) }
             .also { it.resetForRead() }
 
-    private fun encode(value: MqttPacket.SubAck): ReadBuffer = SubAckCodec.encode(value, EncodeContext.Empty, BufferFactory.Default)
+    private fun encode(value: MqttPacket.SubAck): ReadBuffer =
+        MqttPacketSubAckCodec.encode(value, EncodeContext.Empty, BufferFactory.Default)
 }

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttSubscribeCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttSubscribeCodecTest.kt
@@ -20,7 +20,7 @@ import kotlin.test.assertFailsWith
  * packet. Variable-shape body: header `0x82` + remainingLength +
  * packetIdentifier + a non-empty list of `MqttTopicFilter`
  * elements (`<2-byte LP><filter><qos>` per element). Drives
- * `SubscribeCodec` over the emitter slice
+ * `MqttPacketSubscribeCodec` over the emitter slice
  * (`@RemainingBytes List<@ProtocolMessage T>`).
  */
 class MqttSubscribeCodecTest {
@@ -111,7 +111,7 @@ class MqttSubscribeCodecTest {
                 0x01,
             )
         val buf = bigEndianBufferOf(wire)
-        val decoded = SubscribeCodec.decode(buf, DecodeContext.Empty)
+        val decoded = MqttPacketSubscribeCodec.decode(buf, DecodeContext.Empty)
         assertEquals(MqttFixedHeader(0x82u), decoded.header)
         assertEquals(0x000Au.toUShort(), decoded.packetIdentifier)
         assertEquals(listOf(MqttTopicFilter("t/1", 0x01u)), decoded.topicFilters)
@@ -137,7 +137,7 @@ class MqttSubscribeCodecTest {
                 0xAD.toByte(),
             )
         val buf = bigEndianBufferOf(wire)
-        val decoded = SubscribeCodec.decode(buf, DecodeContext.Empty)
+        val decoded = MqttPacketSubscribeCodec.decode(buf, DecodeContext.Empty)
         assertEquals(1, decoded.topicFilters.size, "decode bounded by remainingLength, not buffer remaining")
         assertEquals(8, buf.position(), "decode advanced exactly through SUBSCRIBE")
         assertEquals(4, buf.remaining(), "trailing 4 bytes left in buffer for next packet")
@@ -154,7 +154,7 @@ class MqttSubscribeCodecTest {
         buf.writeByte(0x00)
         buf.resetForRead()
         val originalLimit = buf.limit()
-        SubscribeCodec.decode(buf, DecodeContext.Empty)
+        MqttPacketSubscribeCodec.decode(buf, DecodeContext.Empty)
         assertEquals(originalLimit, buf.limit(), "decode restored the outer limit")
     }
 
@@ -173,7 +173,7 @@ class MqttSubscribeCodecTest {
                     ),
             )
         val buf = encode(original)
-        assertEquals(original, SubscribeCodec.decode(buf, DecodeContext.Empty))
+        assertEquals(original, MqttPacketSubscribeCodec.decode(buf, DecodeContext.Empty))
     }
 
     @Test
@@ -190,7 +190,7 @@ class MqttSubscribeCodecTest {
         val buf = bigEndianBufferOf(wire)
         val ex =
             assertFailsWith<DecodeException> {
-                SubscribeCodec.decode(buf, DecodeContext.Empty)
+                MqttPacketSubscribeCodec.decode(buf, DecodeContext.Empty)
             }
         assertEquals("MqttRemainingLength", ex.fieldPath)
     }
@@ -217,7 +217,7 @@ class MqttSubscribeCodecTest {
                 stream.append(one)
                 assertEquals(
                     PeekResult.NeedsMoreData,
-                    SubscribeCodec.peekFrameSize(stream),
+                    MqttPacketSubscribeCodec.peekFrameSize(stream),
                     "after ${i + 1} bytes",
                 )
             }
@@ -225,7 +225,7 @@ class MqttSubscribeCodecTest {
             last.writeByte(encoded.readByte())
             last.resetForRead()
             stream.append(last)
-            assertEquals(PeekResult.Complete(totalBytes), SubscribeCodec.peekFrameSize(stream))
+            assertEquals(PeekResult.Complete(totalBytes), MqttPacketSubscribeCodec.peekFrameSize(stream))
         } finally {
             stream.release()
             pool.clear()
@@ -248,5 +248,6 @@ class MqttSubscribeCodecTest {
             .also { it.writeBytes(wire) }
             .also { it.resetForRead() }
 
-    private fun encode(value: MqttPacket.Subscribe): ReadBuffer = SubscribeCodec.encode(value, EncodeContext.Empty, BufferFactory.Default)
+    private fun encode(value: MqttPacket.Subscribe): ReadBuffer =
+        MqttPacketSubscribeCodec.encode(value, EncodeContext.Empty, BufferFactory.Default)
 }

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttUnsubAckCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttUnsubAckCodecTest.kt
@@ -37,7 +37,7 @@ class MqttUnsubAckCodecTest {
     fun decodesFromSpecBytes() {
         val wire = byteArrayOf(0xB0.toByte(), 0x02, 0x12, 0x34)
         val buf = bigEndianBufferOf(wire)
-        val decoded = UnsubAckCodec.decode(buf, DecodeContext.Empty)
+        val decoded = MqttPacketUnsubAckCodec.decode(buf, DecodeContext.Empty)
         assertEquals(MqttFixedHeader(0xB0u), decoded.header)
         assertEquals(0x1234u.toUShort(), decoded.packetIdentifier)
     }
@@ -56,7 +56,7 @@ class MqttUnsubAckCodecTest {
                 0xAD.toByte(),
             )
         val buf = bigEndianBufferOf(wire)
-        UnsubAckCodec.decode(buf, DecodeContext.Empty)
+        MqttPacketUnsubAckCodec.decode(buf, DecodeContext.Empty)
         assertEquals(4, buf.position(), "decode advanced exactly through UNSUBACK")
         assertEquals(4, buf.remaining(), "trailing 4 bytes left in buffer for next packet")
     }
@@ -69,7 +69,7 @@ class MqttUnsubAckCodecTest {
         buf.writeShort(0x0001.toShort())
         buf.resetForRead()
         val originalLimit = buf.limit()
-        UnsubAckCodec.decode(buf, DecodeContext.Empty)
+        MqttPacketUnsubAckCodec.decode(buf, DecodeContext.Empty)
         assertEquals(originalLimit, buf.limit(), "decode restored the outer limit")
     }
 
@@ -81,7 +81,7 @@ class MqttUnsubAckCodecTest {
                 packetIdentifier = 0xCAFEu,
             )
         val buf = encode(original)
-        assertEquals(original, UnsubAckCodec.decode(buf, DecodeContext.Empty))
+        assertEquals(original, MqttPacketUnsubAckCodec.decode(buf, DecodeContext.Empty))
     }
 
     @Test
@@ -98,7 +98,7 @@ class MqttUnsubAckCodecTest {
         val buf = bigEndianBufferOf(wire)
         val ex =
             assertFailsWith<DecodeException> {
-                UnsubAckCodec.decode(buf, DecodeContext.Empty)
+                MqttPacketUnsubAckCodec.decode(buf, DecodeContext.Empty)
             }
         assertEquals("MqttRemainingLength", ex.fieldPath)
     }
@@ -120,7 +120,7 @@ class MqttUnsubAckCodecTest {
                 stream.append(one)
                 assertEquals(
                     PeekResult.NeedsMoreData,
-                    UnsubAckCodec.peekFrameSize(stream),
+                    MqttPacketUnsubAckCodec.peekFrameSize(stream),
                     "after ${i + 1} bytes",
                 )
             }
@@ -128,7 +128,7 @@ class MqttUnsubAckCodecTest {
             last.writeByte(encoded.readByte())
             last.resetForRead()
             stream.append(last)
-            assertEquals(PeekResult.Complete(totalBytes), UnsubAckCodec.peekFrameSize(stream))
+            assertEquals(PeekResult.Complete(totalBytes), MqttPacketUnsubAckCodec.peekFrameSize(stream))
         } finally {
             stream.release()
             pool.clear()
@@ -151,5 +151,6 @@ class MqttUnsubAckCodecTest {
             .also { it.writeBytes(wire) }
             .also { it.resetForRead() }
 
-    private fun encode(value: MqttPacket.UnsubAck): ReadBuffer = UnsubAckCodec.encode(value, EncodeContext.Empty, BufferFactory.Default)
+    private fun encode(value: MqttPacket.UnsubAck): ReadBuffer =
+        MqttPacketUnsubAckCodec.encode(value, EncodeContext.Empty, BufferFactory.Default)
 }

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttUnsubscribeCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttUnsubscribeCodecTest.kt
@@ -20,7 +20,7 @@ import kotlin.test.assertFailsWith
  * packet. Variable-shape body: header `0xA2` + remainingLength +
  * packetIdentifier + a non-empty list of `MqttUnsubscribeTopic`
  * elements (each `<2-byte LP><name>` per element). Drives
- * `UnsubscribeCodec` over the emitter slice
+ * `MqttPacketUnsubscribeCodec` over the emitter slice
  * (`@RemainingBytes List<@ProtocolMessage T>`); the topic-element
  * data class wraps the LP string per the brief's gap-5 resolution.
  */
@@ -107,7 +107,7 @@ class MqttUnsubscribeCodecTest {
                 '1'.code.toByte(),
             )
         val buf = bigEndianBufferOf(wire)
-        val decoded = UnsubscribeCodec.decode(buf, DecodeContext.Empty)
+        val decoded = MqttPacketUnsubscribeCodec.decode(buf, DecodeContext.Empty)
         assertEquals(MqttFixedHeader(0xA2u), decoded.header)
         assertEquals(0x000Au.toUShort(), decoded.packetIdentifier)
         assertEquals(listOf(MqttUnsubscribeTopic("t/1")), decoded.topics)
@@ -132,7 +132,7 @@ class MqttUnsubscribeCodecTest {
                 0xAD.toByte(),
             )
         val buf = bigEndianBufferOf(wire)
-        val decoded = UnsubscribeCodec.decode(buf, DecodeContext.Empty)
+        val decoded = MqttPacketUnsubscribeCodec.decode(buf, DecodeContext.Empty)
         assertEquals(1, decoded.topics.size, "decode bounded by remainingLength, not buffer remaining")
         assertEquals(7, buf.position(), "decode advanced exactly through UNSUBSCRIBE")
         assertEquals(4, buf.remaining(), "trailing 4 bytes left in buffer for next packet")
@@ -148,7 +148,7 @@ class MqttUnsubscribeCodecTest {
         buf.writeByte('x'.code.toByte())
         buf.resetForRead()
         val originalLimit = buf.limit()
-        UnsubscribeCodec.decode(buf, DecodeContext.Empty)
+        MqttPacketUnsubscribeCodec.decode(buf, DecodeContext.Empty)
         assertEquals(originalLimit, buf.limit(), "decode restored the outer limit")
     }
 
@@ -166,7 +166,7 @@ class MqttUnsubscribeCodecTest {
                     ),
             )
         val buf = encode(original)
-        assertEquals(original, UnsubscribeCodec.decode(buf, DecodeContext.Empty))
+        assertEquals(original, MqttPacketUnsubscribeCodec.decode(buf, DecodeContext.Empty))
     }
 
     @Test
@@ -183,7 +183,7 @@ class MqttUnsubscribeCodecTest {
         val buf = bigEndianBufferOf(wire)
         val ex =
             assertFailsWith<DecodeException> {
-                UnsubscribeCodec.decode(buf, DecodeContext.Empty)
+                MqttPacketUnsubscribeCodec.decode(buf, DecodeContext.Empty)
             }
         assertEquals("MqttRemainingLength", ex.fieldPath)
     }
@@ -210,7 +210,7 @@ class MqttUnsubscribeCodecTest {
                 stream.append(one)
                 assertEquals(
                     PeekResult.NeedsMoreData,
-                    UnsubscribeCodec.peekFrameSize(stream),
+                    MqttPacketUnsubscribeCodec.peekFrameSize(stream),
                     "after ${i + 1} bytes",
                 )
             }
@@ -218,7 +218,7 @@ class MqttUnsubscribeCodecTest {
             last.writeByte(encoded.readByte())
             last.resetForRead()
             stream.append(last)
-            assertEquals(PeekResult.Complete(totalBytes), UnsubscribeCodec.peekFrameSize(stream))
+            assertEquals(PeekResult.Complete(totalBytes), MqttPacketUnsubscribeCodec.peekFrameSize(stream))
         } finally {
             stream.release()
             pool.clear()
@@ -242,5 +242,5 @@ class MqttUnsubscribeCodecTest {
             .also { it.resetForRead() }
 
     private fun encode(value: MqttPacket.Unsubscribe): ReadBuffer =
-        UnsubscribeCodec.encode(value, EncodeContext.Empty, BufferFactory.Default)
+        MqttPacketUnsubscribeCodec.encode(value, EncodeContext.Empty, BufferFactory.Default)
 }


### PR DESCRIPTION
## Summary

The v5.0 strip-and-rebuild of `buffer-codec-processor` silently dropped commit `923aaa48`'s always-flatten codec naming convention. Two `@ProtocolMessage` data classes nested under different sealed parents in the same package (e.g. `CommandPayload.LedStateSet` and `ResponsePayload.LedStateSet`) both resolved to `LedStateSetCodec.kt` and KSP threw `FileAlreadyExistsException` at file-write time — issue #156.

This PR restores the v4 convention: every codec object name prepends its enclosing-type chain. `MqttPacket.SubAck` → `MqttPacketSubAckCodec`. Wire format and round-trip behavior are unchanged; only the generated codec object name differs.

### Changes
- New `StringUtils.kt` — `flattenedCodecName()` + `enclosingSimpleNames()` helpers, ported from `923aaa48`.
- `CodecEmitter.kt` — 14 codec-naming sites switched to `decl.flattenedCodecName()`.
- New regression fixture (`Issue156NestedNameProtocol` + `Issue156NestedNameTest`) — encodes the exact bug shape from the issue: two same-named nested data classes in sibling sealed parents, both round-trip independently, distinct codec object names.
- 11 MQTT test files renamed for the new convention — 15 distinct codec identifiers (`SubAckCodec` → `MqttPacketSubAckCodec`, etc.). Pure renames, no assertion logic changed.

### Why minor (v5.1), not patch (v5.0.1)
This is a behavioral change for v5.0.x users with nested `@ProtocolMessage` classes whose simple names don't currently collide. Their generated codec names change from simple form to flattened form, breaking import references. Wire format unchanged.

Migration: rename references from `MyVariantCodec` to `OuterClassMyVariantCodec` for `@ProtocolMessage` classes nested inside other types.

Fixes #156.

## Test plan
- [x] `./gradlew :buffer-codec-processor:test :buffer-codec-test:jvmTest ktlintCheck` — green
- [x] `./gradlew :buffer-codec-test:compileTestKotlinWasmJs :buffer-codec-test:compileTestKotlinLinuxX64` — green
- [x] New `Issue156NestedNameTest` round-trips both `Issue156Command.LedStateSet` and `Issue156Response.LedStateSet` and asserts distinct codec object names
- [x] Compiler-verified audit: the 11 MQTT test files are the only references in the repo that used unflattened names; no other protocols, platform-specific code, or docs affected