### PR TITLE
ci: fix PR-files API jq filter (.path → .filename)

### DIFF
--- a/.github/workflows/merged.yaml
+++ b/.github/workflows/merged.yaml
@@ -83,9 +83,12 @@ jobs:
           # Use the paginated "list PR files" API rather than `gh pr diff`: the
           # latter hits the .diff endpoint, which GitHub caps at 300 files and
           # returns HTTP 406 for larger PRs.
+          # The PR-files API returns objects with a `filename` field, not `path`.
+          # The earlier `gh pr diff --name-only` shortcut emitted bare filenames;
+          # switching to the API silently broke the loop when this used `.path`.
           changed_files=$(gh api --paginate \
             "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
-            --jq '.[].path')
+            --jq '.[].filename')
           for file in $changed_files; do
             case "$file" in
               .github/*|*.md|.gitignore|.editorconfig|CLAUDE.md|LICENSE|*.txt)


### PR DESCRIPTION
## Summary

`.github/workflows/merged.yaml`'s "Check if release is needed" step
iterates the list of files changed in a merged PR to decide whether
the release should fire or be auto-skipped (docs-only / .github-only
PRs skip). PR #155 switched the file listing from `gh pr diff --name-only`
to the paginated `gh api .../pulls/<n>/files` endpoint to dodge the
diff-endpoint's 300-file cap.

The PR-files API returns objects with a `filename` field, not `path`.
The jq filter still said `.path`, so `changed_files` was always empty,
the for-loop iterated zero times, and the script always fell through to
`Only non-code files changed, skipping`.

**Impact:** every code PR merged after #155 silently skipped release.
v5.1.0 (fix for #156, PR #158) was not published on merge — it had to
be recovered via `workflow_dispatch`.

## Test plan

Verified by calling the API directly against PR #158:

```
$ gh api repos/DitchOoM/buffer/pulls/158/files --jq '. | length'
15
$ gh api repos/DitchOoM/buffer/pulls/158/files --jq '.[].path'
(empty)
$ gh api repos/DitchOoM/buffer/pulls/158/files --jq '.[].filename'
.github/workflows/...
buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
...
```

The next code PR to merge after this lands should trigger the release
flow normally. The `skip-release` and `draft-release` label paths and
the docs-only auto-skip path (which match against this same loop) all
become correct again.

This PR itself is `.github/*`-only, so on merge it will still match
the docs-only skip path — that's intended; no release should fire for
a workflow-only change.