### PR TITLE
test(codec): KSP golden-file snapshot harness

### DIFF
--- a/buffer-codec-test/build.gradle.kts
+++ b/buffer-codec-test/build.gradle.kts
@@ -107,7 +107,12 @@ ktlint {
     filter {
         exclude("**/generated/**")
         exclude("**/build/**")
-        exclude { it.file.path.contains("/generated/") || it.file.path.contains("/build/") }
+        exclude("**/codec-snapshots/**")
+        exclude {
+            it.file.path.contains("/generated/") ||
+                it.file.path.contains("/build/") ||
+                it.file.path.contains("/codec-snapshots/")
+        }
     }
 }
 
@@ -131,4 +136,25 @@ tasks
 // an existing TLAB never trigger an event and the assertion is non-deterministic.
 tasks.named<Test>("jvmTest") {
     jvmArgs("-XX:-UseTLAB")
+    // CodecSnapshotTest reads KSP-generated output and compares against
+    // the checked-in baseline tree. Hand it the two roots so the test does
+    // not need build-time path knowledge.
+    systemProperty(
+        "codec.snapshot.generated",
+        layout.buildDirectory
+            .dir("generated/ksp/metadata/commonMain/kotlin")
+            .get()
+            .asFile.absolutePath,
+    )
+    systemProperty(
+        "codec.snapshot.baseline",
+        layout.projectDirectory
+            .dir("codec-snapshots")
+            .asFile.absolutePath,
+    )
+    // Forward the regen flag from the gradle command line into the test JVM.
+    systemProperty(
+        "update.snapshots",
+        providers.systemProperty("update.snapshots").getOrElse("false"),
+    )
 }

--- a/buffer-codec-test/codec-snapshots/README.md
+++ b/buffer-codec-test/codec-snapshots/README.md
@@ -1,0 +1,41 @@
+# Codec Snapshots
+
+Checked-in baseline of every `.kt` file `buffer-codec-processor` emits for
+the fixtures in this module. The mirror of
+`build/generated/ksp/metadata/commonMain/kotlin/`.
+
+`CodecSnapshotTest` (in `src/jvmTest`) diffs the live KSP output against
+this tree on every `:buffer-codec-test:jvmTest` run.
+
+## Why this exists
+
+The v4 → v5.0 strip-and-rebuild of `buffer-codec-processor` silently
+changed several emit shapes — nested codec naming regressed (issue #156),
+the batching optimizer was deleted, the SPI extension point was removed.
+Round-trip tests pass on *different but still valid* output, so none of
+these surfaced until an external user hit one in production. Locking the
+emit shape in a checked-in baseline makes every change a reviewable diff.
+
+## Regen workflow
+
+When you intentionally change codec emit shape (new feature, bug fix,
+refactor in the emitter), regenerate the baselines and review the diff:
+
+```
+./gradlew :buffer-codec-test:jvmTest -Dupdate.snapshots=true
+git add buffer-codec-test/codec-snapshots
+git commit
+```
+
+The diff from that commit becomes the change's migration note. Reviewers
+should be able to read it and understand what downstream codec users
+will see differently.
+
+## Don't edit these files by hand
+
+These files are mechanical output of the KSP processor. If something here
+looks wrong, fix the processor and regenerate — do not patch the snapshot
+directly. A snapshot edited by hand will drift from generated output on
+the next regen and the diff will be confusing.
+
+`ktlint` is configured to skip this directory (see `build.gradle.kts`).

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/CommandPayloadCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/CommandPayloadCodec.kt
@@ -1,0 +1,82 @@
+package com.ditchoom.buffer.codec.test.protocols
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object CommandPayloadCodec : Codec<CommandPayload> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): CommandPayload {
+    val discriminatorPosition = buffer.position()
+    val discriminator = buffer.readUByte().toInt()
+    return when (discriminator) {
+      0x22 -> CommandPayloadSetRgbStateCodec.decode(buffer, context)
+      0x23 -> CommandPayloadGetRgbStateCodec.decode(buffer, context)
+      0x24 -> CommandPayloadResetDeviceCodec.decode(buffer, context)
+      else -> {
+        throw DecodeException(fieldPath = "CommandPayload.discriminator", bufferPosition = discriminatorPosition, expected = "one of {0x22, 0x23, 0x24}", actual = """0x${discriminator.toString(16).padStart(2, '0').uppercase()}""")
+      }
+    }
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: CommandPayload,
+    context: EncodeContext,
+  ) {
+    when (value) {
+      is CommandPayload.SetRgbState -> {
+        buffer.writeUByte(0x22.toUByte())
+        CommandPayloadSetRgbStateCodec.encode(buffer, value, context)
+      }
+      is CommandPayload.GetRgbState -> {
+        buffer.writeUByte(0x23.toUByte())
+        CommandPayloadGetRgbStateCodec.encode(buffer, value, context)
+      }
+      is CommandPayload.ResetDevice -> {
+        buffer.writeUByte(0x24.toUByte())
+        CommandPayloadResetDeviceCodec.encode(buffer, value, context)
+      }
+    }
+  }
+
+  override fun wireSize(`value`: CommandPayload, context: EncodeContext): WireSize = when (value) {
+    is CommandPayload.SetRgbState -> WireSize.Exact(4)
+    is CommandPayload.GetRgbState -> WireSize.Exact(1)
+    is CommandPayload.ResetDevice -> WireSize.Exact(1)
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
+    val discriminator = stream.peekByte(baseOffset).toInt() and 0xFF
+    return when (discriminator) {
+      0x22 -> {
+        when (val inner = CommandPayloadSetRgbStateCodec.peekFrameSize(stream, baseOffset + 1)) {
+          is PeekResult.Complete -> PeekResult.Complete(1 + inner.bytes)
+          else -> inner
+        }
+      }
+      0x23 -> {
+        when (val inner = CommandPayloadGetRgbStateCodec.peekFrameSize(stream, baseOffset + 1)) {
+          is PeekResult.Complete -> PeekResult.Complete(1 + inner.bytes)
+          else -> inner
+        }
+      }
+      0x24 -> {
+        when (val inner = CommandPayloadResetDeviceCodec.peekFrameSize(stream, baseOffset + 1)) {
+          is PeekResult.Complete -> PeekResult.Complete(1 + inner.bytes)
+          else -> inner
+        }
+      }
+      else -> {
+        throw DecodeException(fieldPath = "CommandPayload.discriminator", bufferPosition = baseOffset, expected = "one of {0x22, 0x23, 0x24}", actual = """0x${discriminator.toString(16).padStart(2, '0').uppercase()}""")
+      }
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/CommandPayloadGetRgbStateCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/CommandPayloadGetRgbStateCodec.kt
@@ -1,0 +1,26 @@
+package com.ditchoom.buffer.codec.test.protocols
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object CommandPayloadGetRgbStateCodec : Codec<CommandPayload.GetRgbState> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): CommandPayload.GetRgbState = CommandPayload.GetRgbState
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: CommandPayload.GetRgbState,
+    context: EncodeContext,
+  ) {
+  }
+
+  override fun wireSize(`value`: CommandPayload.GetRgbState, context: EncodeContext): WireSize = WireSize.Exact(0)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 0) PeekResult.Complete(0) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/CommandPayloadResetDeviceCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/CommandPayloadResetDeviceCodec.kt
@@ -1,0 +1,26 @@
+package com.ditchoom.buffer.codec.test.protocols
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object CommandPayloadResetDeviceCodec : Codec<CommandPayload.ResetDevice> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): CommandPayload.ResetDevice = CommandPayload.ResetDevice
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: CommandPayload.ResetDevice,
+    context: EncodeContext,
+  ) {
+  }
+
+  override fun wireSize(`value`: CommandPayload.ResetDevice, context: EncodeContext): WireSize = WireSize.Exact(0)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 0) PeekResult.Complete(0) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/CommandPayloadSetRgbStateCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/CommandPayloadSetRgbStateCodec.kt
@@ -1,0 +1,34 @@
+package com.ditchoom.buffer.codec.test.protocols
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object CommandPayloadSetRgbStateCodec : Codec<CommandPayload.SetRgbState> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): CommandPayload.SetRgbState {
+    val r = buffer.readUByte()
+    val g = buffer.readUByte()
+    val b = buffer.readUByte()
+    return CommandPayload.SetRgbState(r = r, g = g, b = b)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: CommandPayload.SetRgbState,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.r)
+    buffer.writeUByte(value.g)
+    buffer.writeUByte(value.b)
+  }
+
+  override fun wireSize(`value`: CommandPayload.SetRgbState, context: EncodeContext): WireSize = WireSize.Exact(3)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 3) PeekResult.Complete(3) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ConnectionStatusCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ConnectionStatusCodec.kt
@@ -1,0 +1,94 @@
+package com.ditchoom.buffer.codec.test.protocols
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object ConnectionStatusCodec : Codec<ConnectionStatus> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): ConnectionStatus {
+    val discriminatorPosition = buffer.position()
+    val discriminator = buffer.readUByte().toInt()
+    return when (discriminator) {
+      0x00 -> ConnectionStatusDisconnectedCodec.decode(buffer, context)
+      0x01 -> ConnectionStatusConnectingCodec.decode(buffer, context)
+      0x02 -> ConnectionStatusConnectedCodec.decode(buffer, context)
+      0x03 -> ConnectionStatusFailedCodec.decode(buffer, context)
+      else -> {
+        throw DecodeException(fieldPath = "ConnectionStatus.discriminator", bufferPosition = discriminatorPosition, expected = "one of {0x00, 0x01, 0x02, 0x03}", actual = """0x${discriminator.toString(16).padStart(2, '0').uppercase()}""")
+      }
+    }
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: ConnectionStatus,
+    context: EncodeContext,
+  ) {
+    when (value) {
+      is ConnectionStatus.Disconnected -> {
+        buffer.writeUByte(0x00.toUByte())
+        ConnectionStatusDisconnectedCodec.encode(buffer, value, context)
+      }
+      is ConnectionStatus.Connecting -> {
+        buffer.writeUByte(0x01.toUByte())
+        ConnectionStatusConnectingCodec.encode(buffer, value, context)
+      }
+      is ConnectionStatus.Connected -> {
+        buffer.writeUByte(0x02.toUByte())
+        ConnectionStatusConnectedCodec.encode(buffer, value, context)
+      }
+      is ConnectionStatus.Failed -> {
+        buffer.writeUByte(0x03.toUByte())
+        ConnectionStatusFailedCodec.encode(buffer, value, context)
+      }
+    }
+  }
+
+  override fun wireSize(`value`: ConnectionStatus, context: EncodeContext): WireSize = when (value) {
+    is ConnectionStatus.Disconnected -> WireSize.Exact(1)
+    is ConnectionStatus.Connecting -> WireSize.Exact(2)
+    is ConnectionStatus.Connected -> WireSize.Exact(1)
+    is ConnectionStatus.Failed -> WireSize.Exact(1)
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
+    val discriminator = stream.peekByte(baseOffset).toInt() and 0xFF
+    return when (discriminator) {
+      0x00 -> {
+        when (val inner = ConnectionStatusDisconnectedCodec.peekFrameSize(stream, baseOffset + 1)) {
+          is PeekResult.Complete -> PeekResult.Complete(1 + inner.bytes)
+          else -> inner
+        }
+      }
+      0x01 -> {
+        when (val inner = ConnectionStatusConnectingCodec.peekFrameSize(stream, baseOffset + 1)) {
+          is PeekResult.Complete -> PeekResult.Complete(1 + inner.bytes)
+          else -> inner
+        }
+      }
+      0x02 -> {
+        when (val inner = ConnectionStatusConnectedCodec.peekFrameSize(stream, baseOffset + 1)) {
+          is PeekResult.Complete -> PeekResult.Complete(1 + inner.bytes)
+          else -> inner
+        }
+      }
+      0x03 -> {
+        when (val inner = ConnectionStatusFailedCodec.peekFrameSize(stream, baseOffset + 1)) {
+          is PeekResult.Complete -> PeekResult.Complete(1 + inner.bytes)
+          else -> inner
+        }
+      }
+      else -> {
+        throw DecodeException(fieldPath = "ConnectionStatus.discriminator", bufferPosition = baseOffset, expected = "one of {0x00, 0x01, 0x02, 0x03}", actual = """0x${discriminator.toString(16).padStart(2, '0').uppercase()}""")
+      }
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ConnectionStatusConnectedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ConnectionStatusConnectedCodec.kt
@@ -1,0 +1,26 @@
+package com.ditchoom.buffer.codec.test.protocols
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object ConnectionStatusConnectedCodec : Codec<ConnectionStatus.Connected> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): ConnectionStatus.Connected = ConnectionStatus.Connected
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: ConnectionStatus.Connected,
+    context: EncodeContext,
+  ) {
+  }
+
+  override fun wireSize(`value`: ConnectionStatus.Connected, context: EncodeContext): WireSize = WireSize.Exact(0)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 0) PeekResult.Complete(0) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ConnectionStatusConnectingCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ConnectionStatusConnectingCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object ConnectionStatusConnectingCodec : Codec<ConnectionStatus.Connecting> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): ConnectionStatus.Connecting {
+    val attempt = buffer.readUByte()
+    return ConnectionStatus.Connecting(attempt = attempt)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: ConnectionStatus.Connecting,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.attempt)
+  }
+
+  override fun wireSize(`value`: ConnectionStatus.Connecting, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ConnectionStatusDisconnectedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ConnectionStatusDisconnectedCodec.kt
@@ -1,0 +1,26 @@
+package com.ditchoom.buffer.codec.test.protocols
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object ConnectionStatusDisconnectedCodec : Codec<ConnectionStatus.Disconnected> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): ConnectionStatus.Disconnected = ConnectionStatus.Disconnected
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: ConnectionStatus.Disconnected,
+    context: EncodeContext,
+  ) {
+  }
+
+  override fun wireSize(`value`: ConnectionStatus.Disconnected, context: EncodeContext): WireSize = WireSize.Exact(0)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 0) PeekResult.Complete(0) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ConnectionStatusFailedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ConnectionStatusFailedCodec.kt
@@ -1,0 +1,26 @@
+package com.ditchoom.buffer.codec.test.protocols
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object ConnectionStatusFailedCodec : Codec<ConnectionStatus.Failed> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): ConnectionStatus.Failed = ConnectionStatus.Failed
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: ConnectionStatus.Failed,
+    context: EncodeContext,
+  ) {
+  }
+
+  override fun wireSize(`value`: ConnectionStatus.Failed, context: EncodeContext): WireSize = WireSize.Exact(0)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 0) PeekResult.Complete(0) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/DeviceStateCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/DeviceStateCodec.kt
@@ -1,0 +1,32 @@
+package com.ditchoom.buffer.codec.test.protocols
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object DeviceStateCodec : Codec<DeviceState> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): DeviceState {
+    val deviceId = buffer.readUByte()
+    val connection = ConnectionStatusCodec.decode(buffer, context)
+    return DeviceState(deviceId = deviceId, connection = connection)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: DeviceState,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.deviceId)
+    ConnectionStatusCodec.encode(buffer, value.connection, context)
+  }
+
+  override fun wireSize(`value`: DeviceState, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/Issue156CommandCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/Issue156CommandCodec.kt
@@ -1,0 +1,58 @@
+package com.ditchoom.buffer.codec.test.protocols
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object Issue156CommandCodec : Codec<Issue156Command> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): Issue156Command {
+    val discriminatorPosition = buffer.position()
+    val discriminator = buffer.readUByte().toInt()
+    return when (discriminator) {
+      0x20 -> Issue156CommandLedStateSetCodec.decode(buffer, context)
+      else -> {
+        throw DecodeException(fieldPath = "Issue156Command.discriminator", bufferPosition = discriminatorPosition, expected = "one of {0x20}", actual = """0x${discriminator.toString(16).padStart(2, '0').uppercase()}""")
+      }
+    }
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: Issue156Command,
+    context: EncodeContext,
+  ) {
+    when (value) {
+      is Issue156Command.LedStateSet -> {
+        buffer.writeUByte(0x20.toUByte())
+        Issue156CommandLedStateSetCodec.encode(buffer, value, context)
+      }
+    }
+  }
+
+  override fun wireSize(`value`: Issue156Command, context: EncodeContext): WireSize = when (value) {
+    is Issue156Command.LedStateSet -> WireSize.Exact(4)
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
+    val discriminator = stream.peekByte(baseOffset).toInt() and 0xFF
+    return when (discriminator) {
+      0x20 -> {
+        when (val inner = Issue156CommandLedStateSetCodec.peekFrameSize(stream, baseOffset + 1)) {
+          is PeekResult.Complete -> PeekResult.Complete(1 + inner.bytes)
+          else -> inner
+        }
+      }
+      else -> {
+        throw DecodeException(fieldPath = "Issue156Command.discriminator", bufferPosition = baseOffset, expected = "one of {0x20}", actual = """0x${discriminator.toString(16).padStart(2, '0').uppercase()}""")
+      }
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/Issue156CommandLedStateSetCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/Issue156CommandLedStateSetCodec.kt
@@ -1,0 +1,32 @@
+package com.ditchoom.buffer.codec.test.protocols
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object Issue156CommandLedStateSetCodec : Codec<Issue156Command.LedStateSet> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): Issue156Command.LedStateSet {
+    val ledId = buffer.readUByte()
+    val duty = buffer.readUShort()
+    return Issue156Command.LedStateSet(ledId = ledId, duty = duty)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: Issue156Command.LedStateSet,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.ledId)
+    buffer.writeUShort(value.duty)
+  }
+
+  override fun wireSize(`value`: Issue156Command.LedStateSet, context: EncodeContext): WireSize = WireSize.Exact(3)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 3) PeekResult.Complete(3) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/Issue156ResponseCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/Issue156ResponseCodec.kt
@@ -1,0 +1,58 @@
+package com.ditchoom.buffer.codec.test.protocols
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object Issue156ResponseCodec : Codec<Issue156Response> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): Issue156Response {
+    val discriminatorPosition = buffer.position()
+    val discriminator = buffer.readUByte().toInt()
+    return when (discriminator) {
+      0x20 -> Issue156ResponseLedStateSetCodec.decode(buffer, context)
+      else -> {
+        throw DecodeException(fieldPath = "Issue156Response.discriminator", bufferPosition = discriminatorPosition, expected = "one of {0x20}", actual = """0x${discriminator.toString(16).padStart(2, '0').uppercase()}""")
+      }
+    }
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: Issue156Response,
+    context: EncodeContext,
+  ) {
+    when (value) {
+      is Issue156Response.LedStateSet -> {
+        buffer.writeUByte(0x20.toUByte())
+        Issue156ResponseLedStateSetCodec.encode(buffer, value, context)
+      }
+    }
+  }
+
+  override fun wireSize(`value`: Issue156Response, context: EncodeContext): WireSize = when (value) {
+    is Issue156Response.LedStateSet -> WireSize.Exact(4)
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
+    val discriminator = stream.peekByte(baseOffset).toInt() and 0xFF
+    return when (discriminator) {
+      0x20 -> {
+        when (val inner = Issue156ResponseLedStateSetCodec.peekFrameSize(stream, baseOffset + 1)) {
+          is PeekResult.Complete -> PeekResult.Complete(1 + inner.bytes)
+          else -> inner
+        }
+      }
+      else -> {
+        throw DecodeException(fieldPath = "Issue156Response.discriminator", bufferPosition = baseOffset, expected = "one of {0x20}", actual = """0x${discriminator.toString(16).padStart(2, '0').uppercase()}""")
+      }
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/Issue156ResponseLedStateSetCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/Issue156ResponseLedStateSetCodec.kt
@@ -1,0 +1,32 @@
+package com.ditchoom.buffer.codec.test.protocols
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object Issue156ResponseLedStateSetCodec : Codec<Issue156Response.LedStateSet> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): Issue156Response.LedStateSet {
+    val ledId = buffer.readUByte()
+    val duty = buffer.readUShort()
+    return Issue156Response.LedStateSet(ledId = ledId, duty = duty)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: Issue156Response.LedStateSet,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.ledId)
+    buffer.writeUShort(value.duty)
+  }
+
+  override fun wireSize(`value`: Issue156Response.LedStateSet, context: EncodeContext): WireSize = WireSize.Exact(3)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 3) PeekResult.Complete(3) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/asciistring/AsciiGreetingCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/asciistring/AsciiGreetingCodec.kt
@@ -1,0 +1,70 @@
+package com.ditchoom.buffer.codec.test.protocols.asciistring
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.AsciiStringCodec
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object AsciiGreetingCodec : Codec<AsciiGreeting> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): AsciiGreeting {
+    val commandPrefixB0 = buffer.readUByte().toUInt()
+    val commandPrefixB1 = buffer.readUByte().toUInt()
+    val commandPrefix = ((commandPrefixB0 shl 8) or commandPrefixB1)
+    if (commandPrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "AsciiGreeting.command", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = commandPrefix.toString())
+    }
+    val commandLength = commandPrefix.toInt()
+    val __commandOuterLimit = buffer.limit()
+    buffer.setLimit(buffer.position() + commandLength)
+    val command = try {
+      AsciiStringCodec.decode(buffer, context)
+    } finally {
+      buffer.setLimit(__commandOuterLimit)
+    }
+    return AsciiGreeting(command = command)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: AsciiGreeting,
+    context: EncodeContext,
+  ) {
+    val commandSizePosition = buffer.position()
+    buffer.position(commandSizePosition + 2)
+    val commandBodyStart = buffer.position()
+    AsciiStringCodec.encode(buffer, value.command, context)
+    val commandEndPosition = buffer.position()
+    val commandByteCount = commandEndPosition - commandBodyStart
+    if (commandByteCount > 65_535) {
+      throw EncodeException(fieldPath = "AsciiGreeting.command", reason = """encoded payload byte length ${commandByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(commandSizePosition)
+    val commandPrefix = commandByteCount.toUInt()
+    buffer.writeUByte(((commandPrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((commandPrefix and 0xFFu).toUByte())
+    buffer.position(commandEndPosition)
+  }
+
+  override fun wireSize(`value`: AsciiGreeting, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val commandPrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val commandPrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val commandPrefix = ((commandPrefixB0 shl 8) or commandPrefixB1).toUInt()
+    if (commandPrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "AsciiGreeting.command", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + commandPrefix.toInt()}""")
+    }
+    __offset += 2 + commandPrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/dns/DnsHeaderCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/dns/DnsHeaderCodec.kt
@@ -1,0 +1,58 @@
+package com.ditchoom.buffer.codec.test.protocols.dns
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object DnsHeaderCodec : Codec<DnsHeader> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): DnsHeader {
+    val idB0 = buffer.readUByte().toUInt()
+    val idB1 = buffer.readUByte().toUInt()
+    val id = ((idB0 shl 8) or idB1).toUShort()
+    val flagsB0 = buffer.readUByte().toUInt()
+    val flagsB1 = buffer.readUByte().toUInt()
+    val flags = ((flagsB0 shl 8) or flagsB1).toUShort()
+    val qdCountB0 = buffer.readUByte().toUInt()
+    val qdCountB1 = buffer.readUByte().toUInt()
+    val qdCount = ((qdCountB0 shl 8) or qdCountB1).toUShort()
+    val anCountB0 = buffer.readUByte().toUInt()
+    val anCountB1 = buffer.readUByte().toUInt()
+    val anCount = ((anCountB0 shl 8) or anCountB1).toUShort()
+    val nsCountB0 = buffer.readUByte().toUInt()
+    val nsCountB1 = buffer.readUByte().toUInt()
+    val nsCount = ((nsCountB0 shl 8) or nsCountB1).toUShort()
+    val arCountB0 = buffer.readUByte().toUInt()
+    val arCountB1 = buffer.readUByte().toUInt()
+    val arCount = ((arCountB0 shl 8) or arCountB1).toUShort()
+    return DnsHeader(id = id, flags = flags, qdCount = qdCount, anCount = anCount, nsCount = nsCount, arCount = arCount)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: DnsHeader,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(((value.id.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.id.toUInt() and 0xFFu).toUByte())
+    buffer.writeUByte(((value.flags.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.flags.toUInt() and 0xFFu).toUByte())
+    buffer.writeUByte(((value.qdCount.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.qdCount.toUInt() and 0xFFu).toUByte())
+    buffer.writeUByte(((value.anCount.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.anCount.toUInt() and 0xFFu).toUByte())
+    buffer.writeUByte(((value.nsCount.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.nsCount.toUInt() and 0xFFu).toUByte())
+    buffer.writeUByte(((value.arCount.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.arCount.toUInt() and 0xFFu).toUByte())
+  }
+
+  override fun wireSize(`value`: DnsHeader, context: EncodeContext): WireSize = WireSize.Exact(12)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 12) PeekResult.Complete(12) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ethernet/EtherTypeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ethernet/EtherTypeCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.ethernet
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object EtherTypeCodec : Codec<EtherType> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): EtherType {
+    val raw = buffer.readUShort()
+    return EtherType(raw = raw)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: EtherType,
+    context: EncodeContext,
+  ) {
+    buffer.writeUShort(value.raw)
+  }
+
+  override fun wireSize(`value`: EtherType, context: EncodeContext): WireSize = WireSize.Exact(2)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ethernet/EthernetFrameByEtherTypeArpCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ethernet/EthernetFrameByEtherTypeArpCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.ethernet
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object EthernetFrameByEtherTypeArpCodec : Codec<EthernetFrameByEtherType.Arp> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): EthernetFrameByEtherType.Arp {
+    val etherType = EtherType(buffer.readUShort())
+    return EthernetFrameByEtherType.Arp(etherType = etherType)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: EthernetFrameByEtherType.Arp,
+    context: EncodeContext,
+  ) {
+    buffer.writeUShort(value.etherType.raw)
+  }
+
+  override fun wireSize(`value`: EthernetFrameByEtherType.Arp, context: EncodeContext): WireSize = WireSize.Exact(2)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ethernet/EthernetFrameByEtherTypeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ethernet/EthernetFrameByEtherTypeCodec.kt
@@ -1,0 +1,68 @@
+package com.ditchoom.buffer.codec.test.protocols.ethernet
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object EthernetFrameByEtherTypeCodec : Codec<EthernetFrameByEtherType> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): EthernetFrameByEtherType {
+    val discriminatorPosition = buffer.position()
+    val __discriminator = EtherTypeCodec.decode(buffer, context)
+    buffer.position(discriminatorPosition)
+    val __dispatchValue = __discriminator.type.toInt()
+    return when (__dispatchValue) {
+      2_048 -> EthernetFrameByEtherTypeIpv4Codec.decode(buffer, context)
+      2_054 -> EthernetFrameByEtherTypeArpCodec.decode(buffer, context)
+      33_024 -> EthernetFrameByEtherTypeVlanTagCodec.decode(buffer, context)
+      34_525 -> EthernetFrameByEtherTypeIpv6Codec.decode(buffer, context)
+      else -> {
+        throw DecodeException(fieldPath = "EthernetFrameByEtherType.discriminator", bufferPosition = discriminatorPosition, expected = "one of {2048, 2054, 33024, 34525}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: EthernetFrameByEtherType,
+    context: EncodeContext,
+  ) {
+    when (value) {
+      is EthernetFrameByEtherType.Ipv4 -> EthernetFrameByEtherTypeIpv4Codec.encode(buffer, value, context)
+      is EthernetFrameByEtherType.Arp -> EthernetFrameByEtherTypeArpCodec.encode(buffer, value, context)
+      is EthernetFrameByEtherType.VlanTag -> EthernetFrameByEtherTypeVlanTagCodec.encode(buffer, value, context)
+      is EthernetFrameByEtherType.Ipv6 -> EthernetFrameByEtherTypeIpv6Codec.encode(buffer, value, context)
+    }
+  }
+
+  override fun wireSize(`value`: EthernetFrameByEtherType, context: EncodeContext): WireSize = when (value) {
+    is EthernetFrameByEtherType.Ipv4 -> EthernetFrameByEtherTypeIpv4Codec.wireSize(value, context)
+    is EthernetFrameByEtherType.Arp -> EthernetFrameByEtherTypeArpCodec.wireSize(value, context)
+    is EthernetFrameByEtherType.VlanTag -> EthernetFrameByEtherTypeVlanTagCodec.wireSize(value, context)
+    is EthernetFrameByEtherType.Ipv6 -> EthernetFrameByEtherTypeIpv6Codec.wireSize(value, context)
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __discRawB0 = stream.peekByte(baseOffset + 0).toInt() and 0xFF
+    val __discRawB1 = stream.peekByte(baseOffset + 0 + 1).toInt() and 0xFF
+    val __discRaw = ((__discRawB0 shl 8) or __discRawB1).toUInt().toUShort()
+    val __discriminator = EtherType(__discRaw)
+    val __dispatchValue = __discriminator.type.toInt()
+    return when (__dispatchValue) {
+      2_048 -> EthernetFrameByEtherTypeIpv4Codec.peekFrameSize(stream, baseOffset)
+      2_054 -> EthernetFrameByEtherTypeArpCodec.peekFrameSize(stream, baseOffset)
+      33_024 -> EthernetFrameByEtherTypeVlanTagCodec.peekFrameSize(stream, baseOffset)
+      34_525 -> EthernetFrameByEtherTypeIpv6Codec.peekFrameSize(stream, baseOffset)
+      else -> {
+        throw DecodeException(fieldPath = "EthernetFrameByEtherType.discriminator", bufferPosition = baseOffset, expected = "one of {2048, 2054, 33024, 34525}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ethernet/EthernetFrameByEtherTypeIpv4Codec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ethernet/EthernetFrameByEtherTypeIpv4Codec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.ethernet
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object EthernetFrameByEtherTypeIpv4Codec : Codec<EthernetFrameByEtherType.Ipv4> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): EthernetFrameByEtherType.Ipv4 {
+    val etherType = EtherType(buffer.readUShort())
+    return EthernetFrameByEtherType.Ipv4(etherType = etherType)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: EthernetFrameByEtherType.Ipv4,
+    context: EncodeContext,
+  ) {
+    buffer.writeUShort(value.etherType.raw)
+  }
+
+  override fun wireSize(`value`: EthernetFrameByEtherType.Ipv4, context: EncodeContext): WireSize = WireSize.Exact(2)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ethernet/EthernetFrameByEtherTypeIpv6Codec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ethernet/EthernetFrameByEtherTypeIpv6Codec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.ethernet
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object EthernetFrameByEtherTypeIpv6Codec : Codec<EthernetFrameByEtherType.Ipv6> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): EthernetFrameByEtherType.Ipv6 {
+    val etherType = EtherType(buffer.readUShort())
+    return EthernetFrameByEtherType.Ipv6(etherType = etherType)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: EthernetFrameByEtherType.Ipv6,
+    context: EncodeContext,
+  ) {
+    buffer.writeUShort(value.etherType.raw)
+  }
+
+  override fun wireSize(`value`: EthernetFrameByEtherType.Ipv6, context: EncodeContext): WireSize = WireSize.Exact(2)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ethernet/EthernetFrameByEtherTypeVlanTagCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ethernet/EthernetFrameByEtherTypeVlanTagCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.ethernet
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object EthernetFrameByEtherTypeVlanTagCodec : Codec<EthernetFrameByEtherType.VlanTag> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): EthernetFrameByEtherType.VlanTag {
+    val etherType = EtherType(buffer.readUShort())
+    return EthernetFrameByEtherType.VlanTag(etherType = etherType)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: EthernetFrameByEtherType.VlanTag,
+    context: EncodeContext,
+  ) {
+    buffer.writeUShort(value.etherType.raw)
+  }
+
+  override fun wireSize(`value`: EthernetFrameByEtherType.VlanTag, context: EncodeContext): WireSize = WireSize.Exact(2)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/flv/FlvTagHeaderCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/flv/FlvTagHeaderCodec.kt
@@ -1,0 +1,63 @@
+package com.ditchoom.buffer.codec.test.protocols.flv
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object FlvTagHeaderCodec : Codec<FlvTagHeader> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): FlvTagHeader {
+    val tagType = buffer.readUByte()
+    val dataSizeB0 = buffer.readUByte().toUInt()
+    val dataSizeB1 = buffer.readUByte().toUInt()
+    val dataSizeB2 = buffer.readUByte().toUInt()
+    val dataSize = ((dataSizeB0 shl 16) or (dataSizeB1 shl 8) or dataSizeB2)
+    val timestampB0 = buffer.readUByte().toUInt()
+    val timestampB1 = buffer.readUByte().toUInt()
+    val timestampB2 = buffer.readUByte().toUInt()
+    val timestamp = ((timestampB0 shl 16) or (timestampB1 shl 8) or timestampB2)
+    val timestampExtended = buffer.readUByte()
+    val streamIdB0 = buffer.readUByte().toUInt()
+    val streamIdB1 = buffer.readUByte().toUInt()
+    val streamIdB2 = buffer.readUByte().toUInt()
+    val streamId = ((streamIdB0 shl 16) or (streamIdB1 shl 8) or streamIdB2)
+    return FlvTagHeader(tagType = tagType, dataSize = dataSize, timestamp = timestamp, timestampExtended = timestampExtended, streamId = streamId)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: FlvTagHeader,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.tagType)
+    if (value.dataSize > ((1u shl 24) - 1u)) {
+      throw EncodeException(fieldPath = "FlvTagHeader.dataSize", reason = "value exceeds @WireBytes(3) range (max 16777215)")
+    }
+    buffer.writeUByte(((value.dataSize shr 16) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.dataSize shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.dataSize and 0xFFu).toUByte())
+    if (value.timestamp > ((1u shl 24) - 1u)) {
+      throw EncodeException(fieldPath = "FlvTagHeader.timestamp", reason = "value exceeds @WireBytes(3) range (max 16777215)")
+    }
+    buffer.writeUByte(((value.timestamp shr 16) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.timestamp shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.timestamp and 0xFFu).toUByte())
+    buffer.writeUByte(value.timestampExtended)
+    if (value.streamId > ((1u shl 24) - 1u)) {
+      throw EncodeException(fieldPath = "FlvTagHeader.streamId", reason = "value exceeds @WireBytes(3) range (max 16777215)")
+    }
+    buffer.writeUByte(((value.streamId shr 16) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.streamId shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.streamId and 0xFFu).toUByte())
+  }
+
+  override fun wireSize(`value`: FlvTagHeader, context: EncodeContext): WireSize = WireSize.Exact(11)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 11) PeekResult.Complete(11) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2FrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2FrameCodec.kt
@@ -1,0 +1,101 @@
+package com.ditchoom.buffer.codec.test.protocols.http2
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.Payload
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public class Http2FrameCodec<P : Payload>(
+  private val payloadCodec: Codec<P>,
+) : Codec<Http2Frame<P>> {
+  private val dataCodec: Http2FrameDataCodec<P> = Http2FrameDataCodec(payloadCodec)
+
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): Http2Frame<P> {
+    val discriminatorPosition = buffer.position()
+    val __discriminator = Http2LengthAndTypeCodec.decode(buffer, context)
+    buffer.position(discriminatorPosition)
+    val __dispatchValue = __discriminator.type
+    return when (__dispatchValue) {
+      0 -> dataCodec.decode(buffer, context)
+      4 -> Http2FrameSettingsCodec.decode(buffer, context)
+      6 -> Http2FramePingCodec.decode(buffer, context)
+      8 -> Http2FrameWindowUpdateCodec.decode(buffer, context)
+      else -> {
+        throw DecodeException(fieldPath = "Http2Frame.discriminator", bufferPosition = discriminatorPosition, expected = "one of {0, 4, 6, 8}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: Http2Frame<P>,
+    context: EncodeContext,
+  ) {
+    @Suppress("UNCHECKED_CAST")
+    when (value) {
+      is Http2Frame.Data<*> -> dataCodec.encode(buffer, value as Http2Frame.Data<P>, context)
+      is Http2Frame.Settings -> Http2FrameSettingsCodec.encode(buffer, value, context)
+      is Http2Frame.Ping -> Http2FramePingCodec.encode(buffer, value, context)
+      is Http2Frame.WindowUpdate -> Http2FrameWindowUpdateCodec.encode(buffer, value, context)
+    }
+  }
+
+  override fun wireSize(`value`: Http2Frame<P>, context: EncodeContext): WireSize {
+    @Suppress("UNCHECKED_CAST")
+    return when (value) {
+      is Http2Frame.Data<*> -> dataCodec.wireSize(value as Http2Frame.Data<P>, context)
+      is Http2Frame.Settings -> Http2FrameSettingsCodec.wireSize(value, context)
+      is Http2Frame.Ping -> Http2FramePingCodec.wireSize(value, context)
+      is Http2Frame.WindowUpdate -> Http2FrameWindowUpdateCodec.wireSize(value, context)
+    }
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    if (stream.available() - baseOffset < 4) return PeekResult.NeedsMoreData
+    val __discRawB0 = stream.peekByte(baseOffset + 0).toInt() and 0xFF
+    val __discRawB1 = stream.peekByte(baseOffset + 0 + 1).toInt() and 0xFF
+    val __discRawB2 = stream.peekByte(baseOffset + 0 + 2).toInt() and 0xFF
+    val __discRawB3 = stream.peekByte(baseOffset + 0 + 3).toInt() and 0xFF
+    val __discRaw = ((__discRawB0 shl 24) or (__discRawB1 shl 16) or (__discRawB2 shl 8) or __discRawB3).toUInt()
+    val __discriminator = Http2LengthAndType(__discRaw)
+    val __dispatchValue = __discriminator.type
+    return when (__dispatchValue) {
+      0 -> dataCodec.peekFrameSize(stream, baseOffset)
+      4 -> Http2FrameSettingsCodec.peekFrameSize(stream, baseOffset)
+      6 -> Http2FramePingCodec.peekFrameSize(stream, baseOffset)
+      8 -> Http2FrameWindowUpdateCodec.peekFrameSize(stream, baseOffset)
+      else -> {
+        throw DecodeException(fieldPath = "Http2Frame.discriminator", bufferPosition = baseOffset, expected = "one of {0, 4, 6, 8}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+
+  public companion object {
+    public fun <P : Payload> decodeAggregating(
+      buffer: ReadBuffer,
+      context: DecodeContext,
+      onData: (Http2FrameDataCodec.Partial<P>) -> Http2Frame.Data<P> = { _ -> throw DecodeException(fieldPath = "Http2Frame.Data.handler", bufferPosition = -1, expected = "consumer-supplied Data handler", actual = "no handler supplied") },
+    ): Http2Frame<P> {
+      val discriminatorPosition = buffer.position()
+      val __discriminator = Http2LengthAndTypeCodec.decode(buffer, context)
+      buffer.position(discriminatorPosition)
+      val __dispatchValue = __discriminator.type
+      return when (__dispatchValue) {
+        0 -> onData(Http2FrameDataCodec.partial<P>(buffer, context))
+        4 -> Http2FrameSettingsCodec.decode(buffer, context)
+        6 -> Http2FramePingCodec.decode(buffer, context)
+        8 -> Http2FrameWindowUpdateCodec.decode(buffer, context)
+        else -> {
+          throw DecodeException(fieldPath = "Http2Frame.discriminator", bufferPosition = discriminatorPosition, expected = "one of {0, 4, 6, 8}", actual = """${__dispatchValue}""")
+        }
+      }
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2FrameDataCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2FrameDataCodec.kt
@@ -1,0 +1,63 @@
+package com.ditchoom.buffer.codec.test.protocols.http2
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.Decoder
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.Payload
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.UByte
+
+public class Http2FrameDataCodec<P : Payload>(
+  private val payloadCodec: Codec<P>,
+) : Codec<Http2Frame.Data<P>> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): Http2Frame.Data<P> {
+    val header = Http2LengthAndType(buffer.readUInt())
+    val flags = buffer.readUByte()
+    val streamId = Http2StreamId(buffer.readUInt())
+    val payload = payloadCodec.decode(buffer, context)
+    return Http2Frame.Data<P>(header = header, flags = flags, streamId = streamId, payload = payload)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: Http2Frame.Data<P>,
+    context: EncodeContext,
+  ) {
+    buffer.writeUInt(value.header.raw)
+    buffer.writeUByte(value.flags)
+    buffer.writeUInt(value.streamId.raw)
+    payloadCodec.encode(buffer, value.payload, context)
+  }
+
+  override fun wireSize(`value`: Http2Frame.Data<P>, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+
+  public class Partial<P : Payload> internal constructor(
+    public val `header`: Http2LengthAndType,
+    public val flags: UByte,
+    public val streamId: Http2StreamId,
+    private val buffer: ReadBuffer,
+    private val context: DecodeContext,
+  ) {
+    public fun complete(payloadCodec: Decoder<P>): Http2Frame.Data<P> {
+      val payload = payloadCodec.decode(buffer, context)
+      return Http2Frame.Data<P>(header = header, flags = flags, streamId = streamId, payload = payload)
+    }
+  }
+
+  public companion object {
+    public fun <P : Payload> partial(buffer: ReadBuffer, context: DecodeContext): Partial<P> {
+      val header = Http2LengthAndType(buffer.readUInt())
+      val flags = buffer.readUByte()
+      val streamId = Http2StreamId(buffer.readUInt())
+      return Partial<P>(header = header, flags = flags, streamId = streamId, buffer = buffer, context = context)
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2FramePingCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2FramePingCodec.kt
@@ -1,0 +1,51 @@
+package com.ditchoom.buffer.codec.test.protocols.http2
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object Http2FramePingCodec : Codec<Http2Frame.Ping> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): Http2Frame.Ping {
+    val header = Http2LengthAndType(buffer.readUInt())
+    val flags = buffer.readUByte()
+    val streamId = Http2StreamId(buffer.readUInt())
+    val opaqueDataB0 = buffer.readUByte().toULong()
+    val opaqueDataB1 = buffer.readUByte().toULong()
+    val opaqueDataB2 = buffer.readUByte().toULong()
+    val opaqueDataB3 = buffer.readUByte().toULong()
+    val opaqueDataB4 = buffer.readUByte().toULong()
+    val opaqueDataB5 = buffer.readUByte().toULong()
+    val opaqueDataB6 = buffer.readUByte().toULong()
+    val opaqueDataB7 = buffer.readUByte().toULong()
+    val opaqueData = ((opaqueDataB0 shl 56) or (opaqueDataB1 shl 48) or (opaqueDataB2 shl 40) or (opaqueDataB3 shl 32) or (opaqueDataB4 shl 24) or (opaqueDataB5 shl 16) or (opaqueDataB6 shl 8) or opaqueDataB7)
+    return Http2Frame.Ping(header = header, flags = flags, streamId = streamId, opaqueData = opaqueData)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: Http2Frame.Ping,
+    context: EncodeContext,
+  ) {
+    buffer.writeUInt(value.header.raw)
+    buffer.writeUByte(value.flags)
+    buffer.writeUInt(value.streamId.raw)
+    buffer.writeUByte(((value.opaqueData shr 56) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.opaqueData shr 48) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.opaqueData shr 40) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.opaqueData shr 32) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.opaqueData shr 24) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.opaqueData shr 16) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.opaqueData shr 8) and 0xFFuL).toUByte())
+    buffer.writeUByte((value.opaqueData and 0xFFuL).toUByte())
+  }
+
+  override fun wireSize(`value`: Http2Frame.Ping, context: EncodeContext): WireSize = WireSize.Exact(17)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 17) PeekResult.Complete(17) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2FrameSettingsCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2FrameSettingsCodec.kt
@@ -1,0 +1,66 @@
+package com.ditchoom.buffer.codec.test.protocols.http2
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object Http2FrameSettingsCodec : Codec<Http2Frame.Settings> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): Http2Frame.Settings {
+    val header = Http2LengthAndType(buffer.readUInt())
+    val flags = buffer.readUByte()
+    val streamId = Http2StreamId(buffer.readUInt())
+    val entriesBytes = header.length
+    val entriesOuterLimit = buffer.limit()
+    buffer.setLimit(buffer.position() + entriesBytes)
+    val entries = mutableListOf<Http2Setting>()
+    try {
+      while (buffer.position() < buffer.limit()) {
+        entries += Http2SettingCodec.decode(buffer, context)
+      }
+    } finally {
+      buffer.setLimit(entriesOuterLimit)
+    }
+    return Http2Frame.Settings(header = header, flags = flags, streamId = streamId, entries = entries)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: Http2Frame.Settings,
+    context: EncodeContext,
+  ) {
+    buffer.writeUInt(value.header.raw)
+    buffer.writeUByte(value.flags)
+    buffer.writeUInt(value.streamId.raw)
+    for (__elem in value.entries) {
+      Http2SettingCodec.encode(buffer, __elem, context)
+    }
+  }
+
+  override fun wireSize(`value`: Http2Frame.Settings, context: EncodeContext): WireSize = WireSize.Exact(9 + value.header.length)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 4) return PeekResult.NeedsMoreData
+    val headerRawB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val headerRawB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val headerRawB2 = stream.peekByte(baseOffset + __offset + 2).toInt() and 0xFF
+    val headerRawB3 = stream.peekByte(baseOffset + __offset + 3).toInt() and 0xFF
+    val headerRaw = ((headerRawB0 shl 24) or (headerRawB1 shl 16) or (headerRawB2 shl 8) or headerRawB3).toUInt()
+    val header = Http2LengthAndType(headerRaw)
+    __offset += 4
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    __offset += 1
+    if (stream.available() - baseOffset < __offset + 4) return PeekResult.NeedsMoreData
+    __offset += 4
+    val entriesBytes = header.length
+    if (stream.available() - baseOffset < __offset + entriesBytes) return PeekResult.NeedsMoreData
+    __offset += entriesBytes
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2FrameWindowUpdateCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2FrameWindowUpdateCodec.kt
@@ -1,0 +1,43 @@
+package com.ditchoom.buffer.codec.test.protocols.http2
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object Http2FrameWindowUpdateCodec : Codec<Http2Frame.WindowUpdate> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): Http2Frame.WindowUpdate {
+    val header = Http2LengthAndType(buffer.readUInt())
+    val flags = buffer.readUByte()
+    val streamId = Http2StreamId(buffer.readUInt())
+    val windowSizeIncrementB0 = buffer.readUByte().toUInt()
+    val windowSizeIncrementB1 = buffer.readUByte().toUInt()
+    val windowSizeIncrementB2 = buffer.readUByte().toUInt()
+    val windowSizeIncrementB3 = buffer.readUByte().toUInt()
+    val windowSizeIncrement = ((windowSizeIncrementB0 shl 24) or (windowSizeIncrementB1 shl 16) or (windowSizeIncrementB2 shl 8) or windowSizeIncrementB3)
+    return Http2Frame.WindowUpdate(header = header, flags = flags, streamId = streamId, windowSizeIncrement = windowSizeIncrement)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: Http2Frame.WindowUpdate,
+    context: EncodeContext,
+  ) {
+    buffer.writeUInt(value.header.raw)
+    buffer.writeUByte(value.flags)
+    buffer.writeUInt(value.streamId.raw)
+    buffer.writeUByte(((value.windowSizeIncrement shr 24) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.windowSizeIncrement shr 16) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.windowSizeIncrement shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.windowSizeIncrement and 0xFFu).toUByte())
+  }
+
+  override fun wireSize(`value`: Http2Frame.WindowUpdate, context: EncodeContext): WireSize = WireSize.Exact(13)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 13) PeekResult.Complete(13) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2LengthAndTypeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2LengthAndTypeCodec.kt
@@ -1,0 +1,37 @@
+package com.ditchoom.buffer.codec.test.protocols.http2
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object Http2LengthAndTypeCodec : Codec<Http2LengthAndType> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): Http2LengthAndType {
+    val rawB0 = buffer.readUByte().toUInt()
+    val rawB1 = buffer.readUByte().toUInt()
+    val rawB2 = buffer.readUByte().toUInt()
+    val rawB3 = buffer.readUByte().toUInt()
+    val raw = ((rawB0 shl 24) or (rawB1 shl 16) or (rawB2 shl 8) or rawB3)
+    return Http2LengthAndType(raw = raw)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: Http2LengthAndType,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(((value.raw shr 24) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.raw shr 16) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.raw shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.raw and 0xFFu).toUByte())
+  }
+
+  override fun wireSize(`value`: Http2LengthAndType, context: EncodeContext): WireSize = WireSize.Exact(4)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 4) PeekResult.Complete(4) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2SettingCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2SettingCodec.kt
@@ -1,0 +1,42 @@
+package com.ditchoom.buffer.codec.test.protocols.http2
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object Http2SettingCodec : Codec<Http2Setting> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): Http2Setting {
+    val identifierB0 = buffer.readUByte().toUInt()
+    val identifierB1 = buffer.readUByte().toUInt()
+    val identifier = ((identifierB0 shl 8) or identifierB1).toUShort()
+    val valueB0 = buffer.readUByte().toUInt()
+    val valueB1 = buffer.readUByte().toUInt()
+    val valueB2 = buffer.readUByte().toUInt()
+    val valueB3 = buffer.readUByte().toUInt()
+    val value = ((valueB0 shl 24) or (valueB1 shl 16) or (valueB2 shl 8) or valueB3)
+    return Http2Setting(identifier = identifier, value = value)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: Http2Setting,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(((value.identifier.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.identifier.toUInt() and 0xFFu).toUByte())
+    buffer.writeUByte(((value.value shr 24) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.value shr 16) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.value shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.value and 0xFFu).toUByte())
+  }
+
+  override fun wireSize(`value`: Http2Setting, context: EncodeContext): WireSize = WireSize.Exact(6)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 6) PeekResult.Complete(6) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2SettingsFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2SettingsFrameCodec.kt
@@ -1,0 +1,84 @@
+package com.ditchoom.buffer.codec.test.protocols.http2
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object Http2SettingsFrameCodec : Codec<Http2SettingsFrame> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): Http2SettingsFrame {
+    val lengthB0 = buffer.readUByte().toUInt()
+    val lengthB1 = buffer.readUByte().toUInt()
+    val lengthB2 = buffer.readUByte().toUInt()
+    val length = ((lengthB0 shl 16) or (lengthB1 shl 8) or lengthB2)
+    val type = buffer.readUByte()
+    val flags = buffer.readUByte()
+    val streamId = Http2StreamId(buffer.readUInt())
+    if (length > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "Http2SettingsFrame.entries", bufferPosition = -1, expected = "@LengthFrom source <= ${'$'}{Int.MAX_VALUE}", actual = length.toString())
+    }
+    val entriesBytes = length.toInt()
+    val entriesOuterLimit = buffer.limit()
+    buffer.setLimit(buffer.position() + entriesBytes)
+    val entries = mutableListOf<Http2Setting>()
+    try {
+      while (buffer.position() < buffer.limit()) {
+        entries += Http2SettingCodec.decode(buffer, context)
+      }
+    } finally {
+      buffer.setLimit(entriesOuterLimit)
+    }
+    return Http2SettingsFrame(length = length, type = type, flags = flags, streamId = streamId, entries = entries)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: Http2SettingsFrame,
+    context: EncodeContext,
+  ) {
+    if (value.length > ((1u shl 24) - 1u)) {
+      throw EncodeException(fieldPath = "Http2SettingsFrame.length", reason = "value exceeds @WireBytes(3) range (max 16777215)")
+    }
+    buffer.writeUByte(((value.length shr 16) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.length shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.length and 0xFFu).toUByte())
+    buffer.writeUByte(value.type)
+    buffer.writeUByte(value.flags)
+    buffer.writeUInt(value.streamId.raw)
+    for (__elem in value.entries) {
+      Http2SettingCodec.encode(buffer, __elem, context)
+    }
+  }
+
+  override fun wireSize(`value`: Http2SettingsFrame, context: EncodeContext): WireSize = WireSize.Exact(9 + value.length.toInt())
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 3) return PeekResult.NeedsMoreData
+    val lengthB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val lengthB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val lengthB2 = stream.peekByte(baseOffset + __offset + 2).toInt() and 0xFF
+    val length = ((lengthB0 shl 16) or (lengthB1 shl 8) or lengthB2).toUInt()
+    __offset += 3
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    __offset += 1
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    __offset += 1
+    if (stream.available() - baseOffset < __offset + 4) return PeekResult.NeedsMoreData
+    __offset += 4
+    if (length > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "Http2SettingsFrame.entries", bufferPosition = -1, expected = "@LengthFrom source <= ${'$'}{Int.MAX_VALUE}", actual = length.toString())
+    }
+    val entriesBytes = length.toInt()
+    if (stream.available() - baseOffset < __offset + entriesBytes) return PeekResult.NeedsMoreData
+    __offset += entriesBytes
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/PropertyBagFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/PropertyBagFrameCodec.kt
@@ -1,0 +1,66 @@
+package com.ditchoom.buffer.codec.test.protocols.lengthprefixedusecodec
+
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttRemainingLengthCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object PropertyBagFrameCodec : Codec<PropertyBagFrame> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): PropertyBagFrame {
+    val __propertiesOuterLimit = buffer.limit()
+    val __propertiesLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __propertiesLength)
+    val properties = mutableListOf<PropertyEntry>()
+    try {
+      while (buffer.position() < buffer.limit()) {
+        properties += PropertyEntryCodec.decode(buffer, context)
+      }
+    } finally {
+      buffer.setLimit(__propertiesOuterLimit)
+    }
+    return PropertyBagFrame(properties = properties)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: PropertyBagFrame,
+    context: EncodeContext,
+  ) {
+    val __propertiesBodyBytes = value.properties.sumOf { (PropertyEntryCodec.wireSize(it, context) as WireSize.Exact).bytes }
+    MqttRemainingLengthCodec.encode(buffer, __propertiesBodyBytes.toUInt(), context)
+    for (__elem in value.properties) {
+      PropertyEntryCodec.encode(buffer, __elem, context)
+    }
+  }
+
+  override fun wireSize(`value`: PropertyBagFrame, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
+    val __propertiesPeekView = stream.peekBuffer(baseOffset + 0, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __propertiesPriorPos = __propertiesPeekView.position()
+      val __propertiesLength = try {
+        MqttRemainingLengthCodec.decode(__propertiesPeekView, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __propertiesWidth = __propertiesPeekView.position() - __propertiesPriorPos
+      val __total = 0 + __propertiesWidth + __propertiesLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__propertiesPeekView as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/PropertyEntryCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/PropertyEntryCodec.kt
@@ -1,0 +1,32 @@
+package com.ditchoom.buffer.codec.test.protocols.lengthprefixedusecodec
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object PropertyEntryCodec : Codec<PropertyEntry> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): PropertyEntry {
+    val id = buffer.readUByte()
+    val value = buffer.readUInt()
+    return PropertyEntry(id = id, value = value)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: PropertyEntry,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id)
+    buffer.writeUInt(value.value)
+  }
+
+  override fun wireSize(`value`: PropertyEntry, context: EncodeContext): WireSize = WireSize.Exact(5)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 5) PeekResult.Complete(5) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/StringTaggedPropertyBagCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/StringTaggedPropertyBagCodec.kt
@@ -1,0 +1,73 @@
+package com.ditchoom.buffer.codec.test.protocols.lengthprefixedusecodec
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttRemainingLengthCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import com.ditchoom.buffer.use
+import kotlin.Int
+import kotlin.Throwable
+
+public object StringTaggedPropertyBagCodec : Codec<StringTaggedPropertyBag> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): StringTaggedPropertyBag {
+    val __propertiesOuterLimit = buffer.limit()
+    val __propertiesLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __propertiesLength)
+    val properties = mutableListOf<StringTaggedProperty>()
+    try {
+      while (buffer.position() < buffer.limit()) {
+        properties += StringTaggedPropertyCodec.decode(buffer, context)
+      }
+    } finally {
+      buffer.setLimit(__propertiesOuterLimit)
+    }
+    return StringTaggedPropertyBag(properties = properties)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: StringTaggedPropertyBag,
+    context: EncodeContext,
+  ) {
+    BufferFactory.Default.allocate(64, buffer.byteOrder).use { __propertiesScratch ->
+      for (__elem in value.properties) {
+        StringTaggedPropertyCodec.encode(__propertiesScratch, __elem, context)
+      }
+      val __propertiesBodyBytes = __propertiesScratch.position()
+      MqttRemainingLengthCodec.encode(buffer, __propertiesBodyBytes.toUInt(), context)
+      __propertiesScratch.resetForRead()
+      buffer.write(__propertiesScratch)
+    }
+  }
+
+  override fun wireSize(`value`: StringTaggedPropertyBag, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
+    val __propertiesPeekView = stream.peekBuffer(baseOffset + 0, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __propertiesPriorPos = __propertiesPeekView.position()
+      val __propertiesLength = try {
+        MqttRemainingLengthCodec.decode(__propertiesPeekView, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __propertiesWidth = __propertiesPeekView.position() - __propertiesPriorPos
+      val __total = 0 + __propertiesWidth + __propertiesLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__propertiesPeekView as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/StringTaggedPropertyCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/StringTaggedPropertyCodec.kt
@@ -1,0 +1,68 @@
+package com.ditchoom.buffer.codec.test.protocols.lengthprefixedusecodec
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object StringTaggedPropertyCodec : Codec<StringTaggedProperty> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): StringTaggedProperty {
+    val tagPrefixB0 = buffer.readUByte().toUInt()
+    val tagPrefixB1 = buffer.readUByte().toUInt()
+    val tagPrefix = ((tagPrefixB0 shl 8) or tagPrefixB1)
+    if (tagPrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "StringTaggedProperty.tag", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = tagPrefix.toString())
+    }
+    val tagLength = tagPrefix.toInt()
+    val tag = buffer.readString(tagLength, Charset.UTF8)
+    val value = buffer.readUByte()
+    return StringTaggedProperty(tag = tag, value = value)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: StringTaggedProperty,
+    context: EncodeContext,
+  ) {
+    val tagSizePosition = buffer.position()
+    buffer.position(tagSizePosition + 2)
+    val tagBodyStart = buffer.position()
+    buffer.writeString(value.tag, Charset.UTF8)
+    val tagEndPosition = buffer.position()
+    val tagByteCount = tagEndPosition - tagBodyStart
+    if (tagByteCount > 65_535) {
+      throw EncodeException(fieldPath = "StringTaggedProperty.tag", reason = """UTF-8 byte length ${tagByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(tagSizePosition)
+    val tagPrefix = tagByteCount.toUInt()
+    buffer.writeUByte(((tagPrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((tagPrefix and 0xFFu).toUByte())
+    buffer.position(tagEndPosition)
+    buffer.writeUByte(value.value)
+  }
+
+  override fun wireSize(`value`: StringTaggedProperty, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val tagPrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val tagPrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val tagPrefix = ((tagPrefixB0 shl 8) or tagPrefixB1).toUInt()
+    if (tagPrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "StringTaggedProperty.tag", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + tagPrefix.toInt()}""")
+    }
+    __offset += 2 + tagPrefix.toInt()
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    __offset += 1
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/TaggedPropertyBagCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/TaggedPropertyBagCodec.kt
@@ -1,0 +1,68 @@
+package com.ditchoom.buffer.codec.test.protocols.lengthprefixedusecodec
+
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttRemainingLengthCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object TaggedPropertyBagCodec : Codec<TaggedPropertyBag> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): TaggedPropertyBag {
+    val tag = buffer.readUByte()
+    val __propertiesOuterLimit = buffer.limit()
+    val __propertiesLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __propertiesLength)
+    val properties = mutableListOf<PropertyEntry>()
+    try {
+      while (buffer.position() < buffer.limit()) {
+        properties += PropertyEntryCodec.decode(buffer, context)
+      }
+    } finally {
+      buffer.setLimit(__propertiesOuterLimit)
+    }
+    return TaggedPropertyBag(tag = tag, properties = properties)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: TaggedPropertyBag,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.tag)
+    val __propertiesBodyBytes = value.properties.sumOf { (PropertyEntryCodec.wireSize(it, context) as WireSize.Exact).bytes }
+    MqttRemainingLengthCodec.encode(buffer, __propertiesBodyBytes.toUInt(), context)
+    for (__elem in value.properties) {
+      PropertyEntryCodec.encode(buffer, __elem, context)
+    }
+  }
+
+  override fun wireSize(`value`: TaggedPropertyBag, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __propertiesPeekView = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __propertiesPriorPos = __propertiesPeekView.position()
+      val __propertiesLength = try {
+        MqttRemainingLengthCodec.decode(__propertiesPeekView, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __propertiesWidth = __propertiesPeekView.position() - __propertiesPriorPos
+      val __total = 1 + __propertiesWidth + __propertiesLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__propertiesPeekView as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttConnectFlagsCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttConnectFlagsCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqtt
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttConnectFlagsCodec : Codec<MqttConnectFlags> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttConnectFlags {
+    val raw = buffer.readUByte()
+    return MqttConnectFlags(raw = raw)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttConnectFlags,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.raw)
+  }
+
+  override fun wireSize(`value`: MqttConnectFlags, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttConnectProtocolNameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttConnectProtocolNameCodec.kt
@@ -1,0 +1,64 @@
+package com.ditchoom.buffer.codec.test.protocols.mqtt
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttConnectProtocolNameCodec : Codec<MqttConnectProtocolName> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttConnectProtocolName {
+    val namePrefixB0 = buffer.readUByte().toUInt()
+    val namePrefixB1 = buffer.readUByte().toUInt()
+    val namePrefix = ((namePrefixB0 shl 8) or namePrefixB1)
+    if (namePrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "MqttConnectProtocolName.name", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = namePrefix.toString())
+    }
+    val nameLength = namePrefix.toInt()
+    val name = buffer.readString(nameLength, Charset.UTF8)
+    return MqttConnectProtocolName(name = name)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttConnectProtocolName,
+    context: EncodeContext,
+  ) {
+    val nameSizePosition = buffer.position()
+    buffer.position(nameSizePosition + 2)
+    val nameBodyStart = buffer.position()
+    buffer.writeString(value.name, Charset.UTF8)
+    val nameEndPosition = buffer.position()
+    val nameByteCount = nameEndPosition - nameBodyStart
+    if (nameByteCount > 65_535) {
+      throw EncodeException(fieldPath = "MqttConnectProtocolName.name", reason = """UTF-8 byte length ${nameByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(nameSizePosition)
+    val namePrefix = nameByteCount.toUInt()
+    buffer.writeUByte(((namePrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((namePrefix and 0xFFu).toUByte())
+    buffer.position(nameEndPosition)
+  }
+
+  override fun wireSize(`value`: MqttConnectProtocolName, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val namePrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val namePrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val namePrefix = ((namePrefixB0 shl 8) or namePrefixB1).toUInt()
+    if (namePrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "MqttConnectProtocolName.name", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + namePrefix.toInt()}""")
+    }
+    __offset += 2 + namePrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttFixedHeaderCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttFixedHeaderCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqtt
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttFixedHeaderCodec : Codec<MqttFixedHeader> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttFixedHeader {
+    val raw = buffer.readUByte()
+    return MqttFixedHeader(raw = raw)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttFixedHeader,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.raw)
+  }
+
+  override fun wireSize(`value`: MqttFixedHeader, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketCodec.kt
@@ -1,0 +1,123 @@
+package com.ditchoom.buffer.codec.test.protocols.mqtt
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.Payload
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public class MqttPacketCodec<P : Payload>(
+  private val payloadCodec: Codec<P>,
+) {
+  private val publishCodec: MqttPacketPublishCodec<P> = MqttPacketPublishCodec(payloadCodec)
+
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): MqttPacket<P> {
+    val discriminatorPosition = buffer.position()
+    val __discriminator = MqttFixedHeaderCodec.decode(buffer, context)
+    buffer.position(discriminatorPosition)
+    val __dispatchValue = __discriminator.packetType
+    return when (__dispatchValue) {
+      1 -> MqttPacketConnectCodec.decode(buffer, context)
+      2 -> MqttPacketConnAckCodec.decode(buffer, context)
+      3 -> publishCodec.decode(buffer, context)
+      4 -> MqttPacketPubAckCodec.decode(buffer, context)
+      5 -> MqttPacketPubRecCodec.decode(buffer, context)
+      6 -> MqttPacketPubRelCodec.decode(buffer, context)
+      7 -> MqttPacketPubCompCodec.decode(buffer, context)
+      8 -> MqttPacketSubscribeCodec.decode(buffer, context)
+      9 -> MqttPacketSubAckCodec.decode(buffer, context)
+      10 -> MqttPacketUnsubscribeCodec.decode(buffer, context)
+      11 -> MqttPacketUnsubAckCodec.decode(buffer, context)
+      12 -> MqttPacketPingReqCodec.decode(buffer, context)
+      13 -> MqttPacketPingRespCodec.decode(buffer, context)
+      14 -> MqttPacketDisconnectCodec.decode(buffer, context)
+      else -> {
+        throw DecodeException(fieldPath = "MqttPacket.discriminator", bufferPosition = discriminatorPosition, expected = "one of {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+
+  public fun encode(
+    `value`: MqttPacket<P>,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer {
+    @Suppress("UNCHECKED_CAST")
+    return when (value) {
+      is MqttPacket.Connect -> MqttPacketConnectCodec.encode(value, context, factory)
+      is MqttPacket.ConnAck -> MqttPacketConnAckCodec.encode(value, context, factory)
+      is MqttPacket.Publish<*> -> publishCodec.encode(value as MqttPacket.Publish<P>, context, factory)
+      is MqttPacket.PubAck -> MqttPacketPubAckCodec.encode(value, context, factory)
+      is MqttPacket.PubRec -> MqttPacketPubRecCodec.encode(value, context, factory)
+      is MqttPacket.PubRel -> MqttPacketPubRelCodec.encode(value, context, factory)
+      is MqttPacket.PubComp -> MqttPacketPubCompCodec.encode(value, context, factory)
+      is MqttPacket.Subscribe -> MqttPacketSubscribeCodec.encode(value, context, factory)
+      is MqttPacket.SubAck -> MqttPacketSubAckCodec.encode(value, context, factory)
+      is MqttPacket.Unsubscribe -> MqttPacketUnsubscribeCodec.encode(value, context, factory)
+      is MqttPacket.UnsubAck -> MqttPacketUnsubAckCodec.encode(value, context, factory)
+      is MqttPacket.PingReq -> MqttPacketPingReqCodec.encode(value, context, factory)
+      is MqttPacket.PingResp -> MqttPacketPingRespCodec.encode(value, context, factory)
+      is MqttPacket.Disconnect -> MqttPacketDisconnectCodec.encode(value, context, factory)
+    }
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+
+  public companion object {
+    public fun <P : Payload> decodeAggregating(
+      buffer: ReadBuffer,
+      context: DecodeContext,
+      onPublish: (MqttPacketPublishCodec.Partial<P>) -> MqttPacket.Publish<P> = { _ -> throw DecodeException(fieldPath = "MqttPacket.Publish.handler", bufferPosition = -1, expected = "consumer-supplied Publish handler", actual = "no handler supplied") },
+    ): MqttPacket<P> {
+      val discriminatorPosition = buffer.position()
+      val __discriminator = MqttFixedHeaderCodec.decode(buffer, context)
+      buffer.position(discriminatorPosition)
+      val __dispatchValue = __discriminator.packetType
+      return when (__dispatchValue) {
+        1 -> MqttPacketConnectCodec.decode(buffer, context)
+        2 -> MqttPacketConnAckCodec.decode(buffer, context)
+        3 -> onPublish(MqttPacketPublishCodec.partial<P>(buffer, context))
+        4 -> MqttPacketPubAckCodec.decode(buffer, context)
+        5 -> MqttPacketPubRecCodec.decode(buffer, context)
+        6 -> MqttPacketPubRelCodec.decode(buffer, context)
+        7 -> MqttPacketPubCompCodec.decode(buffer, context)
+        8 -> MqttPacketSubscribeCodec.decode(buffer, context)
+        9 -> MqttPacketSubAckCodec.decode(buffer, context)
+        10 -> MqttPacketUnsubscribeCodec.decode(buffer, context)
+        11 -> MqttPacketUnsubAckCodec.decode(buffer, context)
+        12 -> MqttPacketPingReqCodec.decode(buffer, context)
+        13 -> MqttPacketPingRespCodec.decode(buffer, context)
+        14 -> MqttPacketDisconnectCodec.decode(buffer, context)
+        else -> {
+          throw DecodeException(fieldPath = "MqttPacket.discriminator", bufferPosition = discriminatorPosition, expected = "one of {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14}", actual = """${__dispatchValue}""")
+        }
+      }
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketConnAckCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketConnAckCodec.kt
@@ -1,0 +1,77 @@
+package com.ditchoom.buffer.codec.test.protocols.mqtt
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object MqttPacketConnAckCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): MqttPacket.ConnAck {
+    val header = MqttFixedHeader(buffer.readUByte())
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val connectAckFlags = buffer.readUByte()
+      val returnCode = buffer.readUByte()
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "ConnAck.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      MqttPacket.ConnAck(header = header, connectAckFlags = connectAckFlags, returnCode = returnCode)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: MqttPacket.ConnAck,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+    headerWireWidth = 1,
+    writeHeader = { buffer ->
+      buffer.writeUByte(value.header.raw)
+    },
+  ) { buffer ->
+    buffer.writeUByte(value.connectAckFlags)
+    buffer.writeUByte(value.returnCode)
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketConnectCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketConnectCodec.kt
@@ -1,0 +1,256 @@
+package com.ditchoom.buffer.codec.test.protocols.mqtt
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.test.protocols.payload.BinaryData
+import com.ditchoom.buffer.codec.test.protocols.payload.BinaryDataCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.String
+import kotlin.Throwable
+
+public object MqttPacketConnectCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): MqttPacket.Connect {
+    val header = MqttFixedHeader(buffer.readUByte())
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val protocolNamePrefixB0 = buffer.readUByte().toUInt()
+      val protocolNamePrefixB1 = buffer.readUByte().toUInt()
+      val protocolNamePrefix = ((protocolNamePrefixB0 shl 8) or protocolNamePrefixB1)
+      if (protocolNamePrefix > Int.MAX_VALUE.toUInt()) {
+        throw DecodeException(fieldPath = "Connect.protocolName", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = protocolNamePrefix.toString())
+      }
+      val protocolNameLength = protocolNamePrefix.toInt()
+      val protocolName = buffer.readString(protocolNameLength, Charset.UTF8)
+      val protocolLevel = buffer.readUByte()
+      val connectFlags = MqttConnectFlags(buffer.readUByte())
+      val keepAliveSeconds = buffer.readUShort()
+      val clientIdPrefixB0 = buffer.readUByte().toUInt()
+      val clientIdPrefixB1 = buffer.readUByte().toUInt()
+      val clientIdPrefix = ((clientIdPrefixB0 shl 8) or clientIdPrefixB1)
+      if (clientIdPrefix > Int.MAX_VALUE.toUInt()) {
+        throw DecodeException(fieldPath = "Connect.clientId", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = clientIdPrefix.toString())
+      }
+      val clientIdLength = clientIdPrefix.toInt()
+      val clientId = buffer.readString(clientIdLength, Charset.UTF8)
+      val willTopic: String? = if (connectFlags.willPresent) {
+        val willTopicPrefixB0 = buffer.readUByte().toUInt()
+        val willTopicPrefixB1 = buffer.readUByte().toUInt()
+        val willTopicPrefix = ((willTopicPrefixB0 shl 8) or willTopicPrefixB1)
+        if (willTopicPrefix > Int.MAX_VALUE.toUInt()) {
+          throw DecodeException(fieldPath = "Connect.willTopic", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = willTopicPrefix.toString())
+        }
+        val willTopicLength = willTopicPrefix.toInt()
+        buffer.readString(willTopicLength, Charset.UTF8)
+      } else {
+        null
+      }
+      val willPayload: BinaryData? = if (connectFlags.willPresent) {
+        val willPayloadPrefixB0 = buffer.readUByte().toUInt()
+        val willPayloadPrefixB1 = buffer.readUByte().toUInt()
+        val willPayloadPrefix = ((willPayloadPrefixB0 shl 8) or willPayloadPrefixB1)
+        if (willPayloadPrefix > Int.MAX_VALUE.toUInt()) {
+          throw DecodeException(fieldPath = "Connect.willPayload", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = willPayloadPrefix.toString())
+        }
+        val willPayloadLength = willPayloadPrefix.toInt()
+        val __willPayloadOuterLimit = buffer.limit()
+        buffer.setLimit(buffer.position() + willPayloadLength)
+        try {
+          BinaryDataCodec.decode(buffer, context)
+        } finally {
+          buffer.setLimit(__willPayloadOuterLimit)
+        }
+      } else {
+        null
+      }
+      val username: String? = if (connectFlags.usernamePresent) {
+        val usernamePrefixB0 = buffer.readUByte().toUInt()
+        val usernamePrefixB1 = buffer.readUByte().toUInt()
+        val usernamePrefix = ((usernamePrefixB0 shl 8) or usernamePrefixB1)
+        if (usernamePrefix > Int.MAX_VALUE.toUInt()) {
+          throw DecodeException(fieldPath = "Connect.username", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = usernamePrefix.toString())
+        }
+        val usernameLength = usernamePrefix.toInt()
+        buffer.readString(usernameLength, Charset.UTF8)
+      } else {
+        null
+      }
+      val password: BinaryData? = if (connectFlags.passwordPresent) {
+        val passwordPrefixB0 = buffer.readUByte().toUInt()
+        val passwordPrefixB1 = buffer.readUByte().toUInt()
+        val passwordPrefix = ((passwordPrefixB0 shl 8) or passwordPrefixB1)
+        if (passwordPrefix > Int.MAX_VALUE.toUInt()) {
+          throw DecodeException(fieldPath = "Connect.password", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = passwordPrefix.toString())
+        }
+        val passwordLength = passwordPrefix.toInt()
+        val __passwordOuterLimit = buffer.limit()
+        buffer.setLimit(buffer.position() + passwordLength)
+        try {
+          BinaryDataCodec.decode(buffer, context)
+        } finally {
+          buffer.setLimit(__passwordOuterLimit)
+        }
+      } else {
+        null
+      }
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "Connect.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      MqttPacket.Connect(header = header, protocolName = protocolName, protocolLevel = protocolLevel, connectFlags = connectFlags, keepAliveSeconds = keepAliveSeconds, clientId = clientId, willTopic = willTopic, willPayload = willPayload, username = username, password = password)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: MqttPacket.Connect,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+    headerWireWidth = 1,
+    writeHeader = { buffer ->
+      buffer.writeUByte(value.header.raw)
+    },
+  ) { buffer ->
+    val protocolNameSizePosition = buffer.position()
+    buffer.position(protocolNameSizePosition + 2)
+    val protocolNameBodyStart = buffer.position()
+    buffer.writeString(value.protocolName, Charset.UTF8)
+    val protocolNameEndPosition = buffer.position()
+    val protocolNameByteCount = protocolNameEndPosition - protocolNameBodyStart
+    if (protocolNameByteCount > 65_535) {
+      throw EncodeException(fieldPath = "Connect.protocolName", reason = """UTF-8 byte length ${protocolNameByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(protocolNameSizePosition)
+    val protocolNamePrefix = protocolNameByteCount.toUInt()
+    buffer.writeUByte(((protocolNamePrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((protocolNamePrefix and 0xFFu).toUByte())
+    buffer.position(protocolNameEndPosition)
+    buffer.writeUByte(value.protocolLevel)
+    buffer.writeUByte(value.connectFlags.raw)
+    buffer.writeUShort(value.keepAliveSeconds)
+    val clientIdSizePosition = buffer.position()
+    buffer.position(clientIdSizePosition + 2)
+    val clientIdBodyStart = buffer.position()
+    buffer.writeString(value.clientId, Charset.UTF8)
+    val clientIdEndPosition = buffer.position()
+    val clientIdByteCount = clientIdEndPosition - clientIdBodyStart
+    if (clientIdByteCount > 65_535) {
+      throw EncodeException(fieldPath = "Connect.clientId", reason = """UTF-8 byte length ${clientIdByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(clientIdSizePosition)
+    val clientIdPrefix = clientIdByteCount.toUInt()
+    buffer.writeUByte(((clientIdPrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((clientIdPrefix and 0xFFu).toUByte())
+    buffer.position(clientIdEndPosition)
+    if (value.connectFlags.willPresent) {
+      val willTopicValue = value.willTopic ?: throw EncodeException(fieldPath = "Connect.willTopic", reason = "@When(\"connectFlags.willPresent\") predicate is true but field is null")
+      val willTopicSizePosition = buffer.position()
+      buffer.position(willTopicSizePosition + 2)
+      val willTopicBodyStart = buffer.position()
+      buffer.writeString(willTopicValue, Charset.UTF8)
+      val willTopicEndPosition = buffer.position()
+      val willTopicByteCount = willTopicEndPosition - willTopicBodyStart
+      if (willTopicByteCount > 65_535) {
+        throw EncodeException(fieldPath = "Connect.willTopic", reason = """UTF-8 byte length ${willTopicByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+      }
+      buffer.position(willTopicSizePosition)
+      val willTopicPrefix = willTopicByteCount.toUInt()
+      buffer.writeUByte(((willTopicPrefix shr 8) and 0xFFu).toUByte())
+      buffer.writeUByte((willTopicPrefix and 0xFFu).toUByte())
+      buffer.position(willTopicEndPosition)
+    }
+    if (value.connectFlags.willPresent) {
+      val willPayloadValue = value.willPayload ?: throw EncodeException(fieldPath = "Connect.willPayload", reason = "@When(\"connectFlags.willPresent\") predicate is true but field is null")
+      val willPayloadSizePosition = buffer.position()
+      buffer.position(willPayloadSizePosition + 2)
+      val willPayloadBodyStart = buffer.position()
+      BinaryDataCodec.encode(buffer, willPayloadValue, context)
+      val willPayloadEndPosition = buffer.position()
+      val willPayloadByteCount = willPayloadEndPosition - willPayloadBodyStart
+      if (willPayloadByteCount > 65_535) {
+        throw EncodeException(fieldPath = "Connect.willPayload", reason = """encoded payload byte length ${willPayloadByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+      }
+      buffer.position(willPayloadSizePosition)
+      val willPayloadPrefix = willPayloadByteCount.toUInt()
+      buffer.writeUByte(((willPayloadPrefix shr 8) and 0xFFu).toUByte())
+      buffer.writeUByte((willPayloadPrefix and 0xFFu).toUByte())
+      buffer.position(willPayloadEndPosition)
+    }
+    if (value.connectFlags.usernamePresent) {
+      val usernameValue = value.username ?: throw EncodeException(fieldPath = "Connect.username", reason = "@When(\"connectFlags.usernamePresent\") predicate is true but field is null")
+      val usernameSizePosition = buffer.position()
+      buffer.position(usernameSizePosition + 2)
+      val usernameBodyStart = buffer.position()
+      buffer.writeString(usernameValue, Charset.UTF8)
+      val usernameEndPosition = buffer.position()
+      val usernameByteCount = usernameEndPosition - usernameBodyStart
+      if (usernameByteCount > 65_535) {
+        throw EncodeException(fieldPath = "Connect.username", reason = """UTF-8 byte length ${usernameByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+      }
+      buffer.position(usernameSizePosition)
+      val usernamePrefix = usernameByteCount.toUInt()
+      buffer.writeUByte(((usernamePrefix shr 8) and 0xFFu).toUByte())
+      buffer.writeUByte((usernamePrefix and 0xFFu).toUByte())
+      buffer.position(usernameEndPosition)
+    }
+    if (value.connectFlags.passwordPresent) {
+      val passwordValue = value.password ?: throw EncodeException(fieldPath = "Connect.password", reason = "@When(\"connectFlags.passwordPresent\") predicate is true but field is null")
+      val passwordSizePosition = buffer.position()
+      buffer.position(passwordSizePosition + 2)
+      val passwordBodyStart = buffer.position()
+      BinaryDataCodec.encode(buffer, passwordValue, context)
+      val passwordEndPosition = buffer.position()
+      val passwordByteCount = passwordEndPosition - passwordBodyStart
+      if (passwordByteCount > 65_535) {
+        throw EncodeException(fieldPath = "Connect.password", reason = """encoded payload byte length ${passwordByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+      }
+      buffer.position(passwordSizePosition)
+      val passwordPrefix = passwordByteCount.toUInt()
+      buffer.writeUByte(((passwordPrefix shr 8) and 0xFFu).toUByte())
+      buffer.writeUByte((passwordPrefix and 0xFFu).toUByte())
+      buffer.position(passwordEndPosition)
+    }
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketDisconnectCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketDisconnectCodec.kt
@@ -1,0 +1,73 @@
+package com.ditchoom.buffer.codec.test.protocols.mqtt
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object MqttPacketDisconnectCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): MqttPacket.Disconnect {
+    val header = MqttFixedHeader(buffer.readUByte())
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "Disconnect.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      MqttPacket.Disconnect(header = header)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: MqttPacket.Disconnect,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+    headerWireWidth = 1,
+    writeHeader = { buffer ->
+      buffer.writeUByte(value.header.raw)
+    },
+  ) { buffer ->
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketPingReqCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketPingReqCodec.kt
@@ -1,0 +1,73 @@
+package com.ditchoom.buffer.codec.test.protocols.mqtt
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object MqttPacketPingReqCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): MqttPacket.PingReq {
+    val header = MqttFixedHeader(buffer.readUByte())
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "PingReq.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      MqttPacket.PingReq(header = header)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: MqttPacket.PingReq,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+    headerWireWidth = 1,
+    writeHeader = { buffer ->
+      buffer.writeUByte(value.header.raw)
+    },
+  ) { buffer ->
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketPingRespCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketPingRespCodec.kt
@@ -1,0 +1,73 @@
+package com.ditchoom.buffer.codec.test.protocols.mqtt
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object MqttPacketPingRespCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): MqttPacket.PingResp {
+    val header = MqttFixedHeader(buffer.readUByte())
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "PingResp.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      MqttPacket.PingResp(header = header)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: MqttPacket.PingResp,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+    headerWireWidth = 1,
+    writeHeader = { buffer ->
+      buffer.writeUByte(value.header.raw)
+    },
+  ) { buffer ->
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketPubAckCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketPubAckCodec.kt
@@ -1,0 +1,78 @@
+package com.ditchoom.buffer.codec.test.protocols.mqtt
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object MqttPacketPubAckCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): MqttPacket.PubAck {
+    val header = MqttFixedHeader(buffer.readUByte())
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val packetIdentifierB0 = buffer.readUByte().toUInt()
+      val packetIdentifierB1 = buffer.readUByte().toUInt()
+      val packetIdentifier = ((packetIdentifierB0 shl 8) or packetIdentifierB1).toUShort()
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "PubAck.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      MqttPacket.PubAck(header = header, packetIdentifier = packetIdentifier)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: MqttPacket.PubAck,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+    headerWireWidth = 1,
+    writeHeader = { buffer ->
+      buffer.writeUByte(value.header.raw)
+    },
+  ) { buffer ->
+    buffer.writeUByte(((value.packetIdentifier.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.packetIdentifier.toUInt() and 0xFFu).toUByte())
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketPubCompCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketPubCompCodec.kt
@@ -1,0 +1,78 @@
+package com.ditchoom.buffer.codec.test.protocols.mqtt
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object MqttPacketPubCompCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): MqttPacket.PubComp {
+    val header = MqttFixedHeader(buffer.readUByte())
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val packetIdentifierB0 = buffer.readUByte().toUInt()
+      val packetIdentifierB1 = buffer.readUByte().toUInt()
+      val packetIdentifier = ((packetIdentifierB0 shl 8) or packetIdentifierB1).toUShort()
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "PubComp.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      MqttPacket.PubComp(header = header, packetIdentifier = packetIdentifier)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: MqttPacket.PubComp,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+    headerWireWidth = 1,
+    writeHeader = { buffer ->
+      buffer.writeUByte(value.header.raw)
+    },
+  ) { buffer ->
+    buffer.writeUByte(((value.packetIdentifier.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.packetIdentifier.toUInt() and 0xFFu).toUByte())
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketPubRecCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketPubRecCodec.kt
@@ -1,0 +1,78 @@
+package com.ditchoom.buffer.codec.test.protocols.mqtt
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object MqttPacketPubRecCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): MqttPacket.PubRec {
+    val header = MqttFixedHeader(buffer.readUByte())
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val packetIdentifierB0 = buffer.readUByte().toUInt()
+      val packetIdentifierB1 = buffer.readUByte().toUInt()
+      val packetIdentifier = ((packetIdentifierB0 shl 8) or packetIdentifierB1).toUShort()
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "PubRec.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      MqttPacket.PubRec(header = header, packetIdentifier = packetIdentifier)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: MqttPacket.PubRec,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+    headerWireWidth = 1,
+    writeHeader = { buffer ->
+      buffer.writeUByte(value.header.raw)
+    },
+  ) { buffer ->
+    buffer.writeUByte(((value.packetIdentifier.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.packetIdentifier.toUInt() and 0xFFu).toUByte())
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketPubRelCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketPubRelCodec.kt
@@ -1,0 +1,78 @@
+package com.ditchoom.buffer.codec.test.protocols.mqtt
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object MqttPacketPubRelCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): MqttPacket.PubRel {
+    val header = MqttFixedHeader(buffer.readUByte())
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val packetIdentifierB0 = buffer.readUByte().toUInt()
+      val packetIdentifierB1 = buffer.readUByte().toUInt()
+      val packetIdentifier = ((packetIdentifierB0 shl 8) or packetIdentifierB1).toUShort()
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "PubRel.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      MqttPacket.PubRel(header = header, packetIdentifier = packetIdentifier)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: MqttPacket.PubRel,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+    headerWireWidth = 1,
+    writeHeader = { buffer ->
+      buffer.writeUByte(value.header.raw)
+    },
+  ) { buffer ->
+    buffer.writeUByte(((value.packetIdentifier.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.packetIdentifier.toUInt() and 0xFFu).toUByte())
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketPublishCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketPublishCodec.kt
@@ -1,0 +1,146 @@
+package com.ditchoom.buffer.codec.test.protocols.mqtt
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.Decoder
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.Payload
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.test.protocols.payload.PacketId
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.String
+import kotlin.Throwable
+
+public class MqttPacketPublishCodec<P : Payload>(
+  private val payloadCodec: Codec<P>,
+) {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): MqttPacket.Publish<P> {
+    val header = MqttFixedHeader(buffer.readUByte())
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val topicPrefixB0 = buffer.readUByte().toUInt()
+      val topicPrefixB1 = buffer.readUByte().toUInt()
+      val topicPrefix = ((topicPrefixB0 shl 8) or topicPrefixB1)
+      if (topicPrefix > Int.MAX_VALUE.toUInt()) {
+        throw DecodeException(fieldPath = "Publish.topic", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = topicPrefix.toString())
+      }
+      val topicLength = topicPrefix.toInt()
+      val topic = buffer.readString(topicLength, Charset.UTF8)
+      val packetId: PacketId? = if (header.qosGreaterThanZero) PacketId(buffer.readUShort()) else null
+      val payload = payloadCodec.decode(buffer, context)
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "Publish.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      MqttPacket.Publish<P>(header = header, topic = topic, packetId = packetId, payload = payload)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: MqttPacket.Publish<P>,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+    headerWireWidth = 1,
+    writeHeader = { buffer ->
+      buffer.writeUByte(value.header.raw)
+    },
+  ) { buffer ->
+    val topicSizePosition = buffer.position()
+    buffer.position(topicSizePosition + 2)
+    val topicBodyStart = buffer.position()
+    buffer.writeString(value.topic, Charset.UTF8)
+    val topicEndPosition = buffer.position()
+    val topicByteCount = topicEndPosition - topicBodyStart
+    if (topicByteCount > 65_535) {
+      throw EncodeException(fieldPath = "Publish.topic", reason = """UTF-8 byte length ${topicByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(topicSizePosition)
+    val topicPrefix = topicByteCount.toUInt()
+    buffer.writeUByte(((topicPrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((topicPrefix and 0xFFu).toUByte())
+    buffer.position(topicEndPosition)
+    if (value.header.qosGreaterThanZero) {
+      val packetIdValue = value.packetId ?: throw EncodeException(fieldPath = "Publish.packetId", reason = "@When(\"header.qosGreaterThanZero\") predicate is true but field is null")
+      buffer.writeUShort(packetIdValue.raw)
+    }
+    payloadCodec.encode(buffer, value.payload, context)
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+
+  public class Partial<P : Payload> internal constructor(
+    public val `header`: MqttFixedHeader,
+    public val topic: String,
+    public val packetId: PacketId?,
+    private val outerLimit: Int,
+    private val buffer: ReadBuffer,
+    private val context: DecodeContext,
+  ) {
+    public fun complete(payloadCodec: Decoder<P>): MqttPacket.Publish<P> = try {
+      val payload = payloadCodec.decode(buffer, context)
+      MqttPacket.Publish<P>(header = header, topic = topic, packetId = packetId, payload = payload)
+    } finally {
+      buffer.setLimit(outerLimit)
+    }
+  }
+
+  public companion object {
+    public fun <P : Payload> partial(buffer: ReadBuffer, context: DecodeContext): Partial<P> {
+      val header = MqttFixedHeader(buffer.readUByte())
+      val __framingOuterLimit = buffer.limit()
+      val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+      MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+      val topicPrefixB0 = buffer.readUByte().toUInt()
+      val topicPrefixB1 = buffer.readUByte().toUInt()
+      val topicPrefix = ((topicPrefixB0 shl 8) or topicPrefixB1)
+      if (topicPrefix > Int.MAX_VALUE.toUInt()) {
+        throw DecodeException(fieldPath = "Publish.topic", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = topicPrefix.toString())
+      }
+      val topicLength = topicPrefix.toInt()
+      val topic = buffer.readString(topicLength, Charset.UTF8)
+      val packetId: PacketId? = if (header.qosGreaterThanZero) PacketId(buffer.readUShort()) else null
+      return Partial<P>(header = header, topic = topic, packetId = packetId, outerLimit = __framingOuterLimit, buffer = buffer, context = context)
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketSubAckCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketSubAckCodec.kt
@@ -1,0 +1,87 @@
+package com.ditchoom.buffer.codec.test.protocols.mqtt
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.test.protocols.mqtt.suback.MqttV3SubAckReturnCode
+import com.ditchoom.buffer.codec.test.protocols.mqtt.suback.MqttV3SubAckReturnCodeCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object MqttPacketSubAckCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): MqttPacket.SubAck {
+    val header = MqttFixedHeader(buffer.readUByte())
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val packetIdentifierB0 = buffer.readUByte().toUInt()
+      val packetIdentifierB1 = buffer.readUByte().toUInt()
+      val packetIdentifier = ((packetIdentifierB0 shl 8) or packetIdentifierB1).toUShort()
+      val returnCodes = mutableListOf<MqttV3SubAckReturnCode>()
+      while (buffer.position() < buffer.limit()) {
+        returnCodes += MqttV3SubAckReturnCodeCodec.decode(buffer, context)
+      }
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "SubAck.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      MqttPacket.SubAck(header = header, packetIdentifier = packetIdentifier, returnCodes = returnCodes)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: MqttPacket.SubAck,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+    headerWireWidth = 1,
+    writeHeader = { buffer ->
+      buffer.writeUByte(value.header.raw)
+    },
+  ) { buffer ->
+    buffer.writeUByte(((value.packetIdentifier.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.packetIdentifier.toUInt() and 0xFFu).toUByte())
+    for (__elem in value.returnCodes) {
+      MqttV3SubAckReturnCodeCodec.encode(buffer, __elem, context)
+    }
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketSubscribeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketSubscribeCodec.kt
@@ -1,0 +1,85 @@
+package com.ditchoom.buffer.codec.test.protocols.mqtt
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object MqttPacketSubscribeCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): MqttPacket.Subscribe {
+    val header = MqttFixedHeader(buffer.readUByte())
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val packetIdentifierB0 = buffer.readUByte().toUInt()
+      val packetIdentifierB1 = buffer.readUByte().toUInt()
+      val packetIdentifier = ((packetIdentifierB0 shl 8) or packetIdentifierB1).toUShort()
+      val topicFilters = mutableListOf<MqttTopicFilter>()
+      while (buffer.position() < buffer.limit()) {
+        topicFilters += MqttTopicFilterCodec.decode(buffer, context)
+      }
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "Subscribe.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      MqttPacket.Subscribe(header = header, packetIdentifier = packetIdentifier, topicFilters = topicFilters)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: MqttPacket.Subscribe,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+    headerWireWidth = 1,
+    writeHeader = { buffer ->
+      buffer.writeUByte(value.header.raw)
+    },
+  ) { buffer ->
+    buffer.writeUByte(((value.packetIdentifier.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.packetIdentifier.toUInt() and 0xFFu).toUByte())
+    for (__elem in value.topicFilters) {
+      MqttTopicFilterCodec.encode(buffer, __elem, context)
+    }
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketUnsubAckCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketUnsubAckCodec.kt
@@ -1,0 +1,78 @@
+package com.ditchoom.buffer.codec.test.protocols.mqtt
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object MqttPacketUnsubAckCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): MqttPacket.UnsubAck {
+    val header = MqttFixedHeader(buffer.readUByte())
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val packetIdentifierB0 = buffer.readUByte().toUInt()
+      val packetIdentifierB1 = buffer.readUByte().toUInt()
+      val packetIdentifier = ((packetIdentifierB0 shl 8) or packetIdentifierB1).toUShort()
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "UnsubAck.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      MqttPacket.UnsubAck(header = header, packetIdentifier = packetIdentifier)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: MqttPacket.UnsubAck,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+    headerWireWidth = 1,
+    writeHeader = { buffer ->
+      buffer.writeUByte(value.header.raw)
+    },
+  ) { buffer ->
+    buffer.writeUByte(((value.packetIdentifier.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.packetIdentifier.toUInt() and 0xFFu).toUByte())
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketUnsubscribeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketUnsubscribeCodec.kt
@@ -1,0 +1,85 @@
+package com.ditchoom.buffer.codec.test.protocols.mqtt
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object MqttPacketUnsubscribeCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): MqttPacket.Unsubscribe {
+    val header = MqttFixedHeader(buffer.readUByte())
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val packetIdentifierB0 = buffer.readUByte().toUInt()
+      val packetIdentifierB1 = buffer.readUByte().toUInt()
+      val packetIdentifier = ((packetIdentifierB0 shl 8) or packetIdentifierB1).toUShort()
+      val topics = mutableListOf<MqttUnsubscribeTopic>()
+      while (buffer.position() < buffer.limit()) {
+        topics += MqttUnsubscribeTopicCodec.decode(buffer, context)
+      }
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "Unsubscribe.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      MqttPacket.Unsubscribe(header = header, packetIdentifier = packetIdentifier, topics = topics)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: MqttPacket.Unsubscribe,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+    headerWireWidth = 1,
+    writeHeader = { buffer ->
+      buffer.writeUByte(value.header.raw)
+    },
+  ) { buffer ->
+    buffer.writeUByte(((value.packetIdentifier.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.packetIdentifier.toUInt() and 0xFFu).toUByte())
+    for (__elem in value.topics) {
+      MqttUnsubscribeTopicCodec.encode(buffer, __elem, context)
+    }
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttTopicFilterCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttTopicFilterCodec.kt
@@ -1,0 +1,68 @@
+package com.ditchoom.buffer.codec.test.protocols.mqtt
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttTopicFilterCodec : Codec<MqttTopicFilter> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttTopicFilter {
+    val filterPrefixB0 = buffer.readUByte().toUInt()
+    val filterPrefixB1 = buffer.readUByte().toUInt()
+    val filterPrefix = ((filterPrefixB0 shl 8) or filterPrefixB1)
+    if (filterPrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "MqttTopicFilter.filter", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = filterPrefix.toString())
+    }
+    val filterLength = filterPrefix.toInt()
+    val filter = buffer.readString(filterLength, Charset.UTF8)
+    val qos = buffer.readUByte()
+    return MqttTopicFilter(filter = filter, qos = qos)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttTopicFilter,
+    context: EncodeContext,
+  ) {
+    val filterSizePosition = buffer.position()
+    buffer.position(filterSizePosition + 2)
+    val filterBodyStart = buffer.position()
+    buffer.writeString(value.filter, Charset.UTF8)
+    val filterEndPosition = buffer.position()
+    val filterByteCount = filterEndPosition - filterBodyStart
+    if (filterByteCount > 65_535) {
+      throw EncodeException(fieldPath = "MqttTopicFilter.filter", reason = """UTF-8 byte length ${filterByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(filterSizePosition)
+    val filterPrefix = filterByteCount.toUInt()
+    buffer.writeUByte(((filterPrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((filterPrefix and 0xFFu).toUByte())
+    buffer.position(filterEndPosition)
+    buffer.writeUByte(value.qos)
+  }
+
+  override fun wireSize(`value`: MqttTopicFilter, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val filterPrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val filterPrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val filterPrefix = ((filterPrefixB0 shl 8) or filterPrefixB1).toUInt()
+    if (filterPrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "MqttTopicFilter.filter", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + filterPrefix.toInt()}""")
+    }
+    __offset += 2 + filterPrefix.toInt()
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    __offset += 1
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttUnsubscribeTopicCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttUnsubscribeTopicCodec.kt
@@ -1,0 +1,64 @@
+package com.ditchoom.buffer.codec.test.protocols.mqtt
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttUnsubscribeTopicCodec : Codec<MqttUnsubscribeTopic> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttUnsubscribeTopic {
+    val namePrefixB0 = buffer.readUByte().toUInt()
+    val namePrefixB1 = buffer.readUByte().toUInt()
+    val namePrefix = ((namePrefixB0 shl 8) or namePrefixB1)
+    if (namePrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "MqttUnsubscribeTopic.name", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = namePrefix.toString())
+    }
+    val nameLength = namePrefix.toInt()
+    val name = buffer.readString(nameLength, Charset.UTF8)
+    return MqttUnsubscribeTopic(name = name)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttUnsubscribeTopic,
+    context: EncodeContext,
+  ) {
+    val nameSizePosition = buffer.position()
+    buffer.position(nameSizePosition + 2)
+    val nameBodyStart = buffer.position()
+    buffer.writeString(value.name, Charset.UTF8)
+    val nameEndPosition = buffer.position()
+    val nameByteCount = nameEndPosition - nameBodyStart
+    if (nameByteCount > 65_535) {
+      throw EncodeException(fieldPath = "MqttUnsubscribeTopic.name", reason = """UTF-8 byte length ${nameByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(nameSizePosition)
+    val namePrefix = nameByteCount.toUInt()
+    buffer.writeUByte(((namePrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((namePrefix and 0xFFu).toUByte())
+    buffer.position(nameEndPosition)
+  }
+
+  override fun wireSize(`value`: MqttUnsubscribeTopic, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val namePrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val namePrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val namePrefix = ((namePrefixB0 shl 8) or namePrefixB1).toUInt()
+    if (namePrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "MqttUnsubscribeTopic.name", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + namePrefix.toInt()}""")
+    }
+    __offset += 2 + namePrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/suback/MqttV3SubAckReturnCodeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/suback/MqttV3SubAckReturnCodeCodec.kt
@@ -1,0 +1,66 @@
+package com.ditchoom.buffer.codec.test.protocols.mqtt.suback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttV3SubAckReturnCodeCodec : Codec<MqttV3SubAckReturnCode> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV3SubAckReturnCode {
+    val discriminatorPosition = buffer.position()
+    val __discriminator = MqttV3SubAckReturnCodeRawCodec.decode(buffer, context)
+    buffer.position(discriminatorPosition)
+    val __dispatchValue = __discriminator.id
+    return when (__dispatchValue) {
+      0 -> MqttV3SubAckReturnCodeSuccessMaximumQoS0Codec.decode(buffer, context)
+      1 -> MqttV3SubAckReturnCodeSuccessMaximumQoS1Codec.decode(buffer, context)
+      2 -> MqttV3SubAckReturnCodeSuccessMaximumQoS2Codec.decode(buffer, context)
+      128 -> MqttV3SubAckReturnCodeFailureCodec.decode(buffer, context)
+      else -> {
+        throw DecodeException(fieldPath = "MqttV3SubAckReturnCode.discriminator", bufferPosition = discriminatorPosition, expected = "one of {0, 1, 2, 128}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttV3SubAckReturnCode,
+    context: EncodeContext,
+  ) {
+    when (value) {
+      is MqttV3SubAckReturnCode.SuccessMaximumQoS0 -> MqttV3SubAckReturnCodeSuccessMaximumQoS0Codec.encode(buffer, value, context)
+      is MqttV3SubAckReturnCode.SuccessMaximumQoS1 -> MqttV3SubAckReturnCodeSuccessMaximumQoS1Codec.encode(buffer, value, context)
+      is MqttV3SubAckReturnCode.SuccessMaximumQoS2 -> MqttV3SubAckReturnCodeSuccessMaximumQoS2Codec.encode(buffer, value, context)
+      is MqttV3SubAckReturnCode.Failure -> MqttV3SubAckReturnCodeFailureCodec.encode(buffer, value, context)
+    }
+  }
+
+  override fun wireSize(`value`: MqttV3SubAckReturnCode, context: EncodeContext): WireSize = when (value) {
+    is MqttV3SubAckReturnCode.SuccessMaximumQoS0 -> MqttV3SubAckReturnCodeSuccessMaximumQoS0Codec.wireSize(value, context)
+    is MqttV3SubAckReturnCode.SuccessMaximumQoS1 -> MqttV3SubAckReturnCodeSuccessMaximumQoS1Codec.wireSize(value, context)
+    is MqttV3SubAckReturnCode.SuccessMaximumQoS2 -> MqttV3SubAckReturnCodeSuccessMaximumQoS2Codec.wireSize(value, context)
+    is MqttV3SubAckReturnCode.Failure -> MqttV3SubAckReturnCodeFailureCodec.wireSize(value, context)
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
+    val __discRaw = stream.peekByte(baseOffset + 0).toUByte()
+    val __discriminator = MqttV3SubAckReturnCodeRaw(__discRaw)
+    val __dispatchValue = __discriminator.id
+    return when (__dispatchValue) {
+      0 -> MqttV3SubAckReturnCodeSuccessMaximumQoS0Codec.peekFrameSize(stream, baseOffset)
+      1 -> MqttV3SubAckReturnCodeSuccessMaximumQoS1Codec.peekFrameSize(stream, baseOffset)
+      2 -> MqttV3SubAckReturnCodeSuccessMaximumQoS2Codec.peekFrameSize(stream, baseOffset)
+      128 -> MqttV3SubAckReturnCodeFailureCodec.peekFrameSize(stream, baseOffset)
+      else -> {
+        throw DecodeException(fieldPath = "MqttV3SubAckReturnCode.discriminator", bufferPosition = baseOffset, expected = "one of {0, 1, 2, 128}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/suback/MqttV3SubAckReturnCodeFailureCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/suback/MqttV3SubAckReturnCodeFailureCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqtt.suback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttV3SubAckReturnCodeFailureCodec : Codec<MqttV3SubAckReturnCode.Failure> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV3SubAckReturnCode.Failure {
+    buffer.readUByte()
+    return MqttV3SubAckReturnCode.Failure
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttV3SubAckReturnCode.Failure,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(0x80.toUByte())
+  }
+
+  override fun wireSize(`value`: MqttV3SubAckReturnCode.Failure, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/suback/MqttV3SubAckReturnCodeRawCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/suback/MqttV3SubAckReturnCodeRawCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqtt.suback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttV3SubAckReturnCodeRawCodec : Codec<MqttV3SubAckReturnCodeRaw> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV3SubAckReturnCodeRaw {
+    val raw = buffer.readUByte()
+    return MqttV3SubAckReturnCodeRaw(raw = raw)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttV3SubAckReturnCodeRaw,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.raw)
+  }
+
+  override fun wireSize(`value`: MqttV3SubAckReturnCodeRaw, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/suback/MqttV3SubAckReturnCodeSuccessMaximumQoS0Codec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/suback/MqttV3SubAckReturnCodeSuccessMaximumQoS0Codec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqtt.suback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttV3SubAckReturnCodeSuccessMaximumQoS0Codec : Codec<MqttV3SubAckReturnCode.SuccessMaximumQoS0> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV3SubAckReturnCode.SuccessMaximumQoS0 {
+    buffer.readUByte()
+    return MqttV3SubAckReturnCode.SuccessMaximumQoS0
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttV3SubAckReturnCode.SuccessMaximumQoS0,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(0x0.toUByte())
+  }
+
+  override fun wireSize(`value`: MqttV3SubAckReturnCode.SuccessMaximumQoS0, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/suback/MqttV3SubAckReturnCodeSuccessMaximumQoS1Codec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/suback/MqttV3SubAckReturnCodeSuccessMaximumQoS1Codec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqtt.suback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttV3SubAckReturnCodeSuccessMaximumQoS1Codec : Codec<MqttV3SubAckReturnCode.SuccessMaximumQoS1> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV3SubAckReturnCode.SuccessMaximumQoS1 {
+    buffer.readUByte()
+    return MqttV3SubAckReturnCode.SuccessMaximumQoS1
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttV3SubAckReturnCode.SuccessMaximumQoS1,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(0x1.toUByte())
+  }
+
+  override fun wireSize(`value`: MqttV3SubAckReturnCode.SuccessMaximumQoS1, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/suback/MqttV3SubAckReturnCodeSuccessMaximumQoS2Codec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/suback/MqttV3SubAckReturnCodeSuccessMaximumQoS2Codec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqtt.suback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttV3SubAckReturnCodeSuccessMaximumQoS2Codec : Codec<MqttV3SubAckReturnCode.SuccessMaximumQoS2> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV3SubAckReturnCode.SuccessMaximumQoS2 {
+    buffer.readUByte()
+    return MqttV3SubAckReturnCode.SuccessMaximumQoS2
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttV3SubAckReturnCode.SuccessMaximumQoS2,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(0x2.toUByte())
+  }
+
+  override fun wireSize(`value`: MqttV3SubAckReturnCode.SuccessMaximumQoS2, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketAuthCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketAuthCodec.kt
@@ -1,0 +1,88 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttFixedHeader
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttRemainingLengthCodec
+import com.ditchoom.buffer.codec.test.protocols.mqttv5.authrc.V5AuthReasonCode
+import com.ditchoom.buffer.codec.test.protocols.mqttv5.authrc.V5AuthReasonCodeCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object MqttV5PacketAuthCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Packet.Auth {
+    val header = MqttFixedHeader(buffer.readUByte())
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val reasonCode: V5AuthReasonCode? = if (buffer.remaining() >= 1) V5AuthReasonCodeCodec.decode(buffer, context) else null
+      val properties: V5PropertyBag? = if (buffer.remaining() >= 1) V5PropertyBagCodec.decode(buffer, context) else null
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "Auth.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      MqttV5Packet.Auth(header = header, reasonCode = reasonCode, properties = properties)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: MqttV5Packet.Auth,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+    headerWireWidth = 1,
+    writeHeader = { buffer ->
+      buffer.writeUByte(value.header.raw)
+    },
+  ) { buffer ->
+    if (value.reasonCode != null) {
+      val reasonCodeValue = value.reasonCode ?: throw EncodeException(fieldPath = "Auth.reasonCode", reason = "@When(\"remaining >= 1\") predicate is true but field is null")
+      V5AuthReasonCodeCodec.encode(buffer, reasonCodeValue, context)
+    }
+    if (value.properties != null) {
+      val propertiesValue = value.properties ?: throw EncodeException(fieldPath = "Auth.properties", reason = "@When(\"remaining >= 1\") predicate is true but field is null")
+      V5PropertyBagCodec.encode(buffer, propertiesValue, context)
+    }
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketCodec.kt
@@ -1,0 +1,128 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.Payload
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttFixedHeaderCodec
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttRemainingLengthCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public class MqttV5PacketCodec<P : Payload>(
+  private val payloadCodec: Codec<P>,
+) {
+  private val publishCodec: MqttV5PacketPublishCodec<P> = MqttV5PacketPublishCodec(payloadCodec)
+
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Packet<P> {
+    val discriminatorPosition = buffer.position()
+    val __discriminator = MqttFixedHeaderCodec.decode(buffer, context)
+    buffer.position(discriminatorPosition)
+    val __dispatchValue = __discriminator.packetType
+    return when (__dispatchValue) {
+      1 -> MqttV5PacketConnectCodec.decode(buffer, context)
+      2 -> MqttV5PacketConnAckCodec.decode(buffer, context)
+      3 -> publishCodec.decode(buffer, context)
+      4 -> MqttV5PacketPubAckCodec.decode(buffer, context)
+      5 -> MqttV5PacketPubRecCodec.decode(buffer, context)
+      6 -> MqttV5PacketPubRelCodec.decode(buffer, context)
+      7 -> MqttV5PacketPubCompCodec.decode(buffer, context)
+      8 -> MqttV5PacketSubscribeCodec.decode(buffer, context)
+      9 -> MqttV5PacketSubAckCodec.decode(buffer, context)
+      10 -> MqttV5PacketUnsubscribeCodec.decode(buffer, context)
+      11 -> MqttV5PacketUnsubAckCodec.decode(buffer, context)
+      12 -> MqttV5PacketPingReqCodec.decode(buffer, context)
+      13 -> MqttV5PacketPingRespCodec.decode(buffer, context)
+      14 -> MqttV5PacketDisconnectCodec.decode(buffer, context)
+      15 -> MqttV5PacketAuthCodec.decode(buffer, context)
+      else -> {
+        throw DecodeException(fieldPath = "MqttV5Packet.discriminator", bufferPosition = discriminatorPosition, expected = "one of {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+
+  public fun encode(
+    `value`: MqttV5Packet<P>,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer {
+    @Suppress("UNCHECKED_CAST")
+    return when (value) {
+      is MqttV5Packet.Connect -> MqttV5PacketConnectCodec.encode(value, context, factory)
+      is MqttV5Packet.ConnAck -> MqttV5PacketConnAckCodec.encode(value, context, factory)
+      is MqttV5Packet.Publish<*> -> publishCodec.encode(value as MqttV5Packet.Publish<P>, context, factory)
+      is MqttV5Packet.PubAck -> MqttV5PacketPubAckCodec.encode(value, context, factory)
+      is MqttV5Packet.PubRec -> MqttV5PacketPubRecCodec.encode(value, context, factory)
+      is MqttV5Packet.PubRel -> MqttV5PacketPubRelCodec.encode(value, context, factory)
+      is MqttV5Packet.PubComp -> MqttV5PacketPubCompCodec.encode(value, context, factory)
+      is MqttV5Packet.Subscribe -> MqttV5PacketSubscribeCodec.encode(value, context, factory)
+      is MqttV5Packet.SubAck -> MqttV5PacketSubAckCodec.encode(value, context, factory)
+      is MqttV5Packet.Unsubscribe -> MqttV5PacketUnsubscribeCodec.encode(value, context, factory)
+      is MqttV5Packet.UnsubAck -> MqttV5PacketUnsubAckCodec.encode(value, context, factory)
+      is MqttV5Packet.PingReq -> MqttV5PacketPingReqCodec.encode(value, context, factory)
+      is MqttV5Packet.PingResp -> MqttV5PacketPingRespCodec.encode(value, context, factory)
+      is MqttV5Packet.Disconnect -> MqttV5PacketDisconnectCodec.encode(value, context, factory)
+      is MqttV5Packet.Auth -> MqttV5PacketAuthCodec.encode(value, context, factory)
+    }
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+
+  public companion object {
+    public fun <P : Payload> decodeAggregating(
+      buffer: ReadBuffer,
+      context: DecodeContext,
+      onPublish: (MqttV5PacketPublishCodec.Partial<P>) -> MqttV5Packet.Publish<P> = { _ -> throw DecodeException(fieldPath = "MqttV5Packet.Publish.handler", bufferPosition = -1, expected = "consumer-supplied Publish handler", actual = "no handler supplied") },
+    ): MqttV5Packet<P> {
+      val discriminatorPosition = buffer.position()
+      val __discriminator = MqttFixedHeaderCodec.decode(buffer, context)
+      buffer.position(discriminatorPosition)
+      val __dispatchValue = __discriminator.packetType
+      return when (__dispatchValue) {
+        1 -> MqttV5PacketConnectCodec.decode(buffer, context)
+        2 -> MqttV5PacketConnAckCodec.decode(buffer, context)
+        3 -> onPublish(MqttV5PacketPublishCodec.partial<P>(buffer, context))
+        4 -> MqttV5PacketPubAckCodec.decode(buffer, context)
+        5 -> MqttV5PacketPubRecCodec.decode(buffer, context)
+        6 -> MqttV5PacketPubRelCodec.decode(buffer, context)
+        7 -> MqttV5PacketPubCompCodec.decode(buffer, context)
+        8 -> MqttV5PacketSubscribeCodec.decode(buffer, context)
+        9 -> MqttV5PacketSubAckCodec.decode(buffer, context)
+        10 -> MqttV5PacketUnsubscribeCodec.decode(buffer, context)
+        11 -> MqttV5PacketUnsubAckCodec.decode(buffer, context)
+        12 -> MqttV5PacketPingReqCodec.decode(buffer, context)
+        13 -> MqttV5PacketPingRespCodec.decode(buffer, context)
+        14 -> MqttV5PacketDisconnectCodec.decode(buffer, context)
+        15 -> MqttV5PacketAuthCodec.decode(buffer, context)
+        else -> {
+          throw DecodeException(fieldPath = "MqttV5Packet.discriminator", bufferPosition = discriminatorPosition, expected = "one of {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}", actual = """${__dispatchValue}""")
+        }
+      }
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketConnAckCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketConnAckCodec.kt
@@ -1,0 +1,82 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttFixedHeader
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttRemainingLengthCodec
+import com.ditchoom.buffer.codec.test.protocols.mqttv5.connack.V5ConnectReasonCodeCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object MqttV5PacketConnAckCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Packet.ConnAck {
+    val header = MqttFixedHeader(buffer.readUByte())
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val connectAckFlags = buffer.readUByte()
+      val reasonCode = V5ConnectReasonCodeCodec.decode(buffer, context)
+      val properties = V5PropertyBagCodec.decode(buffer, context)
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "ConnAck.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      MqttV5Packet.ConnAck(header = header, connectAckFlags = connectAckFlags, reasonCode = reasonCode, properties = properties)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: MqttV5Packet.ConnAck,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+    headerWireWidth = 1,
+    writeHeader = { buffer ->
+      buffer.writeUByte(value.header.raw)
+    },
+  ) { buffer ->
+    buffer.writeUByte(value.connectAckFlags)
+    V5ConnectReasonCodeCodec.encode(buffer, value.reasonCode, context)
+    V5PropertyBagCodec.encode(buffer, value.properties, context)
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketConnectCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketConnectCodec.kt
@@ -1,0 +1,269 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttConnectFlags
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttFixedHeader
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttRemainingLengthCodec
+import com.ditchoom.buffer.codec.test.protocols.payload.BinaryData
+import com.ditchoom.buffer.codec.test.protocols.payload.BinaryDataCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.String
+import kotlin.Throwable
+
+public object MqttV5PacketConnectCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Packet.Connect {
+    val header = MqttFixedHeader(buffer.readUByte())
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val protocolNamePrefixB0 = buffer.readUByte().toUInt()
+      val protocolNamePrefixB1 = buffer.readUByte().toUInt()
+      val protocolNamePrefix = ((protocolNamePrefixB0 shl 8) or protocolNamePrefixB1)
+      if (protocolNamePrefix > Int.MAX_VALUE.toUInt()) {
+        throw DecodeException(fieldPath = "Connect.protocolName", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = protocolNamePrefix.toString())
+      }
+      val protocolNameLength = protocolNamePrefix.toInt()
+      val protocolName = buffer.readString(protocolNameLength, Charset.UTF8)
+      val protocolLevel = buffer.readUByte()
+      val connectFlags = MqttConnectFlags(buffer.readUByte())
+      val keepAliveSecondsB0 = buffer.readUByte().toUInt()
+      val keepAliveSecondsB1 = buffer.readUByte().toUInt()
+      val keepAliveSeconds = ((keepAliveSecondsB0 shl 8) or keepAliveSecondsB1).toUShort()
+      val properties = V5PropertyBagCodec.decode(buffer, context)
+      val clientIdPrefixB0 = buffer.readUByte().toUInt()
+      val clientIdPrefixB1 = buffer.readUByte().toUInt()
+      val clientIdPrefix = ((clientIdPrefixB0 shl 8) or clientIdPrefixB1)
+      if (clientIdPrefix > Int.MAX_VALUE.toUInt()) {
+        throw DecodeException(fieldPath = "Connect.clientId", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = clientIdPrefix.toString())
+      }
+      val clientIdLength = clientIdPrefix.toInt()
+      val clientId = buffer.readString(clientIdLength, Charset.UTF8)
+      val willProperties: V5PropertyBag? = if (connectFlags.willPresent) V5PropertyBagCodec.decode(buffer, context) else null
+      val willTopic: String? = if (connectFlags.willPresent) {
+        val willTopicPrefixB0 = buffer.readUByte().toUInt()
+        val willTopicPrefixB1 = buffer.readUByte().toUInt()
+        val willTopicPrefix = ((willTopicPrefixB0 shl 8) or willTopicPrefixB1)
+        if (willTopicPrefix > Int.MAX_VALUE.toUInt()) {
+          throw DecodeException(fieldPath = "Connect.willTopic", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = willTopicPrefix.toString())
+        }
+        val willTopicLength = willTopicPrefix.toInt()
+        buffer.readString(willTopicLength, Charset.UTF8)
+      } else {
+        null
+      }
+      val willPayload: BinaryData? = if (connectFlags.willPresent) {
+        val willPayloadPrefixB0 = buffer.readUByte().toUInt()
+        val willPayloadPrefixB1 = buffer.readUByte().toUInt()
+        val willPayloadPrefix = ((willPayloadPrefixB0 shl 8) or willPayloadPrefixB1)
+        if (willPayloadPrefix > Int.MAX_VALUE.toUInt()) {
+          throw DecodeException(fieldPath = "Connect.willPayload", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = willPayloadPrefix.toString())
+        }
+        val willPayloadLength = willPayloadPrefix.toInt()
+        val __willPayloadOuterLimit = buffer.limit()
+        buffer.setLimit(buffer.position() + willPayloadLength)
+        try {
+          BinaryDataCodec.decode(buffer, context)
+        } finally {
+          buffer.setLimit(__willPayloadOuterLimit)
+        }
+      } else {
+        null
+      }
+      val username: String? = if (connectFlags.usernamePresent) {
+        val usernamePrefixB0 = buffer.readUByte().toUInt()
+        val usernamePrefixB1 = buffer.readUByte().toUInt()
+        val usernamePrefix = ((usernamePrefixB0 shl 8) or usernamePrefixB1)
+        if (usernamePrefix > Int.MAX_VALUE.toUInt()) {
+          throw DecodeException(fieldPath = "Connect.username", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = usernamePrefix.toString())
+        }
+        val usernameLength = usernamePrefix.toInt()
+        buffer.readString(usernameLength, Charset.UTF8)
+      } else {
+        null
+      }
+      val password: BinaryData? = if (connectFlags.passwordPresent) {
+        val passwordPrefixB0 = buffer.readUByte().toUInt()
+        val passwordPrefixB1 = buffer.readUByte().toUInt()
+        val passwordPrefix = ((passwordPrefixB0 shl 8) or passwordPrefixB1)
+        if (passwordPrefix > Int.MAX_VALUE.toUInt()) {
+          throw DecodeException(fieldPath = "Connect.password", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = passwordPrefix.toString())
+        }
+        val passwordLength = passwordPrefix.toInt()
+        val __passwordOuterLimit = buffer.limit()
+        buffer.setLimit(buffer.position() + passwordLength)
+        try {
+          BinaryDataCodec.decode(buffer, context)
+        } finally {
+          buffer.setLimit(__passwordOuterLimit)
+        }
+      } else {
+        null
+      }
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "Connect.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      MqttV5Packet.Connect(header = header, protocolName = protocolName, protocolLevel = protocolLevel, connectFlags = connectFlags, keepAliveSeconds = keepAliveSeconds, properties = properties, clientId = clientId, willProperties = willProperties, willTopic = willTopic, willPayload = willPayload, username = username, password = password)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: MqttV5Packet.Connect,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+    headerWireWidth = 1,
+    writeHeader = { buffer ->
+      buffer.writeUByte(value.header.raw)
+    },
+  ) { buffer ->
+    val protocolNameSizePosition = buffer.position()
+    buffer.position(protocolNameSizePosition + 2)
+    val protocolNameBodyStart = buffer.position()
+    buffer.writeString(value.protocolName, Charset.UTF8)
+    val protocolNameEndPosition = buffer.position()
+    val protocolNameByteCount = protocolNameEndPosition - protocolNameBodyStart
+    if (protocolNameByteCount > 65_535) {
+      throw EncodeException(fieldPath = "Connect.protocolName", reason = """UTF-8 byte length ${protocolNameByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(protocolNameSizePosition)
+    val protocolNamePrefix = protocolNameByteCount.toUInt()
+    buffer.writeUByte(((protocolNamePrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((protocolNamePrefix and 0xFFu).toUByte())
+    buffer.position(protocolNameEndPosition)
+    buffer.writeUByte(value.protocolLevel)
+    buffer.writeUByte(value.connectFlags.raw)
+    buffer.writeUByte(((value.keepAliveSeconds.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.keepAliveSeconds.toUInt() and 0xFFu).toUByte())
+    V5PropertyBagCodec.encode(buffer, value.properties, context)
+    val clientIdSizePosition = buffer.position()
+    buffer.position(clientIdSizePosition + 2)
+    val clientIdBodyStart = buffer.position()
+    buffer.writeString(value.clientId, Charset.UTF8)
+    val clientIdEndPosition = buffer.position()
+    val clientIdByteCount = clientIdEndPosition - clientIdBodyStart
+    if (clientIdByteCount > 65_535) {
+      throw EncodeException(fieldPath = "Connect.clientId", reason = """UTF-8 byte length ${clientIdByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(clientIdSizePosition)
+    val clientIdPrefix = clientIdByteCount.toUInt()
+    buffer.writeUByte(((clientIdPrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((clientIdPrefix and 0xFFu).toUByte())
+    buffer.position(clientIdEndPosition)
+    if (value.connectFlags.willPresent) {
+      val willPropertiesValue = value.willProperties ?: throw EncodeException(fieldPath = "Connect.willProperties", reason = "@When(\"connectFlags.willPresent\") predicate is true but field is null")
+      V5PropertyBagCodec.encode(buffer, willPropertiesValue, context)
+    }
+    if (value.connectFlags.willPresent) {
+      val willTopicValue = value.willTopic ?: throw EncodeException(fieldPath = "Connect.willTopic", reason = "@When(\"connectFlags.willPresent\") predicate is true but field is null")
+      val willTopicSizePosition = buffer.position()
+      buffer.position(willTopicSizePosition + 2)
+      val willTopicBodyStart = buffer.position()
+      buffer.writeString(willTopicValue, Charset.UTF8)
+      val willTopicEndPosition = buffer.position()
+      val willTopicByteCount = willTopicEndPosition - willTopicBodyStart
+      if (willTopicByteCount > 65_535) {
+        throw EncodeException(fieldPath = "Connect.willTopic", reason = """UTF-8 byte length ${willTopicByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+      }
+      buffer.position(willTopicSizePosition)
+      val willTopicPrefix = willTopicByteCount.toUInt()
+      buffer.writeUByte(((willTopicPrefix shr 8) and 0xFFu).toUByte())
+      buffer.writeUByte((willTopicPrefix and 0xFFu).toUByte())
+      buffer.position(willTopicEndPosition)
+    }
+    if (value.connectFlags.willPresent) {
+      val willPayloadValue = value.willPayload ?: throw EncodeException(fieldPath = "Connect.willPayload", reason = "@When(\"connectFlags.willPresent\") predicate is true but field is null")
+      val willPayloadSizePosition = buffer.position()
+      buffer.position(willPayloadSizePosition + 2)
+      val willPayloadBodyStart = buffer.position()
+      BinaryDataCodec.encode(buffer, willPayloadValue, context)
+      val willPayloadEndPosition = buffer.position()
+      val willPayloadByteCount = willPayloadEndPosition - willPayloadBodyStart
+      if (willPayloadByteCount > 65_535) {
+        throw EncodeException(fieldPath = "Connect.willPayload", reason = """encoded payload byte length ${willPayloadByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+      }
+      buffer.position(willPayloadSizePosition)
+      val willPayloadPrefix = willPayloadByteCount.toUInt()
+      buffer.writeUByte(((willPayloadPrefix shr 8) and 0xFFu).toUByte())
+      buffer.writeUByte((willPayloadPrefix and 0xFFu).toUByte())
+      buffer.position(willPayloadEndPosition)
+    }
+    if (value.connectFlags.usernamePresent) {
+      val usernameValue = value.username ?: throw EncodeException(fieldPath = "Connect.username", reason = "@When(\"connectFlags.usernamePresent\") predicate is true but field is null")
+      val usernameSizePosition = buffer.position()
+      buffer.position(usernameSizePosition + 2)
+      val usernameBodyStart = buffer.position()
+      buffer.writeString(usernameValue, Charset.UTF8)
+      val usernameEndPosition = buffer.position()
+      val usernameByteCount = usernameEndPosition - usernameBodyStart
+      if (usernameByteCount > 65_535) {
+        throw EncodeException(fieldPath = "Connect.username", reason = """UTF-8 byte length ${usernameByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+      }
+      buffer.position(usernameSizePosition)
+      val usernamePrefix = usernameByteCount.toUInt()
+      buffer.writeUByte(((usernamePrefix shr 8) and 0xFFu).toUByte())
+      buffer.writeUByte((usernamePrefix and 0xFFu).toUByte())
+      buffer.position(usernameEndPosition)
+    }
+    if (value.connectFlags.passwordPresent) {
+      val passwordValue = value.password ?: throw EncodeException(fieldPath = "Connect.password", reason = "@When(\"connectFlags.passwordPresent\") predicate is true but field is null")
+      val passwordSizePosition = buffer.position()
+      buffer.position(passwordSizePosition + 2)
+      val passwordBodyStart = buffer.position()
+      BinaryDataCodec.encode(buffer, passwordValue, context)
+      val passwordEndPosition = buffer.position()
+      val passwordByteCount = passwordEndPosition - passwordBodyStart
+      if (passwordByteCount > 65_535) {
+        throw EncodeException(fieldPath = "Connect.password", reason = """encoded payload byte length ${passwordByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+      }
+      buffer.position(passwordSizePosition)
+      val passwordPrefix = passwordByteCount.toUInt()
+      buffer.writeUByte(((passwordPrefix shr 8) and 0xFFu).toUByte())
+      buffer.writeUByte((passwordPrefix and 0xFFu).toUByte())
+      buffer.position(passwordEndPosition)
+    }
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketDisconnectCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketDisconnectCodec.kt
@@ -1,0 +1,88 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttFixedHeader
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttRemainingLengthCodec
+import com.ditchoom.buffer.codec.test.protocols.mqttv5.disconnectrc.V5DisconnectReasonCode
+import com.ditchoom.buffer.codec.test.protocols.mqttv5.disconnectrc.V5DisconnectReasonCodeCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object MqttV5PacketDisconnectCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Packet.Disconnect {
+    val header = MqttFixedHeader(buffer.readUByte())
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val reasonCode: V5DisconnectReasonCode? = if (buffer.remaining() >= 1) V5DisconnectReasonCodeCodec.decode(buffer, context) else null
+      val properties: V5PropertyBag? = if (buffer.remaining() >= 1) V5PropertyBagCodec.decode(buffer, context) else null
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "Disconnect.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      MqttV5Packet.Disconnect(header = header, reasonCode = reasonCode, properties = properties)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: MqttV5Packet.Disconnect,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+    headerWireWidth = 1,
+    writeHeader = { buffer ->
+      buffer.writeUByte(value.header.raw)
+    },
+  ) { buffer ->
+    if (value.reasonCode != null) {
+      val reasonCodeValue = value.reasonCode ?: throw EncodeException(fieldPath = "Disconnect.reasonCode", reason = "@When(\"remaining >= 1\") predicate is true but field is null")
+      V5DisconnectReasonCodeCodec.encode(buffer, reasonCodeValue, context)
+    }
+    if (value.properties != null) {
+      val propertiesValue = value.properties ?: throw EncodeException(fieldPath = "Disconnect.properties", reason = "@When(\"remaining >= 1\") predicate is true but field is null")
+      V5PropertyBagCodec.encode(buffer, propertiesValue, context)
+    }
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketPingReqCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketPingReqCodec.kt
@@ -1,0 +1,75 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttFixedHeader
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttRemainingLengthCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object MqttV5PacketPingReqCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Packet.PingReq {
+    val header = MqttFixedHeader(buffer.readUByte())
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "PingReq.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      MqttV5Packet.PingReq(header = header)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: MqttV5Packet.PingReq,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+    headerWireWidth = 1,
+    writeHeader = { buffer ->
+      buffer.writeUByte(value.header.raw)
+    },
+  ) { buffer ->
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketPingRespCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketPingRespCodec.kt
@@ -1,0 +1,75 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttFixedHeader
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttRemainingLengthCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object MqttV5PacketPingRespCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Packet.PingResp {
+    val header = MqttFixedHeader(buffer.readUByte())
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "PingResp.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      MqttV5Packet.PingResp(header = header)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: MqttV5Packet.PingResp,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+    headerWireWidth = 1,
+    writeHeader = { buffer ->
+      buffer.writeUByte(value.header.raw)
+    },
+  ) { buffer ->
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketPubAckCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketPubAckCodec.kt
@@ -1,0 +1,93 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttFixedHeader
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttRemainingLengthCodec
+import com.ditchoom.buffer.codec.test.protocols.mqttv5.puback.V5PubAckReasonCode
+import com.ditchoom.buffer.codec.test.protocols.mqttv5.puback.V5PubAckReasonCodeCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object MqttV5PacketPubAckCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Packet.PubAck {
+    val header = MqttFixedHeader(buffer.readUByte())
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val packetIdentifierB0 = buffer.readUByte().toUInt()
+      val packetIdentifierB1 = buffer.readUByte().toUInt()
+      val packetIdentifier = ((packetIdentifierB0 shl 8) or packetIdentifierB1).toUShort()
+      val reasonCode: V5PubAckReasonCode? = if (buffer.remaining() >= 1) V5PubAckReasonCodeCodec.decode(buffer, context) else null
+      val properties: V5PropertyBag? = if (buffer.remaining() >= 1) V5PropertyBagCodec.decode(buffer, context) else null
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "PubAck.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      MqttV5Packet.PubAck(header = header, packetIdentifier = packetIdentifier, reasonCode = reasonCode, properties = properties)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: MqttV5Packet.PubAck,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+    headerWireWidth = 1,
+    writeHeader = { buffer ->
+      buffer.writeUByte(value.header.raw)
+    },
+  ) { buffer ->
+    buffer.writeUByte(((value.packetIdentifier.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.packetIdentifier.toUInt() and 0xFFu).toUByte())
+    if (value.reasonCode != null) {
+      val reasonCodeValue = value.reasonCode ?: throw EncodeException(fieldPath = "PubAck.reasonCode", reason = "@When(\"remaining >= 1\") predicate is true but field is null")
+      V5PubAckReasonCodeCodec.encode(buffer, reasonCodeValue, context)
+    }
+    if (value.properties != null) {
+      val propertiesValue = value.properties ?: throw EncodeException(fieldPath = "PubAck.properties", reason = "@When(\"remaining >= 1\") predicate is true but field is null")
+      V5PropertyBagCodec.encode(buffer, propertiesValue, context)
+    }
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketPubCompCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketPubCompCodec.kt
@@ -1,0 +1,93 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttFixedHeader
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttRemainingLengthCodec
+import com.ditchoom.buffer.codec.test.protocols.mqttv5.puback.V5PubAckReasonCode
+import com.ditchoom.buffer.codec.test.protocols.mqttv5.puback.V5PubAckReasonCodeCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object MqttV5PacketPubCompCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Packet.PubComp {
+    val header = MqttFixedHeader(buffer.readUByte())
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val packetIdentifierB0 = buffer.readUByte().toUInt()
+      val packetIdentifierB1 = buffer.readUByte().toUInt()
+      val packetIdentifier = ((packetIdentifierB0 shl 8) or packetIdentifierB1).toUShort()
+      val reasonCode: V5PubAckReasonCode? = if (buffer.remaining() >= 1) V5PubAckReasonCodeCodec.decode(buffer, context) else null
+      val properties: V5PropertyBag? = if (buffer.remaining() >= 1) V5PropertyBagCodec.decode(buffer, context) else null
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "PubComp.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      MqttV5Packet.PubComp(header = header, packetIdentifier = packetIdentifier, reasonCode = reasonCode, properties = properties)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: MqttV5Packet.PubComp,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+    headerWireWidth = 1,
+    writeHeader = { buffer ->
+      buffer.writeUByte(value.header.raw)
+    },
+  ) { buffer ->
+    buffer.writeUByte(((value.packetIdentifier.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.packetIdentifier.toUInt() and 0xFFu).toUByte())
+    if (value.reasonCode != null) {
+      val reasonCodeValue = value.reasonCode ?: throw EncodeException(fieldPath = "PubComp.reasonCode", reason = "@When(\"remaining >= 1\") predicate is true but field is null")
+      V5PubAckReasonCodeCodec.encode(buffer, reasonCodeValue, context)
+    }
+    if (value.properties != null) {
+      val propertiesValue = value.properties ?: throw EncodeException(fieldPath = "PubComp.properties", reason = "@When(\"remaining >= 1\") predicate is true but field is null")
+      V5PropertyBagCodec.encode(buffer, propertiesValue, context)
+    }
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketPubRecCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketPubRecCodec.kt
@@ -1,0 +1,93 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttFixedHeader
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttRemainingLengthCodec
+import com.ditchoom.buffer.codec.test.protocols.mqttv5.puback.V5PubAckReasonCode
+import com.ditchoom.buffer.codec.test.protocols.mqttv5.puback.V5PubAckReasonCodeCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object MqttV5PacketPubRecCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Packet.PubRec {
+    val header = MqttFixedHeader(buffer.readUByte())
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val packetIdentifierB0 = buffer.readUByte().toUInt()
+      val packetIdentifierB1 = buffer.readUByte().toUInt()
+      val packetIdentifier = ((packetIdentifierB0 shl 8) or packetIdentifierB1).toUShort()
+      val reasonCode: V5PubAckReasonCode? = if (buffer.remaining() >= 1) V5PubAckReasonCodeCodec.decode(buffer, context) else null
+      val properties: V5PropertyBag? = if (buffer.remaining() >= 1) V5PropertyBagCodec.decode(buffer, context) else null
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "PubRec.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      MqttV5Packet.PubRec(header = header, packetIdentifier = packetIdentifier, reasonCode = reasonCode, properties = properties)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: MqttV5Packet.PubRec,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+    headerWireWidth = 1,
+    writeHeader = { buffer ->
+      buffer.writeUByte(value.header.raw)
+    },
+  ) { buffer ->
+    buffer.writeUByte(((value.packetIdentifier.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.packetIdentifier.toUInt() and 0xFFu).toUByte())
+    if (value.reasonCode != null) {
+      val reasonCodeValue = value.reasonCode ?: throw EncodeException(fieldPath = "PubRec.reasonCode", reason = "@When(\"remaining >= 1\") predicate is true but field is null")
+      V5PubAckReasonCodeCodec.encode(buffer, reasonCodeValue, context)
+    }
+    if (value.properties != null) {
+      val propertiesValue = value.properties ?: throw EncodeException(fieldPath = "PubRec.properties", reason = "@When(\"remaining >= 1\") predicate is true but field is null")
+      V5PropertyBagCodec.encode(buffer, propertiesValue, context)
+    }
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketPubRelCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketPubRelCodec.kt
@@ -1,0 +1,93 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttFixedHeader
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttRemainingLengthCodec
+import com.ditchoom.buffer.codec.test.protocols.mqttv5.puback.V5PubAckReasonCode
+import com.ditchoom.buffer.codec.test.protocols.mqttv5.puback.V5PubAckReasonCodeCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object MqttV5PacketPubRelCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Packet.PubRel {
+    val header = MqttFixedHeader(buffer.readUByte())
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val packetIdentifierB0 = buffer.readUByte().toUInt()
+      val packetIdentifierB1 = buffer.readUByte().toUInt()
+      val packetIdentifier = ((packetIdentifierB0 shl 8) or packetIdentifierB1).toUShort()
+      val reasonCode: V5PubAckReasonCode? = if (buffer.remaining() >= 1) V5PubAckReasonCodeCodec.decode(buffer, context) else null
+      val properties: V5PropertyBag? = if (buffer.remaining() >= 1) V5PropertyBagCodec.decode(buffer, context) else null
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "PubRel.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      MqttV5Packet.PubRel(header = header, packetIdentifier = packetIdentifier, reasonCode = reasonCode, properties = properties)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: MqttV5Packet.PubRel,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+    headerWireWidth = 1,
+    writeHeader = { buffer ->
+      buffer.writeUByte(value.header.raw)
+    },
+  ) { buffer ->
+    buffer.writeUByte(((value.packetIdentifier.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.packetIdentifier.toUInt() and 0xFFu).toUByte())
+    if (value.reasonCode != null) {
+      val reasonCodeValue = value.reasonCode ?: throw EncodeException(fieldPath = "PubRel.reasonCode", reason = "@When(\"remaining >= 1\") predicate is true but field is null")
+      V5PubAckReasonCodeCodec.encode(buffer, reasonCodeValue, context)
+    }
+    if (value.properties != null) {
+      val propertiesValue = value.properties ?: throw EncodeException(fieldPath = "PubRel.properties", reason = "@When(\"remaining >= 1\") predicate is true but field is null")
+      V5PropertyBagCodec.encode(buffer, propertiesValue, context)
+    }
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketPublishCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketPublishCodec.kt
@@ -1,0 +1,152 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.Decoder
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.Payload
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttFixedHeader
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttRemainingLengthCodec
+import com.ditchoom.buffer.codec.test.protocols.payload.PacketId
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.String
+import kotlin.Throwable
+
+public class MqttV5PacketPublishCodec<P : Payload>(
+  private val payloadCodec: Codec<P>,
+) {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Packet.Publish<P> {
+    val header = MqttFixedHeader(buffer.readUByte())
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val topicPrefixB0 = buffer.readUByte().toUInt()
+      val topicPrefixB1 = buffer.readUByte().toUInt()
+      val topicPrefix = ((topicPrefixB0 shl 8) or topicPrefixB1)
+      if (topicPrefix > Int.MAX_VALUE.toUInt()) {
+        throw DecodeException(fieldPath = "Publish.topic", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = topicPrefix.toString())
+      }
+      val topicLength = topicPrefix.toInt()
+      val topic = buffer.readString(topicLength, Charset.UTF8)
+      val packetId: PacketId? = if (header.qosGreaterThanZero) PacketId(buffer.readUShort()) else null
+      val properties = V5PropertyBagCodec.decode(buffer, context)
+      val payload = payloadCodec.decode(buffer, context)
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "Publish.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      MqttV5Packet.Publish<P>(header = header, topic = topic, packetId = packetId, properties = properties, payload = payload)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: MqttV5Packet.Publish<P>,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+    headerWireWidth = 1,
+    writeHeader = { buffer ->
+      buffer.writeUByte(value.header.raw)
+    },
+  ) { buffer ->
+    val topicSizePosition = buffer.position()
+    buffer.position(topicSizePosition + 2)
+    val topicBodyStart = buffer.position()
+    buffer.writeString(value.topic, Charset.UTF8)
+    val topicEndPosition = buffer.position()
+    val topicByteCount = topicEndPosition - topicBodyStart
+    if (topicByteCount > 65_535) {
+      throw EncodeException(fieldPath = "Publish.topic", reason = """UTF-8 byte length ${topicByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(topicSizePosition)
+    val topicPrefix = topicByteCount.toUInt()
+    buffer.writeUByte(((topicPrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((topicPrefix and 0xFFu).toUByte())
+    buffer.position(topicEndPosition)
+    if (value.header.qosGreaterThanZero) {
+      val packetIdValue = value.packetId ?: throw EncodeException(fieldPath = "Publish.packetId", reason = "@When(\"header.qosGreaterThanZero\") predicate is true but field is null")
+      buffer.writeUShort(packetIdValue.raw)
+    }
+    V5PropertyBagCodec.encode(buffer, value.properties, context)
+    payloadCodec.encode(buffer, value.payload, context)
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+
+  public class Partial<P : Payload> internal constructor(
+    public val `header`: MqttFixedHeader,
+    public val topic: String,
+    public val packetId: PacketId?,
+    public val properties: V5PropertyBag,
+    private val outerLimit: Int,
+    private val buffer: ReadBuffer,
+    private val context: DecodeContext,
+  ) {
+    public fun complete(payloadCodec: Decoder<P>): MqttV5Packet.Publish<P> = try {
+      val payload = payloadCodec.decode(buffer, context)
+      MqttV5Packet.Publish<P>(header = header, topic = topic, packetId = packetId, properties = properties, payload = payload)
+    } finally {
+      buffer.setLimit(outerLimit)
+    }
+  }
+
+  public companion object {
+    public fun <P : Payload> partial(buffer: ReadBuffer, context: DecodeContext): Partial<P> {
+      val header = MqttFixedHeader(buffer.readUByte())
+      val __framingOuterLimit = buffer.limit()
+      val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+      MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+      val topicPrefixB0 = buffer.readUByte().toUInt()
+      val topicPrefixB1 = buffer.readUByte().toUInt()
+      val topicPrefix = ((topicPrefixB0 shl 8) or topicPrefixB1)
+      if (topicPrefix > Int.MAX_VALUE.toUInt()) {
+        throw DecodeException(fieldPath = "Publish.topic", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = topicPrefix.toString())
+      }
+      val topicLength = topicPrefix.toInt()
+      val topic = buffer.readString(topicLength, Charset.UTF8)
+      val packetId: PacketId? = if (header.qosGreaterThanZero) PacketId(buffer.readUShort()) else null
+      val properties = V5PropertyBagCodec.decode(buffer, context)
+      return Partial<P>(header = header, topic = topic, packetId = packetId, properties = properties, outerLimit = __framingOuterLimit, buffer = buffer, context = context)
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketSubAckCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketSubAckCodec.kt
@@ -1,0 +1,91 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttFixedHeader
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttRemainingLengthCodec
+import com.ditchoom.buffer.codec.test.protocols.mqttv5.suback.V5SubAckReasonCode
+import com.ditchoom.buffer.codec.test.protocols.mqttv5.suback.V5SubAckReasonCodeCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object MqttV5PacketSubAckCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Packet.SubAck {
+    val header = MqttFixedHeader(buffer.readUByte())
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val packetIdentifierB0 = buffer.readUByte().toUInt()
+      val packetIdentifierB1 = buffer.readUByte().toUInt()
+      val packetIdentifier = ((packetIdentifierB0 shl 8) or packetIdentifierB1).toUShort()
+      val properties = V5PropertyBagCodec.decode(buffer, context)
+      val reasonCodes = mutableListOf<V5SubAckReasonCode>()
+      while (buffer.position() < buffer.limit()) {
+        reasonCodes += V5SubAckReasonCodeCodec.decode(buffer, context)
+      }
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "SubAck.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      MqttV5Packet.SubAck(header = header, packetIdentifier = packetIdentifier, properties = properties, reasonCodes = reasonCodes)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: MqttV5Packet.SubAck,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+    headerWireWidth = 1,
+    writeHeader = { buffer ->
+      buffer.writeUByte(value.header.raw)
+    },
+  ) { buffer ->
+    buffer.writeUByte(((value.packetIdentifier.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.packetIdentifier.toUInt() and 0xFFu).toUByte())
+    V5PropertyBagCodec.encode(buffer, value.properties, context)
+    for (__elem in value.reasonCodes) {
+      V5SubAckReasonCodeCodec.encode(buffer, __elem, context)
+    }
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketSubscribeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketSubscribeCodec.kt
@@ -1,0 +1,89 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttFixedHeader
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttRemainingLengthCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object MqttV5PacketSubscribeCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Packet.Subscribe {
+    val header = MqttFixedHeader(buffer.readUByte())
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val packetIdentifierB0 = buffer.readUByte().toUInt()
+      val packetIdentifierB1 = buffer.readUByte().toUInt()
+      val packetIdentifier = ((packetIdentifierB0 shl 8) or packetIdentifierB1).toUShort()
+      val properties = V5PropertyBagCodec.decode(buffer, context)
+      val topicFilters = mutableListOf<V5Subscription>()
+      while (buffer.position() < buffer.limit()) {
+        topicFilters += V5SubscriptionCodec.decode(buffer, context)
+      }
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "Subscribe.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      MqttV5Packet.Subscribe(header = header, packetIdentifier = packetIdentifier, properties = properties, topicFilters = topicFilters)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: MqttV5Packet.Subscribe,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+    headerWireWidth = 1,
+    writeHeader = { buffer ->
+      buffer.writeUByte(value.header.raw)
+    },
+  ) { buffer ->
+    buffer.writeUByte(((value.packetIdentifier.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.packetIdentifier.toUInt() and 0xFFu).toUByte())
+    V5PropertyBagCodec.encode(buffer, value.properties, context)
+    for (__elem in value.topicFilters) {
+      V5SubscriptionCodec.encode(buffer, __elem, context)
+    }
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketUnsubAckCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketUnsubAckCodec.kt
@@ -1,0 +1,93 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttFixedHeader
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttRemainingLengthCodec
+import com.ditchoom.buffer.codec.test.protocols.mqttv5.unsuback.V5UnsubAckReasonCode
+import com.ditchoom.buffer.codec.test.protocols.mqttv5.unsuback.V5UnsubAckReasonCodeCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object MqttV5PacketUnsubAckCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Packet.UnsubAck {
+    val header = MqttFixedHeader(buffer.readUByte())
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val packetIdentifierB0 = buffer.readUByte().toUInt()
+      val packetIdentifierB1 = buffer.readUByte().toUInt()
+      val packetIdentifier = ((packetIdentifierB0 shl 8) or packetIdentifierB1).toUShort()
+      val reasonCode: V5UnsubAckReasonCode? = if (buffer.remaining() >= 1) V5UnsubAckReasonCodeCodec.decode(buffer, context) else null
+      val properties: V5PropertyBag? = if (buffer.remaining() >= 1) V5PropertyBagCodec.decode(buffer, context) else null
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "UnsubAck.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      MqttV5Packet.UnsubAck(header = header, packetIdentifier = packetIdentifier, reasonCode = reasonCode, properties = properties)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: MqttV5Packet.UnsubAck,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+    headerWireWidth = 1,
+    writeHeader = { buffer ->
+      buffer.writeUByte(value.header.raw)
+    },
+  ) { buffer ->
+    buffer.writeUByte(((value.packetIdentifier.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.packetIdentifier.toUInt() and 0xFFu).toUByte())
+    if (value.reasonCode != null) {
+      val reasonCodeValue = value.reasonCode ?: throw EncodeException(fieldPath = "UnsubAck.reasonCode", reason = "@When(\"remaining >= 1\") predicate is true but field is null")
+      V5UnsubAckReasonCodeCodec.encode(buffer, reasonCodeValue, context)
+    }
+    if (value.properties != null) {
+      val propertiesValue = value.properties ?: throw EncodeException(fieldPath = "UnsubAck.properties", reason = "@When(\"remaining >= 1\") predicate is true but field is null")
+      V5PropertyBagCodec.encode(buffer, propertiesValue, context)
+    }
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketUnsubscribeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketUnsubscribeCodec.kt
@@ -1,0 +1,91 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttFixedHeader
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttRemainingLengthCodec
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttUnsubscribeTopic
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttUnsubscribeTopicCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object MqttV5PacketUnsubscribeCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Packet.Unsubscribe {
+    val header = MqttFixedHeader(buffer.readUByte())
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val packetIdentifierB0 = buffer.readUByte().toUInt()
+      val packetIdentifierB1 = buffer.readUByte().toUInt()
+      val packetIdentifier = ((packetIdentifierB0 shl 8) or packetIdentifierB1).toUShort()
+      val properties = V5PropertyBagCodec.decode(buffer, context)
+      val topics = mutableListOf<MqttUnsubscribeTopic>()
+      while (buffer.position() < buffer.limit()) {
+        topics += MqttUnsubscribeTopicCodec.decode(buffer, context)
+      }
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "Unsubscribe.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      MqttV5Packet.Unsubscribe(header = header, packetIdentifier = packetIdentifier, properties = properties, topics = topics)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: MqttV5Packet.Unsubscribe,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+    headerWireWidth = 1,
+    writeHeader = { buffer ->
+      buffer.writeUByte(value.header.raw)
+    },
+  ) { buffer ->
+    buffer.writeUByte(((value.packetIdentifier.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.packetIdentifier.toUInt() and 0xFFu).toUByte())
+    V5PropertyBagCodec.encode(buffer, value.properties, context)
+    for (__elem in value.topics) {
+      MqttUnsubscribeTopicCodec.encode(buffer, __elem, context)
+    }
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyAssignedClientIdentifierCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyAssignedClientIdentifierCodec.kt
@@ -1,0 +1,68 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttV5PropertyAssignedClientIdentifierCodec : Codec<MqttV5Property.AssignedClientIdentifier> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Property.AssignedClientIdentifier {
+    val id = MqttV5PropertyId(buffer.readUByte())
+    val valuePrefixB0 = buffer.readUByte().toUInt()
+    val valuePrefixB1 = buffer.readUByte().toUInt()
+    val valuePrefix = ((valuePrefixB0 shl 8) or valuePrefixB1)
+    if (valuePrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "AssignedClientIdentifier.value", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = valuePrefix.toString())
+    }
+    val valueLength = valuePrefix.toInt()
+    val value = buffer.readString(valueLength, Charset.UTF8)
+    return MqttV5Property.AssignedClientIdentifier(id = id, value = value)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttV5Property.AssignedClientIdentifier,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+    val valueSizePosition = buffer.position()
+    buffer.position(valueSizePosition + 2)
+    val valueBodyStart = buffer.position()
+    buffer.writeString(value.value, Charset.UTF8)
+    val valueEndPosition = buffer.position()
+    val valueByteCount = valueEndPosition - valueBodyStart
+    if (valueByteCount > 65_535) {
+      throw EncodeException(fieldPath = "AssignedClientIdentifier.value", reason = """UTF-8 byte length ${valueByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(valueSizePosition)
+    val valuePrefix = valueByteCount.toUInt()
+    buffer.writeUByte(((valuePrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((valuePrefix and 0xFFu).toUByte())
+    buffer.position(valueEndPosition)
+  }
+
+  override fun wireSize(`value`: MqttV5Property.AssignedClientIdentifier, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    __offset += 1
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val valuePrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val valuePrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val valuePrefix = ((valuePrefixB0 shl 8) or valuePrefixB1).toUInt()
+    if (valuePrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "AssignedClientIdentifier.value", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + valuePrefix.toInt()}""")
+    }
+    __offset += 2 + valuePrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyAuthenticationDataCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyAuthenticationDataCodec.kt
@@ -1,0 +1,74 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.codec.test.protocols.payload.BinaryDataCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttV5PropertyAuthenticationDataCodec : Codec<MqttV5Property.AuthenticationData> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Property.AuthenticationData {
+    val id = MqttV5PropertyId(buffer.readUByte())
+    val dataPrefixB0 = buffer.readUByte().toUInt()
+    val dataPrefixB1 = buffer.readUByte().toUInt()
+    val dataPrefix = ((dataPrefixB0 shl 8) or dataPrefixB1)
+    if (dataPrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "AuthenticationData.data", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = dataPrefix.toString())
+    }
+    val dataLength = dataPrefix.toInt()
+    val __dataOuterLimit = buffer.limit()
+    buffer.setLimit(buffer.position() + dataLength)
+    val data = try {
+      BinaryDataCodec.decode(buffer, context)
+    } finally {
+      buffer.setLimit(__dataOuterLimit)
+    }
+    return MqttV5Property.AuthenticationData(id = id, data = data)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttV5Property.AuthenticationData,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+    val dataSizePosition = buffer.position()
+    buffer.position(dataSizePosition + 2)
+    val dataBodyStart = buffer.position()
+    BinaryDataCodec.encode(buffer, value.data, context)
+    val dataEndPosition = buffer.position()
+    val dataByteCount = dataEndPosition - dataBodyStart
+    if (dataByteCount > 65_535) {
+      throw EncodeException(fieldPath = "AuthenticationData.data", reason = """encoded payload byte length ${dataByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(dataSizePosition)
+    val dataPrefix = dataByteCount.toUInt()
+    buffer.writeUByte(((dataPrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((dataPrefix and 0xFFu).toUByte())
+    buffer.position(dataEndPosition)
+  }
+
+  override fun wireSize(`value`: MqttV5Property.AuthenticationData, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    __offset += 1
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val dataPrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val dataPrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val dataPrefix = ((dataPrefixB0 shl 8) or dataPrefixB1).toUInt()
+    if (dataPrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "AuthenticationData.data", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + dataPrefix.toInt()}""")
+    }
+    __offset += 2 + dataPrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyAuthenticationMethodCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyAuthenticationMethodCodec.kt
@@ -1,0 +1,68 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttV5PropertyAuthenticationMethodCodec : Codec<MqttV5Property.AuthenticationMethod> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Property.AuthenticationMethod {
+    val id = MqttV5PropertyId(buffer.readUByte())
+    val valuePrefixB0 = buffer.readUByte().toUInt()
+    val valuePrefixB1 = buffer.readUByte().toUInt()
+    val valuePrefix = ((valuePrefixB0 shl 8) or valuePrefixB1)
+    if (valuePrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "AuthenticationMethod.value", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = valuePrefix.toString())
+    }
+    val valueLength = valuePrefix.toInt()
+    val value = buffer.readString(valueLength, Charset.UTF8)
+    return MqttV5Property.AuthenticationMethod(id = id, value = value)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttV5Property.AuthenticationMethod,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+    val valueSizePosition = buffer.position()
+    buffer.position(valueSizePosition + 2)
+    val valueBodyStart = buffer.position()
+    buffer.writeString(value.value, Charset.UTF8)
+    val valueEndPosition = buffer.position()
+    val valueByteCount = valueEndPosition - valueBodyStart
+    if (valueByteCount > 65_535) {
+      throw EncodeException(fieldPath = "AuthenticationMethod.value", reason = """UTF-8 byte length ${valueByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(valueSizePosition)
+    val valuePrefix = valueByteCount.toUInt()
+    buffer.writeUByte(((valuePrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((valuePrefix and 0xFFu).toUByte())
+    buffer.position(valueEndPosition)
+  }
+
+  override fun wireSize(`value`: MqttV5Property.AuthenticationMethod, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    __offset += 1
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val valuePrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val valuePrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val valuePrefix = ((valuePrefixB0 shl 8) or valuePrefixB1).toUInt()
+    if (valuePrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "AuthenticationMethod.value", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + valuePrefix.toInt()}""")
+    }
+    __offset += 2 + valuePrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyCodec.kt
@@ -1,0 +1,158 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttV5PropertyCodec : Codec<MqttV5Property> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Property {
+    val discriminatorPosition = buffer.position()
+    val __discriminator = MqttV5PropertyIdCodec.decode(buffer, context)
+    buffer.position(discriminatorPosition)
+    val __dispatchValue = __discriminator.id
+    return when (__dispatchValue) {
+      1 -> MqttV5PropertyPayloadFormatIndicatorCodec.decode(buffer, context)
+      2 -> MqttV5PropertyMessageExpiryIntervalCodec.decode(buffer, context)
+      3 -> MqttV5PropertyContentTypeCodec.decode(buffer, context)
+      8 -> MqttV5PropertyResponseTopicCodec.decode(buffer, context)
+      9 -> MqttV5PropertyCorrelationDataCodec.decode(buffer, context)
+      11 -> MqttV5PropertySubscriptionIdentifierCodec.decode(buffer, context)
+      17 -> MqttV5PropertySessionExpiryIntervalCodec.decode(buffer, context)
+      18 -> MqttV5PropertyAssignedClientIdentifierCodec.decode(buffer, context)
+      19 -> MqttV5PropertyServerKeepAliveCodec.decode(buffer, context)
+      21 -> MqttV5PropertyAuthenticationMethodCodec.decode(buffer, context)
+      22 -> MqttV5PropertyAuthenticationDataCodec.decode(buffer, context)
+      23 -> MqttV5PropertyRequestProblemInformationCodec.decode(buffer, context)
+      24 -> MqttV5PropertyWillDelayIntervalCodec.decode(buffer, context)
+      25 -> MqttV5PropertyRequestResponseInformationCodec.decode(buffer, context)
+      26 -> MqttV5PropertyResponseInformationCodec.decode(buffer, context)
+      28 -> MqttV5PropertyServerReferenceCodec.decode(buffer, context)
+      31 -> MqttV5PropertyReasonStringCodec.decode(buffer, context)
+      33 -> MqttV5PropertyReceiveMaximumCodec.decode(buffer, context)
+      34 -> MqttV5PropertyTopicAliasMaximumCodec.decode(buffer, context)
+      35 -> MqttV5PropertyTopicAliasCodec.decode(buffer, context)
+      36 -> MqttV5PropertyMaximumQoSCodec.decode(buffer, context)
+      37 -> MqttV5PropertyRetainAvailableCodec.decode(buffer, context)
+      38 -> MqttV5PropertyUserPropertyCodec.decode(buffer, context)
+      39 -> MqttV5PropertyMaximumPacketSizeCodec.decode(buffer, context)
+      40 -> MqttV5PropertyWildcardSubscriptionAvailableCodec.decode(buffer, context)
+      41 -> MqttV5PropertySubscriptionIdentifiersAvailableCodec.decode(buffer, context)
+      42 -> MqttV5PropertySharedSubscriptionAvailableCodec.decode(buffer, context)
+      else -> {
+        throw DecodeException(fieldPath = "MqttV5Property.discriminator", bufferPosition = discriminatorPosition, expected = "one of {1, 2, 3, 8, 9, 11, 17, 18, 19, 21, 22, 23, 24, 25, 26, 28, 31, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttV5Property,
+    context: EncodeContext,
+  ) {
+    when (value) {
+      is MqttV5Property.PayloadFormatIndicator -> MqttV5PropertyPayloadFormatIndicatorCodec.encode(buffer, value, context)
+      is MqttV5Property.MessageExpiryInterval -> MqttV5PropertyMessageExpiryIntervalCodec.encode(buffer, value, context)
+      is MqttV5Property.ContentType -> MqttV5PropertyContentTypeCodec.encode(buffer, value, context)
+      is MqttV5Property.ResponseTopic -> MqttV5PropertyResponseTopicCodec.encode(buffer, value, context)
+      is MqttV5Property.CorrelationData -> MqttV5PropertyCorrelationDataCodec.encode(buffer, value, context)
+      is MqttV5Property.SubscriptionIdentifier -> MqttV5PropertySubscriptionIdentifierCodec.encode(buffer, value, context)
+      is MqttV5Property.SessionExpiryInterval -> MqttV5PropertySessionExpiryIntervalCodec.encode(buffer, value, context)
+      is MqttV5Property.AssignedClientIdentifier -> MqttV5PropertyAssignedClientIdentifierCodec.encode(buffer, value, context)
+      is MqttV5Property.ServerKeepAlive -> MqttV5PropertyServerKeepAliveCodec.encode(buffer, value, context)
+      is MqttV5Property.AuthenticationMethod -> MqttV5PropertyAuthenticationMethodCodec.encode(buffer, value, context)
+      is MqttV5Property.AuthenticationData -> MqttV5PropertyAuthenticationDataCodec.encode(buffer, value, context)
+      is MqttV5Property.RequestProblemInformation -> MqttV5PropertyRequestProblemInformationCodec.encode(buffer, value, context)
+      is MqttV5Property.WillDelayInterval -> MqttV5PropertyWillDelayIntervalCodec.encode(buffer, value, context)
+      is MqttV5Property.RequestResponseInformation -> MqttV5PropertyRequestResponseInformationCodec.encode(buffer, value, context)
+      is MqttV5Property.ResponseInformation -> MqttV5PropertyResponseInformationCodec.encode(buffer, value, context)
+      is MqttV5Property.ServerReference -> MqttV5PropertyServerReferenceCodec.encode(buffer, value, context)
+      is MqttV5Property.ReasonString -> MqttV5PropertyReasonStringCodec.encode(buffer, value, context)
+      is MqttV5Property.ReceiveMaximum -> MqttV5PropertyReceiveMaximumCodec.encode(buffer, value, context)
+      is MqttV5Property.TopicAliasMaximum -> MqttV5PropertyTopicAliasMaximumCodec.encode(buffer, value, context)
+      is MqttV5Property.TopicAlias -> MqttV5PropertyTopicAliasCodec.encode(buffer, value, context)
+      is MqttV5Property.MaximumQoS -> MqttV5PropertyMaximumQoSCodec.encode(buffer, value, context)
+      is MqttV5Property.RetainAvailable -> MqttV5PropertyRetainAvailableCodec.encode(buffer, value, context)
+      is MqttV5Property.UserProperty -> MqttV5PropertyUserPropertyCodec.encode(buffer, value, context)
+      is MqttV5Property.MaximumPacketSize -> MqttV5PropertyMaximumPacketSizeCodec.encode(buffer, value, context)
+      is MqttV5Property.WildcardSubscriptionAvailable -> MqttV5PropertyWildcardSubscriptionAvailableCodec.encode(buffer, value, context)
+      is MqttV5Property.SubscriptionIdentifiersAvailable -> MqttV5PropertySubscriptionIdentifiersAvailableCodec.encode(buffer, value, context)
+      is MqttV5Property.SharedSubscriptionAvailable -> MqttV5PropertySharedSubscriptionAvailableCodec.encode(buffer, value, context)
+    }
+  }
+
+  override fun wireSize(`value`: MqttV5Property, context: EncodeContext): WireSize = when (value) {
+    is MqttV5Property.PayloadFormatIndicator -> MqttV5PropertyPayloadFormatIndicatorCodec.wireSize(value, context)
+    is MqttV5Property.MessageExpiryInterval -> MqttV5PropertyMessageExpiryIntervalCodec.wireSize(value, context)
+    is MqttV5Property.ContentType -> MqttV5PropertyContentTypeCodec.wireSize(value, context)
+    is MqttV5Property.ResponseTopic -> MqttV5PropertyResponseTopicCodec.wireSize(value, context)
+    is MqttV5Property.CorrelationData -> MqttV5PropertyCorrelationDataCodec.wireSize(value, context)
+    is MqttV5Property.SubscriptionIdentifier -> MqttV5PropertySubscriptionIdentifierCodec.wireSize(value, context)
+    is MqttV5Property.SessionExpiryInterval -> MqttV5PropertySessionExpiryIntervalCodec.wireSize(value, context)
+    is MqttV5Property.AssignedClientIdentifier -> MqttV5PropertyAssignedClientIdentifierCodec.wireSize(value, context)
+    is MqttV5Property.ServerKeepAlive -> MqttV5PropertyServerKeepAliveCodec.wireSize(value, context)
+    is MqttV5Property.AuthenticationMethod -> MqttV5PropertyAuthenticationMethodCodec.wireSize(value, context)
+    is MqttV5Property.AuthenticationData -> MqttV5PropertyAuthenticationDataCodec.wireSize(value, context)
+    is MqttV5Property.RequestProblemInformation -> MqttV5PropertyRequestProblemInformationCodec.wireSize(value, context)
+    is MqttV5Property.WillDelayInterval -> MqttV5PropertyWillDelayIntervalCodec.wireSize(value, context)
+    is MqttV5Property.RequestResponseInformation -> MqttV5PropertyRequestResponseInformationCodec.wireSize(value, context)
+    is MqttV5Property.ResponseInformation -> MqttV5PropertyResponseInformationCodec.wireSize(value, context)
+    is MqttV5Property.ServerReference -> MqttV5PropertyServerReferenceCodec.wireSize(value, context)
+    is MqttV5Property.ReasonString -> MqttV5PropertyReasonStringCodec.wireSize(value, context)
+    is MqttV5Property.ReceiveMaximum -> MqttV5PropertyReceiveMaximumCodec.wireSize(value, context)
+    is MqttV5Property.TopicAliasMaximum -> MqttV5PropertyTopicAliasMaximumCodec.wireSize(value, context)
+    is MqttV5Property.TopicAlias -> MqttV5PropertyTopicAliasCodec.wireSize(value, context)
+    is MqttV5Property.MaximumQoS -> MqttV5PropertyMaximumQoSCodec.wireSize(value, context)
+    is MqttV5Property.RetainAvailable -> MqttV5PropertyRetainAvailableCodec.wireSize(value, context)
+    is MqttV5Property.UserProperty -> MqttV5PropertyUserPropertyCodec.wireSize(value, context)
+    is MqttV5Property.MaximumPacketSize -> MqttV5PropertyMaximumPacketSizeCodec.wireSize(value, context)
+    is MqttV5Property.WildcardSubscriptionAvailable -> MqttV5PropertyWildcardSubscriptionAvailableCodec.wireSize(value, context)
+    is MqttV5Property.SubscriptionIdentifiersAvailable -> MqttV5PropertySubscriptionIdentifiersAvailableCodec.wireSize(value, context)
+    is MqttV5Property.SharedSubscriptionAvailable -> MqttV5PropertySharedSubscriptionAvailableCodec.wireSize(value, context)
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
+    val __discRaw = stream.peekByte(baseOffset + 0).toUByte()
+    val __discriminator = MqttV5PropertyId(__discRaw)
+    val __dispatchValue = __discriminator.id
+    return when (__dispatchValue) {
+      1 -> MqttV5PropertyPayloadFormatIndicatorCodec.peekFrameSize(stream, baseOffset)
+      2 -> MqttV5PropertyMessageExpiryIntervalCodec.peekFrameSize(stream, baseOffset)
+      3 -> MqttV5PropertyContentTypeCodec.peekFrameSize(stream, baseOffset)
+      8 -> MqttV5PropertyResponseTopicCodec.peekFrameSize(stream, baseOffset)
+      9 -> MqttV5PropertyCorrelationDataCodec.peekFrameSize(stream, baseOffset)
+      11 -> MqttV5PropertySubscriptionIdentifierCodec.peekFrameSize(stream, baseOffset)
+      17 -> MqttV5PropertySessionExpiryIntervalCodec.peekFrameSize(stream, baseOffset)
+      18 -> MqttV5PropertyAssignedClientIdentifierCodec.peekFrameSize(stream, baseOffset)
+      19 -> MqttV5PropertyServerKeepAliveCodec.peekFrameSize(stream, baseOffset)
+      21 -> MqttV5PropertyAuthenticationMethodCodec.peekFrameSize(stream, baseOffset)
+      22 -> MqttV5PropertyAuthenticationDataCodec.peekFrameSize(stream, baseOffset)
+      23 -> MqttV5PropertyRequestProblemInformationCodec.peekFrameSize(stream, baseOffset)
+      24 -> MqttV5PropertyWillDelayIntervalCodec.peekFrameSize(stream, baseOffset)
+      25 -> MqttV5PropertyRequestResponseInformationCodec.peekFrameSize(stream, baseOffset)
+      26 -> MqttV5PropertyResponseInformationCodec.peekFrameSize(stream, baseOffset)
+      28 -> MqttV5PropertyServerReferenceCodec.peekFrameSize(stream, baseOffset)
+      31 -> MqttV5PropertyReasonStringCodec.peekFrameSize(stream, baseOffset)
+      33 -> MqttV5PropertyReceiveMaximumCodec.peekFrameSize(stream, baseOffset)
+      34 -> MqttV5PropertyTopicAliasMaximumCodec.peekFrameSize(stream, baseOffset)
+      35 -> MqttV5PropertyTopicAliasCodec.peekFrameSize(stream, baseOffset)
+      36 -> MqttV5PropertyMaximumQoSCodec.peekFrameSize(stream, baseOffset)
+      37 -> MqttV5PropertyRetainAvailableCodec.peekFrameSize(stream, baseOffset)
+      38 -> MqttV5PropertyUserPropertyCodec.peekFrameSize(stream, baseOffset)
+      39 -> MqttV5PropertyMaximumPacketSizeCodec.peekFrameSize(stream, baseOffset)
+      40 -> MqttV5PropertyWildcardSubscriptionAvailableCodec.peekFrameSize(stream, baseOffset)
+      41 -> MqttV5PropertySubscriptionIdentifiersAvailableCodec.peekFrameSize(stream, baseOffset)
+      42 -> MqttV5PropertySharedSubscriptionAvailableCodec.peekFrameSize(stream, baseOffset)
+      else -> {
+        throw DecodeException(fieldPath = "MqttV5Property.discriminator", bufferPosition = baseOffset, expected = "one of {1, 2, 3, 8, 9, 11, 17, 18, 19, 21, 22, 23, 24, 25, 26, 28, 31, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyContentTypeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyContentTypeCodec.kt
@@ -1,0 +1,68 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttV5PropertyContentTypeCodec : Codec<MqttV5Property.ContentType> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Property.ContentType {
+    val id = MqttV5PropertyId(buffer.readUByte())
+    val valuePrefixB0 = buffer.readUByte().toUInt()
+    val valuePrefixB1 = buffer.readUByte().toUInt()
+    val valuePrefix = ((valuePrefixB0 shl 8) or valuePrefixB1)
+    if (valuePrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "ContentType.value", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = valuePrefix.toString())
+    }
+    val valueLength = valuePrefix.toInt()
+    val value = buffer.readString(valueLength, Charset.UTF8)
+    return MqttV5Property.ContentType(id = id, value = value)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttV5Property.ContentType,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+    val valueSizePosition = buffer.position()
+    buffer.position(valueSizePosition + 2)
+    val valueBodyStart = buffer.position()
+    buffer.writeString(value.value, Charset.UTF8)
+    val valueEndPosition = buffer.position()
+    val valueByteCount = valueEndPosition - valueBodyStart
+    if (valueByteCount > 65_535) {
+      throw EncodeException(fieldPath = "ContentType.value", reason = """UTF-8 byte length ${valueByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(valueSizePosition)
+    val valuePrefix = valueByteCount.toUInt()
+    buffer.writeUByte(((valuePrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((valuePrefix and 0xFFu).toUByte())
+    buffer.position(valueEndPosition)
+  }
+
+  override fun wireSize(`value`: MqttV5Property.ContentType, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    __offset += 1
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val valuePrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val valuePrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val valuePrefix = ((valuePrefixB0 shl 8) or valuePrefixB1).toUInt()
+    if (valuePrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "ContentType.value", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + valuePrefix.toInt()}""")
+    }
+    __offset += 2 + valuePrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyCorrelationDataCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyCorrelationDataCodec.kt
@@ -1,0 +1,74 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.codec.test.protocols.payload.BinaryDataCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttV5PropertyCorrelationDataCodec : Codec<MqttV5Property.CorrelationData> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Property.CorrelationData {
+    val id = MqttV5PropertyId(buffer.readUByte())
+    val dataPrefixB0 = buffer.readUByte().toUInt()
+    val dataPrefixB1 = buffer.readUByte().toUInt()
+    val dataPrefix = ((dataPrefixB0 shl 8) or dataPrefixB1)
+    if (dataPrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "CorrelationData.data", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = dataPrefix.toString())
+    }
+    val dataLength = dataPrefix.toInt()
+    val __dataOuterLimit = buffer.limit()
+    buffer.setLimit(buffer.position() + dataLength)
+    val data = try {
+      BinaryDataCodec.decode(buffer, context)
+    } finally {
+      buffer.setLimit(__dataOuterLimit)
+    }
+    return MqttV5Property.CorrelationData(id = id, data = data)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttV5Property.CorrelationData,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+    val dataSizePosition = buffer.position()
+    buffer.position(dataSizePosition + 2)
+    val dataBodyStart = buffer.position()
+    BinaryDataCodec.encode(buffer, value.data, context)
+    val dataEndPosition = buffer.position()
+    val dataByteCount = dataEndPosition - dataBodyStart
+    if (dataByteCount > 65_535) {
+      throw EncodeException(fieldPath = "CorrelationData.data", reason = """encoded payload byte length ${dataByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(dataSizePosition)
+    val dataPrefix = dataByteCount.toUInt()
+    buffer.writeUByte(((dataPrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((dataPrefix and 0xFFu).toUByte())
+    buffer.position(dataEndPosition)
+  }
+
+  override fun wireSize(`value`: MqttV5Property.CorrelationData, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    __offset += 1
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val dataPrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val dataPrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val dataPrefix = ((dataPrefixB0 shl 8) or dataPrefixB1).toUInt()
+    if (dataPrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "CorrelationData.data", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + dataPrefix.toInt()}""")
+    }
+    __offset += 2 + dataPrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyIdCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyIdCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttV5PropertyIdCodec : Codec<MqttV5PropertyId> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5PropertyId {
+    val raw = buffer.readUByte()
+    return MqttV5PropertyId(raw = raw)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttV5PropertyId,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.raw)
+  }
+
+  override fun wireSize(`value`: MqttV5PropertyId, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyMaximumPacketSizeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyMaximumPacketSizeCodec.kt
@@ -1,0 +1,39 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttV5PropertyMaximumPacketSizeCodec : Codec<MqttV5Property.MaximumPacketSize> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Property.MaximumPacketSize {
+    val id = MqttV5PropertyId(buffer.readUByte())
+    val valueB0 = buffer.readUByte().toUInt()
+    val valueB1 = buffer.readUByte().toUInt()
+    val valueB2 = buffer.readUByte().toUInt()
+    val valueB3 = buffer.readUByte().toUInt()
+    val value = ((valueB0 shl 24) or (valueB1 shl 16) or (valueB2 shl 8) or valueB3)
+    return MqttV5Property.MaximumPacketSize(id = id, value = value)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttV5Property.MaximumPacketSize,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+    buffer.writeUByte(((value.value shr 24) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.value shr 16) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.value shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.value and 0xFFu).toUByte())
+  }
+
+  override fun wireSize(`value`: MqttV5Property.MaximumPacketSize, context: EncodeContext): WireSize = WireSize.Exact(5)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 5) PeekResult.Complete(5) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyMaximumQoSCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyMaximumQoSCodec.kt
@@ -1,0 +1,32 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttV5PropertyMaximumQoSCodec : Codec<MqttV5Property.MaximumQoS> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Property.MaximumQoS {
+    val id = MqttV5PropertyId(buffer.readUByte())
+    val value = buffer.readUByte()
+    return MqttV5Property.MaximumQoS(id = id, value = value)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttV5Property.MaximumQoS,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+    buffer.writeUByte(value.value)
+  }
+
+  override fun wireSize(`value`: MqttV5Property.MaximumQoS, context: EncodeContext): WireSize = WireSize.Exact(2)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyMessageExpiryIntervalCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyMessageExpiryIntervalCodec.kt
@@ -1,0 +1,39 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttV5PropertyMessageExpiryIntervalCodec : Codec<MqttV5Property.MessageExpiryInterval> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Property.MessageExpiryInterval {
+    val id = MqttV5PropertyId(buffer.readUByte())
+    val secondsB0 = buffer.readUByte().toUInt()
+    val secondsB1 = buffer.readUByte().toUInt()
+    val secondsB2 = buffer.readUByte().toUInt()
+    val secondsB3 = buffer.readUByte().toUInt()
+    val seconds = ((secondsB0 shl 24) or (secondsB1 shl 16) or (secondsB2 shl 8) or secondsB3)
+    return MqttV5Property.MessageExpiryInterval(id = id, seconds = seconds)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttV5Property.MessageExpiryInterval,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+    buffer.writeUByte(((value.seconds shr 24) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.seconds shr 16) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.seconds shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.seconds and 0xFFu).toUByte())
+  }
+
+  override fun wireSize(`value`: MqttV5Property.MessageExpiryInterval, context: EncodeContext): WireSize = WireSize.Exact(5)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 5) PeekResult.Complete(5) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyPayloadFormatIndicatorCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyPayloadFormatIndicatorCodec.kt
@@ -1,0 +1,32 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttV5PropertyPayloadFormatIndicatorCodec : Codec<MqttV5Property.PayloadFormatIndicator> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Property.PayloadFormatIndicator {
+    val id = MqttV5PropertyId(buffer.readUByte())
+    val value = buffer.readUByte()
+    return MqttV5Property.PayloadFormatIndicator(id = id, value = value)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttV5Property.PayloadFormatIndicator,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+    buffer.writeUByte(value.value)
+  }
+
+  override fun wireSize(`value`: MqttV5Property.PayloadFormatIndicator, context: EncodeContext): WireSize = WireSize.Exact(2)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyReasonStringCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyReasonStringCodec.kt
@@ -1,0 +1,68 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttV5PropertyReasonStringCodec : Codec<MqttV5Property.ReasonString> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Property.ReasonString {
+    val id = MqttV5PropertyId(buffer.readUByte())
+    val valuePrefixB0 = buffer.readUByte().toUInt()
+    val valuePrefixB1 = buffer.readUByte().toUInt()
+    val valuePrefix = ((valuePrefixB0 shl 8) or valuePrefixB1)
+    if (valuePrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "ReasonString.value", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = valuePrefix.toString())
+    }
+    val valueLength = valuePrefix.toInt()
+    val value = buffer.readString(valueLength, Charset.UTF8)
+    return MqttV5Property.ReasonString(id = id, value = value)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttV5Property.ReasonString,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+    val valueSizePosition = buffer.position()
+    buffer.position(valueSizePosition + 2)
+    val valueBodyStart = buffer.position()
+    buffer.writeString(value.value, Charset.UTF8)
+    val valueEndPosition = buffer.position()
+    val valueByteCount = valueEndPosition - valueBodyStart
+    if (valueByteCount > 65_535) {
+      throw EncodeException(fieldPath = "ReasonString.value", reason = """UTF-8 byte length ${valueByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(valueSizePosition)
+    val valuePrefix = valueByteCount.toUInt()
+    buffer.writeUByte(((valuePrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((valuePrefix and 0xFFu).toUByte())
+    buffer.position(valueEndPosition)
+  }
+
+  override fun wireSize(`value`: MqttV5Property.ReasonString, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    __offset += 1
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val valuePrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val valuePrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val valuePrefix = ((valuePrefixB0 shl 8) or valuePrefixB1).toUInt()
+    if (valuePrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "ReasonString.value", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + valuePrefix.toInt()}""")
+    }
+    __offset += 2 + valuePrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyReceiveMaximumCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyReceiveMaximumCodec.kt
@@ -1,0 +1,35 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttV5PropertyReceiveMaximumCodec : Codec<MqttV5Property.ReceiveMaximum> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Property.ReceiveMaximum {
+    val id = MqttV5PropertyId(buffer.readUByte())
+    val valueB0 = buffer.readUByte().toUInt()
+    val valueB1 = buffer.readUByte().toUInt()
+    val value = ((valueB0 shl 8) or valueB1).toUShort()
+    return MqttV5Property.ReceiveMaximum(id = id, value = value)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttV5Property.ReceiveMaximum,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+    buffer.writeUByte(((value.value.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.value.toUInt() and 0xFFu).toUByte())
+  }
+
+  override fun wireSize(`value`: MqttV5Property.ReceiveMaximum, context: EncodeContext): WireSize = WireSize.Exact(3)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 3) PeekResult.Complete(3) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyRequestProblemInformationCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyRequestProblemInformationCodec.kt
@@ -1,0 +1,32 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttV5PropertyRequestProblemInformationCodec : Codec<MqttV5Property.RequestProblemInformation> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Property.RequestProblemInformation {
+    val id = MqttV5PropertyId(buffer.readUByte())
+    val value = buffer.readUByte()
+    return MqttV5Property.RequestProblemInformation(id = id, value = value)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttV5Property.RequestProblemInformation,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+    buffer.writeUByte(value.value)
+  }
+
+  override fun wireSize(`value`: MqttV5Property.RequestProblemInformation, context: EncodeContext): WireSize = WireSize.Exact(2)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyRequestResponseInformationCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyRequestResponseInformationCodec.kt
@@ -1,0 +1,32 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttV5PropertyRequestResponseInformationCodec : Codec<MqttV5Property.RequestResponseInformation> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Property.RequestResponseInformation {
+    val id = MqttV5PropertyId(buffer.readUByte())
+    val value = buffer.readUByte()
+    return MqttV5Property.RequestResponseInformation(id = id, value = value)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttV5Property.RequestResponseInformation,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+    buffer.writeUByte(value.value)
+  }
+
+  override fun wireSize(`value`: MqttV5Property.RequestResponseInformation, context: EncodeContext): WireSize = WireSize.Exact(2)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyResponseInformationCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyResponseInformationCodec.kt
@@ -1,0 +1,68 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttV5PropertyResponseInformationCodec : Codec<MqttV5Property.ResponseInformation> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Property.ResponseInformation {
+    val id = MqttV5PropertyId(buffer.readUByte())
+    val valuePrefixB0 = buffer.readUByte().toUInt()
+    val valuePrefixB1 = buffer.readUByte().toUInt()
+    val valuePrefix = ((valuePrefixB0 shl 8) or valuePrefixB1)
+    if (valuePrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "ResponseInformation.value", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = valuePrefix.toString())
+    }
+    val valueLength = valuePrefix.toInt()
+    val value = buffer.readString(valueLength, Charset.UTF8)
+    return MqttV5Property.ResponseInformation(id = id, value = value)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttV5Property.ResponseInformation,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+    val valueSizePosition = buffer.position()
+    buffer.position(valueSizePosition + 2)
+    val valueBodyStart = buffer.position()
+    buffer.writeString(value.value, Charset.UTF8)
+    val valueEndPosition = buffer.position()
+    val valueByteCount = valueEndPosition - valueBodyStart
+    if (valueByteCount > 65_535) {
+      throw EncodeException(fieldPath = "ResponseInformation.value", reason = """UTF-8 byte length ${valueByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(valueSizePosition)
+    val valuePrefix = valueByteCount.toUInt()
+    buffer.writeUByte(((valuePrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((valuePrefix and 0xFFu).toUByte())
+    buffer.position(valueEndPosition)
+  }
+
+  override fun wireSize(`value`: MqttV5Property.ResponseInformation, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    __offset += 1
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val valuePrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val valuePrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val valuePrefix = ((valuePrefixB0 shl 8) or valuePrefixB1).toUInt()
+    if (valuePrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "ResponseInformation.value", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + valuePrefix.toInt()}""")
+    }
+    __offset += 2 + valuePrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyResponseTopicCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyResponseTopicCodec.kt
@@ -1,0 +1,68 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttV5PropertyResponseTopicCodec : Codec<MqttV5Property.ResponseTopic> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Property.ResponseTopic {
+    val id = MqttV5PropertyId(buffer.readUByte())
+    val valuePrefixB0 = buffer.readUByte().toUInt()
+    val valuePrefixB1 = buffer.readUByte().toUInt()
+    val valuePrefix = ((valuePrefixB0 shl 8) or valuePrefixB1)
+    if (valuePrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "ResponseTopic.value", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = valuePrefix.toString())
+    }
+    val valueLength = valuePrefix.toInt()
+    val value = buffer.readString(valueLength, Charset.UTF8)
+    return MqttV5Property.ResponseTopic(id = id, value = value)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttV5Property.ResponseTopic,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+    val valueSizePosition = buffer.position()
+    buffer.position(valueSizePosition + 2)
+    val valueBodyStart = buffer.position()
+    buffer.writeString(value.value, Charset.UTF8)
+    val valueEndPosition = buffer.position()
+    val valueByteCount = valueEndPosition - valueBodyStart
+    if (valueByteCount > 65_535) {
+      throw EncodeException(fieldPath = "ResponseTopic.value", reason = """UTF-8 byte length ${valueByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(valueSizePosition)
+    val valuePrefix = valueByteCount.toUInt()
+    buffer.writeUByte(((valuePrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((valuePrefix and 0xFFu).toUByte())
+    buffer.position(valueEndPosition)
+  }
+
+  override fun wireSize(`value`: MqttV5Property.ResponseTopic, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    __offset += 1
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val valuePrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val valuePrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val valuePrefix = ((valuePrefixB0 shl 8) or valuePrefixB1).toUInt()
+    if (valuePrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "ResponseTopic.value", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + valuePrefix.toInt()}""")
+    }
+    __offset += 2 + valuePrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyRetainAvailableCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyRetainAvailableCodec.kt
@@ -1,0 +1,32 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttV5PropertyRetainAvailableCodec : Codec<MqttV5Property.RetainAvailable> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Property.RetainAvailable {
+    val id = MqttV5PropertyId(buffer.readUByte())
+    val value = buffer.readUByte()
+    return MqttV5Property.RetainAvailable(id = id, value = value)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttV5Property.RetainAvailable,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+    buffer.writeUByte(value.value)
+  }
+
+  override fun wireSize(`value`: MqttV5Property.RetainAvailable, context: EncodeContext): WireSize = WireSize.Exact(2)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyServerKeepAliveCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyServerKeepAliveCodec.kt
@@ -1,0 +1,35 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttV5PropertyServerKeepAliveCodec : Codec<MqttV5Property.ServerKeepAlive> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Property.ServerKeepAlive {
+    val id = MqttV5PropertyId(buffer.readUByte())
+    val secondsB0 = buffer.readUByte().toUInt()
+    val secondsB1 = buffer.readUByte().toUInt()
+    val seconds = ((secondsB0 shl 8) or secondsB1).toUShort()
+    return MqttV5Property.ServerKeepAlive(id = id, seconds = seconds)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttV5Property.ServerKeepAlive,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+    buffer.writeUByte(((value.seconds.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.seconds.toUInt() and 0xFFu).toUByte())
+  }
+
+  override fun wireSize(`value`: MqttV5Property.ServerKeepAlive, context: EncodeContext): WireSize = WireSize.Exact(3)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 3) PeekResult.Complete(3) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyServerReferenceCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyServerReferenceCodec.kt
@@ -1,0 +1,68 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttV5PropertyServerReferenceCodec : Codec<MqttV5Property.ServerReference> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Property.ServerReference {
+    val id = MqttV5PropertyId(buffer.readUByte())
+    val valuePrefixB0 = buffer.readUByte().toUInt()
+    val valuePrefixB1 = buffer.readUByte().toUInt()
+    val valuePrefix = ((valuePrefixB0 shl 8) or valuePrefixB1)
+    if (valuePrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "ServerReference.value", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = valuePrefix.toString())
+    }
+    val valueLength = valuePrefix.toInt()
+    val value = buffer.readString(valueLength, Charset.UTF8)
+    return MqttV5Property.ServerReference(id = id, value = value)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttV5Property.ServerReference,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+    val valueSizePosition = buffer.position()
+    buffer.position(valueSizePosition + 2)
+    val valueBodyStart = buffer.position()
+    buffer.writeString(value.value, Charset.UTF8)
+    val valueEndPosition = buffer.position()
+    val valueByteCount = valueEndPosition - valueBodyStart
+    if (valueByteCount > 65_535) {
+      throw EncodeException(fieldPath = "ServerReference.value", reason = """UTF-8 byte length ${valueByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(valueSizePosition)
+    val valuePrefix = valueByteCount.toUInt()
+    buffer.writeUByte(((valuePrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((valuePrefix and 0xFFu).toUByte())
+    buffer.position(valueEndPosition)
+  }
+
+  override fun wireSize(`value`: MqttV5Property.ServerReference, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    __offset += 1
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val valuePrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val valuePrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val valuePrefix = ((valuePrefixB0 shl 8) or valuePrefixB1).toUInt()
+    if (valuePrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "ServerReference.value", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + valuePrefix.toInt()}""")
+    }
+    __offset += 2 + valuePrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertySessionExpiryIntervalCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertySessionExpiryIntervalCodec.kt
@@ -1,0 +1,39 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttV5PropertySessionExpiryIntervalCodec : Codec<MqttV5Property.SessionExpiryInterval> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Property.SessionExpiryInterval {
+    val id = MqttV5PropertyId(buffer.readUByte())
+    val secondsB0 = buffer.readUByte().toUInt()
+    val secondsB1 = buffer.readUByte().toUInt()
+    val secondsB2 = buffer.readUByte().toUInt()
+    val secondsB3 = buffer.readUByte().toUInt()
+    val seconds = ((secondsB0 shl 24) or (secondsB1 shl 16) or (secondsB2 shl 8) or secondsB3)
+    return MqttV5Property.SessionExpiryInterval(id = id, seconds = seconds)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttV5Property.SessionExpiryInterval,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+    buffer.writeUByte(((value.seconds shr 24) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.seconds shr 16) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.seconds shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.seconds and 0xFFu).toUByte())
+  }
+
+  override fun wireSize(`value`: MqttV5Property.SessionExpiryInterval, context: EncodeContext): WireSize = WireSize.Exact(5)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 5) PeekResult.Complete(5) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertySharedSubscriptionAvailableCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertySharedSubscriptionAvailableCodec.kt
@@ -1,0 +1,32 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttV5PropertySharedSubscriptionAvailableCodec : Codec<MqttV5Property.SharedSubscriptionAvailable> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Property.SharedSubscriptionAvailable {
+    val id = MqttV5PropertyId(buffer.readUByte())
+    val value = buffer.readUByte()
+    return MqttV5Property.SharedSubscriptionAvailable(id = id, value = value)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttV5Property.SharedSubscriptionAvailable,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+    buffer.writeUByte(value.value)
+  }
+
+  override fun wireSize(`value`: MqttV5Property.SharedSubscriptionAvailable, context: EncodeContext): WireSize = WireSize.Exact(2)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertySubscriptionIdentifierCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertySubscriptionIdentifierCodec.kt
@@ -1,0 +1,32 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttV5PropertySubscriptionIdentifierCodec : Codec<MqttV5Property.SubscriptionIdentifier> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Property.SubscriptionIdentifier {
+    val id = MqttV5PropertyId(buffer.readUByte())
+    val value = VariableByteIntegerCodec.decode(buffer, context)
+    return MqttV5Property.SubscriptionIdentifier(id = id, value = value)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttV5Property.SubscriptionIdentifier,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+    VariableByteIntegerCodec.encode(buffer, value.value, context)
+  }
+
+  override fun wireSize(`value`: MqttV5Property.SubscriptionIdentifier, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertySubscriptionIdentifiersAvailableCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertySubscriptionIdentifiersAvailableCodec.kt
@@ -1,0 +1,32 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttV5PropertySubscriptionIdentifiersAvailableCodec : Codec<MqttV5Property.SubscriptionIdentifiersAvailable> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Property.SubscriptionIdentifiersAvailable {
+    val id = MqttV5PropertyId(buffer.readUByte())
+    val value = buffer.readUByte()
+    return MqttV5Property.SubscriptionIdentifiersAvailable(id = id, value = value)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttV5Property.SubscriptionIdentifiersAvailable,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+    buffer.writeUByte(value.value)
+  }
+
+  override fun wireSize(`value`: MqttV5Property.SubscriptionIdentifiersAvailable, context: EncodeContext): WireSize = WireSize.Exact(2)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyTopicAliasCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyTopicAliasCodec.kt
@@ -1,0 +1,35 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttV5PropertyTopicAliasCodec : Codec<MqttV5Property.TopicAlias> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Property.TopicAlias {
+    val id = MqttV5PropertyId(buffer.readUByte())
+    val valueB0 = buffer.readUByte().toUInt()
+    val valueB1 = buffer.readUByte().toUInt()
+    val value = ((valueB0 shl 8) or valueB1).toUShort()
+    return MqttV5Property.TopicAlias(id = id, value = value)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttV5Property.TopicAlias,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+    buffer.writeUByte(((value.value.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.value.toUInt() and 0xFFu).toUByte())
+  }
+
+  override fun wireSize(`value`: MqttV5Property.TopicAlias, context: EncodeContext): WireSize = WireSize.Exact(3)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 3) PeekResult.Complete(3) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyTopicAliasMaximumCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyTopicAliasMaximumCodec.kt
@@ -1,0 +1,35 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttV5PropertyTopicAliasMaximumCodec : Codec<MqttV5Property.TopicAliasMaximum> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Property.TopicAliasMaximum {
+    val id = MqttV5PropertyId(buffer.readUByte())
+    val valueB0 = buffer.readUByte().toUInt()
+    val valueB1 = buffer.readUByte().toUInt()
+    val value = ((valueB0 shl 8) or valueB1).toUShort()
+    return MqttV5Property.TopicAliasMaximum(id = id, value = value)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttV5Property.TopicAliasMaximum,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+    buffer.writeUByte(((value.value.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.value.toUInt() and 0xFFu).toUByte())
+  }
+
+  override fun wireSize(`value`: MqttV5Property.TopicAliasMaximum, context: EncodeContext): WireSize = WireSize.Exact(3)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 3) PeekResult.Complete(3) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyUserPropertyCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyUserPropertyCodec.kt
@@ -1,0 +1,98 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttV5PropertyUserPropertyCodec : Codec<MqttV5Property.UserProperty> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Property.UserProperty {
+    val id = MqttV5PropertyId(buffer.readUByte())
+    val keyPrefixB0 = buffer.readUByte().toUInt()
+    val keyPrefixB1 = buffer.readUByte().toUInt()
+    val keyPrefix = ((keyPrefixB0 shl 8) or keyPrefixB1)
+    if (keyPrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "UserProperty.key", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = keyPrefix.toString())
+    }
+    val keyLength = keyPrefix.toInt()
+    val key = buffer.readString(keyLength, Charset.UTF8)
+    val valuePrefixB0 = buffer.readUByte().toUInt()
+    val valuePrefixB1 = buffer.readUByte().toUInt()
+    val valuePrefix = ((valuePrefixB0 shl 8) or valuePrefixB1)
+    if (valuePrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "UserProperty.value", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = valuePrefix.toString())
+    }
+    val valueLength = valuePrefix.toInt()
+    val value = buffer.readString(valueLength, Charset.UTF8)
+    return MqttV5Property.UserProperty(id = id, key = key, value = value)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttV5Property.UserProperty,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+    val keySizePosition = buffer.position()
+    buffer.position(keySizePosition + 2)
+    val keyBodyStart = buffer.position()
+    buffer.writeString(value.key, Charset.UTF8)
+    val keyEndPosition = buffer.position()
+    val keyByteCount = keyEndPosition - keyBodyStart
+    if (keyByteCount > 65_535) {
+      throw EncodeException(fieldPath = "UserProperty.key", reason = """UTF-8 byte length ${keyByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(keySizePosition)
+    val keyPrefix = keyByteCount.toUInt()
+    buffer.writeUByte(((keyPrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((keyPrefix and 0xFFu).toUByte())
+    buffer.position(keyEndPosition)
+    val valueSizePosition = buffer.position()
+    buffer.position(valueSizePosition + 2)
+    val valueBodyStart = buffer.position()
+    buffer.writeString(value.value, Charset.UTF8)
+    val valueEndPosition = buffer.position()
+    val valueByteCount = valueEndPosition - valueBodyStart
+    if (valueByteCount > 65_535) {
+      throw EncodeException(fieldPath = "UserProperty.value", reason = """UTF-8 byte length ${valueByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(valueSizePosition)
+    val valuePrefix = valueByteCount.toUInt()
+    buffer.writeUByte(((valuePrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((valuePrefix and 0xFFu).toUByte())
+    buffer.position(valueEndPosition)
+  }
+
+  override fun wireSize(`value`: MqttV5Property.UserProperty, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    __offset += 1
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val keyPrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val keyPrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val keyPrefix = ((keyPrefixB0 shl 8) or keyPrefixB1).toUInt()
+    if (keyPrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "UserProperty.key", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + keyPrefix.toInt()}""")
+    }
+    __offset += 2 + keyPrefix.toInt()
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val valuePrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val valuePrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val valuePrefix = ((valuePrefixB0 shl 8) or valuePrefixB1).toUInt()
+    if (valuePrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "UserProperty.value", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + valuePrefix.toInt()}""")
+    }
+    __offset += 2 + valuePrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyWildcardSubscriptionAvailableCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyWildcardSubscriptionAvailableCodec.kt
@@ -1,0 +1,32 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttV5PropertyWildcardSubscriptionAvailableCodec : Codec<MqttV5Property.WildcardSubscriptionAvailable> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Property.WildcardSubscriptionAvailable {
+    val id = MqttV5PropertyId(buffer.readUByte())
+    val value = buffer.readUByte()
+    return MqttV5Property.WildcardSubscriptionAvailable(id = id, value = value)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttV5Property.WildcardSubscriptionAvailable,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+    buffer.writeUByte(value.value)
+  }
+
+  override fun wireSize(`value`: MqttV5Property.WildcardSubscriptionAvailable, context: EncodeContext): WireSize = WireSize.Exact(2)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyWillDelayIntervalCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyWillDelayIntervalCodec.kt
@@ -1,0 +1,39 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MqttV5PropertyWillDelayIntervalCodec : Codec<MqttV5Property.WillDelayInterval> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttV5Property.WillDelayInterval {
+    val id = MqttV5PropertyId(buffer.readUByte())
+    val secondsB0 = buffer.readUByte().toUInt()
+    val secondsB1 = buffer.readUByte().toUInt()
+    val secondsB2 = buffer.readUByte().toUInt()
+    val secondsB3 = buffer.readUByte().toUInt()
+    val seconds = ((secondsB0 shl 24) or (secondsB1 shl 16) or (secondsB2 shl 8) or secondsB3)
+    return MqttV5Property.WillDelayInterval(id = id, seconds = seconds)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttV5Property.WillDelayInterval,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+    buffer.writeUByte(((value.seconds shr 24) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.seconds shr 16) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.seconds shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.seconds and 0xFFu).toUByte())
+  }
+
+  override fun wireSize(`value`: MqttV5Property.WillDelayInterval, context: EncodeContext): WireSize = WireSize.Exact(5)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 5) PeekResult.Complete(5) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/V5SubscriptionCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/V5SubscriptionCodec.kt
@@ -1,0 +1,68 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5SubscriptionCodec : Codec<V5Subscription> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5Subscription {
+    val topicFilterPrefixB0 = buffer.readUByte().toUInt()
+    val topicFilterPrefixB1 = buffer.readUByte().toUInt()
+    val topicFilterPrefix = ((topicFilterPrefixB0 shl 8) or topicFilterPrefixB1)
+    if (topicFilterPrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "V5Subscription.topicFilter", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = topicFilterPrefix.toString())
+    }
+    val topicFilterLength = topicFilterPrefix.toInt()
+    val topicFilter = buffer.readString(topicFilterLength, Charset.UTF8)
+    val subscriptionOptions = V5SubscriptionOptions(buffer.readUByte())
+    return V5Subscription(topicFilter = topicFilter, subscriptionOptions = subscriptionOptions)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5Subscription,
+    context: EncodeContext,
+  ) {
+    val topicFilterSizePosition = buffer.position()
+    buffer.position(topicFilterSizePosition + 2)
+    val topicFilterBodyStart = buffer.position()
+    buffer.writeString(value.topicFilter, Charset.UTF8)
+    val topicFilterEndPosition = buffer.position()
+    val topicFilterByteCount = topicFilterEndPosition - topicFilterBodyStart
+    if (topicFilterByteCount > 65_535) {
+      throw EncodeException(fieldPath = "V5Subscription.topicFilter", reason = """UTF-8 byte length ${topicFilterByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(topicFilterSizePosition)
+    val topicFilterPrefix = topicFilterByteCount.toUInt()
+    buffer.writeUByte(((topicFilterPrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((topicFilterPrefix and 0xFFu).toUByte())
+    buffer.position(topicFilterEndPosition)
+    buffer.writeUByte(value.subscriptionOptions.raw)
+  }
+
+  override fun wireSize(`value`: V5Subscription, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val topicFilterPrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val topicFilterPrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val topicFilterPrefix = ((topicFilterPrefixB0 shl 8) or topicFilterPrefixB1).toUInt()
+    if (topicFilterPrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "V5Subscription.topicFilter", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + topicFilterPrefix.toInt()}""")
+    }
+    __offset += 2 + topicFilterPrefix.toInt()
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    __offset += 1
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/V5SubscriptionOptionsCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/V5SubscriptionOptionsCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5SubscriptionOptionsCodec : Codec<V5SubscriptionOptions> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5SubscriptionOptions {
+    val raw = buffer.readUByte()
+    return V5SubscriptionOptions(raw = raw)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5SubscriptionOptions,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.raw)
+  }
+
+  override fun wireSize(`value`: V5SubscriptionOptions, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/authrc/V5AuthReasonCodeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/authrc/V5AuthReasonCodeCodec.kt
@@ -1,0 +1,62 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.authrc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5AuthReasonCodeCodec : Codec<V5AuthReasonCode> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5AuthReasonCode {
+    val discriminatorPosition = buffer.position()
+    val __discriminator = V5AuthReasonCodeRawCodec.decode(buffer, context)
+    buffer.position(discriminatorPosition)
+    val __dispatchValue = __discriminator.id
+    return when (__dispatchValue) {
+      0 -> V5AuthReasonCodeSuccessCodec.decode(buffer, context)
+      24 -> V5AuthReasonCodeContinueAuthenticationCodec.decode(buffer, context)
+      25 -> V5AuthReasonCodeReAuthenticateCodec.decode(buffer, context)
+      else -> {
+        throw DecodeException(fieldPath = "V5AuthReasonCode.discriminator", bufferPosition = discriminatorPosition, expected = "one of {0, 24, 25}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5AuthReasonCode,
+    context: EncodeContext,
+  ) {
+    when (value) {
+      is V5AuthReasonCode.Success -> V5AuthReasonCodeSuccessCodec.encode(buffer, value, context)
+      is V5AuthReasonCode.ContinueAuthentication -> V5AuthReasonCodeContinueAuthenticationCodec.encode(buffer, value, context)
+      is V5AuthReasonCode.ReAuthenticate -> V5AuthReasonCodeReAuthenticateCodec.encode(buffer, value, context)
+    }
+  }
+
+  override fun wireSize(`value`: V5AuthReasonCode, context: EncodeContext): WireSize = when (value) {
+    is V5AuthReasonCode.Success -> V5AuthReasonCodeSuccessCodec.wireSize(value, context)
+    is V5AuthReasonCode.ContinueAuthentication -> V5AuthReasonCodeContinueAuthenticationCodec.wireSize(value, context)
+    is V5AuthReasonCode.ReAuthenticate -> V5AuthReasonCodeReAuthenticateCodec.wireSize(value, context)
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
+    val __discRaw = stream.peekByte(baseOffset + 0).toUByte()
+    val __discriminator = V5AuthReasonCodeRaw(__discRaw)
+    val __dispatchValue = __discriminator.id
+    return when (__dispatchValue) {
+      0 -> V5AuthReasonCodeSuccessCodec.peekFrameSize(stream, baseOffset)
+      24 -> V5AuthReasonCodeContinueAuthenticationCodec.peekFrameSize(stream, baseOffset)
+      25 -> V5AuthReasonCodeReAuthenticateCodec.peekFrameSize(stream, baseOffset)
+      else -> {
+        throw DecodeException(fieldPath = "V5AuthReasonCode.discriminator", bufferPosition = baseOffset, expected = "one of {0, 24, 25}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/authrc/V5AuthReasonCodeContinueAuthenticationCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/authrc/V5AuthReasonCodeContinueAuthenticationCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.authrc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5AuthReasonCodeContinueAuthenticationCodec : Codec<V5AuthReasonCode.ContinueAuthentication> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5AuthReasonCode.ContinueAuthentication {
+    val id = V5AuthReasonCodeRaw(buffer.readUByte())
+    return V5AuthReasonCode.ContinueAuthentication(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5AuthReasonCode.ContinueAuthentication,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5AuthReasonCode.ContinueAuthentication, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/authrc/V5AuthReasonCodeRawCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/authrc/V5AuthReasonCodeRawCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.authrc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5AuthReasonCodeRawCodec : Codec<V5AuthReasonCodeRaw> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5AuthReasonCodeRaw {
+    val raw = buffer.readUByte()
+    return V5AuthReasonCodeRaw(raw = raw)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5AuthReasonCodeRaw,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.raw)
+  }
+
+  override fun wireSize(`value`: V5AuthReasonCodeRaw, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/authrc/V5AuthReasonCodeReAuthenticateCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/authrc/V5AuthReasonCodeReAuthenticateCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.authrc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5AuthReasonCodeReAuthenticateCodec : Codec<V5AuthReasonCode.ReAuthenticate> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5AuthReasonCode.ReAuthenticate {
+    val id = V5AuthReasonCodeRaw(buffer.readUByte())
+    return V5AuthReasonCode.ReAuthenticate(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5AuthReasonCode.ReAuthenticate,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5AuthReasonCode.ReAuthenticate, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/authrc/V5AuthReasonCodeSuccessCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/authrc/V5AuthReasonCodeSuccessCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.authrc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5AuthReasonCodeSuccessCodec : Codec<V5AuthReasonCode.Success> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5AuthReasonCode.Success {
+    val id = V5AuthReasonCodeRaw(buffer.readUByte())
+    return V5AuthReasonCode.Success(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5AuthReasonCode.Success,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5AuthReasonCode.Success, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeBadAuthenticationMethodCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeBadAuthenticationMethodCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.connack
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5ConnectReasonCodeBadAuthenticationMethodCodec : Codec<V5ConnectReasonCode.BadAuthenticationMethod> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5ConnectReasonCode.BadAuthenticationMethod {
+    val id = V5ConnectReasonCodeRaw(buffer.readUByte())
+    return V5ConnectReasonCode.BadAuthenticationMethod(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5ConnectReasonCode.BadAuthenticationMethod,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5ConnectReasonCode.BadAuthenticationMethod, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeBadUserNameOrPasswordCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeBadUserNameOrPasswordCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.connack
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5ConnectReasonCodeBadUserNameOrPasswordCodec : Codec<V5ConnectReasonCode.BadUserNameOrPassword> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5ConnectReasonCode.BadUserNameOrPassword {
+    val id = V5ConnectReasonCodeRaw(buffer.readUByte())
+    return V5ConnectReasonCode.BadUserNameOrPassword(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5ConnectReasonCode.BadUserNameOrPassword,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5ConnectReasonCode.BadUserNameOrPassword, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeBannedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeBannedCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.connack
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5ConnectReasonCodeBannedCodec : Codec<V5ConnectReasonCode.Banned> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5ConnectReasonCode.Banned {
+    val id = V5ConnectReasonCodeRaw(buffer.readUByte())
+    return V5ConnectReasonCode.Banned(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5ConnectReasonCode.Banned,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5ConnectReasonCode.Banned, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeClientIdentifierNotValidCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeClientIdentifierNotValidCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.connack
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5ConnectReasonCodeClientIdentifierNotValidCodec : Codec<V5ConnectReasonCode.ClientIdentifierNotValid> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5ConnectReasonCode.ClientIdentifierNotValid {
+    val id = V5ConnectReasonCodeRaw(buffer.readUByte())
+    return V5ConnectReasonCode.ClientIdentifierNotValid(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5ConnectReasonCode.ClientIdentifierNotValid,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5ConnectReasonCode.ClientIdentifierNotValid, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeCodec.kt
@@ -1,0 +1,138 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.connack
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5ConnectReasonCodeCodec : Codec<V5ConnectReasonCode> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5ConnectReasonCode {
+    val discriminatorPosition = buffer.position()
+    val __discriminator = V5ConnectReasonCodeRawCodec.decode(buffer, context)
+    buffer.position(discriminatorPosition)
+    val __dispatchValue = __discriminator.id
+    return when (__dispatchValue) {
+      0 -> V5ConnectReasonCodeSuccessCodec.decode(buffer, context)
+      128 -> V5ConnectReasonCodeUnspecifiedErrorCodec.decode(buffer, context)
+      129 -> V5ConnectReasonCodeMalformedPacketCodec.decode(buffer, context)
+      130 -> V5ConnectReasonCodeProtocolErrorCodec.decode(buffer, context)
+      131 -> V5ConnectReasonCodeImplementationSpecificErrorCodec.decode(buffer, context)
+      132 -> V5ConnectReasonCodeUnsupportedProtocolVersionCodec.decode(buffer, context)
+      133 -> V5ConnectReasonCodeClientIdentifierNotValidCodec.decode(buffer, context)
+      134 -> V5ConnectReasonCodeBadUserNameOrPasswordCodec.decode(buffer, context)
+      135 -> V5ConnectReasonCodeNotAuthorizedCodec.decode(buffer, context)
+      136 -> V5ConnectReasonCodeServerUnavailableCodec.decode(buffer, context)
+      137 -> V5ConnectReasonCodeServerBusyCodec.decode(buffer, context)
+      138 -> V5ConnectReasonCodeBannedCodec.decode(buffer, context)
+      140 -> V5ConnectReasonCodeBadAuthenticationMethodCodec.decode(buffer, context)
+      144 -> V5ConnectReasonCodeTopicNameInvalidCodec.decode(buffer, context)
+      149 -> V5ConnectReasonCodePacketTooLargeCodec.decode(buffer, context)
+      151 -> V5ConnectReasonCodeQuotaExceededCodec.decode(buffer, context)
+      153 -> V5ConnectReasonCodePayloadFormatInvalidCodec.decode(buffer, context)
+      154 -> V5ConnectReasonCodeRetainNotSupportedCodec.decode(buffer, context)
+      155 -> V5ConnectReasonCodeQoSNotSupportedCodec.decode(buffer, context)
+      156 -> V5ConnectReasonCodeUseAnotherServerCodec.decode(buffer, context)
+      157 -> V5ConnectReasonCodeServerMovedCodec.decode(buffer, context)
+      159 -> V5ConnectReasonCodeConnectionRateExceededCodec.decode(buffer, context)
+      else -> {
+        throw DecodeException(fieldPath = "V5ConnectReasonCode.discriminator", bufferPosition = discriminatorPosition, expected = "one of {0, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 140, 144, 149, 151, 153, 154, 155, 156, 157, 159}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5ConnectReasonCode,
+    context: EncodeContext,
+  ) {
+    when (value) {
+      is V5ConnectReasonCode.Success -> V5ConnectReasonCodeSuccessCodec.encode(buffer, value, context)
+      is V5ConnectReasonCode.UnspecifiedError -> V5ConnectReasonCodeUnspecifiedErrorCodec.encode(buffer, value, context)
+      is V5ConnectReasonCode.MalformedPacket -> V5ConnectReasonCodeMalformedPacketCodec.encode(buffer, value, context)
+      is V5ConnectReasonCode.ProtocolError -> V5ConnectReasonCodeProtocolErrorCodec.encode(buffer, value, context)
+      is V5ConnectReasonCode.ImplementationSpecificError -> V5ConnectReasonCodeImplementationSpecificErrorCodec.encode(buffer, value, context)
+      is V5ConnectReasonCode.UnsupportedProtocolVersion -> V5ConnectReasonCodeUnsupportedProtocolVersionCodec.encode(buffer, value, context)
+      is V5ConnectReasonCode.ClientIdentifierNotValid -> V5ConnectReasonCodeClientIdentifierNotValidCodec.encode(buffer, value, context)
+      is V5ConnectReasonCode.BadUserNameOrPassword -> V5ConnectReasonCodeBadUserNameOrPasswordCodec.encode(buffer, value, context)
+      is V5ConnectReasonCode.NotAuthorized -> V5ConnectReasonCodeNotAuthorizedCodec.encode(buffer, value, context)
+      is V5ConnectReasonCode.ServerUnavailable -> V5ConnectReasonCodeServerUnavailableCodec.encode(buffer, value, context)
+      is V5ConnectReasonCode.ServerBusy -> V5ConnectReasonCodeServerBusyCodec.encode(buffer, value, context)
+      is V5ConnectReasonCode.Banned -> V5ConnectReasonCodeBannedCodec.encode(buffer, value, context)
+      is V5ConnectReasonCode.BadAuthenticationMethod -> V5ConnectReasonCodeBadAuthenticationMethodCodec.encode(buffer, value, context)
+      is V5ConnectReasonCode.TopicNameInvalid -> V5ConnectReasonCodeTopicNameInvalidCodec.encode(buffer, value, context)
+      is V5ConnectReasonCode.PacketTooLarge -> V5ConnectReasonCodePacketTooLargeCodec.encode(buffer, value, context)
+      is V5ConnectReasonCode.QuotaExceeded -> V5ConnectReasonCodeQuotaExceededCodec.encode(buffer, value, context)
+      is V5ConnectReasonCode.PayloadFormatInvalid -> V5ConnectReasonCodePayloadFormatInvalidCodec.encode(buffer, value, context)
+      is V5ConnectReasonCode.RetainNotSupported -> V5ConnectReasonCodeRetainNotSupportedCodec.encode(buffer, value, context)
+      is V5ConnectReasonCode.QoSNotSupported -> V5ConnectReasonCodeQoSNotSupportedCodec.encode(buffer, value, context)
+      is V5ConnectReasonCode.UseAnotherServer -> V5ConnectReasonCodeUseAnotherServerCodec.encode(buffer, value, context)
+      is V5ConnectReasonCode.ServerMoved -> V5ConnectReasonCodeServerMovedCodec.encode(buffer, value, context)
+      is V5ConnectReasonCode.ConnectionRateExceeded -> V5ConnectReasonCodeConnectionRateExceededCodec.encode(buffer, value, context)
+    }
+  }
+
+  override fun wireSize(`value`: V5ConnectReasonCode, context: EncodeContext): WireSize = when (value) {
+    is V5ConnectReasonCode.Success -> V5ConnectReasonCodeSuccessCodec.wireSize(value, context)
+    is V5ConnectReasonCode.UnspecifiedError -> V5ConnectReasonCodeUnspecifiedErrorCodec.wireSize(value, context)
+    is V5ConnectReasonCode.MalformedPacket -> V5ConnectReasonCodeMalformedPacketCodec.wireSize(value, context)
+    is V5ConnectReasonCode.ProtocolError -> V5ConnectReasonCodeProtocolErrorCodec.wireSize(value, context)
+    is V5ConnectReasonCode.ImplementationSpecificError -> V5ConnectReasonCodeImplementationSpecificErrorCodec.wireSize(value, context)
+    is V5ConnectReasonCode.UnsupportedProtocolVersion -> V5ConnectReasonCodeUnsupportedProtocolVersionCodec.wireSize(value, context)
+    is V5ConnectReasonCode.ClientIdentifierNotValid -> V5ConnectReasonCodeClientIdentifierNotValidCodec.wireSize(value, context)
+    is V5ConnectReasonCode.BadUserNameOrPassword -> V5ConnectReasonCodeBadUserNameOrPasswordCodec.wireSize(value, context)
+    is V5ConnectReasonCode.NotAuthorized -> V5ConnectReasonCodeNotAuthorizedCodec.wireSize(value, context)
+    is V5ConnectReasonCode.ServerUnavailable -> V5ConnectReasonCodeServerUnavailableCodec.wireSize(value, context)
+    is V5ConnectReasonCode.ServerBusy -> V5ConnectReasonCodeServerBusyCodec.wireSize(value, context)
+    is V5ConnectReasonCode.Banned -> V5ConnectReasonCodeBannedCodec.wireSize(value, context)
+    is V5ConnectReasonCode.BadAuthenticationMethod -> V5ConnectReasonCodeBadAuthenticationMethodCodec.wireSize(value, context)
+    is V5ConnectReasonCode.TopicNameInvalid -> V5ConnectReasonCodeTopicNameInvalidCodec.wireSize(value, context)
+    is V5ConnectReasonCode.PacketTooLarge -> V5ConnectReasonCodePacketTooLargeCodec.wireSize(value, context)
+    is V5ConnectReasonCode.QuotaExceeded -> V5ConnectReasonCodeQuotaExceededCodec.wireSize(value, context)
+    is V5ConnectReasonCode.PayloadFormatInvalid -> V5ConnectReasonCodePayloadFormatInvalidCodec.wireSize(value, context)
+    is V5ConnectReasonCode.RetainNotSupported -> V5ConnectReasonCodeRetainNotSupportedCodec.wireSize(value, context)
+    is V5ConnectReasonCode.QoSNotSupported -> V5ConnectReasonCodeQoSNotSupportedCodec.wireSize(value, context)
+    is V5ConnectReasonCode.UseAnotherServer -> V5ConnectReasonCodeUseAnotherServerCodec.wireSize(value, context)
+    is V5ConnectReasonCode.ServerMoved -> V5ConnectReasonCodeServerMovedCodec.wireSize(value, context)
+    is V5ConnectReasonCode.ConnectionRateExceeded -> V5ConnectReasonCodeConnectionRateExceededCodec.wireSize(value, context)
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
+    val __discRaw = stream.peekByte(baseOffset + 0).toUByte()
+    val __discriminator = V5ConnectReasonCodeRaw(__discRaw)
+    val __dispatchValue = __discriminator.id
+    return when (__dispatchValue) {
+      0 -> V5ConnectReasonCodeSuccessCodec.peekFrameSize(stream, baseOffset)
+      128 -> V5ConnectReasonCodeUnspecifiedErrorCodec.peekFrameSize(stream, baseOffset)
+      129 -> V5ConnectReasonCodeMalformedPacketCodec.peekFrameSize(stream, baseOffset)
+      130 -> V5ConnectReasonCodeProtocolErrorCodec.peekFrameSize(stream, baseOffset)
+      131 -> V5ConnectReasonCodeImplementationSpecificErrorCodec.peekFrameSize(stream, baseOffset)
+      132 -> V5ConnectReasonCodeUnsupportedProtocolVersionCodec.peekFrameSize(stream, baseOffset)
+      133 -> V5ConnectReasonCodeClientIdentifierNotValidCodec.peekFrameSize(stream, baseOffset)
+      134 -> V5ConnectReasonCodeBadUserNameOrPasswordCodec.peekFrameSize(stream, baseOffset)
+      135 -> V5ConnectReasonCodeNotAuthorizedCodec.peekFrameSize(stream, baseOffset)
+      136 -> V5ConnectReasonCodeServerUnavailableCodec.peekFrameSize(stream, baseOffset)
+      137 -> V5ConnectReasonCodeServerBusyCodec.peekFrameSize(stream, baseOffset)
+      138 -> V5ConnectReasonCodeBannedCodec.peekFrameSize(stream, baseOffset)
+      140 -> V5ConnectReasonCodeBadAuthenticationMethodCodec.peekFrameSize(stream, baseOffset)
+      144 -> V5ConnectReasonCodeTopicNameInvalidCodec.peekFrameSize(stream, baseOffset)
+      149 -> V5ConnectReasonCodePacketTooLargeCodec.peekFrameSize(stream, baseOffset)
+      151 -> V5ConnectReasonCodeQuotaExceededCodec.peekFrameSize(stream, baseOffset)
+      153 -> V5ConnectReasonCodePayloadFormatInvalidCodec.peekFrameSize(stream, baseOffset)
+      154 -> V5ConnectReasonCodeRetainNotSupportedCodec.peekFrameSize(stream, baseOffset)
+      155 -> V5ConnectReasonCodeQoSNotSupportedCodec.peekFrameSize(stream, baseOffset)
+      156 -> V5ConnectReasonCodeUseAnotherServerCodec.peekFrameSize(stream, baseOffset)
+      157 -> V5ConnectReasonCodeServerMovedCodec.peekFrameSize(stream, baseOffset)
+      159 -> V5ConnectReasonCodeConnectionRateExceededCodec.peekFrameSize(stream, baseOffset)
+      else -> {
+        throw DecodeException(fieldPath = "V5ConnectReasonCode.discriminator", bufferPosition = baseOffset, expected = "one of {0, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 140, 144, 149, 151, 153, 154, 155, 156, 157, 159}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeConnectionRateExceededCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeConnectionRateExceededCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.connack
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5ConnectReasonCodeConnectionRateExceededCodec : Codec<V5ConnectReasonCode.ConnectionRateExceeded> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5ConnectReasonCode.ConnectionRateExceeded {
+    val id = V5ConnectReasonCodeRaw(buffer.readUByte())
+    return V5ConnectReasonCode.ConnectionRateExceeded(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5ConnectReasonCode.ConnectionRateExceeded,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5ConnectReasonCode.ConnectionRateExceeded, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeImplementationSpecificErrorCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeImplementationSpecificErrorCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.connack
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5ConnectReasonCodeImplementationSpecificErrorCodec : Codec<V5ConnectReasonCode.ImplementationSpecificError> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5ConnectReasonCode.ImplementationSpecificError {
+    val id = V5ConnectReasonCodeRaw(buffer.readUByte())
+    return V5ConnectReasonCode.ImplementationSpecificError(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5ConnectReasonCode.ImplementationSpecificError,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5ConnectReasonCode.ImplementationSpecificError, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeMalformedPacketCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeMalformedPacketCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.connack
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5ConnectReasonCodeMalformedPacketCodec : Codec<V5ConnectReasonCode.MalformedPacket> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5ConnectReasonCode.MalformedPacket {
+    val id = V5ConnectReasonCodeRaw(buffer.readUByte())
+    return V5ConnectReasonCode.MalformedPacket(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5ConnectReasonCode.MalformedPacket,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5ConnectReasonCode.MalformedPacket, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeNotAuthorizedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeNotAuthorizedCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.connack
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5ConnectReasonCodeNotAuthorizedCodec : Codec<V5ConnectReasonCode.NotAuthorized> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5ConnectReasonCode.NotAuthorized {
+    val id = V5ConnectReasonCodeRaw(buffer.readUByte())
+    return V5ConnectReasonCode.NotAuthorized(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5ConnectReasonCode.NotAuthorized,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5ConnectReasonCode.NotAuthorized, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodePacketTooLargeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodePacketTooLargeCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.connack
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5ConnectReasonCodePacketTooLargeCodec : Codec<V5ConnectReasonCode.PacketTooLarge> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5ConnectReasonCode.PacketTooLarge {
+    val id = V5ConnectReasonCodeRaw(buffer.readUByte())
+    return V5ConnectReasonCode.PacketTooLarge(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5ConnectReasonCode.PacketTooLarge,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5ConnectReasonCode.PacketTooLarge, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodePayloadFormatInvalidCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodePayloadFormatInvalidCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.connack
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5ConnectReasonCodePayloadFormatInvalidCodec : Codec<V5ConnectReasonCode.PayloadFormatInvalid> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5ConnectReasonCode.PayloadFormatInvalid {
+    val id = V5ConnectReasonCodeRaw(buffer.readUByte())
+    return V5ConnectReasonCode.PayloadFormatInvalid(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5ConnectReasonCode.PayloadFormatInvalid,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5ConnectReasonCode.PayloadFormatInvalid, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeProtocolErrorCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeProtocolErrorCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.connack
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5ConnectReasonCodeProtocolErrorCodec : Codec<V5ConnectReasonCode.ProtocolError> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5ConnectReasonCode.ProtocolError {
+    val id = V5ConnectReasonCodeRaw(buffer.readUByte())
+    return V5ConnectReasonCode.ProtocolError(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5ConnectReasonCode.ProtocolError,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5ConnectReasonCode.ProtocolError, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeQoSNotSupportedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeQoSNotSupportedCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.connack
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5ConnectReasonCodeQoSNotSupportedCodec : Codec<V5ConnectReasonCode.QoSNotSupported> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5ConnectReasonCode.QoSNotSupported {
+    val id = V5ConnectReasonCodeRaw(buffer.readUByte())
+    return V5ConnectReasonCode.QoSNotSupported(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5ConnectReasonCode.QoSNotSupported,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5ConnectReasonCode.QoSNotSupported, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeQuotaExceededCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeQuotaExceededCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.connack
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5ConnectReasonCodeQuotaExceededCodec : Codec<V5ConnectReasonCode.QuotaExceeded> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5ConnectReasonCode.QuotaExceeded {
+    val id = V5ConnectReasonCodeRaw(buffer.readUByte())
+    return V5ConnectReasonCode.QuotaExceeded(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5ConnectReasonCode.QuotaExceeded,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5ConnectReasonCode.QuotaExceeded, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeRawCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeRawCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.connack
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5ConnectReasonCodeRawCodec : Codec<V5ConnectReasonCodeRaw> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5ConnectReasonCodeRaw {
+    val raw = buffer.readUByte()
+    return V5ConnectReasonCodeRaw(raw = raw)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5ConnectReasonCodeRaw,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.raw)
+  }
+
+  override fun wireSize(`value`: V5ConnectReasonCodeRaw, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeRetainNotSupportedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeRetainNotSupportedCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.connack
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5ConnectReasonCodeRetainNotSupportedCodec : Codec<V5ConnectReasonCode.RetainNotSupported> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5ConnectReasonCode.RetainNotSupported {
+    val id = V5ConnectReasonCodeRaw(buffer.readUByte())
+    return V5ConnectReasonCode.RetainNotSupported(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5ConnectReasonCode.RetainNotSupported,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5ConnectReasonCode.RetainNotSupported, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeServerBusyCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeServerBusyCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.connack
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5ConnectReasonCodeServerBusyCodec : Codec<V5ConnectReasonCode.ServerBusy> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5ConnectReasonCode.ServerBusy {
+    val id = V5ConnectReasonCodeRaw(buffer.readUByte())
+    return V5ConnectReasonCode.ServerBusy(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5ConnectReasonCode.ServerBusy,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5ConnectReasonCode.ServerBusy, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeServerMovedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeServerMovedCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.connack
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5ConnectReasonCodeServerMovedCodec : Codec<V5ConnectReasonCode.ServerMoved> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5ConnectReasonCode.ServerMoved {
+    val id = V5ConnectReasonCodeRaw(buffer.readUByte())
+    return V5ConnectReasonCode.ServerMoved(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5ConnectReasonCode.ServerMoved,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5ConnectReasonCode.ServerMoved, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeServerUnavailableCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeServerUnavailableCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.connack
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5ConnectReasonCodeServerUnavailableCodec : Codec<V5ConnectReasonCode.ServerUnavailable> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5ConnectReasonCode.ServerUnavailable {
+    val id = V5ConnectReasonCodeRaw(buffer.readUByte())
+    return V5ConnectReasonCode.ServerUnavailable(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5ConnectReasonCode.ServerUnavailable,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5ConnectReasonCode.ServerUnavailable, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeSuccessCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeSuccessCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.connack
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5ConnectReasonCodeSuccessCodec : Codec<V5ConnectReasonCode.Success> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5ConnectReasonCode.Success {
+    val id = V5ConnectReasonCodeRaw(buffer.readUByte())
+    return V5ConnectReasonCode.Success(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5ConnectReasonCode.Success,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5ConnectReasonCode.Success, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeTopicNameInvalidCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeTopicNameInvalidCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.connack
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5ConnectReasonCodeTopicNameInvalidCodec : Codec<V5ConnectReasonCode.TopicNameInvalid> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5ConnectReasonCode.TopicNameInvalid {
+    val id = V5ConnectReasonCodeRaw(buffer.readUByte())
+    return V5ConnectReasonCode.TopicNameInvalid(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5ConnectReasonCode.TopicNameInvalid,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5ConnectReasonCode.TopicNameInvalid, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeUnspecifiedErrorCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeUnspecifiedErrorCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.connack
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5ConnectReasonCodeUnspecifiedErrorCodec : Codec<V5ConnectReasonCode.UnspecifiedError> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5ConnectReasonCode.UnspecifiedError {
+    val id = V5ConnectReasonCodeRaw(buffer.readUByte())
+    return V5ConnectReasonCode.UnspecifiedError(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5ConnectReasonCode.UnspecifiedError,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5ConnectReasonCode.UnspecifiedError, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeUnsupportedProtocolVersionCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeUnsupportedProtocolVersionCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.connack
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5ConnectReasonCodeUnsupportedProtocolVersionCodec : Codec<V5ConnectReasonCode.UnsupportedProtocolVersion> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5ConnectReasonCode.UnsupportedProtocolVersion {
+    val id = V5ConnectReasonCodeRaw(buffer.readUByte())
+    return V5ConnectReasonCode.UnsupportedProtocolVersion(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5ConnectReasonCode.UnsupportedProtocolVersion,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5ConnectReasonCode.UnsupportedProtocolVersion, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeUseAnotherServerCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeUseAnotherServerCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.connack
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5ConnectReasonCodeUseAnotherServerCodec : Codec<V5ConnectReasonCode.UseAnotherServer> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5ConnectReasonCode.UseAnotherServer {
+    val id = V5ConnectReasonCodeRaw(buffer.readUByte())
+    return V5ConnectReasonCode.UseAnotherServer(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5ConnectReasonCode.UseAnotherServer,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5ConnectReasonCode.UseAnotherServer, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeAdministrativeActionCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeAdministrativeActionCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.disconnectrc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5DisconnectReasonCodeAdministrativeActionCodec : Codec<V5DisconnectReasonCode.AdministrativeAction> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5DisconnectReasonCode.AdministrativeAction {
+    val id = V5DisconnectReasonCodeRaw(buffer.readUByte())
+    return V5DisconnectReasonCode.AdministrativeAction(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5DisconnectReasonCode.AdministrativeAction,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5DisconnectReasonCode.AdministrativeAction, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeCodec.kt
@@ -1,0 +1,162 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.disconnectrc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5DisconnectReasonCodeCodec : Codec<V5DisconnectReasonCode> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5DisconnectReasonCode {
+    val discriminatorPosition = buffer.position()
+    val __discriminator = V5DisconnectReasonCodeRawCodec.decode(buffer, context)
+    buffer.position(discriminatorPosition)
+    val __dispatchValue = __discriminator.id
+    return when (__dispatchValue) {
+      0 -> V5DisconnectReasonCodeNormalDisconnectionCodec.decode(buffer, context)
+      4 -> V5DisconnectReasonCodeDisconnectWithWillMessageCodec.decode(buffer, context)
+      128 -> V5DisconnectReasonCodeUnspecifiedErrorCodec.decode(buffer, context)
+      129 -> V5DisconnectReasonCodeMalformedPacketCodec.decode(buffer, context)
+      130 -> V5DisconnectReasonCodeProtocolErrorCodec.decode(buffer, context)
+      131 -> V5DisconnectReasonCodeImplementationSpecificErrorCodec.decode(buffer, context)
+      135 -> V5DisconnectReasonCodeNotAuthorizedCodec.decode(buffer, context)
+      137 -> V5DisconnectReasonCodeServerBusyCodec.decode(buffer, context)
+      139 -> V5DisconnectReasonCodeServerShuttingDownCodec.decode(buffer, context)
+      141 -> V5DisconnectReasonCodeKeepAliveTimeoutCodec.decode(buffer, context)
+      142 -> V5DisconnectReasonCodeSessionTakenOverCodec.decode(buffer, context)
+      143 -> V5DisconnectReasonCodeTopicFilterInvalidCodec.decode(buffer, context)
+      144 -> V5DisconnectReasonCodeTopicNameInvalidCodec.decode(buffer, context)
+      147 -> V5DisconnectReasonCodeReceiveMaximumExceededCodec.decode(buffer, context)
+      148 -> V5DisconnectReasonCodeTopicAliasInvalidCodec.decode(buffer, context)
+      149 -> V5DisconnectReasonCodePacketTooLargeCodec.decode(buffer, context)
+      151 -> V5DisconnectReasonCodeQuotaExceededCodec.decode(buffer, context)
+      152 -> V5DisconnectReasonCodeAdministrativeActionCodec.decode(buffer, context)
+      153 -> V5DisconnectReasonCodePayloadFormatInvalidCodec.decode(buffer, context)
+      154 -> V5DisconnectReasonCodeRetainNotSupportedCodec.decode(buffer, context)
+      155 -> V5DisconnectReasonCodeQoSNotSupportedCodec.decode(buffer, context)
+      156 -> V5DisconnectReasonCodeUseAnotherServerCodec.decode(buffer, context)
+      157 -> V5DisconnectReasonCodeServerMovedCodec.decode(buffer, context)
+      158 -> V5DisconnectReasonCodeSharedSubscriptionsNotSupportedCodec.decode(buffer, context)
+      159 -> V5DisconnectReasonCodeConnectionRateExceededCodec.decode(buffer, context)
+      160 -> V5DisconnectReasonCodeMaximumConnectTimeCodec.decode(buffer, context)
+      161 -> V5DisconnectReasonCodeSubscriptionIdentifiersNotSupportedCodec.decode(buffer, context)
+      162 -> V5DisconnectReasonCodeWildcardSubscriptionsNotSupportedCodec.decode(buffer, context)
+      else -> {
+        throw DecodeException(fieldPath = "V5DisconnectReasonCode.discriminator", bufferPosition = discriminatorPosition, expected = "one of {0, 4, 128, 129, 130, 131, 135, 137, 139, 141, 142, 143, 144, 147, 148, 149, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5DisconnectReasonCode,
+    context: EncodeContext,
+  ) {
+    when (value) {
+      is V5DisconnectReasonCode.NormalDisconnection -> V5DisconnectReasonCodeNormalDisconnectionCodec.encode(buffer, value, context)
+      is V5DisconnectReasonCode.DisconnectWithWillMessage -> V5DisconnectReasonCodeDisconnectWithWillMessageCodec.encode(buffer, value, context)
+      is V5DisconnectReasonCode.UnspecifiedError -> V5DisconnectReasonCodeUnspecifiedErrorCodec.encode(buffer, value, context)
+      is V5DisconnectReasonCode.MalformedPacket -> V5DisconnectReasonCodeMalformedPacketCodec.encode(buffer, value, context)
+      is V5DisconnectReasonCode.ProtocolError -> V5DisconnectReasonCodeProtocolErrorCodec.encode(buffer, value, context)
+      is V5DisconnectReasonCode.ImplementationSpecificError -> V5DisconnectReasonCodeImplementationSpecificErrorCodec.encode(buffer, value, context)
+      is V5DisconnectReasonCode.NotAuthorized -> V5DisconnectReasonCodeNotAuthorizedCodec.encode(buffer, value, context)
+      is V5DisconnectReasonCode.ServerBusy -> V5DisconnectReasonCodeServerBusyCodec.encode(buffer, value, context)
+      is V5DisconnectReasonCode.ServerShuttingDown -> V5DisconnectReasonCodeServerShuttingDownCodec.encode(buffer, value, context)
+      is V5DisconnectReasonCode.KeepAliveTimeout -> V5DisconnectReasonCodeKeepAliveTimeoutCodec.encode(buffer, value, context)
+      is V5DisconnectReasonCode.SessionTakenOver -> V5DisconnectReasonCodeSessionTakenOverCodec.encode(buffer, value, context)
+      is V5DisconnectReasonCode.TopicFilterInvalid -> V5DisconnectReasonCodeTopicFilterInvalidCodec.encode(buffer, value, context)
+      is V5DisconnectReasonCode.TopicNameInvalid -> V5DisconnectReasonCodeTopicNameInvalidCodec.encode(buffer, value, context)
+      is V5DisconnectReasonCode.ReceiveMaximumExceeded -> V5DisconnectReasonCodeReceiveMaximumExceededCodec.encode(buffer, value, context)
+      is V5DisconnectReasonCode.TopicAliasInvalid -> V5DisconnectReasonCodeTopicAliasInvalidCodec.encode(buffer, value, context)
+      is V5DisconnectReasonCode.PacketTooLarge -> V5DisconnectReasonCodePacketTooLargeCodec.encode(buffer, value, context)
+      is V5DisconnectReasonCode.QuotaExceeded -> V5DisconnectReasonCodeQuotaExceededCodec.encode(buffer, value, context)
+      is V5DisconnectReasonCode.AdministrativeAction -> V5DisconnectReasonCodeAdministrativeActionCodec.encode(buffer, value, context)
+      is V5DisconnectReasonCode.PayloadFormatInvalid -> V5DisconnectReasonCodePayloadFormatInvalidCodec.encode(buffer, value, context)
+      is V5DisconnectReasonCode.RetainNotSupported -> V5DisconnectReasonCodeRetainNotSupportedCodec.encode(buffer, value, context)
+      is V5DisconnectReasonCode.QoSNotSupported -> V5DisconnectReasonCodeQoSNotSupportedCodec.encode(buffer, value, context)
+      is V5DisconnectReasonCode.UseAnotherServer -> V5DisconnectReasonCodeUseAnotherServerCodec.encode(buffer, value, context)
+      is V5DisconnectReasonCode.ServerMoved -> V5DisconnectReasonCodeServerMovedCodec.encode(buffer, value, context)
+      is V5DisconnectReasonCode.SharedSubscriptionsNotSupported -> V5DisconnectReasonCodeSharedSubscriptionsNotSupportedCodec.encode(buffer, value, context)
+      is V5DisconnectReasonCode.ConnectionRateExceeded -> V5DisconnectReasonCodeConnectionRateExceededCodec.encode(buffer, value, context)
+      is V5DisconnectReasonCode.MaximumConnectTime -> V5DisconnectReasonCodeMaximumConnectTimeCodec.encode(buffer, value, context)
+      is V5DisconnectReasonCode.SubscriptionIdentifiersNotSupported -> V5DisconnectReasonCodeSubscriptionIdentifiersNotSupportedCodec.encode(buffer, value, context)
+      is V5DisconnectReasonCode.WildcardSubscriptionsNotSupported -> V5DisconnectReasonCodeWildcardSubscriptionsNotSupportedCodec.encode(buffer, value, context)
+    }
+  }
+
+  override fun wireSize(`value`: V5DisconnectReasonCode, context: EncodeContext): WireSize = when (value) {
+    is V5DisconnectReasonCode.NormalDisconnection -> V5DisconnectReasonCodeNormalDisconnectionCodec.wireSize(value, context)
+    is V5DisconnectReasonCode.DisconnectWithWillMessage -> V5DisconnectReasonCodeDisconnectWithWillMessageCodec.wireSize(value, context)
+    is V5DisconnectReasonCode.UnspecifiedError -> V5DisconnectReasonCodeUnspecifiedErrorCodec.wireSize(value, context)
+    is V5DisconnectReasonCode.MalformedPacket -> V5DisconnectReasonCodeMalformedPacketCodec.wireSize(value, context)
+    is V5DisconnectReasonCode.ProtocolError -> V5DisconnectReasonCodeProtocolErrorCodec.wireSize(value, context)
+    is V5DisconnectReasonCode.ImplementationSpecificError -> V5DisconnectReasonCodeImplementationSpecificErrorCodec.wireSize(value, context)
+    is V5DisconnectReasonCode.NotAuthorized -> V5DisconnectReasonCodeNotAuthorizedCodec.wireSize(value, context)
+    is V5DisconnectReasonCode.ServerBusy -> V5DisconnectReasonCodeServerBusyCodec.wireSize(value, context)
+    is V5DisconnectReasonCode.ServerShuttingDown -> V5DisconnectReasonCodeServerShuttingDownCodec.wireSize(value, context)
+    is V5DisconnectReasonCode.KeepAliveTimeout -> V5DisconnectReasonCodeKeepAliveTimeoutCodec.wireSize(value, context)
+    is V5DisconnectReasonCode.SessionTakenOver -> V5DisconnectReasonCodeSessionTakenOverCodec.wireSize(value, context)
+    is V5DisconnectReasonCode.TopicFilterInvalid -> V5DisconnectReasonCodeTopicFilterInvalidCodec.wireSize(value, context)
+    is V5DisconnectReasonCode.TopicNameInvalid -> V5DisconnectReasonCodeTopicNameInvalidCodec.wireSize(value, context)
+    is V5DisconnectReasonCode.ReceiveMaximumExceeded -> V5DisconnectReasonCodeReceiveMaximumExceededCodec.wireSize(value, context)
+    is V5DisconnectReasonCode.TopicAliasInvalid -> V5DisconnectReasonCodeTopicAliasInvalidCodec.wireSize(value, context)
+    is V5DisconnectReasonCode.PacketTooLarge -> V5DisconnectReasonCodePacketTooLargeCodec.wireSize(value, context)
+    is V5DisconnectReasonCode.QuotaExceeded -> V5DisconnectReasonCodeQuotaExceededCodec.wireSize(value, context)
+    is V5DisconnectReasonCode.AdministrativeAction -> V5DisconnectReasonCodeAdministrativeActionCodec.wireSize(value, context)
+    is V5DisconnectReasonCode.PayloadFormatInvalid -> V5DisconnectReasonCodePayloadFormatInvalidCodec.wireSize(value, context)
+    is V5DisconnectReasonCode.RetainNotSupported -> V5DisconnectReasonCodeRetainNotSupportedCodec.wireSize(value, context)
+    is V5DisconnectReasonCode.QoSNotSupported -> V5DisconnectReasonCodeQoSNotSupportedCodec.wireSize(value, context)
+    is V5DisconnectReasonCode.UseAnotherServer -> V5DisconnectReasonCodeUseAnotherServerCodec.wireSize(value, context)
+    is V5DisconnectReasonCode.ServerMoved -> V5DisconnectReasonCodeServerMovedCodec.wireSize(value, context)
+    is V5DisconnectReasonCode.SharedSubscriptionsNotSupported -> V5DisconnectReasonCodeSharedSubscriptionsNotSupportedCodec.wireSize(value, context)
+    is V5DisconnectReasonCode.ConnectionRateExceeded -> V5DisconnectReasonCodeConnectionRateExceededCodec.wireSize(value, context)
+    is V5DisconnectReasonCode.MaximumConnectTime -> V5DisconnectReasonCodeMaximumConnectTimeCodec.wireSize(value, context)
+    is V5DisconnectReasonCode.SubscriptionIdentifiersNotSupported -> V5DisconnectReasonCodeSubscriptionIdentifiersNotSupportedCodec.wireSize(value, context)
+    is V5DisconnectReasonCode.WildcardSubscriptionsNotSupported -> V5DisconnectReasonCodeWildcardSubscriptionsNotSupportedCodec.wireSize(value, context)
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
+    val __discRaw = stream.peekByte(baseOffset + 0).toUByte()
+    val __discriminator = V5DisconnectReasonCodeRaw(__discRaw)
+    val __dispatchValue = __discriminator.id
+    return when (__dispatchValue) {
+      0 -> V5DisconnectReasonCodeNormalDisconnectionCodec.peekFrameSize(stream, baseOffset)
+      4 -> V5DisconnectReasonCodeDisconnectWithWillMessageCodec.peekFrameSize(stream, baseOffset)
+      128 -> V5DisconnectReasonCodeUnspecifiedErrorCodec.peekFrameSize(stream, baseOffset)
+      129 -> V5DisconnectReasonCodeMalformedPacketCodec.peekFrameSize(stream, baseOffset)
+      130 -> V5DisconnectReasonCodeProtocolErrorCodec.peekFrameSize(stream, baseOffset)
+      131 -> V5DisconnectReasonCodeImplementationSpecificErrorCodec.peekFrameSize(stream, baseOffset)
+      135 -> V5DisconnectReasonCodeNotAuthorizedCodec.peekFrameSize(stream, baseOffset)
+      137 -> V5DisconnectReasonCodeServerBusyCodec.peekFrameSize(stream, baseOffset)
+      139 -> V5DisconnectReasonCodeServerShuttingDownCodec.peekFrameSize(stream, baseOffset)
+      141 -> V5DisconnectReasonCodeKeepAliveTimeoutCodec.peekFrameSize(stream, baseOffset)
+      142 -> V5DisconnectReasonCodeSessionTakenOverCodec.peekFrameSize(stream, baseOffset)
+      143 -> V5DisconnectReasonCodeTopicFilterInvalidCodec.peekFrameSize(stream, baseOffset)
+      144 -> V5DisconnectReasonCodeTopicNameInvalidCodec.peekFrameSize(stream, baseOffset)
+      147 -> V5DisconnectReasonCodeReceiveMaximumExceededCodec.peekFrameSize(stream, baseOffset)
+      148 -> V5DisconnectReasonCodeTopicAliasInvalidCodec.peekFrameSize(stream, baseOffset)
+      149 -> V5DisconnectReasonCodePacketTooLargeCodec.peekFrameSize(stream, baseOffset)
+      151 -> V5DisconnectReasonCodeQuotaExceededCodec.peekFrameSize(stream, baseOffset)
+      152 -> V5DisconnectReasonCodeAdministrativeActionCodec.peekFrameSize(stream, baseOffset)
+      153 -> V5DisconnectReasonCodePayloadFormatInvalidCodec.peekFrameSize(stream, baseOffset)
+      154 -> V5DisconnectReasonCodeRetainNotSupportedCodec.peekFrameSize(stream, baseOffset)
+      155 -> V5DisconnectReasonCodeQoSNotSupportedCodec.peekFrameSize(stream, baseOffset)
+      156 -> V5DisconnectReasonCodeUseAnotherServerCodec.peekFrameSize(stream, baseOffset)
+      157 -> V5DisconnectReasonCodeServerMovedCodec.peekFrameSize(stream, baseOffset)
+      158 -> V5DisconnectReasonCodeSharedSubscriptionsNotSupportedCodec.peekFrameSize(stream, baseOffset)
+      159 -> V5DisconnectReasonCodeConnectionRateExceededCodec.peekFrameSize(stream, baseOffset)
+      160 -> V5DisconnectReasonCodeMaximumConnectTimeCodec.peekFrameSize(stream, baseOffset)
+      161 -> V5DisconnectReasonCodeSubscriptionIdentifiersNotSupportedCodec.peekFrameSize(stream, baseOffset)
+      162 -> V5DisconnectReasonCodeWildcardSubscriptionsNotSupportedCodec.peekFrameSize(stream, baseOffset)
+      else -> {
+        throw DecodeException(fieldPath = "V5DisconnectReasonCode.discriminator", bufferPosition = baseOffset, expected = "one of {0, 4, 128, 129, 130, 131, 135, 137, 139, 141, 142, 143, 144, 147, 148, 149, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeConnectionRateExceededCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeConnectionRateExceededCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.disconnectrc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5DisconnectReasonCodeConnectionRateExceededCodec : Codec<V5DisconnectReasonCode.ConnectionRateExceeded> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5DisconnectReasonCode.ConnectionRateExceeded {
+    val id = V5DisconnectReasonCodeRaw(buffer.readUByte())
+    return V5DisconnectReasonCode.ConnectionRateExceeded(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5DisconnectReasonCode.ConnectionRateExceeded,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5DisconnectReasonCode.ConnectionRateExceeded, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeDisconnectWithWillMessageCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeDisconnectWithWillMessageCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.disconnectrc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5DisconnectReasonCodeDisconnectWithWillMessageCodec : Codec<V5DisconnectReasonCode.DisconnectWithWillMessage> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5DisconnectReasonCode.DisconnectWithWillMessage {
+    val id = V5DisconnectReasonCodeRaw(buffer.readUByte())
+    return V5DisconnectReasonCode.DisconnectWithWillMessage(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5DisconnectReasonCode.DisconnectWithWillMessage,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5DisconnectReasonCode.DisconnectWithWillMessage, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeImplementationSpecificErrorCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeImplementationSpecificErrorCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.disconnectrc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5DisconnectReasonCodeImplementationSpecificErrorCodec : Codec<V5DisconnectReasonCode.ImplementationSpecificError> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5DisconnectReasonCode.ImplementationSpecificError {
+    val id = V5DisconnectReasonCodeRaw(buffer.readUByte())
+    return V5DisconnectReasonCode.ImplementationSpecificError(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5DisconnectReasonCode.ImplementationSpecificError,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5DisconnectReasonCode.ImplementationSpecificError, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeKeepAliveTimeoutCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeKeepAliveTimeoutCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.disconnectrc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5DisconnectReasonCodeKeepAliveTimeoutCodec : Codec<V5DisconnectReasonCode.KeepAliveTimeout> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5DisconnectReasonCode.KeepAliveTimeout {
+    val id = V5DisconnectReasonCodeRaw(buffer.readUByte())
+    return V5DisconnectReasonCode.KeepAliveTimeout(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5DisconnectReasonCode.KeepAliveTimeout,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5DisconnectReasonCode.KeepAliveTimeout, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeMalformedPacketCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeMalformedPacketCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.disconnectrc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5DisconnectReasonCodeMalformedPacketCodec : Codec<V5DisconnectReasonCode.MalformedPacket> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5DisconnectReasonCode.MalformedPacket {
+    val id = V5DisconnectReasonCodeRaw(buffer.readUByte())
+    return V5DisconnectReasonCode.MalformedPacket(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5DisconnectReasonCode.MalformedPacket,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5DisconnectReasonCode.MalformedPacket, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeMaximumConnectTimeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeMaximumConnectTimeCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.disconnectrc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5DisconnectReasonCodeMaximumConnectTimeCodec : Codec<V5DisconnectReasonCode.MaximumConnectTime> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5DisconnectReasonCode.MaximumConnectTime {
+    val id = V5DisconnectReasonCodeRaw(buffer.readUByte())
+    return V5DisconnectReasonCode.MaximumConnectTime(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5DisconnectReasonCode.MaximumConnectTime,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5DisconnectReasonCode.MaximumConnectTime, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeNormalDisconnectionCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeNormalDisconnectionCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.disconnectrc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5DisconnectReasonCodeNormalDisconnectionCodec : Codec<V5DisconnectReasonCode.NormalDisconnection> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5DisconnectReasonCode.NormalDisconnection {
+    val id = V5DisconnectReasonCodeRaw(buffer.readUByte())
+    return V5DisconnectReasonCode.NormalDisconnection(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5DisconnectReasonCode.NormalDisconnection,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5DisconnectReasonCode.NormalDisconnection, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeNotAuthorizedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeNotAuthorizedCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.disconnectrc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5DisconnectReasonCodeNotAuthorizedCodec : Codec<V5DisconnectReasonCode.NotAuthorized> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5DisconnectReasonCode.NotAuthorized {
+    val id = V5DisconnectReasonCodeRaw(buffer.readUByte())
+    return V5DisconnectReasonCode.NotAuthorized(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5DisconnectReasonCode.NotAuthorized,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5DisconnectReasonCode.NotAuthorized, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodePacketTooLargeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodePacketTooLargeCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.disconnectrc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5DisconnectReasonCodePacketTooLargeCodec : Codec<V5DisconnectReasonCode.PacketTooLarge> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5DisconnectReasonCode.PacketTooLarge {
+    val id = V5DisconnectReasonCodeRaw(buffer.readUByte())
+    return V5DisconnectReasonCode.PacketTooLarge(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5DisconnectReasonCode.PacketTooLarge,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5DisconnectReasonCode.PacketTooLarge, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodePayloadFormatInvalidCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodePayloadFormatInvalidCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.disconnectrc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5DisconnectReasonCodePayloadFormatInvalidCodec : Codec<V5DisconnectReasonCode.PayloadFormatInvalid> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5DisconnectReasonCode.PayloadFormatInvalid {
+    val id = V5DisconnectReasonCodeRaw(buffer.readUByte())
+    return V5DisconnectReasonCode.PayloadFormatInvalid(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5DisconnectReasonCode.PayloadFormatInvalid,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5DisconnectReasonCode.PayloadFormatInvalid, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeProtocolErrorCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeProtocolErrorCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.disconnectrc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5DisconnectReasonCodeProtocolErrorCodec : Codec<V5DisconnectReasonCode.ProtocolError> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5DisconnectReasonCode.ProtocolError {
+    val id = V5DisconnectReasonCodeRaw(buffer.readUByte())
+    return V5DisconnectReasonCode.ProtocolError(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5DisconnectReasonCode.ProtocolError,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5DisconnectReasonCode.ProtocolError, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeQoSNotSupportedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeQoSNotSupportedCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.disconnectrc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5DisconnectReasonCodeQoSNotSupportedCodec : Codec<V5DisconnectReasonCode.QoSNotSupported> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5DisconnectReasonCode.QoSNotSupported {
+    val id = V5DisconnectReasonCodeRaw(buffer.readUByte())
+    return V5DisconnectReasonCode.QoSNotSupported(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5DisconnectReasonCode.QoSNotSupported,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5DisconnectReasonCode.QoSNotSupported, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeQuotaExceededCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeQuotaExceededCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.disconnectrc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5DisconnectReasonCodeQuotaExceededCodec : Codec<V5DisconnectReasonCode.QuotaExceeded> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5DisconnectReasonCode.QuotaExceeded {
+    val id = V5DisconnectReasonCodeRaw(buffer.readUByte())
+    return V5DisconnectReasonCode.QuotaExceeded(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5DisconnectReasonCode.QuotaExceeded,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5DisconnectReasonCode.QuotaExceeded, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeRawCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeRawCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.disconnectrc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5DisconnectReasonCodeRawCodec : Codec<V5DisconnectReasonCodeRaw> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5DisconnectReasonCodeRaw {
+    val raw = buffer.readUByte()
+    return V5DisconnectReasonCodeRaw(raw = raw)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5DisconnectReasonCodeRaw,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.raw)
+  }
+
+  override fun wireSize(`value`: V5DisconnectReasonCodeRaw, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeReceiveMaximumExceededCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeReceiveMaximumExceededCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.disconnectrc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5DisconnectReasonCodeReceiveMaximumExceededCodec : Codec<V5DisconnectReasonCode.ReceiveMaximumExceeded> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5DisconnectReasonCode.ReceiveMaximumExceeded {
+    val id = V5DisconnectReasonCodeRaw(buffer.readUByte())
+    return V5DisconnectReasonCode.ReceiveMaximumExceeded(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5DisconnectReasonCode.ReceiveMaximumExceeded,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5DisconnectReasonCode.ReceiveMaximumExceeded, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeRetainNotSupportedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeRetainNotSupportedCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.disconnectrc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5DisconnectReasonCodeRetainNotSupportedCodec : Codec<V5DisconnectReasonCode.RetainNotSupported> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5DisconnectReasonCode.RetainNotSupported {
+    val id = V5DisconnectReasonCodeRaw(buffer.readUByte())
+    return V5DisconnectReasonCode.RetainNotSupported(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5DisconnectReasonCode.RetainNotSupported,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5DisconnectReasonCode.RetainNotSupported, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeServerBusyCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeServerBusyCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.disconnectrc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5DisconnectReasonCodeServerBusyCodec : Codec<V5DisconnectReasonCode.ServerBusy> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5DisconnectReasonCode.ServerBusy {
+    val id = V5DisconnectReasonCodeRaw(buffer.readUByte())
+    return V5DisconnectReasonCode.ServerBusy(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5DisconnectReasonCode.ServerBusy,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5DisconnectReasonCode.ServerBusy, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeServerMovedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeServerMovedCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.disconnectrc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5DisconnectReasonCodeServerMovedCodec : Codec<V5DisconnectReasonCode.ServerMoved> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5DisconnectReasonCode.ServerMoved {
+    val id = V5DisconnectReasonCodeRaw(buffer.readUByte())
+    return V5DisconnectReasonCode.ServerMoved(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5DisconnectReasonCode.ServerMoved,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5DisconnectReasonCode.ServerMoved, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeServerShuttingDownCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeServerShuttingDownCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.disconnectrc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5DisconnectReasonCodeServerShuttingDownCodec : Codec<V5DisconnectReasonCode.ServerShuttingDown> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5DisconnectReasonCode.ServerShuttingDown {
+    val id = V5DisconnectReasonCodeRaw(buffer.readUByte())
+    return V5DisconnectReasonCode.ServerShuttingDown(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5DisconnectReasonCode.ServerShuttingDown,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5DisconnectReasonCode.ServerShuttingDown, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeSessionTakenOverCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeSessionTakenOverCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.disconnectrc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5DisconnectReasonCodeSessionTakenOverCodec : Codec<V5DisconnectReasonCode.SessionTakenOver> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5DisconnectReasonCode.SessionTakenOver {
+    val id = V5DisconnectReasonCodeRaw(buffer.readUByte())
+    return V5DisconnectReasonCode.SessionTakenOver(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5DisconnectReasonCode.SessionTakenOver,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5DisconnectReasonCode.SessionTakenOver, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeSharedSubscriptionsNotSupportedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeSharedSubscriptionsNotSupportedCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.disconnectrc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5DisconnectReasonCodeSharedSubscriptionsNotSupportedCodec : Codec<V5DisconnectReasonCode.SharedSubscriptionsNotSupported> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5DisconnectReasonCode.SharedSubscriptionsNotSupported {
+    val id = V5DisconnectReasonCodeRaw(buffer.readUByte())
+    return V5DisconnectReasonCode.SharedSubscriptionsNotSupported(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5DisconnectReasonCode.SharedSubscriptionsNotSupported,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5DisconnectReasonCode.SharedSubscriptionsNotSupported, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeSubscriptionIdentifiersNotSupportedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeSubscriptionIdentifiersNotSupportedCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.disconnectrc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5DisconnectReasonCodeSubscriptionIdentifiersNotSupportedCodec : Codec<V5DisconnectReasonCode.SubscriptionIdentifiersNotSupported> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5DisconnectReasonCode.SubscriptionIdentifiersNotSupported {
+    val id = V5DisconnectReasonCodeRaw(buffer.readUByte())
+    return V5DisconnectReasonCode.SubscriptionIdentifiersNotSupported(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5DisconnectReasonCode.SubscriptionIdentifiersNotSupported,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5DisconnectReasonCode.SubscriptionIdentifiersNotSupported, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeTopicAliasInvalidCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeTopicAliasInvalidCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.disconnectrc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5DisconnectReasonCodeTopicAliasInvalidCodec : Codec<V5DisconnectReasonCode.TopicAliasInvalid> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5DisconnectReasonCode.TopicAliasInvalid {
+    val id = V5DisconnectReasonCodeRaw(buffer.readUByte())
+    return V5DisconnectReasonCode.TopicAliasInvalid(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5DisconnectReasonCode.TopicAliasInvalid,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5DisconnectReasonCode.TopicAliasInvalid, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeTopicFilterInvalidCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeTopicFilterInvalidCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.disconnectrc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5DisconnectReasonCodeTopicFilterInvalidCodec : Codec<V5DisconnectReasonCode.TopicFilterInvalid> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5DisconnectReasonCode.TopicFilterInvalid {
+    val id = V5DisconnectReasonCodeRaw(buffer.readUByte())
+    return V5DisconnectReasonCode.TopicFilterInvalid(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5DisconnectReasonCode.TopicFilterInvalid,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5DisconnectReasonCode.TopicFilterInvalid, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeTopicNameInvalidCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeTopicNameInvalidCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.disconnectrc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5DisconnectReasonCodeTopicNameInvalidCodec : Codec<V5DisconnectReasonCode.TopicNameInvalid> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5DisconnectReasonCode.TopicNameInvalid {
+    val id = V5DisconnectReasonCodeRaw(buffer.readUByte())
+    return V5DisconnectReasonCode.TopicNameInvalid(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5DisconnectReasonCode.TopicNameInvalid,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5DisconnectReasonCode.TopicNameInvalid, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeUnspecifiedErrorCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeUnspecifiedErrorCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.disconnectrc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5DisconnectReasonCodeUnspecifiedErrorCodec : Codec<V5DisconnectReasonCode.UnspecifiedError> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5DisconnectReasonCode.UnspecifiedError {
+    val id = V5DisconnectReasonCodeRaw(buffer.readUByte())
+    return V5DisconnectReasonCode.UnspecifiedError(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5DisconnectReasonCode.UnspecifiedError,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5DisconnectReasonCode.UnspecifiedError, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeUseAnotherServerCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeUseAnotherServerCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.disconnectrc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5DisconnectReasonCodeUseAnotherServerCodec : Codec<V5DisconnectReasonCode.UseAnotherServer> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5DisconnectReasonCode.UseAnotherServer {
+    val id = V5DisconnectReasonCodeRaw(buffer.readUByte())
+    return V5DisconnectReasonCode.UseAnotherServer(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5DisconnectReasonCode.UseAnotherServer,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5DisconnectReasonCode.UseAnotherServer, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeWildcardSubscriptionsNotSupportedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeWildcardSubscriptionsNotSupportedCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.disconnectrc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5DisconnectReasonCodeWildcardSubscriptionsNotSupportedCodec : Codec<V5DisconnectReasonCode.WildcardSubscriptionsNotSupported> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5DisconnectReasonCode.WildcardSubscriptionsNotSupported {
+    val id = V5DisconnectReasonCodeRaw(buffer.readUByte())
+    return V5DisconnectReasonCode.WildcardSubscriptionsNotSupported(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5DisconnectReasonCode.WildcardSubscriptionsNotSupported,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5DisconnectReasonCode.WildcardSubscriptionsNotSupported, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodeCodec.kt
@@ -1,0 +1,90 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.puback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5PubAckReasonCodeCodec : Codec<V5PubAckReasonCode> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5PubAckReasonCode {
+    val discriminatorPosition = buffer.position()
+    val __discriminator = V5PubAckReasonCodeRawCodec.decode(buffer, context)
+    buffer.position(discriminatorPosition)
+    val __dispatchValue = __discriminator.id
+    return when (__dispatchValue) {
+      0 -> V5PubAckReasonCodeSuccessCodec.decode(buffer, context)
+      16 -> V5PubAckReasonCodeNoMatchingSubscribersCodec.decode(buffer, context)
+      128 -> V5PubAckReasonCodeUnspecifiedErrorCodec.decode(buffer, context)
+      131 -> V5PubAckReasonCodeImplementationSpecificErrorCodec.decode(buffer, context)
+      135 -> V5PubAckReasonCodeNotAuthorizedCodec.decode(buffer, context)
+      144 -> V5PubAckReasonCodeTopicNameInvalidCodec.decode(buffer, context)
+      145 -> V5PubAckReasonCodePacketIdentifierInUseCodec.decode(buffer, context)
+      146 -> V5PubAckReasonCodePacketIdentifierNotFoundCodec.decode(buffer, context)
+      151 -> V5PubAckReasonCodeQuotaExceededCodec.decode(buffer, context)
+      153 -> V5PubAckReasonCodePayloadFormatInvalidCodec.decode(buffer, context)
+      else -> {
+        throw DecodeException(fieldPath = "V5PubAckReasonCode.discriminator", bufferPosition = discriminatorPosition, expected = "one of {0, 16, 128, 131, 135, 144, 145, 146, 151, 153}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5PubAckReasonCode,
+    context: EncodeContext,
+  ) {
+    when (value) {
+      is V5PubAckReasonCode.Success -> V5PubAckReasonCodeSuccessCodec.encode(buffer, value, context)
+      is V5PubAckReasonCode.NoMatchingSubscribers -> V5PubAckReasonCodeNoMatchingSubscribersCodec.encode(buffer, value, context)
+      is V5PubAckReasonCode.UnspecifiedError -> V5PubAckReasonCodeUnspecifiedErrorCodec.encode(buffer, value, context)
+      is V5PubAckReasonCode.ImplementationSpecificError -> V5PubAckReasonCodeImplementationSpecificErrorCodec.encode(buffer, value, context)
+      is V5PubAckReasonCode.NotAuthorized -> V5PubAckReasonCodeNotAuthorizedCodec.encode(buffer, value, context)
+      is V5PubAckReasonCode.TopicNameInvalid -> V5PubAckReasonCodeTopicNameInvalidCodec.encode(buffer, value, context)
+      is V5PubAckReasonCode.PacketIdentifierInUse -> V5PubAckReasonCodePacketIdentifierInUseCodec.encode(buffer, value, context)
+      is V5PubAckReasonCode.PacketIdentifierNotFound -> V5PubAckReasonCodePacketIdentifierNotFoundCodec.encode(buffer, value, context)
+      is V5PubAckReasonCode.QuotaExceeded -> V5PubAckReasonCodeQuotaExceededCodec.encode(buffer, value, context)
+      is V5PubAckReasonCode.PayloadFormatInvalid -> V5PubAckReasonCodePayloadFormatInvalidCodec.encode(buffer, value, context)
+    }
+  }
+
+  override fun wireSize(`value`: V5PubAckReasonCode, context: EncodeContext): WireSize = when (value) {
+    is V5PubAckReasonCode.Success -> V5PubAckReasonCodeSuccessCodec.wireSize(value, context)
+    is V5PubAckReasonCode.NoMatchingSubscribers -> V5PubAckReasonCodeNoMatchingSubscribersCodec.wireSize(value, context)
+    is V5PubAckReasonCode.UnspecifiedError -> V5PubAckReasonCodeUnspecifiedErrorCodec.wireSize(value, context)
+    is V5PubAckReasonCode.ImplementationSpecificError -> V5PubAckReasonCodeImplementationSpecificErrorCodec.wireSize(value, context)
+    is V5PubAckReasonCode.NotAuthorized -> V5PubAckReasonCodeNotAuthorizedCodec.wireSize(value, context)
+    is V5PubAckReasonCode.TopicNameInvalid -> V5PubAckReasonCodeTopicNameInvalidCodec.wireSize(value, context)
+    is V5PubAckReasonCode.PacketIdentifierInUse -> V5PubAckReasonCodePacketIdentifierInUseCodec.wireSize(value, context)
+    is V5PubAckReasonCode.PacketIdentifierNotFound -> V5PubAckReasonCodePacketIdentifierNotFoundCodec.wireSize(value, context)
+    is V5PubAckReasonCode.QuotaExceeded -> V5PubAckReasonCodeQuotaExceededCodec.wireSize(value, context)
+    is V5PubAckReasonCode.PayloadFormatInvalid -> V5PubAckReasonCodePayloadFormatInvalidCodec.wireSize(value, context)
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
+    val __discRaw = stream.peekByte(baseOffset + 0).toUByte()
+    val __discriminator = V5PubAckReasonCodeRaw(__discRaw)
+    val __dispatchValue = __discriminator.id
+    return when (__dispatchValue) {
+      0 -> V5PubAckReasonCodeSuccessCodec.peekFrameSize(stream, baseOffset)
+      16 -> V5PubAckReasonCodeNoMatchingSubscribersCodec.peekFrameSize(stream, baseOffset)
+      128 -> V5PubAckReasonCodeUnspecifiedErrorCodec.peekFrameSize(stream, baseOffset)
+      131 -> V5PubAckReasonCodeImplementationSpecificErrorCodec.peekFrameSize(stream, baseOffset)
+      135 -> V5PubAckReasonCodeNotAuthorizedCodec.peekFrameSize(stream, baseOffset)
+      144 -> V5PubAckReasonCodeTopicNameInvalidCodec.peekFrameSize(stream, baseOffset)
+      145 -> V5PubAckReasonCodePacketIdentifierInUseCodec.peekFrameSize(stream, baseOffset)
+      146 -> V5PubAckReasonCodePacketIdentifierNotFoundCodec.peekFrameSize(stream, baseOffset)
+      151 -> V5PubAckReasonCodeQuotaExceededCodec.peekFrameSize(stream, baseOffset)
+      153 -> V5PubAckReasonCodePayloadFormatInvalidCodec.peekFrameSize(stream, baseOffset)
+      else -> {
+        throw DecodeException(fieldPath = "V5PubAckReasonCode.discriminator", bufferPosition = baseOffset, expected = "one of {0, 16, 128, 131, 135, 144, 145, 146, 151, 153}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodeImplementationSpecificErrorCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodeImplementationSpecificErrorCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.puback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5PubAckReasonCodeImplementationSpecificErrorCodec : Codec<V5PubAckReasonCode.ImplementationSpecificError> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5PubAckReasonCode.ImplementationSpecificError {
+    val id = V5PubAckReasonCodeRaw(buffer.readUByte())
+    return V5PubAckReasonCode.ImplementationSpecificError(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5PubAckReasonCode.ImplementationSpecificError,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5PubAckReasonCode.ImplementationSpecificError, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodeNoMatchingSubscribersCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodeNoMatchingSubscribersCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.puback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5PubAckReasonCodeNoMatchingSubscribersCodec : Codec<V5PubAckReasonCode.NoMatchingSubscribers> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5PubAckReasonCode.NoMatchingSubscribers {
+    val id = V5PubAckReasonCodeRaw(buffer.readUByte())
+    return V5PubAckReasonCode.NoMatchingSubscribers(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5PubAckReasonCode.NoMatchingSubscribers,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5PubAckReasonCode.NoMatchingSubscribers, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodeNotAuthorizedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodeNotAuthorizedCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.puback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5PubAckReasonCodeNotAuthorizedCodec : Codec<V5PubAckReasonCode.NotAuthorized> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5PubAckReasonCode.NotAuthorized {
+    val id = V5PubAckReasonCodeRaw(buffer.readUByte())
+    return V5PubAckReasonCode.NotAuthorized(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5PubAckReasonCode.NotAuthorized,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5PubAckReasonCode.NotAuthorized, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodePacketIdentifierInUseCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodePacketIdentifierInUseCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.puback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5PubAckReasonCodePacketIdentifierInUseCodec : Codec<V5PubAckReasonCode.PacketIdentifierInUse> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5PubAckReasonCode.PacketIdentifierInUse {
+    val id = V5PubAckReasonCodeRaw(buffer.readUByte())
+    return V5PubAckReasonCode.PacketIdentifierInUse(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5PubAckReasonCode.PacketIdentifierInUse,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5PubAckReasonCode.PacketIdentifierInUse, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodePacketIdentifierNotFoundCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodePacketIdentifierNotFoundCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.puback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5PubAckReasonCodePacketIdentifierNotFoundCodec : Codec<V5PubAckReasonCode.PacketIdentifierNotFound> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5PubAckReasonCode.PacketIdentifierNotFound {
+    val id = V5PubAckReasonCodeRaw(buffer.readUByte())
+    return V5PubAckReasonCode.PacketIdentifierNotFound(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5PubAckReasonCode.PacketIdentifierNotFound,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5PubAckReasonCode.PacketIdentifierNotFound, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodePayloadFormatInvalidCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodePayloadFormatInvalidCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.puback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5PubAckReasonCodePayloadFormatInvalidCodec : Codec<V5PubAckReasonCode.PayloadFormatInvalid> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5PubAckReasonCode.PayloadFormatInvalid {
+    val id = V5PubAckReasonCodeRaw(buffer.readUByte())
+    return V5PubAckReasonCode.PayloadFormatInvalid(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5PubAckReasonCode.PayloadFormatInvalid,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5PubAckReasonCode.PayloadFormatInvalid, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodeQuotaExceededCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodeQuotaExceededCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.puback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5PubAckReasonCodeQuotaExceededCodec : Codec<V5PubAckReasonCode.QuotaExceeded> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5PubAckReasonCode.QuotaExceeded {
+    val id = V5PubAckReasonCodeRaw(buffer.readUByte())
+    return V5PubAckReasonCode.QuotaExceeded(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5PubAckReasonCode.QuotaExceeded,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5PubAckReasonCode.QuotaExceeded, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodeRawCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodeRawCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.puback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5PubAckReasonCodeRawCodec : Codec<V5PubAckReasonCodeRaw> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5PubAckReasonCodeRaw {
+    val raw = buffer.readUByte()
+    return V5PubAckReasonCodeRaw(raw = raw)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5PubAckReasonCodeRaw,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.raw)
+  }
+
+  override fun wireSize(`value`: V5PubAckReasonCodeRaw, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodeSuccessCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodeSuccessCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.puback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5PubAckReasonCodeSuccessCodec : Codec<V5PubAckReasonCode.Success> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5PubAckReasonCode.Success {
+    val id = V5PubAckReasonCodeRaw(buffer.readUByte())
+    return V5PubAckReasonCode.Success(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5PubAckReasonCode.Success,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5PubAckReasonCode.Success, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodeTopicNameInvalidCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodeTopicNameInvalidCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.puback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5PubAckReasonCodeTopicNameInvalidCodec : Codec<V5PubAckReasonCode.TopicNameInvalid> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5PubAckReasonCode.TopicNameInvalid {
+    val id = V5PubAckReasonCodeRaw(buffer.readUByte())
+    return V5PubAckReasonCode.TopicNameInvalid(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5PubAckReasonCode.TopicNameInvalid,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5PubAckReasonCode.TopicNameInvalid, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodeUnspecifiedErrorCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodeUnspecifiedErrorCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.puback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5PubAckReasonCodeUnspecifiedErrorCodec : Codec<V5PubAckReasonCode.UnspecifiedError> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5PubAckReasonCode.UnspecifiedError {
+    val id = V5PubAckReasonCodeRaw(buffer.readUByte())
+    return V5PubAckReasonCode.UnspecifiedError(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5PubAckReasonCode.UnspecifiedError,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5PubAckReasonCode.UnspecifiedError, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeCodec.kt
@@ -1,0 +1,98 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.suback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5SubAckReasonCodeCodec : Codec<V5SubAckReasonCode> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5SubAckReasonCode {
+    val discriminatorPosition = buffer.position()
+    val __discriminator = V5SubAckReasonCodeRawCodec.decode(buffer, context)
+    buffer.position(discriminatorPosition)
+    val __dispatchValue = __discriminator.id
+    return when (__dispatchValue) {
+      0 -> V5SubAckReasonCodeGrantedQoS0Codec.decode(buffer, context)
+      1 -> V5SubAckReasonCodeGrantedQoS1Codec.decode(buffer, context)
+      2 -> V5SubAckReasonCodeGrantedQoS2Codec.decode(buffer, context)
+      128 -> V5SubAckReasonCodeUnspecifiedErrorCodec.decode(buffer, context)
+      131 -> V5SubAckReasonCodeImplementationSpecificErrorCodec.decode(buffer, context)
+      135 -> V5SubAckReasonCodeNotAuthorizedCodec.decode(buffer, context)
+      143 -> V5SubAckReasonCodeTopicFilterInvalidCodec.decode(buffer, context)
+      145 -> V5SubAckReasonCodePacketIdentifierInUseCodec.decode(buffer, context)
+      151 -> V5SubAckReasonCodeQuotaExceededCodec.decode(buffer, context)
+      158 -> V5SubAckReasonCodeSharedSubscriptionsNotSupportedCodec.decode(buffer, context)
+      161 -> V5SubAckReasonCodeSubscriptionIdentifiersNotSupportedCodec.decode(buffer, context)
+      162 -> V5SubAckReasonCodeWildcardSubscriptionsNotSupportedCodec.decode(buffer, context)
+      else -> {
+        throw DecodeException(fieldPath = "V5SubAckReasonCode.discriminator", bufferPosition = discriminatorPosition, expected = "one of {0, 1, 2, 128, 131, 135, 143, 145, 151, 158, 161, 162}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5SubAckReasonCode,
+    context: EncodeContext,
+  ) {
+    when (value) {
+      is V5SubAckReasonCode.GrantedQoS0 -> V5SubAckReasonCodeGrantedQoS0Codec.encode(buffer, value, context)
+      is V5SubAckReasonCode.GrantedQoS1 -> V5SubAckReasonCodeGrantedQoS1Codec.encode(buffer, value, context)
+      is V5SubAckReasonCode.GrantedQoS2 -> V5SubAckReasonCodeGrantedQoS2Codec.encode(buffer, value, context)
+      is V5SubAckReasonCode.UnspecifiedError -> V5SubAckReasonCodeUnspecifiedErrorCodec.encode(buffer, value, context)
+      is V5SubAckReasonCode.ImplementationSpecificError -> V5SubAckReasonCodeImplementationSpecificErrorCodec.encode(buffer, value, context)
+      is V5SubAckReasonCode.NotAuthorized -> V5SubAckReasonCodeNotAuthorizedCodec.encode(buffer, value, context)
+      is V5SubAckReasonCode.TopicFilterInvalid -> V5SubAckReasonCodeTopicFilterInvalidCodec.encode(buffer, value, context)
+      is V5SubAckReasonCode.PacketIdentifierInUse -> V5SubAckReasonCodePacketIdentifierInUseCodec.encode(buffer, value, context)
+      is V5SubAckReasonCode.QuotaExceeded -> V5SubAckReasonCodeQuotaExceededCodec.encode(buffer, value, context)
+      is V5SubAckReasonCode.SharedSubscriptionsNotSupported -> V5SubAckReasonCodeSharedSubscriptionsNotSupportedCodec.encode(buffer, value, context)
+      is V5SubAckReasonCode.SubscriptionIdentifiersNotSupported -> V5SubAckReasonCodeSubscriptionIdentifiersNotSupportedCodec.encode(buffer, value, context)
+      is V5SubAckReasonCode.WildcardSubscriptionsNotSupported -> V5SubAckReasonCodeWildcardSubscriptionsNotSupportedCodec.encode(buffer, value, context)
+    }
+  }
+
+  override fun wireSize(`value`: V5SubAckReasonCode, context: EncodeContext): WireSize = when (value) {
+    is V5SubAckReasonCode.GrantedQoS0 -> V5SubAckReasonCodeGrantedQoS0Codec.wireSize(value, context)
+    is V5SubAckReasonCode.GrantedQoS1 -> V5SubAckReasonCodeGrantedQoS1Codec.wireSize(value, context)
+    is V5SubAckReasonCode.GrantedQoS2 -> V5SubAckReasonCodeGrantedQoS2Codec.wireSize(value, context)
+    is V5SubAckReasonCode.UnspecifiedError -> V5SubAckReasonCodeUnspecifiedErrorCodec.wireSize(value, context)
+    is V5SubAckReasonCode.ImplementationSpecificError -> V5SubAckReasonCodeImplementationSpecificErrorCodec.wireSize(value, context)
+    is V5SubAckReasonCode.NotAuthorized -> V5SubAckReasonCodeNotAuthorizedCodec.wireSize(value, context)
+    is V5SubAckReasonCode.TopicFilterInvalid -> V5SubAckReasonCodeTopicFilterInvalidCodec.wireSize(value, context)
+    is V5SubAckReasonCode.PacketIdentifierInUse -> V5SubAckReasonCodePacketIdentifierInUseCodec.wireSize(value, context)
+    is V5SubAckReasonCode.QuotaExceeded -> V5SubAckReasonCodeQuotaExceededCodec.wireSize(value, context)
+    is V5SubAckReasonCode.SharedSubscriptionsNotSupported -> V5SubAckReasonCodeSharedSubscriptionsNotSupportedCodec.wireSize(value, context)
+    is V5SubAckReasonCode.SubscriptionIdentifiersNotSupported -> V5SubAckReasonCodeSubscriptionIdentifiersNotSupportedCodec.wireSize(value, context)
+    is V5SubAckReasonCode.WildcardSubscriptionsNotSupported -> V5SubAckReasonCodeWildcardSubscriptionsNotSupportedCodec.wireSize(value, context)
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
+    val __discRaw = stream.peekByte(baseOffset + 0).toUByte()
+    val __discriminator = V5SubAckReasonCodeRaw(__discRaw)
+    val __dispatchValue = __discriminator.id
+    return when (__dispatchValue) {
+      0 -> V5SubAckReasonCodeGrantedQoS0Codec.peekFrameSize(stream, baseOffset)
+      1 -> V5SubAckReasonCodeGrantedQoS1Codec.peekFrameSize(stream, baseOffset)
+      2 -> V5SubAckReasonCodeGrantedQoS2Codec.peekFrameSize(stream, baseOffset)
+      128 -> V5SubAckReasonCodeUnspecifiedErrorCodec.peekFrameSize(stream, baseOffset)
+      131 -> V5SubAckReasonCodeImplementationSpecificErrorCodec.peekFrameSize(stream, baseOffset)
+      135 -> V5SubAckReasonCodeNotAuthorizedCodec.peekFrameSize(stream, baseOffset)
+      143 -> V5SubAckReasonCodeTopicFilterInvalidCodec.peekFrameSize(stream, baseOffset)
+      145 -> V5SubAckReasonCodePacketIdentifierInUseCodec.peekFrameSize(stream, baseOffset)
+      151 -> V5SubAckReasonCodeQuotaExceededCodec.peekFrameSize(stream, baseOffset)
+      158 -> V5SubAckReasonCodeSharedSubscriptionsNotSupportedCodec.peekFrameSize(stream, baseOffset)
+      161 -> V5SubAckReasonCodeSubscriptionIdentifiersNotSupportedCodec.peekFrameSize(stream, baseOffset)
+      162 -> V5SubAckReasonCodeWildcardSubscriptionsNotSupportedCodec.peekFrameSize(stream, baseOffset)
+      else -> {
+        throw DecodeException(fieldPath = "V5SubAckReasonCode.discriminator", bufferPosition = baseOffset, expected = "one of {0, 1, 2, 128, 131, 135, 143, 145, 151, 158, 161, 162}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeGrantedQoS0Codec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeGrantedQoS0Codec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.suback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5SubAckReasonCodeGrantedQoS0Codec : Codec<V5SubAckReasonCode.GrantedQoS0> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5SubAckReasonCode.GrantedQoS0 {
+    val id = V5SubAckReasonCodeRaw(buffer.readUByte())
+    return V5SubAckReasonCode.GrantedQoS0(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5SubAckReasonCode.GrantedQoS0,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5SubAckReasonCode.GrantedQoS0, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeGrantedQoS1Codec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeGrantedQoS1Codec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.suback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5SubAckReasonCodeGrantedQoS1Codec : Codec<V5SubAckReasonCode.GrantedQoS1> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5SubAckReasonCode.GrantedQoS1 {
+    val id = V5SubAckReasonCodeRaw(buffer.readUByte())
+    return V5SubAckReasonCode.GrantedQoS1(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5SubAckReasonCode.GrantedQoS1,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5SubAckReasonCode.GrantedQoS1, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeGrantedQoS2Codec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeGrantedQoS2Codec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.suback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5SubAckReasonCodeGrantedQoS2Codec : Codec<V5SubAckReasonCode.GrantedQoS2> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5SubAckReasonCode.GrantedQoS2 {
+    val id = V5SubAckReasonCodeRaw(buffer.readUByte())
+    return V5SubAckReasonCode.GrantedQoS2(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5SubAckReasonCode.GrantedQoS2,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5SubAckReasonCode.GrantedQoS2, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeImplementationSpecificErrorCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeImplementationSpecificErrorCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.suback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5SubAckReasonCodeImplementationSpecificErrorCodec : Codec<V5SubAckReasonCode.ImplementationSpecificError> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5SubAckReasonCode.ImplementationSpecificError {
+    val id = V5SubAckReasonCodeRaw(buffer.readUByte())
+    return V5SubAckReasonCode.ImplementationSpecificError(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5SubAckReasonCode.ImplementationSpecificError,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5SubAckReasonCode.ImplementationSpecificError, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeNotAuthorizedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeNotAuthorizedCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.suback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5SubAckReasonCodeNotAuthorizedCodec : Codec<V5SubAckReasonCode.NotAuthorized> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5SubAckReasonCode.NotAuthorized {
+    val id = V5SubAckReasonCodeRaw(buffer.readUByte())
+    return V5SubAckReasonCode.NotAuthorized(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5SubAckReasonCode.NotAuthorized,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5SubAckReasonCode.NotAuthorized, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodePacketIdentifierInUseCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodePacketIdentifierInUseCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.suback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5SubAckReasonCodePacketIdentifierInUseCodec : Codec<V5SubAckReasonCode.PacketIdentifierInUse> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5SubAckReasonCode.PacketIdentifierInUse {
+    val id = V5SubAckReasonCodeRaw(buffer.readUByte())
+    return V5SubAckReasonCode.PacketIdentifierInUse(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5SubAckReasonCode.PacketIdentifierInUse,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5SubAckReasonCode.PacketIdentifierInUse, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeQuotaExceededCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeQuotaExceededCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.suback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5SubAckReasonCodeQuotaExceededCodec : Codec<V5SubAckReasonCode.QuotaExceeded> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5SubAckReasonCode.QuotaExceeded {
+    val id = V5SubAckReasonCodeRaw(buffer.readUByte())
+    return V5SubAckReasonCode.QuotaExceeded(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5SubAckReasonCode.QuotaExceeded,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5SubAckReasonCode.QuotaExceeded, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeRawCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeRawCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.suback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5SubAckReasonCodeRawCodec : Codec<V5SubAckReasonCodeRaw> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5SubAckReasonCodeRaw {
+    val raw = buffer.readUByte()
+    return V5SubAckReasonCodeRaw(raw = raw)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5SubAckReasonCodeRaw,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.raw)
+  }
+
+  override fun wireSize(`value`: V5SubAckReasonCodeRaw, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeSharedSubscriptionsNotSupportedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeSharedSubscriptionsNotSupportedCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.suback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5SubAckReasonCodeSharedSubscriptionsNotSupportedCodec : Codec<V5SubAckReasonCode.SharedSubscriptionsNotSupported> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5SubAckReasonCode.SharedSubscriptionsNotSupported {
+    val id = V5SubAckReasonCodeRaw(buffer.readUByte())
+    return V5SubAckReasonCode.SharedSubscriptionsNotSupported(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5SubAckReasonCode.SharedSubscriptionsNotSupported,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5SubAckReasonCode.SharedSubscriptionsNotSupported, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeSubscriptionIdentifiersNotSupportedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeSubscriptionIdentifiersNotSupportedCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.suback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5SubAckReasonCodeSubscriptionIdentifiersNotSupportedCodec : Codec<V5SubAckReasonCode.SubscriptionIdentifiersNotSupported> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5SubAckReasonCode.SubscriptionIdentifiersNotSupported {
+    val id = V5SubAckReasonCodeRaw(buffer.readUByte())
+    return V5SubAckReasonCode.SubscriptionIdentifiersNotSupported(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5SubAckReasonCode.SubscriptionIdentifiersNotSupported,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5SubAckReasonCode.SubscriptionIdentifiersNotSupported, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeTopicFilterInvalidCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeTopicFilterInvalidCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.suback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5SubAckReasonCodeTopicFilterInvalidCodec : Codec<V5SubAckReasonCode.TopicFilterInvalid> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5SubAckReasonCode.TopicFilterInvalid {
+    val id = V5SubAckReasonCodeRaw(buffer.readUByte())
+    return V5SubAckReasonCode.TopicFilterInvalid(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5SubAckReasonCode.TopicFilterInvalid,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5SubAckReasonCode.TopicFilterInvalid, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeUnspecifiedErrorCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeUnspecifiedErrorCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.suback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5SubAckReasonCodeUnspecifiedErrorCodec : Codec<V5SubAckReasonCode.UnspecifiedError> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5SubAckReasonCode.UnspecifiedError {
+    val id = V5SubAckReasonCodeRaw(buffer.readUByte())
+    return V5SubAckReasonCode.UnspecifiedError(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5SubAckReasonCode.UnspecifiedError,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5SubAckReasonCode.UnspecifiedError, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeWildcardSubscriptionsNotSupportedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeWildcardSubscriptionsNotSupportedCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.suback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5SubAckReasonCodeWildcardSubscriptionsNotSupportedCodec : Codec<V5SubAckReasonCode.WildcardSubscriptionsNotSupported> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5SubAckReasonCode.WildcardSubscriptionsNotSupported {
+    val id = V5SubAckReasonCodeRaw(buffer.readUByte())
+    return V5SubAckReasonCode.WildcardSubscriptionsNotSupported(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5SubAckReasonCode.WildcardSubscriptionsNotSupported,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5SubAckReasonCode.WildcardSubscriptionsNotSupported, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/unsuback/V5UnsubAckReasonCodeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/unsuback/V5UnsubAckReasonCodeCodec.kt
@@ -1,0 +1,78 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.unsuback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5UnsubAckReasonCodeCodec : Codec<V5UnsubAckReasonCode> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5UnsubAckReasonCode {
+    val discriminatorPosition = buffer.position()
+    val __discriminator = V5UnsubAckReasonCodeRawCodec.decode(buffer, context)
+    buffer.position(discriminatorPosition)
+    val __dispatchValue = __discriminator.id
+    return when (__dispatchValue) {
+      0 -> V5UnsubAckReasonCodeSuccessCodec.decode(buffer, context)
+      17 -> V5UnsubAckReasonCodeNoSubscriptionExistedCodec.decode(buffer, context)
+      128 -> V5UnsubAckReasonCodeUnspecifiedErrorCodec.decode(buffer, context)
+      131 -> V5UnsubAckReasonCodeImplementationSpecificErrorCodec.decode(buffer, context)
+      135 -> V5UnsubAckReasonCodeNotAuthorizedCodec.decode(buffer, context)
+      143 -> V5UnsubAckReasonCodeTopicFilterInvalidCodec.decode(buffer, context)
+      145 -> V5UnsubAckReasonCodePacketIdentifierInUseCodec.decode(buffer, context)
+      else -> {
+        throw DecodeException(fieldPath = "V5UnsubAckReasonCode.discriminator", bufferPosition = discriminatorPosition, expected = "one of {0, 17, 128, 131, 135, 143, 145}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5UnsubAckReasonCode,
+    context: EncodeContext,
+  ) {
+    when (value) {
+      is V5UnsubAckReasonCode.Success -> V5UnsubAckReasonCodeSuccessCodec.encode(buffer, value, context)
+      is V5UnsubAckReasonCode.NoSubscriptionExisted -> V5UnsubAckReasonCodeNoSubscriptionExistedCodec.encode(buffer, value, context)
+      is V5UnsubAckReasonCode.UnspecifiedError -> V5UnsubAckReasonCodeUnspecifiedErrorCodec.encode(buffer, value, context)
+      is V5UnsubAckReasonCode.ImplementationSpecificError -> V5UnsubAckReasonCodeImplementationSpecificErrorCodec.encode(buffer, value, context)
+      is V5UnsubAckReasonCode.NotAuthorized -> V5UnsubAckReasonCodeNotAuthorizedCodec.encode(buffer, value, context)
+      is V5UnsubAckReasonCode.TopicFilterInvalid -> V5UnsubAckReasonCodeTopicFilterInvalidCodec.encode(buffer, value, context)
+      is V5UnsubAckReasonCode.PacketIdentifierInUse -> V5UnsubAckReasonCodePacketIdentifierInUseCodec.encode(buffer, value, context)
+    }
+  }
+
+  override fun wireSize(`value`: V5UnsubAckReasonCode, context: EncodeContext): WireSize = when (value) {
+    is V5UnsubAckReasonCode.Success -> V5UnsubAckReasonCodeSuccessCodec.wireSize(value, context)
+    is V5UnsubAckReasonCode.NoSubscriptionExisted -> V5UnsubAckReasonCodeNoSubscriptionExistedCodec.wireSize(value, context)
+    is V5UnsubAckReasonCode.UnspecifiedError -> V5UnsubAckReasonCodeUnspecifiedErrorCodec.wireSize(value, context)
+    is V5UnsubAckReasonCode.ImplementationSpecificError -> V5UnsubAckReasonCodeImplementationSpecificErrorCodec.wireSize(value, context)
+    is V5UnsubAckReasonCode.NotAuthorized -> V5UnsubAckReasonCodeNotAuthorizedCodec.wireSize(value, context)
+    is V5UnsubAckReasonCode.TopicFilterInvalid -> V5UnsubAckReasonCodeTopicFilterInvalidCodec.wireSize(value, context)
+    is V5UnsubAckReasonCode.PacketIdentifierInUse -> V5UnsubAckReasonCodePacketIdentifierInUseCodec.wireSize(value, context)
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
+    val __discRaw = stream.peekByte(baseOffset + 0).toUByte()
+    val __discriminator = V5UnsubAckReasonCodeRaw(__discRaw)
+    val __dispatchValue = __discriminator.id
+    return when (__dispatchValue) {
+      0 -> V5UnsubAckReasonCodeSuccessCodec.peekFrameSize(stream, baseOffset)
+      17 -> V5UnsubAckReasonCodeNoSubscriptionExistedCodec.peekFrameSize(stream, baseOffset)
+      128 -> V5UnsubAckReasonCodeUnspecifiedErrorCodec.peekFrameSize(stream, baseOffset)
+      131 -> V5UnsubAckReasonCodeImplementationSpecificErrorCodec.peekFrameSize(stream, baseOffset)
+      135 -> V5UnsubAckReasonCodeNotAuthorizedCodec.peekFrameSize(stream, baseOffset)
+      143 -> V5UnsubAckReasonCodeTopicFilterInvalidCodec.peekFrameSize(stream, baseOffset)
+      145 -> V5UnsubAckReasonCodePacketIdentifierInUseCodec.peekFrameSize(stream, baseOffset)
+      else -> {
+        throw DecodeException(fieldPath = "V5UnsubAckReasonCode.discriminator", bufferPosition = baseOffset, expected = "one of {0, 17, 128, 131, 135, 143, 145}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/unsuback/V5UnsubAckReasonCodeImplementationSpecificErrorCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/unsuback/V5UnsubAckReasonCodeImplementationSpecificErrorCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.unsuback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5UnsubAckReasonCodeImplementationSpecificErrorCodec : Codec<V5UnsubAckReasonCode.ImplementationSpecificError> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5UnsubAckReasonCode.ImplementationSpecificError {
+    val id = V5UnsubAckReasonCodeRaw(buffer.readUByte())
+    return V5UnsubAckReasonCode.ImplementationSpecificError(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5UnsubAckReasonCode.ImplementationSpecificError,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5UnsubAckReasonCode.ImplementationSpecificError, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/unsuback/V5UnsubAckReasonCodeNoSubscriptionExistedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/unsuback/V5UnsubAckReasonCodeNoSubscriptionExistedCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.unsuback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5UnsubAckReasonCodeNoSubscriptionExistedCodec : Codec<V5UnsubAckReasonCode.NoSubscriptionExisted> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5UnsubAckReasonCode.NoSubscriptionExisted {
+    val id = V5UnsubAckReasonCodeRaw(buffer.readUByte())
+    return V5UnsubAckReasonCode.NoSubscriptionExisted(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5UnsubAckReasonCode.NoSubscriptionExisted,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5UnsubAckReasonCode.NoSubscriptionExisted, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/unsuback/V5UnsubAckReasonCodeNotAuthorizedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/unsuback/V5UnsubAckReasonCodeNotAuthorizedCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.unsuback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5UnsubAckReasonCodeNotAuthorizedCodec : Codec<V5UnsubAckReasonCode.NotAuthorized> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5UnsubAckReasonCode.NotAuthorized {
+    val id = V5UnsubAckReasonCodeRaw(buffer.readUByte())
+    return V5UnsubAckReasonCode.NotAuthorized(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5UnsubAckReasonCode.NotAuthorized,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5UnsubAckReasonCode.NotAuthorized, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/unsuback/V5UnsubAckReasonCodePacketIdentifierInUseCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/unsuback/V5UnsubAckReasonCodePacketIdentifierInUseCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.unsuback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5UnsubAckReasonCodePacketIdentifierInUseCodec : Codec<V5UnsubAckReasonCode.PacketIdentifierInUse> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5UnsubAckReasonCode.PacketIdentifierInUse {
+    val id = V5UnsubAckReasonCodeRaw(buffer.readUByte())
+    return V5UnsubAckReasonCode.PacketIdentifierInUse(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5UnsubAckReasonCode.PacketIdentifierInUse,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5UnsubAckReasonCode.PacketIdentifierInUse, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/unsuback/V5UnsubAckReasonCodeRawCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/unsuback/V5UnsubAckReasonCodeRawCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.unsuback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5UnsubAckReasonCodeRawCodec : Codec<V5UnsubAckReasonCodeRaw> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5UnsubAckReasonCodeRaw {
+    val raw = buffer.readUByte()
+    return V5UnsubAckReasonCodeRaw(raw = raw)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5UnsubAckReasonCodeRaw,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.raw)
+  }
+
+  override fun wireSize(`value`: V5UnsubAckReasonCodeRaw, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/unsuback/V5UnsubAckReasonCodeSuccessCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/unsuback/V5UnsubAckReasonCodeSuccessCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.unsuback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5UnsubAckReasonCodeSuccessCodec : Codec<V5UnsubAckReasonCode.Success> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5UnsubAckReasonCode.Success {
+    val id = V5UnsubAckReasonCodeRaw(buffer.readUByte())
+    return V5UnsubAckReasonCode.Success(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5UnsubAckReasonCode.Success,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5UnsubAckReasonCode.Success, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/unsuback/V5UnsubAckReasonCodeTopicFilterInvalidCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/unsuback/V5UnsubAckReasonCodeTopicFilterInvalidCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.unsuback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5UnsubAckReasonCodeTopicFilterInvalidCodec : Codec<V5UnsubAckReasonCode.TopicFilterInvalid> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5UnsubAckReasonCode.TopicFilterInvalid {
+    val id = V5UnsubAckReasonCodeRaw(buffer.readUByte())
+    return V5UnsubAckReasonCode.TopicFilterInvalid(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5UnsubAckReasonCode.TopicFilterInvalid,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5UnsubAckReasonCode.TopicFilterInvalid, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/unsuback/V5UnsubAckReasonCodeUnspecifiedErrorCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/unsuback/V5UnsubAckReasonCodeUnspecifiedErrorCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.mqttv5.unsuback
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object V5UnsubAckReasonCodeUnspecifiedErrorCodec : Codec<V5UnsubAckReasonCode.UnspecifiedError> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): V5UnsubAckReasonCode.UnspecifiedError {
+    val id = V5UnsubAckReasonCodeRaw(buffer.readUByte())
+    return V5UnsubAckReasonCode.UnspecifiedError(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: V5UnsubAckReasonCode.UnspecifiedError,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id.raw)
+  }
+
+  override fun wireSize(`value`: V5UnsubAckReasonCode.UnspecifiedError, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mysql/MySqlPacketHeaderCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mysql/MySqlPacketHeaderCodec.kt
@@ -1,0 +1,37 @@
+package com.ditchoom.buffer.codec.test.protocols.mysql
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MySqlPacketHeaderCodec : Codec<MySqlPacketHeader> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MySqlPacketHeader {
+    val rawB0 = buffer.readUByte().toUInt()
+    val rawB1 = buffer.readUByte().toUInt()
+    val rawB2 = buffer.readUByte().toUInt()
+    val rawB3 = buffer.readUByte().toUInt()
+    val raw = (rawB0 or (rawB1 shl 8) or (rawB2 shl 16) or (rawB3 shl 24))
+    return MySqlPacketHeader(raw = raw)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MySqlPacketHeader,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte((value.raw and 0xFFu).toUByte())
+    buffer.writeUByte(((value.raw shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.raw shr 16) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.raw shr 24) and 0xFFu).toUByte())
+  }
+
+  override fun wireSize(`value`: MySqlPacketHeader, context: EncodeContext): WireSize = WireSize.Exact(4)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 4) PeekResult.Complete(4) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/payload/MqttPublishV3Codec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/payload/MqttPublishV3Codec.kt
@@ -1,0 +1,94 @@
+package com.ditchoom.buffer.codec.test.protocols.payload
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.Decoder
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.Payload
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttFixedHeader
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.String
+
+public class MqttPublishV3Codec<P : Payload>(
+  private val payloadCodec: Codec<P>,
+) : Codec<MqttPublishV3<P>> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttPublishV3<P> {
+    val header = MqttFixedHeader(buffer.readUByte())
+    val topicPrefixB0 = buffer.readUByte().toUInt()
+    val topicPrefixB1 = buffer.readUByte().toUInt()
+    val topicPrefix = ((topicPrefixB0 shl 8) or topicPrefixB1)
+    if (topicPrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "MqttPublishV3.topic", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = topicPrefix.toString())
+    }
+    val topicLength = topicPrefix.toInt()
+    val topic = buffer.readString(topicLength, Charset.UTF8)
+    val packetId = PacketId(buffer.readUShort())
+    val payload = payloadCodec.decode(buffer, context)
+    return MqttPublishV3<P>(header = header, topic = topic, packetId = packetId, payload = payload)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttPublishV3<P>,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.header.raw)
+    val topicSizePosition = buffer.position()
+    buffer.position(topicSizePosition + 2)
+    val topicBodyStart = buffer.position()
+    buffer.writeString(value.topic, Charset.UTF8)
+    val topicEndPosition = buffer.position()
+    val topicByteCount = topicEndPosition - topicBodyStart
+    if (topicByteCount > 65_535) {
+      throw EncodeException(fieldPath = "MqttPublishV3.topic", reason = """UTF-8 byte length ${topicByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(topicSizePosition)
+    val topicPrefix = topicByteCount.toUInt()
+    buffer.writeUByte(((topicPrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((topicPrefix and 0xFFu).toUByte())
+    buffer.position(topicEndPosition)
+    buffer.writeUShort(value.packetId.raw)
+    payloadCodec.encode(buffer, value.payload, context)
+  }
+
+  override fun wireSize(`value`: MqttPublishV3<P>, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+
+  public class Partial<P : Payload> internal constructor(
+    public val `header`: MqttFixedHeader,
+    public val topic: String,
+    public val packetId: PacketId,
+    private val buffer: ReadBuffer,
+    private val context: DecodeContext,
+  ) {
+    public fun complete(payloadCodec: Decoder<P>): MqttPublishV3<P> {
+      val payload = payloadCodec.decode(buffer, context)
+      return MqttPublishV3<P>(header = header, topic = topic, packetId = packetId, payload = payload)
+    }
+  }
+
+  public companion object {
+    public fun <P : Payload> partial(buffer: ReadBuffer, context: DecodeContext): Partial<P> {
+      val header = MqttFixedHeader(buffer.readUByte())
+      val topicPrefixB0 = buffer.readUByte().toUInt()
+      val topicPrefixB1 = buffer.readUByte().toUInt()
+      val topicPrefix = ((topicPrefixB0 shl 8) or topicPrefixB1)
+      if (topicPrefix > Int.MAX_VALUE.toUInt()) {
+        throw DecodeException(fieldPath = "MqttPublishV3.topic", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = topicPrefix.toString())
+      }
+      val topicLength = topicPrefix.toInt()
+      val topic = buffer.readString(topicLength, Charset.UTF8)
+      val packetId = PacketId(buffer.readUShort())
+      return Partial<P>(header = header, topic = topic, packetId = packetId, buffer = buffer, context = context)
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/payload/MqttPublishV3ConcreteCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/payload/MqttPublishV3ConcreteCodec.kt
@@ -1,0 +1,88 @@
+package com.ditchoom.buffer.codec.test.protocols.payload
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttFixedHeader
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.String
+
+public object MqttPublishV3ConcreteCodec : Codec<MqttPublishV3Concrete> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MqttPublishV3Concrete {
+    val header = MqttFixedHeader(buffer.readUByte())
+    val topicPrefixB0 = buffer.readUByte().toUInt()
+    val topicPrefixB1 = buffer.readUByte().toUInt()
+    val topicPrefix = ((topicPrefixB0 shl 8) or topicPrefixB1)
+    if (topicPrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "MqttPublishV3Concrete.topic", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = topicPrefix.toString())
+    }
+    val topicLength = topicPrefix.toInt()
+    val topic = buffer.readString(topicLength, Charset.UTF8)
+    val packetId = PacketId(buffer.readUShort())
+    val payload = JpegImageCodec.decode(buffer, context)
+    return MqttPublishV3Concrete(header = header, topic = topic, packetId = packetId, payload = payload)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MqttPublishV3Concrete,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.header.raw)
+    val topicSizePosition = buffer.position()
+    buffer.position(topicSizePosition + 2)
+    val topicBodyStart = buffer.position()
+    buffer.writeString(value.topic, Charset.UTF8)
+    val topicEndPosition = buffer.position()
+    val topicByteCount = topicEndPosition - topicBodyStart
+    if (topicByteCount > 65_535) {
+      throw EncodeException(fieldPath = "MqttPublishV3Concrete.topic", reason = """UTF-8 byte length ${topicByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(topicSizePosition)
+    val topicPrefix = topicByteCount.toUInt()
+    buffer.writeUByte(((topicPrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((topicPrefix and 0xFFu).toUByte())
+    buffer.position(topicEndPosition)
+    buffer.writeUShort(value.packetId.raw)
+    JpegImageCodec.encode(buffer, value.payload, context)
+  }
+
+  override fun wireSize(`value`: MqttPublishV3Concrete, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+
+  public fun partial(buffer: ReadBuffer, context: DecodeContext): Partial {
+    val header = MqttFixedHeader(buffer.readUByte())
+    val topicPrefixB0 = buffer.readUByte().toUInt()
+    val topicPrefixB1 = buffer.readUByte().toUInt()
+    val topicPrefix = ((topicPrefixB0 shl 8) or topicPrefixB1)
+    if (topicPrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "MqttPublishV3Concrete.topic", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = topicPrefix.toString())
+    }
+    val topicLength = topicPrefix.toInt()
+    val topic = buffer.readString(topicLength, Charset.UTF8)
+    val packetId = PacketId(buffer.readUShort())
+    return Partial(header = header, topic = topic, packetId = packetId, buffer = buffer, context = context)
+  }
+
+  public class Partial internal constructor(
+    public val `header`: MqttFixedHeader,
+    public val topic: String,
+    public val packetId: PacketId,
+    private val buffer: ReadBuffer,
+    private val context: DecodeContext,
+  ) {
+    public fun complete(): MqttPublishV3Concrete {
+      val payload = JpegImageCodec.decode(buffer, context)
+      return MqttPublishV3Concrete(header = header, topic = topic, packetId = packetId, payload = payload)
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/payload/PacketIdCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/payload/PacketIdCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.payload
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object PacketIdCodec : Codec<PacketId> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): PacketId {
+    val raw = buffer.readUShort()
+    return PacketId(raw = raw)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: PacketId,
+    context: EncodeContext,
+  ) {
+    buffer.writeUShort(value.raw)
+  }
+
+  override fun wireSize(`value`: PacketId, context: EncodeContext): WireSize = WireSize.Exact(2)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/png/PngChunkCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/png/PngChunkCodec.kt
@@ -1,0 +1,64 @@
+package com.ditchoom.buffer.codec.test.protocols.png
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.codec.test.protocols.payload.BinaryDataCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object PngChunkCodec : Codec<PngChunk> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): PngChunk {
+    val lengthB0 = buffer.readUByte().toUInt()
+    val lengthB1 = buffer.readUByte().toUInt()
+    val lengthB2 = buffer.readUByte().toUInt()
+    val lengthB3 = buffer.readUByte().toUInt()
+    val length = ((lengthB0 shl 24) or (lengthB1 shl 16) or (lengthB2 shl 8) or lengthB3)
+    val typeB0 = buffer.readUByte().toUInt()
+    val typeB1 = buffer.readUByte().toUInt()
+    val typeB2 = buffer.readUByte().toUInt()
+    val typeB3 = buffer.readUByte().toUInt()
+    val type = ((typeB0 shl 24) or (typeB1 shl 16) or (typeB2 shl 8) or typeB3)
+    val __dataOuterLimit = buffer.limit()
+    buffer.setLimit(__dataOuterLimit - 4)
+    val data = try {
+      BinaryDataCodec.decode(buffer, context)
+    } finally {
+      buffer.setLimit(__dataOuterLimit)
+    }
+    val crcB0 = buffer.readUByte().toUInt()
+    val crcB1 = buffer.readUByte().toUInt()
+    val crcB2 = buffer.readUByte().toUInt()
+    val crcB3 = buffer.readUByte().toUInt()
+    val crc = ((crcB0 shl 24) or (crcB1 shl 16) or (crcB2 shl 8) or crcB3)
+    return PngChunk(length = length, type = type, data = data, crc = crc)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: PngChunk,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(((value.length shr 24) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.length shr 16) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.length shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.length and 0xFFu).toUByte())
+    buffer.writeUByte(((value.type shr 24) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.type shr 16) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.type shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.type and 0xFFu).toUByte())
+    BinaryDataCodec.encode(buffer, value.data, context)
+    buffer.writeUByte(((value.crc shr 24) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.crc shr 16) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.crc shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.crc and 0xFFu).toUByte())
+  }
+
+  override fun wireSize(`value`: PngChunk, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/quic/QuicHeaderByteCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/quic/QuicHeaderByteCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.quic
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object QuicHeaderByteCodec : Codec<QuicHeaderByte> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): QuicHeaderByte {
+    val raw = buffer.readUByte()
+    return QuicHeaderByte(raw = raw)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: QuicHeaderByte,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.raw)
+  }
+
+  override fun wireSize(`value`: QuicHeaderByte, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/quic/QuicPacketHeaderCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/quic/QuicPacketHeaderCodec.kt
@@ -1,0 +1,58 @@
+package com.ditchoom.buffer.codec.test.protocols.quic
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object QuicPacketHeaderCodec : Codec<QuicPacketHeader> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): QuicPacketHeader {
+    val discriminatorPosition = buffer.position()
+    val __discriminator = QuicHeaderByteCodec.decode(buffer, context)
+    buffer.position(discriminatorPosition)
+    val __dispatchValue = if (__discriminator.isLongHeader) 1 else 0
+    return when (__dispatchValue) {
+      0 -> QuicPacketHeaderShortHeaderCodec.decode(buffer, context)
+      1 -> QuicPacketHeaderLongHeaderCodec.decode(buffer, context)
+      else -> {
+        throw DecodeException(fieldPath = "QuicPacketHeader.discriminator", bufferPosition = discriminatorPosition, expected = "one of {0, 1}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: QuicPacketHeader,
+    context: EncodeContext,
+  ) {
+    when (value) {
+      is QuicPacketHeader.ShortHeader -> QuicPacketHeaderShortHeaderCodec.encode(buffer, value, context)
+      is QuicPacketHeader.LongHeader -> QuicPacketHeaderLongHeaderCodec.encode(buffer, value, context)
+    }
+  }
+
+  override fun wireSize(`value`: QuicPacketHeader, context: EncodeContext): WireSize = when (value) {
+    is QuicPacketHeader.ShortHeader -> QuicPacketHeaderShortHeaderCodec.wireSize(value, context)
+    is QuicPacketHeader.LongHeader -> QuicPacketHeaderLongHeaderCodec.wireSize(value, context)
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
+    val __discRaw = stream.peekByte(baseOffset + 0).toUByte()
+    val __discriminator = QuicHeaderByte(__discRaw)
+    val __dispatchValue = if (__discriminator.isLongHeader) 1 else 0
+    return when (__dispatchValue) {
+      0 -> QuicPacketHeaderShortHeaderCodec.peekFrameSize(stream, baseOffset)
+      1 -> QuicPacketHeaderLongHeaderCodec.peekFrameSize(stream, baseOffset)
+      else -> {
+        throw DecodeException(fieldPath = "QuicPacketHeader.discriminator", bufferPosition = baseOffset, expected = "one of {0, 1}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/quic/QuicPacketHeaderLongHeaderCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/quic/QuicPacketHeaderLongHeaderCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.quic
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object QuicPacketHeaderLongHeaderCodec : Codec<QuicPacketHeader.LongHeader> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): QuicPacketHeader.LongHeader {
+    val firstByte = QuicHeaderByte(buffer.readUByte())
+    return QuicPacketHeader.LongHeader(firstByte = firstByte)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: QuicPacketHeader.LongHeader,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.firstByte.raw)
+  }
+
+  override fun wireSize(`value`: QuicPacketHeader.LongHeader, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/quic/QuicPacketHeaderShortHeaderCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/quic/QuicPacketHeaderShortHeaderCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.quic
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object QuicPacketHeaderShortHeaderCodec : Codec<QuicPacketHeader.ShortHeader> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): QuicPacketHeader.ShortHeader {
+    val firstByte = QuicHeaderByte(buffer.readUByte())
+    return QuicPacketHeader.ShortHeader(firstByte = firstByte)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: QuicPacketHeader.ShortHeader,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.firstByte.raw)
+  }
+
+  override fun wireSize(`value`: QuicPacketHeader.ShortHeader, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/riff/RiffChunkHeaderCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/riff/RiffChunkHeaderCodec.kt
@@ -1,0 +1,46 @@
+package com.ditchoom.buffer.codec.test.protocols.riff
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object RiffChunkHeaderCodec : Codec<RiffChunkHeader> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): RiffChunkHeader {
+    val fourCCB0 = buffer.readUByte().toUInt()
+    val fourCCB1 = buffer.readUByte().toUInt()
+    val fourCCB2 = buffer.readUByte().toUInt()
+    val fourCCB3 = buffer.readUByte().toUInt()
+    val fourCC = ((fourCCB0 shl 24) or (fourCCB1 shl 16) or (fourCCB2 shl 8) or fourCCB3)
+    val chunkSizeB0 = buffer.readUByte().toUInt()
+    val chunkSizeB1 = buffer.readUByte().toUInt()
+    val chunkSizeB2 = buffer.readUByte().toUInt()
+    val chunkSizeB3 = buffer.readUByte().toUInt()
+    val chunkSize = (chunkSizeB0 or (chunkSizeB1 shl 8) or (chunkSizeB2 shl 16) or (chunkSizeB3 shl 24))
+    return RiffChunkHeader(fourCC = fourCC, chunkSize = chunkSize)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: RiffChunkHeader,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(((value.fourCC shr 24) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.fourCC shr 16) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.fourCC shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.fourCC and 0xFFu).toUByte())
+    buffer.writeUByte((value.chunkSize and 0xFFu).toUByte())
+    buffer.writeUByte(((value.chunkSize shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.chunkSize shr 16) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.chunkSize shr 24) and 0xFFu).toUByte())
+  }
+
+  override fun wireSize(`value`: RiffChunkHeader, context: EncodeContext): WireSize = WireSize.Exact(8)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 8) PeekResult.Complete(8) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/riff/WavFmtBodyCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/riff/WavFmtBodyCodec.kt
@@ -1,0 +1,66 @@
+package com.ditchoom.buffer.codec.test.protocols.riff
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object WavFmtBodyCodec : Codec<WavFmtBody> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): WavFmtBody {
+    val audioFormatB0 = buffer.readUByte().toUInt()
+    val audioFormatB1 = buffer.readUByte().toUInt()
+    val audioFormat = (audioFormatB0 or (audioFormatB1 shl 8)).toUShort()
+    val numChannelsB0 = buffer.readUByte().toUInt()
+    val numChannelsB1 = buffer.readUByte().toUInt()
+    val numChannels = (numChannelsB0 or (numChannelsB1 shl 8)).toUShort()
+    val sampleRateB0 = buffer.readUByte().toUInt()
+    val sampleRateB1 = buffer.readUByte().toUInt()
+    val sampleRateB2 = buffer.readUByte().toUInt()
+    val sampleRateB3 = buffer.readUByte().toUInt()
+    val sampleRate = (sampleRateB0 or (sampleRateB1 shl 8) or (sampleRateB2 shl 16) or (sampleRateB3 shl 24))
+    val byteRateB0 = buffer.readUByte().toUInt()
+    val byteRateB1 = buffer.readUByte().toUInt()
+    val byteRateB2 = buffer.readUByte().toUInt()
+    val byteRateB3 = buffer.readUByte().toUInt()
+    val byteRate = (byteRateB0 or (byteRateB1 shl 8) or (byteRateB2 shl 16) or (byteRateB3 shl 24))
+    val blockAlignB0 = buffer.readUByte().toUInt()
+    val blockAlignB1 = buffer.readUByte().toUInt()
+    val blockAlign = (blockAlignB0 or (blockAlignB1 shl 8)).toUShort()
+    val bitsPerSampleB0 = buffer.readUByte().toUInt()
+    val bitsPerSampleB1 = buffer.readUByte().toUInt()
+    val bitsPerSample = (bitsPerSampleB0 or (bitsPerSampleB1 shl 8)).toUShort()
+    return WavFmtBody(audioFormat = audioFormat, numChannels = numChannels, sampleRate = sampleRate, byteRate = byteRate, blockAlign = blockAlign, bitsPerSample = bitsPerSample)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: WavFmtBody,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte((value.audioFormat.toUInt() and 0xFFu).toUByte())
+    buffer.writeUByte(((value.audioFormat.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.numChannels.toUInt() and 0xFFu).toUByte())
+    buffer.writeUByte(((value.numChannels.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.sampleRate and 0xFFu).toUByte())
+    buffer.writeUByte(((value.sampleRate shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.sampleRate shr 16) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.sampleRate shr 24) and 0xFFu).toUByte())
+    buffer.writeUByte((value.byteRate and 0xFFu).toUByte())
+    buffer.writeUByte(((value.byteRate shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.byteRate shr 16) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.byteRate shr 24) and 0xFFu).toUByte())
+    buffer.writeUByte((value.blockAlign.toUInt() and 0xFFu).toUByte())
+    buffer.writeUByte(((value.blockAlign.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.bitsPerSample.toUInt() and 0xFFu).toUByte())
+    buffer.writeUByte(((value.bitsPerSample.toUInt() shr 8) and 0xFFu).toUByte())
+  }
+
+  override fun wireSize(`value`: WavFmtBody, context: EncodeContext): WireSize = WireSize.Exact(16)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 16) PeekResult.Complete(16) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/riff/WavFmtChunkCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/riff/WavFmtChunkCodec.kt
@@ -1,0 +1,78 @@
+package com.ditchoom.buffer.codec.test.protocols.riff
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object WavFmtChunkCodec : Codec<WavFmtChunk> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): WavFmtChunk {
+    val fourCCB0 = buffer.readUByte().toUInt()
+    val fourCCB1 = buffer.readUByte().toUInt()
+    val fourCCB2 = buffer.readUByte().toUInt()
+    val fourCCB3 = buffer.readUByte().toUInt()
+    val fourCC = ((fourCCB0 shl 24) or (fourCCB1 shl 16) or (fourCCB2 shl 8) or fourCCB3)
+    val bodyPrefixB0 = buffer.readUByte().toUInt()
+    val bodyPrefixB1 = buffer.readUByte().toUInt()
+    val bodyPrefixB2 = buffer.readUByte().toUInt()
+    val bodyPrefixB3 = buffer.readUByte().toUInt()
+    val bodyPrefix = (bodyPrefixB0 or (bodyPrefixB1 shl 8) or (bodyPrefixB2 shl 16) or (bodyPrefixB3 shl 24))
+    if (bodyPrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "WavFmtChunk.body", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = bodyPrefix.toString())
+    }
+    val bodyLength = bodyPrefix.toInt()
+    val bodyOuterLimit = buffer.limit()
+    buffer.setLimit(buffer.position() + bodyLength)
+    val body = try {
+      WavFmtBodyCodec.decode(buffer, context)
+    } finally {
+      buffer.setLimit(bodyOuterLimit)
+    }
+    return WavFmtChunk(fourCC = fourCC, body = body)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: WavFmtChunk,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(((value.fourCC shr 24) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.fourCC shr 16) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.fourCC shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.fourCC and 0xFFu).toUByte())
+    val bodyPrefix = (WavFmtBodyCodec.wireSize(value.body, context) as WireSize.Exact).bytes.toUInt()
+    buffer.writeUByte((bodyPrefix and 0xFFu).toUByte())
+    buffer.writeUByte(((bodyPrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte(((bodyPrefix shr 16) and 0xFFu).toUByte())
+    buffer.writeUByte(((bodyPrefix shr 24) and 0xFFu).toUByte())
+    WavFmtBodyCodec.encode(buffer, value.body, context)
+  }
+
+  override fun wireSize(`value`: WavFmtChunk, context: EncodeContext): WireSize {
+    val bodySize = (WavFmtBodyCodec.wireSize(value.body, context) as WireSize.Exact).bytes
+    return WireSize.Exact(8 + bodySize)
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 4) return PeekResult.NeedsMoreData
+    __offset += 4
+    if (stream.available() - baseOffset < __offset + 4) return PeekResult.NeedsMoreData
+    val bodyPrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val bodyPrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val bodyPrefixB2 = stream.peekByte(baseOffset + __offset + 2).toInt() and 0xFF
+    val bodyPrefixB3 = stream.peekByte(baseOffset + __offset + 3).toInt() and 0xFF
+    val bodyPrefix = (bodyPrefixB0 or (bodyPrefixB1 shl 8) or (bodyPrefixB2 shl 16) or (bodyPrefixB3 shl 24)).toUInt()
+    if (bodyPrefix > (Int.MAX_VALUE - __offset - 4).toUInt()) {
+      throw DecodeException(fieldPath = "WavFmtChunk.body", bufferPosition = baseOffset + __offset, expected = "__offset + 4 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 4 + bodyPrefix.toInt()}""")
+    }
+    __offset += 4 + bodyPrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/BytePrefixedStringCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/BytePrefixedStringCodec.kt
@@ -1,0 +1,59 @@
+package com.ditchoom.buffer.codec.test.protocols.simple
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object BytePrefixedStringCodec : Codec<BytePrefixedString> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): BytePrefixedString {
+    val namePrefix = buffer.readUByte().toUInt()
+    if (namePrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "BytePrefixedString.name", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = namePrefix.toString())
+    }
+    val nameLength = namePrefix.toInt()
+    val name = buffer.readString(nameLength, Charset.UTF8)
+    return BytePrefixedString(name = name)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: BytePrefixedString,
+    context: EncodeContext,
+  ) {
+    val nameSizePosition = buffer.position()
+    buffer.position(nameSizePosition + 1)
+    val nameBodyStart = buffer.position()
+    buffer.writeString(value.name, Charset.UTF8)
+    val nameEndPosition = buffer.position()
+    val nameByteCount = nameEndPosition - nameBodyStart
+    if (nameByteCount > 255) {
+      throw EncodeException(fieldPath = "BytePrefixedString.name", reason = """UTF-8 byte length ${nameByteCount} exceeds @LengthPrefixed(LengthPrefix.Byte) max 255""")
+    }
+    buffer.position(nameSizePosition)
+    val namePrefix = nameByteCount.toUInt()
+    buffer.writeUByte((namePrefix and 0xFFu).toUByte())
+    buffer.position(nameEndPosition)
+  }
+
+  override fun wireSize(`value`: BytePrefixedString, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    val namePrefix = (stream.peekByte(baseOffset + __offset).toInt() and 0xFF).toUInt()
+    if (namePrefix > (Int.MAX_VALUE - __offset - 1).toUInt()) {
+      throw DecodeException(fieldPath = "BytePrefixedString.name", bufferPosition = baseOffset + __offset, expected = "__offset + 1 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 1 + namePrefix.toInt()}""")
+    }
+    __offset += 1 + namePrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/CommandCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/CommandCodec.kt
@@ -1,0 +1,70 @@
+package com.ditchoom.buffer.codec.test.protocols.simple
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object CommandCodec : Codec<Command> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): Command {
+    val discriminatorPosition = buffer.position()
+    val discriminator = buffer.readUByte().toInt()
+    return when (discriminator) {
+      0x01 -> CommandPingCodec.decode(buffer, context)
+      0x02 -> CommandEchoCodec.decode(buffer, context)
+      else -> {
+        throw DecodeException(fieldPath = "Command.discriminator", bufferPosition = discriminatorPosition, expected = "one of {0x01, 0x02}", actual = """0x${discriminator.toString(16).padStart(2, '0').uppercase()}""")
+      }
+    }
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: Command,
+    context: EncodeContext,
+  ) {
+    when (value) {
+      is Command.Ping -> {
+        buffer.writeUByte(0x01.toUByte())
+        CommandPingCodec.encode(buffer, value, context)
+      }
+      is Command.Echo -> {
+        buffer.writeUByte(0x02.toUByte())
+        CommandEchoCodec.encode(buffer, value, context)
+      }
+    }
+  }
+
+  override fun wireSize(`value`: Command, context: EncodeContext): WireSize = when (value) {
+    is Command.Ping -> WireSize.Exact(9)
+    is Command.Echo -> WireSize.BackPatch
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
+    val discriminator = stream.peekByte(baseOffset).toInt() and 0xFF
+    return when (discriminator) {
+      0x01 -> {
+        when (val inner = CommandPingCodec.peekFrameSize(stream, baseOffset + 1)) {
+          is PeekResult.Complete -> PeekResult.Complete(1 + inner.bytes)
+          else -> inner
+        }
+      }
+      0x02 -> {
+        when (val inner = CommandEchoCodec.peekFrameSize(stream, baseOffset + 1)) {
+          is PeekResult.Complete -> PeekResult.Complete(1 + inner.bytes)
+          else -> inner
+        }
+      }
+      else -> {
+        throw DecodeException(fieldPath = "Command.discriminator", bufferPosition = baseOffset, expected = "one of {0x01, 0x02}", actual = """0x${discriminator.toString(16).padStart(2, '0').uppercase()}""")
+      }
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/CommandEchoCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/CommandEchoCodec.kt
@@ -1,0 +1,64 @@
+package com.ditchoom.buffer.codec.test.protocols.simple
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object CommandEchoCodec : Codec<Command.Echo> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): Command.Echo {
+    val msgPrefixB0 = buffer.readUByte().toUInt()
+    val msgPrefixB1 = buffer.readUByte().toUInt()
+    val msgPrefix = ((msgPrefixB0 shl 8) or msgPrefixB1)
+    if (msgPrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "Echo.msg", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = msgPrefix.toString())
+    }
+    val msgLength = msgPrefix.toInt()
+    val msg = buffer.readString(msgLength, Charset.UTF8)
+    return Command.Echo(msg = msg)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: Command.Echo,
+    context: EncodeContext,
+  ) {
+    val msgSizePosition = buffer.position()
+    buffer.position(msgSizePosition + 2)
+    val msgBodyStart = buffer.position()
+    buffer.writeString(value.msg, Charset.UTF8)
+    val msgEndPosition = buffer.position()
+    val msgByteCount = msgEndPosition - msgBodyStart
+    if (msgByteCount > 65_535) {
+      throw EncodeException(fieldPath = "Echo.msg", reason = """UTF-8 byte length ${msgByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(msgSizePosition)
+    val msgPrefix = msgByteCount.toUInt()
+    buffer.writeUByte(((msgPrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((msgPrefix and 0xFFu).toUByte())
+    buffer.position(msgEndPosition)
+  }
+
+  override fun wireSize(`value`: Command.Echo, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val msgPrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val msgPrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val msgPrefix = ((msgPrefixB0 shl 8) or msgPrefixB1).toUInt()
+    if (msgPrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "Echo.msg", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + msgPrefix.toInt()}""")
+    }
+    __offset += 2 + msgPrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/CommandPingCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/CommandPingCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.simple
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object CommandPingCodec : Codec<Command.Ping> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): Command.Ping {
+    val ts = buffer.readLong()
+    return Command.Ping(ts = ts)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: Command.Ping,
+    context: EncodeContext,
+  ) {
+    buffer.writeLong(value.ts)
+  }
+
+  override fun wireSize(`value`: Command.Ping, context: EncodeContext): WireSize = WireSize.Exact(8)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 8) PeekResult.Complete(8) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/IntPrefixedStringCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/IntPrefixedStringCodec.kt
@@ -1,0 +1,66 @@
+package com.ditchoom.buffer.codec.test.protocols.simple
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object IntPrefixedStringCodec : Codec<IntPrefixedString> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): IntPrefixedString {
+    val namePrefixB0 = buffer.readUByte().toUInt()
+    val namePrefixB1 = buffer.readUByte().toUInt()
+    val namePrefixB2 = buffer.readUByte().toUInt()
+    val namePrefixB3 = buffer.readUByte().toUInt()
+    val namePrefix = ((namePrefixB0 shl 24) or (namePrefixB1 shl 16) or (namePrefixB2 shl 8) or namePrefixB3)
+    if (namePrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "IntPrefixedString.name", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = namePrefix.toString())
+    }
+    val nameLength = namePrefix.toInt()
+    val name = buffer.readString(nameLength, Charset.UTF8)
+    return IntPrefixedString(name = name)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: IntPrefixedString,
+    context: EncodeContext,
+  ) {
+    val nameSizePosition = buffer.position()
+    buffer.position(nameSizePosition + 4)
+    val nameBodyStart = buffer.position()
+    buffer.writeString(value.name, Charset.UTF8)
+    val nameEndPosition = buffer.position()
+    val nameByteCount = nameEndPosition - nameBodyStart
+    buffer.position(nameSizePosition)
+    val namePrefix = nameByteCount.toUInt()
+    buffer.writeUByte(((namePrefix shr 24) and 0xFFu).toUByte())
+    buffer.writeUByte(((namePrefix shr 16) and 0xFFu).toUByte())
+    buffer.writeUByte(((namePrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((namePrefix and 0xFFu).toUByte())
+    buffer.position(nameEndPosition)
+  }
+
+  override fun wireSize(`value`: IntPrefixedString, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 4) return PeekResult.NeedsMoreData
+    val namePrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val namePrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val namePrefixB2 = stream.peekByte(baseOffset + __offset + 2).toInt() and 0xFF
+    val namePrefixB3 = stream.peekByte(baseOffset + __offset + 3).toInt() and 0xFF
+    val namePrefix = ((namePrefixB0 shl 24) or (namePrefixB1 shl 16) or (namePrefixB2 shl 8) or namePrefixB3).toUInt()
+    if (namePrefix > (Int.MAX_VALUE - __offset - 4).toUInt()) {
+      throw DecodeException(fieldPath = "IntPrefixedString.name", bufferPosition = baseOffset + __offset, expected = "__offset + 4 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 4 + namePrefix.toInt()}""")
+    }
+    __offset += 4 + namePrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/LeHeaderCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/LeHeaderCodec.kt
@@ -1,0 +1,33 @@
+package com.ditchoom.buffer.codec.test.protocols.simple
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object LeHeaderCodec : Codec<LeHeader> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): LeHeader {
+    val rawB0 = buffer.readUByte().toUInt()
+    val rawB1 = buffer.readUByte().toUInt()
+    val raw = (rawB0 or (rawB1 shl 8)).toUShort()
+    return LeHeader(raw = raw)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: LeHeader,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte((value.raw.toUInt() and 0xFFu).toUByte())
+    buffer.writeUByte(((value.raw.toUInt() shr 8) and 0xFFu).toUByte())
+  }
+
+  override fun wireSize(`value`: LeHeader, context: EncodeContext): WireSize = WireSize.Exact(2)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/LePacketCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/LePacketCodec.kt
@@ -1,0 +1,45 @@
+package com.ditchoom.buffer.codec.test.protocols.simple
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object LePacketCodec : Codec<LePacket> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): LePacket {
+    val header = LeHeader(buffer.readUShort())
+    val payload = buffer.readString(header.length, Charset.UTF8)
+    return LePacket(header = header, payload = payload)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: LePacket,
+    context: EncodeContext,
+  ) {
+    buffer.writeUShort(value.header.raw)
+    buffer.writeString(value.payload, Charset.UTF8)
+  }
+
+  override fun wireSize(`value`: LePacket, context: EncodeContext): WireSize = WireSize.Exact(2 + value.header.length)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val headerRawB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val headerRawB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val headerRaw = (headerRawB0 or (headerRawB1 shl 8)).toUInt().toUShort()
+    val header = LeHeader(headerRaw)
+    __offset += 2
+    val payloadBytes = header.length
+    if (stream.available() - baseOffset < __offset + payloadBytes) return PeekResult.NeedsMoreData
+    __offset += payloadBytes
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/RemoteHeaderCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/RemoteHeaderCodec.kt
@@ -1,0 +1,52 @@
+package com.ditchoom.buffer.codec.test.protocols.simple
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object RemoteHeaderCodec : Codec<RemoteHeader> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): RemoteHeader {
+    val payloadLength = buffer.readUShort()
+    val flags = buffer.readUByte()
+    val correlationId = buffer.readUInt()
+    val payload = buffer.readString(payloadLength.toInt(), Charset.UTF8)
+    return RemoteHeader(payloadLength = payloadLength, flags = flags, correlationId = correlationId, payload = payload)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: RemoteHeader,
+    context: EncodeContext,
+  ) {
+    buffer.writeUShort(value.payloadLength)
+    buffer.writeUByte(value.flags)
+    buffer.writeUInt(value.correlationId)
+    buffer.writeString(value.payload, Charset.UTF8)
+  }
+
+  override fun wireSize(`value`: RemoteHeader, context: EncodeContext): WireSize = WireSize.Exact(7 + value.payloadLength.toInt())
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val payloadLengthB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val payloadLengthB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val payloadLength = ((payloadLengthB0 shl 8) or payloadLengthB1).toUInt().toUShort()
+    __offset += 2
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    __offset += 1
+    if (stream.available() - baseOffset < __offset + 4) return PeekResult.NeedsMoreData
+    __offset += 4
+    val payloadBytes = payloadLength.toInt()
+    if (stream.available() - baseOffset < __offset + payloadBytes) return PeekResult.NeedsMoreData
+    __offset += payloadBytes
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/SimpleHeaderCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/SimpleHeaderCodec.kt
@@ -1,0 +1,68 @@
+package com.ditchoom.buffer.codec.test.protocols.simple
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object SimpleHeaderCodec : Codec<SimpleHeader> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): SimpleHeader {
+    val id = buffer.readInt()
+    val namePrefixB0 = buffer.readUByte().toUInt()
+    val namePrefixB1 = buffer.readUByte().toUInt()
+    val namePrefix = ((namePrefixB0 shl 8) or namePrefixB1)
+    if (namePrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "SimpleHeader.name", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = namePrefix.toString())
+    }
+    val nameLength = namePrefix.toInt()
+    val name = buffer.readString(nameLength, Charset.UTF8)
+    return SimpleHeader(id = id, name = name)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: SimpleHeader,
+    context: EncodeContext,
+  ) {
+    buffer.writeInt(value.id)
+    val nameSizePosition = buffer.position()
+    buffer.position(nameSizePosition + 2)
+    val nameBodyStart = buffer.position()
+    buffer.writeString(value.name, Charset.UTF8)
+    val nameEndPosition = buffer.position()
+    val nameByteCount = nameEndPosition - nameBodyStart
+    if (nameByteCount > 65_535) {
+      throw EncodeException(fieldPath = "SimpleHeader.name", reason = """UTF-8 byte length ${nameByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(nameSizePosition)
+    val namePrefix = nameByteCount.toUInt()
+    buffer.writeUByte(((namePrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((namePrefix and 0xFFu).toUByte())
+    buffer.position(nameEndPosition)
+  }
+
+  override fun wireSize(`value`: SimpleHeader, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 4) return PeekResult.NeedsMoreData
+    __offset += 4
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val namePrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val namePrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val namePrefix = ((namePrefixB0 shl 8) or namePrefixB1).toUInt()
+    if (namePrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "SimpleHeader.name", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + namePrefix.toInt()}""")
+    }
+    __offset += 2 + namePrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/SmallFlagsCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/SmallFlagsCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.simple
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object SmallFlagsCodec : Codec<SmallFlags> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): SmallFlags {
+    val raw = buffer.readUByte()
+    return SmallFlags(raw = raw)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: SmallFlags,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.raw)
+  }
+
+  override fun wireSize(`value`: SmallFlags, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/TwoStringsCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/TwoStringsCodec.kt
@@ -1,0 +1,94 @@
+package com.ditchoom.buffer.codec.test.protocols.simple
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object TwoStringsCodec : Codec<TwoStrings> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): TwoStrings {
+    val firstPrefixB0 = buffer.readUByte().toUInt()
+    val firstPrefixB1 = buffer.readUByte().toUInt()
+    val firstPrefix = ((firstPrefixB0 shl 8) or firstPrefixB1)
+    if (firstPrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "TwoStrings.first", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = firstPrefix.toString())
+    }
+    val firstLength = firstPrefix.toInt()
+    val first = buffer.readString(firstLength, Charset.UTF8)
+    val secondPrefixB0 = buffer.readUByte().toUInt()
+    val secondPrefixB1 = buffer.readUByte().toUInt()
+    val secondPrefix = ((secondPrefixB0 shl 8) or secondPrefixB1)
+    if (secondPrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "TwoStrings.second", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = secondPrefix.toString())
+    }
+    val secondLength = secondPrefix.toInt()
+    val second = buffer.readString(secondLength, Charset.UTF8)
+    return TwoStrings(first = first, second = second)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: TwoStrings,
+    context: EncodeContext,
+  ) {
+    val firstSizePosition = buffer.position()
+    buffer.position(firstSizePosition + 2)
+    val firstBodyStart = buffer.position()
+    buffer.writeString(value.first, Charset.UTF8)
+    val firstEndPosition = buffer.position()
+    val firstByteCount = firstEndPosition - firstBodyStart
+    if (firstByteCount > 65_535) {
+      throw EncodeException(fieldPath = "TwoStrings.first", reason = """UTF-8 byte length ${firstByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(firstSizePosition)
+    val firstPrefix = firstByteCount.toUInt()
+    buffer.writeUByte(((firstPrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((firstPrefix and 0xFFu).toUByte())
+    buffer.position(firstEndPosition)
+    val secondSizePosition = buffer.position()
+    buffer.position(secondSizePosition + 2)
+    val secondBodyStart = buffer.position()
+    buffer.writeString(value.second, Charset.UTF8)
+    val secondEndPosition = buffer.position()
+    val secondByteCount = secondEndPosition - secondBodyStart
+    if (secondByteCount > 65_535) {
+      throw EncodeException(fieldPath = "TwoStrings.second", reason = """UTF-8 byte length ${secondByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(secondSizePosition)
+    val secondPrefix = secondByteCount.toUInt()
+    buffer.writeUByte(((secondPrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((secondPrefix and 0xFFu).toUByte())
+    buffer.position(secondEndPosition)
+  }
+
+  override fun wireSize(`value`: TwoStrings, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val firstPrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val firstPrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val firstPrefix = ((firstPrefixB0 shl 8) or firstPrefixB1).toUInt()
+    if (firstPrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "TwoStrings.first", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + firstPrefix.toInt()}""")
+    }
+    __offset += 2 + firstPrefix.toInt()
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val secondPrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val secondPrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val secondPrefix = ((secondPrefixB0 shl 8) or secondPrefixB1).toUInt()
+    if (secondPrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "TwoStrings.second", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + secondPrefix.toInt()}""")
+    }
+    __offset += 2 + secondPrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/WithFlagPayloadCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/WithFlagPayloadCodec.kt
@@ -1,0 +1,80 @@
+package com.ditchoom.buffer.codec.test.protocols.simple
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.String
+
+public object WithFlagPayloadCodec : Codec<WithFlagPayload> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): WithFlagPayload {
+    val flags = SmallFlags(buffer.readUByte())
+    val payload: String? = if (flags.want) {
+      val payloadPrefixB0 = buffer.readUByte().toUInt()
+      val payloadPrefixB1 = buffer.readUByte().toUInt()
+      val payloadPrefix = ((payloadPrefixB0 shl 8) or payloadPrefixB1)
+      if (payloadPrefix > Int.MAX_VALUE.toUInt()) {
+        throw DecodeException(fieldPath = "WithFlagPayload.payload", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = payloadPrefix.toString())
+      }
+      val payloadLength = payloadPrefix.toInt()
+      buffer.readString(payloadLength, Charset.UTF8)
+    } else {
+      null
+    }
+    return WithFlagPayload(flags = flags, payload = payload)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: WithFlagPayload,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.flags.raw)
+    if (value.flags.want) {
+      val payloadValue = value.payload ?: throw EncodeException(fieldPath = "WithFlagPayload.payload", reason = "@When(\"flags.want\") predicate is true but field is null")
+      val payloadSizePosition = buffer.position()
+      buffer.position(payloadSizePosition + 2)
+      val payloadBodyStart = buffer.position()
+      buffer.writeString(payloadValue, Charset.UTF8)
+      val payloadEndPosition = buffer.position()
+      val payloadByteCount = payloadEndPosition - payloadBodyStart
+      if (payloadByteCount > 65_535) {
+        throw EncodeException(fieldPath = "WithFlagPayload.payload", reason = """UTF-8 byte length ${payloadByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+      }
+      buffer.position(payloadSizePosition)
+      val payloadPrefix = payloadByteCount.toUInt()
+      buffer.writeUByte(((payloadPrefix shr 8) and 0xFFu).toUByte())
+      buffer.writeUByte((payloadPrefix and 0xFFu).toUByte())
+      buffer.position(payloadEndPosition)
+    }
+  }
+
+  override fun wireSize(`value`: WithFlagPayload, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    val flagsRaw = stream.peekByte(baseOffset + __offset).toUByte()
+    val flags = SmallFlags(flagsRaw)
+    __offset += 1
+    if (flags.want) {
+      if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+      val payloadPrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+      val payloadPrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+      val payloadPrefix = ((payloadPrefixB0 shl 8) or payloadPrefixB1).toUInt()
+      if (payloadPrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+        throw DecodeException(fieldPath = "WithFlagPayload.payload", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + payloadPrefix.toInt()}""")
+      }
+      __offset += 2 + payloadPrefix.toInt()
+    }
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/WithOptionalCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/WithOptionalCodec.kt
@@ -1,0 +1,46 @@
+package com.ditchoom.buffer.codec.test.protocols.simple
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object WithOptionalCodec : Codec<WithOptional> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): WithOptional {
+    val hasExtra = buffer.readByte() != 0.toByte()
+    val extra: Int? = if (hasExtra) buffer.readInt() else null
+    return WithOptional(hasExtra = hasExtra, extra = extra)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: WithOptional,
+    context: EncodeContext,
+  ) {
+    buffer.writeByte(if (value.hasExtra) 1.toByte() else 0.toByte())
+    if (value.hasExtra) {
+      val extraValue = value.extra ?: throw EncodeException(fieldPath = "WithOptional.extra", reason = "@When(\"hasExtra\") predicate is true but field is null")
+      buffer.writeInt(extraValue)
+    }
+  }
+
+  override fun wireSize(`value`: WithOptional, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    val hasExtra = stream.peekByte(baseOffset + __offset) != 0.toByte()
+    __offset += 1
+    if (hasExtra) {
+      if (stream.available() - baseOffset < __offset + 4) return PeekResult.NeedsMoreData
+      __offset += 4
+    }
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice10e/RemoteCommandCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice10e/RemoteCommandCodec.kt
@@ -1,0 +1,79 @@
+package com.ditchoom.buffer.codec.test.protocols.slice10e
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.String
+
+public object RemoteCommandCodec : Codec<RemoteCommand> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): RemoteCommand {
+    val idPrefixB0 = buffer.readUByte().toUInt()
+    val idPrefixB1 = buffer.readUByte().toUInt()
+    val idPrefix = ((idPrefixB0 shl 8) or idPrefixB1)
+    if (idPrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "RemoteCommand.id", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = idPrefix.toString())
+    }
+    val idLength = idPrefix.toInt()
+    val id = buffer.readString(idLength, Charset.UTF8)
+    val payload = RemoteCommandPayloadCodec.decode(buffer, context)
+    return RemoteCommand(id = id, payload = payload)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: RemoteCommand,
+    context: EncodeContext,
+  ) {
+    val idSizePosition = buffer.position()
+    buffer.position(idSizePosition + 2)
+    val idBodyStart = buffer.position()
+    buffer.writeString(value.id, Charset.UTF8)
+    val idEndPosition = buffer.position()
+    val idByteCount = idEndPosition - idBodyStart
+    if (idByteCount > 65_535) {
+      throw EncodeException(fieldPath = "RemoteCommand.id", reason = """UTF-8 byte length ${idByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(idSizePosition)
+    val idPrefix = idByteCount.toUInt()
+    buffer.writeUByte(((idPrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((idPrefix and 0xFFu).toUByte())
+    buffer.position(idEndPosition)
+    RemoteCommandPayloadCodec.encode(buffer, value.payload, context)
+  }
+
+  override fun wireSize(`value`: RemoteCommand, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+
+  public fun partial(buffer: ReadBuffer, context: DecodeContext): Partial {
+    val idPrefixB0 = buffer.readUByte().toUInt()
+    val idPrefixB1 = buffer.readUByte().toUInt()
+    val idPrefix = ((idPrefixB0 shl 8) or idPrefixB1)
+    if (idPrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "RemoteCommand.id", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = idPrefix.toString())
+    }
+    val idLength = idPrefix.toInt()
+    val id = buffer.readString(idLength, Charset.UTF8)
+    return Partial(id = id, buffer = buffer, context = context)
+  }
+
+  public class Partial internal constructor(
+    public val id: String,
+    private val buffer: ReadBuffer,
+    private val context: DecodeContext,
+  ) {
+    public fun complete(): RemoteCommand {
+      val payload = RemoteCommandPayloadCodec.decode(buffer, context)
+      return RemoteCommand(id = id, payload = payload)
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice11a/ProbeConditionalCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice11a/ProbeConditionalCodec.kt
@@ -1,0 +1,36 @@
+package com.ditchoom.buffer.codec.test.protocols.slice11a
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object ProbeConditionalCodec : Codec<ProbeConditional> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): ProbeConditional {
+    val present = buffer.readByte() != 0.toByte()
+    val seal: ProbeSealed? = if (present) ProbeSealedDelegateCodec.decode(buffer, context) else null
+    return ProbeConditional(present = present, seal = seal)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: ProbeConditional,
+    context: EncodeContext,
+  ) {
+    buffer.writeByte(if (value.present) 1.toByte() else 0.toByte())
+    if (value.present) {
+      val sealValue = value.seal ?: throw EncodeException(fieldPath = "ProbeConditional.seal", reason = "@When(\"present\") predicate is true but field is null")
+      ProbeSealedDelegateCodec.encode(buffer, sealValue, context)
+    }
+  }
+
+  override fun wireSize(`value`: ProbeConditional, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice11a/ProbeRemainingBytesListCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice11a/ProbeRemainingBytesListCodec.kt
@@ -1,0 +1,35 @@
+package com.ditchoom.buffer.codec.test.protocols.slice11a
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object ProbeRemainingBytesListCodec : Codec<ProbeRemainingBytesList> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): ProbeRemainingBytesList {
+    val xs = mutableListOf<ProbeSealed>()
+    while (buffer.position() < buffer.limit()) {
+      xs += ProbeSealedCodec.decode(buffer, context)
+    }
+    return ProbeRemainingBytesList(xs = xs)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: ProbeRemainingBytesList,
+    context: EncodeContext,
+  ) {
+    for (__elem in value.xs) {
+      ProbeSealedCodec.encode(buffer, __elem, context)
+    }
+  }
+
+  override fun wireSize(`value`: ProbeRemainingBytesList, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice11a/ProbeSealedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice11a/ProbeSealedCodec.kt
@@ -1,0 +1,70 @@
+package com.ditchoom.buffer.codec.test.protocols.slice11a
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object ProbeSealedCodec : Codec<ProbeSealed> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): ProbeSealed {
+    val discriminatorPosition = buffer.position()
+    val discriminator = buffer.readUByte().toInt()
+    return when (discriminator) {
+      0x01 -> ProbeSealedTag1Codec.decode(buffer, context)
+      0x02 -> ProbeSealedTag2Codec.decode(buffer, context)
+      else -> {
+        throw DecodeException(fieldPath = "ProbeSealed.discriminator", bufferPosition = discriminatorPosition, expected = "one of {0x01, 0x02}", actual = """0x${discriminator.toString(16).padStart(2, '0').uppercase()}""")
+      }
+    }
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: ProbeSealed,
+    context: EncodeContext,
+  ) {
+    when (value) {
+      is ProbeSealed.Tag1 -> {
+        buffer.writeUByte(0x01.toUByte())
+        ProbeSealedTag1Codec.encode(buffer, value, context)
+      }
+      is ProbeSealed.Tag2 -> {
+        buffer.writeUByte(0x02.toUByte())
+        ProbeSealedTag2Codec.encode(buffer, value, context)
+      }
+    }
+  }
+
+  override fun wireSize(`value`: ProbeSealed, context: EncodeContext): WireSize = when (value) {
+    is ProbeSealed.Tag1 -> WireSize.Exact(2)
+    is ProbeSealed.Tag2 -> WireSize.BackPatch
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
+    val discriminator = stream.peekByte(baseOffset).toInt() and 0xFF
+    return when (discriminator) {
+      0x01 -> {
+        when (val inner = ProbeSealedTag1Codec.peekFrameSize(stream, baseOffset + 1)) {
+          is PeekResult.Complete -> PeekResult.Complete(1 + inner.bytes)
+          else -> inner
+        }
+      }
+      0x02 -> {
+        when (val inner = ProbeSealedTag2Codec.peekFrameSize(stream, baseOffset + 1)) {
+          is PeekResult.Complete -> PeekResult.Complete(1 + inner.bytes)
+          else -> inner
+        }
+      }
+      else -> {
+        throw DecodeException(fieldPath = "ProbeSealed.discriminator", bufferPosition = baseOffset, expected = "one of {0x01, 0x02}", actual = """0x${discriminator.toString(16).padStart(2, '0').uppercase()}""")
+      }
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice11a/ProbeSealedTag1Codec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice11a/ProbeSealedTag1Codec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.slice11a
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object ProbeSealedTag1Codec : Codec<ProbeSealed.Tag1> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): ProbeSealed.Tag1 {
+    val n = buffer.readUByte()
+    return ProbeSealed.Tag1(n = n)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: ProbeSealed.Tag1,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.n)
+  }
+
+  override fun wireSize(`value`: ProbeSealed.Tag1, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice11a/ProbeSealedTag2Codec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice11a/ProbeSealedTag2Codec.kt
@@ -1,0 +1,64 @@
+package com.ditchoom.buffer.codec.test.protocols.slice11a
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object ProbeSealedTag2Codec : Codec<ProbeSealed.Tag2> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): ProbeSealed.Tag2 {
+    val msgPrefixB0 = buffer.readUByte().toUInt()
+    val msgPrefixB1 = buffer.readUByte().toUInt()
+    val msgPrefix = ((msgPrefixB0 shl 8) or msgPrefixB1)
+    if (msgPrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "Tag2.msg", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = msgPrefix.toString())
+    }
+    val msgLength = msgPrefix.toInt()
+    val msg = buffer.readString(msgLength, Charset.UTF8)
+    return ProbeSealed.Tag2(msg = msg)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: ProbeSealed.Tag2,
+    context: EncodeContext,
+  ) {
+    val msgSizePosition = buffer.position()
+    buffer.position(msgSizePosition + 2)
+    val msgBodyStart = buffer.position()
+    buffer.writeString(value.msg, Charset.UTF8)
+    val msgEndPosition = buffer.position()
+    val msgByteCount = msgEndPosition - msgBodyStart
+    if (msgByteCount > 65_535) {
+      throw EncodeException(fieldPath = "Tag2.msg", reason = """UTF-8 byte length ${msgByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(msgSizePosition)
+    val msgPrefix = msgByteCount.toUInt()
+    buffer.writeUByte(((msgPrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((msgPrefix and 0xFFu).toUByte())
+    buffer.position(msgEndPosition)
+  }
+
+  override fun wireSize(`value`: ProbeSealed.Tag2, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val msgPrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val msgPrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val msgPrefix = ((msgPrefixB0 shl 8) or msgPrefixB1).toUInt()
+    if (msgPrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "Tag2.msg", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + msgPrefix.toInt()}""")
+    }
+    __offset += 2 + msgPrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14b/Slice14bFramedFrameFixedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14b/Slice14bFramedFrameFixedCodec.kt
@@ -1,0 +1,73 @@
+package com.ditchoom.buffer.codec.test.protocols.slice14b
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttRemainingLengthCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object Slice14bFramedFrameFixedCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): Slice14bFramedFrameFixed {
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val payload = buffer.readUByte()
+      val tail = buffer.readUShort()
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "Slice14bFramedFrameFixed.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      Slice14bFramedFrameFixed(payload = payload, tail = tail)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: Slice14bFramedFrameFixed,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+  ) { buffer ->
+    buffer.writeUByte(value.payload)
+    buffer.writeUShort(value.tail)
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 0, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 0 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14b/Slice14bFramedFrameVariableCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14b/Slice14bFramedFrameVariableCodec.kt
@@ -1,0 +1,93 @@
+package com.ditchoom.buffer.codec.test.protocols.slice14b
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttRemainingLengthCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object Slice14bFramedFrameVariableCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): Slice14bFramedFrameVariable {
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val messagePrefixB0 = buffer.readUByte().toUInt()
+      val messagePrefixB1 = buffer.readUByte().toUInt()
+      val messagePrefix = ((messagePrefixB0 shl 8) or messagePrefixB1)
+      if (messagePrefix > Int.MAX_VALUE.toUInt()) {
+        throw DecodeException(fieldPath = "Slice14bFramedFrameVariable.message", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = messagePrefix.toString())
+      }
+      val messageLength = messagePrefix.toInt()
+      val message = buffer.readString(messageLength, Charset.UTF8)
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "Slice14bFramedFrameVariable.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      Slice14bFramedFrameVariable(message = message)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: Slice14bFramedFrameVariable,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+  ) { buffer ->
+    val messageSizePosition = buffer.position()
+    buffer.position(messageSizePosition + 2)
+    val messageBodyStart = buffer.position()
+    buffer.writeString(value.message, Charset.UTF8)
+    val messageEndPosition = buffer.position()
+    val messageByteCount = messageEndPosition - messageBodyStart
+    if (messageByteCount > 65_535) {
+      throw EncodeException(fieldPath = "Slice14bFramedFrameVariable.message", reason = """UTF-8 byte length ${messageByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(messageSizePosition)
+    val messagePrefix = messageByteCount.toUInt()
+    buffer.writeUByte(((messagePrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((messagePrefix and 0xFFu).toUByte())
+    buffer.position(messageEndPosition)
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 0, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 0 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14c/Slice14cFramedDispatchACodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14c/Slice14cFramedDispatchACodec.kt
@@ -1,0 +1,78 @@
+package com.ditchoom.buffer.codec.test.protocols.slice14c
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttRemainingLengthCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object Slice14cFramedDispatchACodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): Slice14cFramedDispatch.A {
+    val header = Slice14cTinyHeader(buffer.readUByte())
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val a = buffer.readUByte()
+      val b = buffer.readUShort()
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "A.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      Slice14cFramedDispatch.A(header = header, a = a, b = b)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: Slice14cFramedDispatch.A,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+    headerWireWidth = 1,
+    writeHeader = { buffer ->
+      buffer.writeUByte(value.header.raw)
+    },
+  ) { buffer ->
+    buffer.writeUByte(value.a)
+    buffer.writeUShort(value.b)
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14c/Slice14cFramedDispatchBCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14c/Slice14cFramedDispatchBCodec.kt
@@ -1,0 +1,98 @@
+package com.ditchoom.buffer.codec.test.protocols.slice14c
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttRemainingLengthCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object Slice14cFramedDispatchBCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): Slice14cFramedDispatch.B {
+    val header = Slice14cTinyHeader(buffer.readUByte())
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val messagePrefixB0 = buffer.readUByte().toUInt()
+      val messagePrefixB1 = buffer.readUByte().toUInt()
+      val messagePrefix = ((messagePrefixB0 shl 8) or messagePrefixB1)
+      if (messagePrefix > Int.MAX_VALUE.toUInt()) {
+        throw DecodeException(fieldPath = "B.message", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = messagePrefix.toString())
+      }
+      val messageLength = messagePrefix.toInt()
+      val message = buffer.readString(messageLength, Charset.UTF8)
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "B.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      Slice14cFramedDispatch.B(header = header, message = message)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: Slice14cFramedDispatch.B,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+    headerWireWidth = 1,
+    writeHeader = { buffer ->
+      buffer.writeUByte(value.header.raw)
+    },
+  ) { buffer ->
+    val messageSizePosition = buffer.position()
+    buffer.position(messageSizePosition + 2)
+    val messageBodyStart = buffer.position()
+    buffer.writeString(value.message, Charset.UTF8)
+    val messageEndPosition = buffer.position()
+    val messageByteCount = messageEndPosition - messageBodyStart
+    if (messageByteCount > 65_535) {
+      throw EncodeException(fieldPath = "B.message", reason = """UTF-8 byte length ${messageByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(messageSizePosition)
+    val messagePrefix = messageByteCount.toUInt()
+    buffer.writeUByte(((messagePrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((messagePrefix and 0xFFu).toUByte())
+    buffer.position(messageEndPosition)
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14c/Slice14cFramedDispatchCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14c/Slice14cFramedDispatchCodec.kt
@@ -1,0 +1,59 @@
+package com.ditchoom.buffer.codec.test.protocols.slice14c
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttRemainingLengthCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object Slice14cFramedDispatchCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): Slice14cFramedDispatch {
+    val discriminatorPosition = buffer.position()
+    val __discriminator = Slice14cTinyHeaderCodec.decode(buffer, context)
+    buffer.position(discriminatorPosition)
+    val __dispatchValue = __discriminator.packetType
+    return when (__dispatchValue) {
+      1 -> Slice14cFramedDispatchACodec.decode(buffer, context)
+      2 -> Slice14cFramedDispatchBCodec.decode(buffer, context)
+      else -> {
+        throw DecodeException(fieldPath = "Slice14cFramedDispatch.discriminator", bufferPosition = discriminatorPosition, expected = "one of {1, 2}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+
+  public fun encode(
+    `value`: Slice14cFramedDispatch,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = when (value) {
+    is Slice14cFramedDispatch.A -> Slice14cFramedDispatchACodec.encode(value, context, factory)
+    is Slice14cFramedDispatch.B -> Slice14cFramedDispatchBCodec.encode(value, context, factory)
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14c/Slice14cTinyHeaderCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14c/Slice14cTinyHeaderCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.slice14c
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object Slice14cTinyHeaderCodec : Codec<Slice14cTinyHeader> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): Slice14cTinyHeader {
+    val raw = buffer.readUByte()
+    return Slice14cTinyHeader(raw = raw)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: Slice14cTinyHeader,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.raw)
+  }
+
+  override fun wireSize(`value`: Slice14cTinyHeader, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14cgeneric/Slice14cGenericFramedDispatchCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14cgeneric/Slice14cGenericFramedDispatchCodec.kt
@@ -1,0 +1,90 @@
+package com.ditchoom.buffer.codec.test.protocols.slice14cgeneric
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.Payload
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttRemainingLengthCodec
+import com.ditchoom.buffer.codec.test.protocols.slice14c.Slice14cTinyHeaderCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public class Slice14cGenericFramedDispatchCodec<P : Payload>(
+  private val payloadCodec: Codec<P>,
+) {
+  private val withPayloadCodec: Slice14cGenericFramedDispatchWithPayloadCodec<P> =
+      Slice14cGenericFramedDispatchWithPayloadCodec(payloadCodec)
+
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): Slice14cGenericFramedDispatch<P> {
+    val discriminatorPosition = buffer.position()
+    val __discriminator = Slice14cTinyHeaderCodec.decode(buffer, context)
+    buffer.position(discriminatorPosition)
+    val __dispatchValue = __discriminator.packetType
+    return when (__dispatchValue) {
+      1 -> Slice14cGenericFramedDispatchHeaderedCodec.decode(buffer, context)
+      2 -> withPayloadCodec.decode(buffer, context)
+      else -> {
+        throw DecodeException(fieldPath = "Slice14cGenericFramedDispatch.discriminator", bufferPosition = discriminatorPosition, expected = "one of {1, 2}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+
+  public fun encode(
+    `value`: Slice14cGenericFramedDispatch<P>,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer {
+    @Suppress("UNCHECKED_CAST")
+    return when (value) {
+      is Slice14cGenericFramedDispatch.Headered -> Slice14cGenericFramedDispatchHeaderedCodec.encode(value, context, factory)
+      is Slice14cGenericFramedDispatch.WithPayload<*> -> withPayloadCodec.encode(value as Slice14cGenericFramedDispatch.WithPayload<P>, context, factory)
+    }
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+
+  public companion object {
+    public fun <P : Payload> decodeAggregating(
+      buffer: ReadBuffer,
+      context: DecodeContext,
+      onWithPayload: (Slice14cGenericFramedDispatchWithPayloadCodec.Partial<P>) -> Slice14cGenericFramedDispatch.WithPayload<P> = { _ -> throw DecodeException(fieldPath = "Slice14cGenericFramedDispatch.WithPayload.handler", bufferPosition = -1, expected = "consumer-supplied WithPayload handler", actual = "no handler supplied") },
+    ): Slice14cGenericFramedDispatch<P> {
+      val discriminatorPosition = buffer.position()
+      val __discriminator = Slice14cTinyHeaderCodec.decode(buffer, context)
+      buffer.position(discriminatorPosition)
+      val __dispatchValue = __discriminator.packetType
+      return when (__dispatchValue) {
+        1 -> Slice14cGenericFramedDispatchHeaderedCodec.decode(buffer, context)
+        2 -> onWithPayload(Slice14cGenericFramedDispatchWithPayloadCodec.partial<P>(buffer, context))
+        else -> {
+          throw DecodeException(fieldPath = "Slice14cGenericFramedDispatch.discriminator", bufferPosition = discriminatorPosition, expected = "one of {1, 2}", actual = """${__dispatchValue}""")
+        }
+      }
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14cgeneric/Slice14cGenericFramedDispatchHeaderedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14cgeneric/Slice14cGenericFramedDispatchHeaderedCodec.kt
@@ -1,0 +1,79 @@
+package com.ditchoom.buffer.codec.test.protocols.slice14cgeneric
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttRemainingLengthCodec
+import com.ditchoom.buffer.codec.test.protocols.slice14c.Slice14cTinyHeader
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object Slice14cGenericFramedDispatchHeaderedCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): Slice14cGenericFramedDispatch.Headered {
+    val header = Slice14cTinyHeader(buffer.readUByte())
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val a = buffer.readUByte()
+      val b = buffer.readUShort()
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "Headered.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      Slice14cGenericFramedDispatch.Headered(header = header, a = a, b = b)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: Slice14cGenericFramedDispatch.Headered,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+    headerWireWidth = 1,
+    writeHeader = { buffer ->
+      buffer.writeUByte(value.header.raw)
+    },
+  ) { buffer ->
+    buffer.writeUByte(value.a)
+    buffer.writeUShort(value.b)
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14cgeneric/Slice14cGenericFramedDispatchWithPayloadCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14cgeneric/Slice14cGenericFramedDispatchWithPayloadCodec.kt
@@ -1,0 +1,140 @@
+package com.ditchoom.buffer.codec.test.protocols.slice14cgeneric
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.Decoder
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.Payload
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttRemainingLengthCodec
+import com.ditchoom.buffer.codec.test.protocols.slice14c.Slice14cTinyHeader
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.String
+import kotlin.Throwable
+
+public class Slice14cGenericFramedDispatchWithPayloadCodec<P : Payload>(
+  private val payloadCodec: Codec<P>,
+) {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): Slice14cGenericFramedDispatch.WithPayload<P> {
+    val header = Slice14cTinyHeader(buffer.readUByte())
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val topicPrefixB0 = buffer.readUByte().toUInt()
+      val topicPrefixB1 = buffer.readUByte().toUInt()
+      val topicPrefix = ((topicPrefixB0 shl 8) or topicPrefixB1)
+      if (topicPrefix > Int.MAX_VALUE.toUInt()) {
+        throw DecodeException(fieldPath = "WithPayload.topic", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = topicPrefix.toString())
+      }
+      val topicLength = topicPrefix.toInt()
+      val topic = buffer.readString(topicLength, Charset.UTF8)
+      val payload = payloadCodec.decode(buffer, context)
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "WithPayload.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      Slice14cGenericFramedDispatch.WithPayload<P>(header = header, topic = topic, payload = payload)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: Slice14cGenericFramedDispatch.WithPayload<P>,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+    headerWireWidth = 1,
+    writeHeader = { buffer ->
+      buffer.writeUByte(value.header.raw)
+    },
+  ) { buffer ->
+    val topicSizePosition = buffer.position()
+    buffer.position(topicSizePosition + 2)
+    val topicBodyStart = buffer.position()
+    buffer.writeString(value.topic, Charset.UTF8)
+    val topicEndPosition = buffer.position()
+    val topicByteCount = topicEndPosition - topicBodyStart
+    if (topicByteCount > 65_535) {
+      throw EncodeException(fieldPath = "WithPayload.topic", reason = """UTF-8 byte length ${topicByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(topicSizePosition)
+    val topicPrefix = topicByteCount.toUInt()
+    buffer.writeUByte(((topicPrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((topicPrefix and 0xFFu).toUByte())
+    buffer.position(topicEndPosition)
+    payloadCodec.encode(buffer, value.payload, context)
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+
+  public class Partial<P : Payload> internal constructor(
+    public val `header`: Slice14cTinyHeader,
+    public val topic: String,
+    private val outerLimit: Int,
+    private val buffer: ReadBuffer,
+    private val context: DecodeContext,
+  ) {
+    public fun complete(payloadCodec: Decoder<P>): Slice14cGenericFramedDispatch.WithPayload<P> = try {
+      val payload = payloadCodec.decode(buffer, context)
+      Slice14cGenericFramedDispatch.WithPayload<P>(header = header, topic = topic, payload = payload)
+    } finally {
+      buffer.setLimit(outerLimit)
+    }
+  }
+
+  public companion object {
+    public fun <P : Payload> partial(buffer: ReadBuffer, context: DecodeContext): Partial<P> {
+      val header = Slice14cTinyHeader(buffer.readUByte())
+      val __framingOuterLimit = buffer.limit()
+      val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+      MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+      val topicPrefixB0 = buffer.readUByte().toUInt()
+      val topicPrefixB1 = buffer.readUByte().toUInt()
+      val topicPrefix = ((topicPrefixB0 shl 8) or topicPrefixB1)
+      if (topicPrefix > Int.MAX_VALUE.toUInt()) {
+        throw DecodeException(fieldPath = "WithPayload.topic", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = topicPrefix.toString())
+      }
+      val topicLength = topicPrefix.toInt()
+      val topic = buffer.readString(topicLength, Charset.UTF8)
+      return Partial<P>(header = header, topic = topic, outerLimit = __framingOuterLimit, buffer = buffer, context = context)
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice15a/Slice15aLengthPrefixedPayloadCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice15a/Slice15aLengthPrefixedPayloadCodec.kt
@@ -1,0 +1,70 @@
+package com.ditchoom.buffer.codec.test.protocols.slice15a
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.codec.test.protocols.payload.BinaryDataCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object Slice15aLengthPrefixedPayloadCodec : Codec<Slice15aLengthPrefixedPayload> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): Slice15aLengthPrefixedPayload {
+    val dataPrefixB0 = buffer.readUByte().toUInt()
+    val dataPrefixB1 = buffer.readUByte().toUInt()
+    val dataPrefix = ((dataPrefixB0 shl 8) or dataPrefixB1)
+    if (dataPrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "Slice15aLengthPrefixedPayload.data", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = dataPrefix.toString())
+    }
+    val dataLength = dataPrefix.toInt()
+    val __dataOuterLimit = buffer.limit()
+    buffer.setLimit(buffer.position() + dataLength)
+    val data = try {
+      BinaryDataCodec.decode(buffer, context)
+    } finally {
+      buffer.setLimit(__dataOuterLimit)
+    }
+    return Slice15aLengthPrefixedPayload(data = data)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: Slice15aLengthPrefixedPayload,
+    context: EncodeContext,
+  ) {
+    val dataSizePosition = buffer.position()
+    buffer.position(dataSizePosition + 2)
+    val dataBodyStart = buffer.position()
+    BinaryDataCodec.encode(buffer, value.data, context)
+    val dataEndPosition = buffer.position()
+    val dataByteCount = dataEndPosition - dataBodyStart
+    if (dataByteCount > 65_535) {
+      throw EncodeException(fieldPath = "Slice15aLengthPrefixedPayload.data", reason = """encoded payload byte length ${dataByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(dataSizePosition)
+    val dataPrefix = dataByteCount.toUInt()
+    buffer.writeUByte(((dataPrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((dataPrefix and 0xFFu).toUByte())
+    buffer.position(dataEndPosition)
+  }
+
+  override fun wireSize(`value`: Slice15aLengthPrefixedPayload, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val dataPrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val dataPrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val dataPrefix = ((dataPrefixB0 shl 8) or dataPrefixB1).toUInt()
+    if (dataPrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "Slice15aLengthPrefixedPayload.data", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + dataPrefix.toInt()}""")
+    }
+    __offset += 2 + dataPrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice7c/RepeatedBlockCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice7c/RepeatedBlockCodec.kt
@@ -1,0 +1,35 @@
+package com.ditchoom.buffer.codec.test.protocols.slice7c
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object RepeatedBlockCodec : Codec<RepeatedBlock> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): RepeatedBlock {
+    val blockIdB0 = buffer.readUByte().toUInt()
+    val blockIdB1 = buffer.readUByte().toUInt()
+    val blockId = ((blockIdB0 shl 8) or blockIdB1).toUShort()
+    val blockKind = buffer.readUByte()
+    return RepeatedBlock(blockId = blockId, blockKind = blockKind)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: RepeatedBlock,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(((value.blockId.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.blockId.toUInt() and 0xFFu).toUByte())
+    buffer.writeUByte(value.blockKind)
+  }
+
+  override fun wireSize(`value`: RepeatedBlock, context: EncodeContext): WireSize = WireSize.Exact(3)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 3) PeekResult.Complete(3) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice7c/RepeatedBlocksCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice7c/RepeatedBlocksCodec.kt
@@ -1,0 +1,40 @@
+package com.ditchoom.buffer.codec.test.protocols.slice7c
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object RepeatedBlocksCodec : Codec<RepeatedBlocks> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): RepeatedBlocks {
+    val streamIdB0 = buffer.readUByte().toUInt()
+    val streamIdB1 = buffer.readUByte().toUInt()
+    val streamId = ((streamIdB0 shl 8) or streamIdB1).toUShort()
+    val blocks = mutableListOf<RepeatedBlock>()
+    while (buffer.position() < buffer.limit()) {
+      blocks += RepeatedBlockCodec.decode(buffer, context)
+    }
+    return RepeatedBlocks(streamId = streamId, blocks = blocks)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: RepeatedBlocks,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(((value.streamId.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.streamId.toUInt() and 0xFFu).toUByte())
+    for (__elem in value.blocks) {
+      RepeatedBlockCodec.encode(buffer, __elem, context)
+    }
+  }
+
+  override fun wireSize(`value`: RepeatedBlocks, context: EncodeContext): WireSize = WireSize.Exact(2 + value.blocks.sumOf { (RepeatedBlockCodec.wireSize(it, context) as WireSize.Exact).bytes })
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tcp/TcpFlagsByteCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tcp/TcpFlagsByteCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.tcp
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object TcpFlagsByteCodec : Codec<TcpFlagsByte> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): TcpFlagsByte {
+    val raw = buffer.readUByte()
+    return TcpFlagsByte(raw = raw)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: TcpFlagsByte,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.raw)
+  }
+
+  override fun wireSize(`value`: TcpFlagsByte, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tcp/TcpSegmentByFlagsAckCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tcp/TcpSegmentByFlagsAckCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.tcp
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object TcpSegmentByFlagsAckCodec : Codec<TcpSegmentByFlags.Ack> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): TcpSegmentByFlags.Ack {
+    val flags = TcpFlagsByte(buffer.readUByte())
+    return TcpSegmentByFlags.Ack(flags = flags)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: TcpSegmentByFlags.Ack,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.flags.raw)
+  }
+
+  override fun wireSize(`value`: TcpSegmentByFlags.Ack, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tcp/TcpSegmentByFlagsCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tcp/TcpSegmentByFlagsCodec.kt
@@ -1,0 +1,70 @@
+package com.ditchoom.buffer.codec.test.protocols.tcp
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object TcpSegmentByFlagsCodec : Codec<TcpSegmentByFlags> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): TcpSegmentByFlags {
+    val discriminatorPosition = buffer.position()
+    val __discriminator = TcpFlagsByteCodec.decode(buffer, context)
+    buffer.position(discriminatorPosition)
+    val __dispatchValue = __discriminator.flags.toInt()
+    return when (__dispatchValue) {
+      2 -> TcpSegmentByFlagsSynCodec.decode(buffer, context)
+      4 -> TcpSegmentByFlagsRstCodec.decode(buffer, context)
+      16 -> TcpSegmentByFlagsAckCodec.decode(buffer, context)
+      17 -> TcpSegmentByFlagsFinAckCodec.decode(buffer, context)
+      18 -> TcpSegmentByFlagsSynAckCodec.decode(buffer, context)
+      else -> {
+        throw DecodeException(fieldPath = "TcpSegmentByFlags.discriminator", bufferPosition = discriminatorPosition, expected = "one of {2, 4, 16, 17, 18}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: TcpSegmentByFlags,
+    context: EncodeContext,
+  ) {
+    when (value) {
+      is TcpSegmentByFlags.Syn -> TcpSegmentByFlagsSynCodec.encode(buffer, value, context)
+      is TcpSegmentByFlags.Rst -> TcpSegmentByFlagsRstCodec.encode(buffer, value, context)
+      is TcpSegmentByFlags.Ack -> TcpSegmentByFlagsAckCodec.encode(buffer, value, context)
+      is TcpSegmentByFlags.FinAck -> TcpSegmentByFlagsFinAckCodec.encode(buffer, value, context)
+      is TcpSegmentByFlags.SynAck -> TcpSegmentByFlagsSynAckCodec.encode(buffer, value, context)
+    }
+  }
+
+  override fun wireSize(`value`: TcpSegmentByFlags, context: EncodeContext): WireSize = when (value) {
+    is TcpSegmentByFlags.Syn -> TcpSegmentByFlagsSynCodec.wireSize(value, context)
+    is TcpSegmentByFlags.Rst -> TcpSegmentByFlagsRstCodec.wireSize(value, context)
+    is TcpSegmentByFlags.Ack -> TcpSegmentByFlagsAckCodec.wireSize(value, context)
+    is TcpSegmentByFlags.FinAck -> TcpSegmentByFlagsFinAckCodec.wireSize(value, context)
+    is TcpSegmentByFlags.SynAck -> TcpSegmentByFlagsSynAckCodec.wireSize(value, context)
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
+    val __discRaw = stream.peekByte(baseOffset + 0).toUByte()
+    val __discriminator = TcpFlagsByte(__discRaw)
+    val __dispatchValue = __discriminator.flags.toInt()
+    return when (__dispatchValue) {
+      2 -> TcpSegmentByFlagsSynCodec.peekFrameSize(stream, baseOffset)
+      4 -> TcpSegmentByFlagsRstCodec.peekFrameSize(stream, baseOffset)
+      16 -> TcpSegmentByFlagsAckCodec.peekFrameSize(stream, baseOffset)
+      17 -> TcpSegmentByFlagsFinAckCodec.peekFrameSize(stream, baseOffset)
+      18 -> TcpSegmentByFlagsSynAckCodec.peekFrameSize(stream, baseOffset)
+      else -> {
+        throw DecodeException(fieldPath = "TcpSegmentByFlags.discriminator", bufferPosition = baseOffset, expected = "one of {2, 4, 16, 17, 18}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tcp/TcpSegmentByFlagsFinAckCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tcp/TcpSegmentByFlagsFinAckCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.tcp
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object TcpSegmentByFlagsFinAckCodec : Codec<TcpSegmentByFlags.FinAck> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): TcpSegmentByFlags.FinAck {
+    val flags = TcpFlagsByte(buffer.readUByte())
+    return TcpSegmentByFlags.FinAck(flags = flags)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: TcpSegmentByFlags.FinAck,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.flags.raw)
+  }
+
+  override fun wireSize(`value`: TcpSegmentByFlags.FinAck, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tcp/TcpSegmentByFlagsRstCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tcp/TcpSegmentByFlagsRstCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.tcp
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object TcpSegmentByFlagsRstCodec : Codec<TcpSegmentByFlags.Rst> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): TcpSegmentByFlags.Rst {
+    val flags = TcpFlagsByte(buffer.readUByte())
+    return TcpSegmentByFlags.Rst(flags = flags)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: TcpSegmentByFlags.Rst,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.flags.raw)
+  }
+
+  override fun wireSize(`value`: TcpSegmentByFlags.Rst, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tcp/TcpSegmentByFlagsSynAckCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tcp/TcpSegmentByFlagsSynAckCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.tcp
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object TcpSegmentByFlagsSynAckCodec : Codec<TcpSegmentByFlags.SynAck> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): TcpSegmentByFlags.SynAck {
+    val flags = TcpFlagsByte(buffer.readUByte())
+    return TcpSegmentByFlags.SynAck(flags = flags)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: TcpSegmentByFlags.SynAck,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.flags.raw)
+  }
+
+  override fun wireSize(`value`: TcpSegmentByFlags.SynAck, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tcp/TcpSegmentByFlagsSynCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tcp/TcpSegmentByFlagsSynCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.tcp
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object TcpSegmentByFlagsSynCodec : Codec<TcpSegmentByFlags.Syn> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): TcpSegmentByFlags.Syn {
+    val flags = TcpFlagsByte(buffer.readUByte())
+    return TcpSegmentByFlags.Syn(flags = flags)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: TcpSegmentByFlags.Syn,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.flags.raw)
+  }
+
+  override fun wireSize(`value`: TcpSegmentByFlags.Syn, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeBodyCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeBodyCodec.kt
@@ -1,0 +1,55 @@
+package com.ditchoom.buffer.codec.test.protocols.tls
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.codec.test.protocols.payload.BinaryDataCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.UShort
+
+public object TlsHandshakeBodyCodec : Codec<TlsHandshakeBody> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): TlsHandshakeBody {
+    val legacyVersionB0 = buffer.readUByte().toUInt()
+    val legacyVersionB1 = buffer.readUByte().toUInt()
+    val legacyVersion = ((legacyVersionB0 shl 8) or legacyVersionB1).toUShort()
+    val random = BinaryDataCodec.decode(buffer, context)
+    return TlsHandshakeBody(legacyVersion = legacyVersion, random = random)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: TlsHandshakeBody,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(((value.legacyVersion.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.legacyVersion.toUInt() and 0xFFu).toUByte())
+    BinaryDataCodec.encode(buffer, value.random, context)
+  }
+
+  override fun wireSize(`value`: TlsHandshakeBody, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+
+  public fun partial(buffer: ReadBuffer, context: DecodeContext): Partial {
+    val legacyVersionB0 = buffer.readUByte().toUInt()
+    val legacyVersionB1 = buffer.readUByte().toUInt()
+    val legacyVersion = ((legacyVersionB0 shl 8) or legacyVersionB1).toUShort()
+    return Partial(legacyVersion = legacyVersion, buffer = buffer, context = context)
+  }
+
+  public class Partial internal constructor(
+    public val legacyVersion: UShort,
+    private val buffer: ReadBuffer,
+    private val context: DecodeContext,
+  ) {
+    public fun complete(): TlsHandshakeBody {
+      val random = BinaryDataCodec.decode(buffer, context)
+      return TlsHandshakeBody(legacyVersion = legacyVersion, random = random)
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeCodec.kt
@@ -1,0 +1,71 @@
+package com.ditchoom.buffer.codec.test.protocols.tls
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object TlsHandshakeCodec : Codec<TlsHandshake> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): TlsHandshake {
+    val msgType = buffer.readUByte()
+    val lengthB0 = buffer.readUByte().toUInt()
+    val lengthB1 = buffer.readUByte().toUInt()
+    val lengthB2 = buffer.readUByte().toUInt()
+    val length = ((lengthB0 shl 16) or (lengthB1 shl 8) or lengthB2)
+    if (length > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "TlsHandshake.body", bufferPosition = -1, expected = "@LengthFrom source <= ${'$'}{Int.MAX_VALUE}", actual = length.toString())
+    }
+    val bodyBytes = length.toInt()
+    val bodyOuterLimit = buffer.limit()
+    buffer.setLimit(buffer.position() + bodyBytes)
+    val body = try {
+      TlsHandshakeBodyCodec.decode(buffer, context)
+    } finally {
+      buffer.setLimit(bodyOuterLimit)
+    }
+    return TlsHandshake(msgType = msgType, length = length, body = body)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: TlsHandshake,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.msgType)
+    if (value.length > ((1u shl 24) - 1u)) {
+      throw EncodeException(fieldPath = "TlsHandshake.length", reason = "value exceeds @WireBytes(3) range (max 16777215)")
+    }
+    buffer.writeUByte(((value.length shr 16) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.length shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.length and 0xFFu).toUByte())
+    TlsHandshakeBodyCodec.encode(buffer, value.body, context)
+  }
+
+  override fun wireSize(`value`: TlsHandshake, context: EncodeContext): WireSize = WireSize.Exact(4 + value.length.toInt())
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    __offset += 1
+    if (stream.available() - baseOffset < __offset + 3) return PeekResult.NeedsMoreData
+    val lengthB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val lengthB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val lengthB2 = stream.peekByte(baseOffset + __offset + 2).toInt() and 0xFF
+    val length = ((lengthB0 shl 16) or (lengthB1 shl 8) or lengthB2).toUInt()
+    __offset += 3
+    if (length > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "TlsHandshake.body", bufferPosition = -1, expected = "@LengthFrom source <= ${'$'}{Int.MAX_VALUE}", actual = length.toString())
+    }
+    val bodyBytes = length.toInt()
+    if (stream.available() - baseOffset < __offset + bodyBytes) return PeekResult.NeedsMoreData
+    __offset += bodyBytes
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeSealedBodyClientHelloCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeSealedBodyClientHelloCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.tls
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object TlsHandshakeSealedBodyClientHelloCodec : Codec<TlsHandshakeSealedBody.ClientHello> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): TlsHandshakeSealedBody.ClientHello {
+    val legacyVersion = buffer.readUShort()
+    return TlsHandshakeSealedBody.ClientHello(legacyVersion = legacyVersion)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: TlsHandshakeSealedBody.ClientHello,
+    context: EncodeContext,
+  ) {
+    buffer.writeUShort(value.legacyVersion)
+  }
+
+  override fun wireSize(`value`: TlsHandshakeSealedBody.ClientHello, context: EncodeContext): WireSize = WireSize.Exact(2)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeSealedBodyCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeSealedBodyCodec.kt
@@ -1,0 +1,70 @@
+package com.ditchoom.buffer.codec.test.protocols.tls
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object TlsHandshakeSealedBodyCodec : Codec<TlsHandshakeSealedBody> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): TlsHandshakeSealedBody {
+    val discriminatorPosition = buffer.position()
+    val discriminator = buffer.readUByte().toInt()
+    return when (discriminator) {
+      0x01 -> TlsHandshakeSealedBodyClientHelloCodec.decode(buffer, context)
+      0x02 -> TlsHandshakeSealedBodyHelloRequestCodec.decode(buffer, context)
+      else -> {
+        throw DecodeException(fieldPath = "TlsHandshakeSealedBody.discriminator", bufferPosition = discriminatorPosition, expected = "one of {0x01, 0x02}", actual = """0x${discriminator.toString(16).padStart(2, '0').uppercase()}""")
+      }
+    }
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: TlsHandshakeSealedBody,
+    context: EncodeContext,
+  ) {
+    when (value) {
+      is TlsHandshakeSealedBody.ClientHello -> {
+        buffer.writeUByte(0x01.toUByte())
+        TlsHandshakeSealedBodyClientHelloCodec.encode(buffer, value, context)
+      }
+      is TlsHandshakeSealedBody.HelloRequest -> {
+        buffer.writeUByte(0x02.toUByte())
+        TlsHandshakeSealedBodyHelloRequestCodec.encode(buffer, value, context)
+      }
+    }
+  }
+
+  override fun wireSize(`value`: TlsHandshakeSealedBody, context: EncodeContext): WireSize = when (value) {
+    is TlsHandshakeSealedBody.ClientHello -> WireSize.Exact(3)
+    is TlsHandshakeSealedBody.HelloRequest -> WireSize.Exact(1)
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
+    val discriminator = stream.peekByte(baseOffset).toInt() and 0xFF
+    return when (discriminator) {
+      0x01 -> {
+        when (val inner = TlsHandshakeSealedBodyClientHelloCodec.peekFrameSize(stream, baseOffset + 1)) {
+          is PeekResult.Complete -> PeekResult.Complete(1 + inner.bytes)
+          else -> inner
+        }
+      }
+      0x02 -> {
+        when (val inner = TlsHandshakeSealedBodyHelloRequestCodec.peekFrameSize(stream, baseOffset + 1)) {
+          is PeekResult.Complete -> PeekResult.Complete(1 + inner.bytes)
+          else -> inner
+        }
+      }
+      else -> {
+        throw DecodeException(fieldPath = "TlsHandshakeSealedBody.discriminator", bufferPosition = baseOffset, expected = "one of {0x01, 0x02}", actual = """0x${discriminator.toString(16).padStart(2, '0').uppercase()}""")
+      }
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeSealedBodyHelloRequestCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeSealedBodyHelloRequestCodec.kt
@@ -1,0 +1,26 @@
+package com.ditchoom.buffer.codec.test.protocols.tls
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object TlsHandshakeSealedBodyHelloRequestCodec : Codec<TlsHandshakeSealedBody.HelloRequest> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): TlsHandshakeSealedBody.HelloRequest = TlsHandshakeSealedBody.HelloRequest
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: TlsHandshakeSealedBody.HelloRequest,
+    context: EncodeContext,
+  ) {
+  }
+
+  override fun wireSize(`value`: TlsHandshakeSealedBody.HelloRequest, context: EncodeContext): WireSize = WireSize.Exact(0)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 0) PeekResult.Complete(0) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeWithSealedBodyCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeWithSealedBodyCodec.kt
@@ -1,0 +1,71 @@
+package com.ditchoom.buffer.codec.test.protocols.tls
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object TlsHandshakeWithSealedBodyCodec : Codec<TlsHandshakeWithSealedBody> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): TlsHandshakeWithSealedBody {
+    val msgType = buffer.readUByte()
+    val lengthB0 = buffer.readUByte().toUInt()
+    val lengthB1 = buffer.readUByte().toUInt()
+    val lengthB2 = buffer.readUByte().toUInt()
+    val length = ((lengthB0 shl 16) or (lengthB1 shl 8) or lengthB2)
+    if (length > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "TlsHandshakeWithSealedBody.body", bufferPosition = -1, expected = "@LengthFrom source <= ${'$'}{Int.MAX_VALUE}", actual = length.toString())
+    }
+    val bodyBytes = length.toInt()
+    val bodyOuterLimit = buffer.limit()
+    buffer.setLimit(buffer.position() + bodyBytes)
+    val body = try {
+      TlsHandshakeSealedBodyCodec.decode(buffer, context)
+    } finally {
+      buffer.setLimit(bodyOuterLimit)
+    }
+    return TlsHandshakeWithSealedBody(msgType = msgType, length = length, body = body)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: TlsHandshakeWithSealedBody,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.msgType)
+    if (value.length > ((1u shl 24) - 1u)) {
+      throw EncodeException(fieldPath = "TlsHandshakeWithSealedBody.length", reason = "value exceeds @WireBytes(3) range (max 16777215)")
+    }
+    buffer.writeUByte(((value.length shr 16) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.length shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.length and 0xFFu).toUByte())
+    TlsHandshakeSealedBodyCodec.encode(buffer, value.body, context)
+  }
+
+  override fun wireSize(`value`: TlsHandshakeWithSealedBody, context: EncodeContext): WireSize = WireSize.Exact(4 + value.length.toInt())
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    __offset += 1
+    if (stream.available() - baseOffset < __offset + 3) return PeekResult.NeedsMoreData
+    val lengthB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val lengthB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val lengthB2 = stream.peekByte(baseOffset + __offset + 2).toInt() and 0xFF
+    val length = ((lengthB0 shl 16) or (lengthB1 shl 8) or lengthB2).toUInt()
+    __offset += 3
+    if (length > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "TlsHandshakeWithSealedBody.body", bufferPosition = -1, expected = "@LengthFrom source <= ${'$'}{Int.MAX_VALUE}", actual = length.toString())
+    }
+    val bodyBytes = length.toInt()
+    if (stream.available() - baseOffset < __offset + bodyBytes) return PeekResult.NeedsMoreData
+    __offset += bodyBytes
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/BoundedFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/BoundedFrameCodec.kt
@@ -1,0 +1,87 @@
+package com.ditchoom.buffer.codec.test.protocols.usecodecscalar
+
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.codec.test.protocols.payload.BinaryDataCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Short
+import kotlin.Throwable
+import kotlin.UInt
+
+public object BoundedFrameCodec : Codec<BoundedFrame> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): BoundedFrame {
+    val tag = buffer.readShort()
+    val __lengthOuterLimit = buffer.limit()
+    val length = Le32LengthCodec.decode(buffer, context)
+    Le32LengthCodec.applyBound(buffer, length)
+    return try {
+      val payload = BinaryDataCodec.decode(buffer, context)
+      BoundedFrame(tag = tag, length = length, payload = payload)
+    } finally {
+      buffer.setLimit(__lengthOuterLimit)
+    }
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: BoundedFrame,
+    context: EncodeContext,
+  ) {
+    buffer.writeShort(value.tag)
+    Le32LengthCodec.encode(buffer, value.length, context)
+    BinaryDataCodec.encode(buffer, value.payload, context)
+  }
+
+  override fun wireSize(`value`: BoundedFrame, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    if (stream.available() - baseOffset < 3) return PeekResult.NeedsMoreData
+    val __lengthPeekView = stream.peekBuffer(baseOffset + 2, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __lengthPriorPos = __lengthPeekView.position()
+      val length = try {
+        Le32LengthCodec.decode(__lengthPeekView, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __lengthWidth = __lengthPeekView.position() - __lengthPriorPos
+      val __total = 2 + __lengthWidth + length.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__lengthPeekView as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+
+  public fun partial(buffer: ReadBuffer, context: DecodeContext): Partial {
+    val tag = buffer.readShort()
+    val __lengthOuterLimit = buffer.limit()
+    val length = Le32LengthCodec.decode(buffer, context)
+    Le32LengthCodec.applyBound(buffer, length)
+    return Partial(tag = tag, length = length, outerLimit = __lengthOuterLimit, buffer = buffer, context = context)
+  }
+
+  public class Partial internal constructor(
+    public val tag: Short,
+    public val length: UInt,
+    private val outerLimit: Int,
+    private val buffer: ReadBuffer,
+    private val context: DecodeContext,
+  ) {
+    public fun complete(): BoundedFrame = try {
+      val payload = BinaryDataCodec.decode(buffer, context)
+      BoundedFrame(tag = tag, length = length, payload = payload)
+    } finally {
+      buffer.setLimit(outerLimit)
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/ZigZagFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/ZigZagFrameCodec.kt
@@ -1,0 +1,32 @@
+package com.ditchoom.buffer.codec.test.protocols.usecodecscalar
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object ZigZagFrameCodec : Codec<ZigZagFrame> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): ZigZagFrame {
+    val id = buffer.readInt()
+    val value = ZigZagUIntCodec.decode(buffer, context)
+    return ZigZagFrame(id = id, value = value)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: ZigZagFrame,
+    context: EncodeContext,
+  ) {
+    buffer.writeInt(value.id)
+    ZigZagUIntCodec.encode(buffer, value.value, context)
+  }
+
+  override fun wireSize(`value`: ZigZagFrame, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/FrameHeaderByte1Codec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/FrameHeaderByte1Codec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.websocket
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object FrameHeaderByte1Codec : Codec<FrameHeaderByte1> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): FrameHeaderByte1 {
+    val raw = buffer.readUByte()
+    return FrameHeaderByte1(raw = raw)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: FrameHeaderByte1,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.raw)
+  }
+
+  override fun wireSize(`value`: FrameHeaderByte1, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsCloseBodyCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsCloseBodyCodec.kt
@@ -1,0 +1,36 @@
+package com.ditchoom.buffer.codec.test.protocols.websocket
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object WsCloseBodyCodec : Codec<WsCloseBody> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): WsCloseBody {
+    val statusCodeB0 = buffer.readUByte().toUInt()
+    val statusCodeB1 = buffer.readUByte().toUInt()
+    val statusCode = ((statusCodeB0 shl 8) or statusCodeB1).toUShort()
+    val reason = buffer.readString(buffer.remaining(), Charset.UTF8)
+    return WsCloseBody(statusCode = statusCode, reason = reason)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: WsCloseBody,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(((value.statusCode.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.statusCode.toUInt() and 0xFFu).toUByte())
+    buffer.writeString(value.reason, Charset.UTF8)
+  }
+
+  override fun wireSize(`value`: WsCloseBody, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsFrameBinaryCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsFrameBinaryCodec.kt
@@ -1,0 +1,82 @@
+package com.ditchoom.buffer.codec.test.protocols.websocket
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.Decoder
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.Payload
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Long
+import kotlin.UShort
+
+public class WsFrameBinaryCodec<P : Payload>(
+  private val payloadCodec: Codec<P>,
+) : Codec<WsFrame.Binary<P>> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): WsFrame.Binary<P> {
+    val byte1 = FrameHeaderByte1(buffer.readUByte())
+    val byte2 = WsHeaderByte2(buffer.readUByte())
+    val extendedLength16: UShort? = if (byte2.extended16) buffer.readUShort() else null
+    val extendedLength64: Long? = if (byte2.extended64) buffer.readLong() else null
+    val maskingKey: WsMaskingKey? = if (byte2.masked) WsMaskingKey(buffer.readUInt()) else null
+    val payload = payloadCodec.decode(buffer, context)
+    return WsFrame.Binary<P>(byte1 = byte1, byte2 = byte2, extendedLength16 = extendedLength16, extendedLength64 = extendedLength64, maskingKey = maskingKey, payload = payload)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: WsFrame.Binary<P>,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.byte1.raw)
+    buffer.writeUByte(value.byte2.raw)
+    if (value.byte2.extended16) {
+      val extendedLength16Value = value.extendedLength16 ?: throw EncodeException(fieldPath = "Binary.extendedLength16", reason = "@When(\"byte2.extended16\") predicate is true but field is null")
+      buffer.writeUShort(extendedLength16Value)
+    }
+    if (value.byte2.extended64) {
+      val extendedLength64Value = value.extendedLength64 ?: throw EncodeException(fieldPath = "Binary.extendedLength64", reason = "@When(\"byte2.extended64\") predicate is true but field is null")
+      buffer.writeLong(extendedLength64Value)
+    }
+    if (value.byte2.masked) {
+      val maskingKeyValue = value.maskingKey ?: throw EncodeException(fieldPath = "Binary.maskingKey", reason = "@When(\"byte2.masked\") predicate is true but field is null")
+      buffer.writeUInt(maskingKeyValue.raw)
+    }
+    payloadCodec.encode(buffer, value.payload, context)
+  }
+
+  override fun wireSize(`value`: WsFrame.Binary<P>, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+
+  public class Partial<P : Payload> internal constructor(
+    public val byte1: FrameHeaderByte1,
+    public val byte2: WsHeaderByte2,
+    public val extendedLength16: UShort?,
+    public val extendedLength64: Long?,
+    public val maskingKey: WsMaskingKey?,
+    private val buffer: ReadBuffer,
+    private val context: DecodeContext,
+  ) {
+    public fun complete(payloadCodec: Decoder<P>): WsFrame.Binary<P> {
+      val payload = payloadCodec.decode(buffer, context)
+      return WsFrame.Binary<P>(byte1 = byte1, byte2 = byte2, extendedLength16 = extendedLength16, extendedLength64 = extendedLength64, maskingKey = maskingKey, payload = payload)
+    }
+  }
+
+  public companion object {
+    public fun <P : Payload> partial(buffer: ReadBuffer, context: DecodeContext): Partial<P> {
+      val byte1 = FrameHeaderByte1(buffer.readUByte())
+      val byte2 = WsHeaderByte2(buffer.readUByte())
+      val extendedLength16: UShort? = if (byte2.extended16) buffer.readUShort() else null
+      val extendedLength64: Long? = if (byte2.extended64) buffer.readLong() else null
+      val maskingKey: WsMaskingKey? = if (byte2.masked) WsMaskingKey(buffer.readUInt()) else null
+      return Partial<P>(byte1 = byte1, byte2 = byte2, extendedLength16 = extendedLength16, extendedLength64 = extendedLength64, maskingKey = maskingKey, buffer = buffer, context = context)
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsFrameCloseCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsFrameCloseCodec.kt
@@ -1,0 +1,55 @@
+package com.ditchoom.buffer.codec.test.protocols.websocket
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Long
+import kotlin.UShort
+
+public object WsFrameCloseCodec : Codec<WsFrame.Close> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): WsFrame.Close {
+    val byte1 = FrameHeaderByte1(buffer.readUByte())
+    val byte2 = WsHeaderByte2(buffer.readUByte())
+    val extendedLength16: UShort? = if (byte2.extended16) buffer.readUShort() else null
+    val extendedLength64: Long? = if (byte2.extended64) buffer.readLong() else null
+    val maskingKey: WsMaskingKey? = if (byte2.masked) WsMaskingKey(buffer.readUInt()) else null
+    val body: WsCloseBody? = if (buffer.remaining() >= 2) WsCloseBodyCodec.decode(buffer, context) else null
+    return WsFrame.Close(byte1 = byte1, byte2 = byte2, extendedLength16 = extendedLength16, extendedLength64 = extendedLength64, maskingKey = maskingKey, body = body)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: WsFrame.Close,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.byte1.raw)
+    buffer.writeUByte(value.byte2.raw)
+    if (value.byte2.extended16) {
+      val extendedLength16Value = value.extendedLength16 ?: throw EncodeException(fieldPath = "Close.extendedLength16", reason = "@When(\"byte2.extended16\") predicate is true but field is null")
+      buffer.writeUShort(extendedLength16Value)
+    }
+    if (value.byte2.extended64) {
+      val extendedLength64Value = value.extendedLength64 ?: throw EncodeException(fieldPath = "Close.extendedLength64", reason = "@When(\"byte2.extended64\") predicate is true but field is null")
+      buffer.writeLong(extendedLength64Value)
+    }
+    if (value.byte2.masked) {
+      val maskingKeyValue = value.maskingKey ?: throw EncodeException(fieldPath = "Close.maskingKey", reason = "@When(\"byte2.masked\") predicate is true but field is null")
+      buffer.writeUInt(maskingKeyValue.raw)
+    }
+    if (value.body != null) {
+      val bodyValue = value.body ?: throw EncodeException(fieldPath = "Close.body", reason = "@When(\"remaining >= 2\") predicate is true but field is null")
+      WsCloseBodyCodec.encode(buffer, bodyValue, context)
+    }
+  }
+
+  override fun wireSize(`value`: WsFrame.Close, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsFrameCodec.kt
@@ -1,0 +1,120 @@
+package com.ditchoom.buffer.codec.test.protocols.websocket
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.Payload
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public class WsFrameCodec<P : Payload>(
+  private val payloadCodec: Codec<P>,
+) : Codec<WsFrame<P>> {
+  private val continuationCodec: WsFrameContinuationCodec<P> =
+      WsFrameContinuationCodec(payloadCodec)
+
+  private val textCodec: WsFrameTextCodec<P> = WsFrameTextCodec(payloadCodec)
+
+  private val binaryCodec: WsFrameBinaryCodec<P> = WsFrameBinaryCodec(payloadCodec)
+
+  private val pingCodec: WsFramePingCodec<P> = WsFramePingCodec(payloadCodec)
+
+  private val pongCodec: WsFramePongCodec<P> = WsFramePongCodec(payloadCodec)
+
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): WsFrame<P> {
+    val discriminatorPosition = buffer.position()
+    val __discriminator = FrameHeaderByte1Codec.decode(buffer, context)
+    buffer.position(discriminatorPosition)
+    val __dispatchValue = __discriminator.opcode
+    return when (__dispatchValue) {
+      0 -> continuationCodec.decode(buffer, context)
+      1 -> textCodec.decode(buffer, context)
+      2 -> binaryCodec.decode(buffer, context)
+      8 -> WsFrameCloseCodec.decode(buffer, context)
+      9 -> pingCodec.decode(buffer, context)
+      10 -> pongCodec.decode(buffer, context)
+      else -> {
+        throw DecodeException(fieldPath = "WsFrame.discriminator", bufferPosition = discriminatorPosition, expected = "one of {0, 1, 2, 8, 9, 10}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: WsFrame<P>,
+    context: EncodeContext,
+  ) {
+    @Suppress("UNCHECKED_CAST")
+    when (value) {
+      is WsFrame.Continuation<*> -> continuationCodec.encode(buffer, value as WsFrame.Continuation<P>, context)
+      is WsFrame.Text<*> -> textCodec.encode(buffer, value as WsFrame.Text<P>, context)
+      is WsFrame.Binary<*> -> binaryCodec.encode(buffer, value as WsFrame.Binary<P>, context)
+      is WsFrame.Close -> WsFrameCloseCodec.encode(buffer, value, context)
+      is WsFrame.Ping<*> -> pingCodec.encode(buffer, value as WsFrame.Ping<P>, context)
+      is WsFrame.Pong<*> -> pongCodec.encode(buffer, value as WsFrame.Pong<P>, context)
+    }
+  }
+
+  override fun wireSize(`value`: WsFrame<P>, context: EncodeContext): WireSize {
+    @Suppress("UNCHECKED_CAST")
+    return when (value) {
+      is WsFrame.Continuation<*> -> continuationCodec.wireSize(value as WsFrame.Continuation<P>, context)
+      is WsFrame.Text<*> -> textCodec.wireSize(value as WsFrame.Text<P>, context)
+      is WsFrame.Binary<*> -> binaryCodec.wireSize(value as WsFrame.Binary<P>, context)
+      is WsFrame.Close -> WsFrameCloseCodec.wireSize(value, context)
+      is WsFrame.Ping<*> -> pingCodec.wireSize(value as WsFrame.Ping<P>, context)
+      is WsFrame.Pong<*> -> pongCodec.wireSize(value as WsFrame.Pong<P>, context)
+    }
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
+    val __discRaw = stream.peekByte(baseOffset + 0).toUByte()
+    val __discriminator = FrameHeaderByte1(__discRaw)
+    val __dispatchValue = __discriminator.opcode
+    return when (__dispatchValue) {
+      0 -> continuationCodec.peekFrameSize(stream, baseOffset)
+      1 -> textCodec.peekFrameSize(stream, baseOffset)
+      2 -> binaryCodec.peekFrameSize(stream, baseOffset)
+      8 -> WsFrameCloseCodec.peekFrameSize(stream, baseOffset)
+      9 -> pingCodec.peekFrameSize(stream, baseOffset)
+      10 -> pongCodec.peekFrameSize(stream, baseOffset)
+      else -> {
+        throw DecodeException(fieldPath = "WsFrame.discriminator", bufferPosition = baseOffset, expected = "one of {0, 1, 2, 8, 9, 10}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+
+  public companion object {
+    public fun <P : Payload> decodeAggregating(
+      buffer: ReadBuffer,
+      context: DecodeContext,
+      onContinuation: (WsFrameContinuationCodec.Partial<P>) -> WsFrame.Continuation<P> = { _ -> throw DecodeException(fieldPath = "WsFrame.Continuation.handler", bufferPosition = -1, expected = "consumer-supplied Continuation handler", actual = "no handler supplied") },
+      onText: (WsFrameTextCodec.Partial<P>) -> WsFrame.Text<P> = { _ -> throw DecodeException(fieldPath = "WsFrame.Text.handler", bufferPosition = -1, expected = "consumer-supplied Text handler", actual = "no handler supplied") },
+      onBinary: (WsFrameBinaryCodec.Partial<P>) -> WsFrame.Binary<P> = { _ -> throw DecodeException(fieldPath = "WsFrame.Binary.handler", bufferPosition = -1, expected = "consumer-supplied Binary handler", actual = "no handler supplied") },
+      onPing: (WsFramePingCodec.Partial<P>) -> WsFrame.Ping<P> = { _ -> throw DecodeException(fieldPath = "WsFrame.Ping.handler", bufferPosition = -1, expected = "consumer-supplied Ping handler", actual = "no handler supplied") },
+      onPong: (WsFramePongCodec.Partial<P>) -> WsFrame.Pong<P> = { _ -> throw DecodeException(fieldPath = "WsFrame.Pong.handler", bufferPosition = -1, expected = "consumer-supplied Pong handler", actual = "no handler supplied") },
+    ): WsFrame<P> {
+      val discriminatorPosition = buffer.position()
+      val __discriminator = FrameHeaderByte1Codec.decode(buffer, context)
+      buffer.position(discriminatorPosition)
+      val __dispatchValue = __discriminator.opcode
+      return when (__dispatchValue) {
+        0 -> onContinuation(WsFrameContinuationCodec.partial<P>(buffer, context))
+        1 -> onText(WsFrameTextCodec.partial<P>(buffer, context))
+        2 -> onBinary(WsFrameBinaryCodec.partial<P>(buffer, context))
+        8 -> WsFrameCloseCodec.decode(buffer, context)
+        9 -> onPing(WsFramePingCodec.partial<P>(buffer, context))
+        10 -> onPong(WsFramePongCodec.partial<P>(buffer, context))
+        else -> {
+          throw DecodeException(fieldPath = "WsFrame.discriminator", bufferPosition = discriminatorPosition, expected = "one of {0, 1, 2, 8, 9, 10}", actual = """${__dispatchValue}""")
+        }
+      }
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsFrameContinuationCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsFrameContinuationCodec.kt
@@ -1,0 +1,82 @@
+package com.ditchoom.buffer.codec.test.protocols.websocket
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.Decoder
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.Payload
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Long
+import kotlin.UShort
+
+public class WsFrameContinuationCodec<P : Payload>(
+  private val payloadCodec: Codec<P>,
+) : Codec<WsFrame.Continuation<P>> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): WsFrame.Continuation<P> {
+    val byte1 = FrameHeaderByte1(buffer.readUByte())
+    val byte2 = WsHeaderByte2(buffer.readUByte())
+    val extendedLength16: UShort? = if (byte2.extended16) buffer.readUShort() else null
+    val extendedLength64: Long? = if (byte2.extended64) buffer.readLong() else null
+    val maskingKey: WsMaskingKey? = if (byte2.masked) WsMaskingKey(buffer.readUInt()) else null
+    val payload = payloadCodec.decode(buffer, context)
+    return WsFrame.Continuation<P>(byte1 = byte1, byte2 = byte2, extendedLength16 = extendedLength16, extendedLength64 = extendedLength64, maskingKey = maskingKey, payload = payload)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: WsFrame.Continuation<P>,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.byte1.raw)
+    buffer.writeUByte(value.byte2.raw)
+    if (value.byte2.extended16) {
+      val extendedLength16Value = value.extendedLength16 ?: throw EncodeException(fieldPath = "Continuation.extendedLength16", reason = "@When(\"byte2.extended16\") predicate is true but field is null")
+      buffer.writeUShort(extendedLength16Value)
+    }
+    if (value.byte2.extended64) {
+      val extendedLength64Value = value.extendedLength64 ?: throw EncodeException(fieldPath = "Continuation.extendedLength64", reason = "@When(\"byte2.extended64\") predicate is true but field is null")
+      buffer.writeLong(extendedLength64Value)
+    }
+    if (value.byte2.masked) {
+      val maskingKeyValue = value.maskingKey ?: throw EncodeException(fieldPath = "Continuation.maskingKey", reason = "@When(\"byte2.masked\") predicate is true but field is null")
+      buffer.writeUInt(maskingKeyValue.raw)
+    }
+    payloadCodec.encode(buffer, value.payload, context)
+  }
+
+  override fun wireSize(`value`: WsFrame.Continuation<P>, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+
+  public class Partial<P : Payload> internal constructor(
+    public val byte1: FrameHeaderByte1,
+    public val byte2: WsHeaderByte2,
+    public val extendedLength16: UShort?,
+    public val extendedLength64: Long?,
+    public val maskingKey: WsMaskingKey?,
+    private val buffer: ReadBuffer,
+    private val context: DecodeContext,
+  ) {
+    public fun complete(payloadCodec: Decoder<P>): WsFrame.Continuation<P> {
+      val payload = payloadCodec.decode(buffer, context)
+      return WsFrame.Continuation<P>(byte1 = byte1, byte2 = byte2, extendedLength16 = extendedLength16, extendedLength64 = extendedLength64, maskingKey = maskingKey, payload = payload)
+    }
+  }
+
+  public companion object {
+    public fun <P : Payload> partial(buffer: ReadBuffer, context: DecodeContext): Partial<P> {
+      val byte1 = FrameHeaderByte1(buffer.readUByte())
+      val byte2 = WsHeaderByte2(buffer.readUByte())
+      val extendedLength16: UShort? = if (byte2.extended16) buffer.readUShort() else null
+      val extendedLength64: Long? = if (byte2.extended64) buffer.readLong() else null
+      val maskingKey: WsMaskingKey? = if (byte2.masked) WsMaskingKey(buffer.readUInt()) else null
+      return Partial<P>(byte1 = byte1, byte2 = byte2, extendedLength16 = extendedLength16, extendedLength64 = extendedLength64, maskingKey = maskingKey, buffer = buffer, context = context)
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsFrameHeaderCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsFrameHeaderCodec.kt
@@ -1,0 +1,71 @@
+package com.ditchoom.buffer.codec.test.protocols.websocket
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Long
+import kotlin.UShort
+
+public object WsFrameHeaderCodec : Codec<WsFrameHeader> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): WsFrameHeader {
+    val byte1 = FrameHeaderByte1(buffer.readUByte())
+    val byte2 = WsHeaderByte2(buffer.readUByte())
+    val extendedLength16: UShort? = if (byte2.extended16) buffer.readUShort() else null
+    val extendedLength64: Long? = if (byte2.extended64) buffer.readLong() else null
+    val maskingKey: WsMaskingKey? = if (byte2.masked) WsMaskingKey(buffer.readUInt()) else null
+    return WsFrameHeader(byte1 = byte1, byte2 = byte2, extendedLength16 = extendedLength16, extendedLength64 = extendedLength64, maskingKey = maskingKey)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: WsFrameHeader,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.byte1.raw)
+    buffer.writeUByte(value.byte2.raw)
+    if (value.byte2.extended16) {
+      val extendedLength16Value = value.extendedLength16 ?: throw EncodeException(fieldPath = "WsFrameHeader.extendedLength16", reason = "@When(\"byte2.extended16\") predicate is true but field is null")
+      buffer.writeUShort(extendedLength16Value)
+    }
+    if (value.byte2.extended64) {
+      val extendedLength64Value = value.extendedLength64 ?: throw EncodeException(fieldPath = "WsFrameHeader.extendedLength64", reason = "@When(\"byte2.extended64\") predicate is true but field is null")
+      buffer.writeLong(extendedLength64Value)
+    }
+    if (value.byte2.masked) {
+      val maskingKeyValue = value.maskingKey ?: throw EncodeException(fieldPath = "WsFrameHeader.maskingKey", reason = "@When(\"byte2.masked\") predicate is true but field is null")
+      buffer.writeUInt(maskingKeyValue.raw)
+    }
+  }
+
+  override fun wireSize(`value`: WsFrameHeader, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    __offset += 1
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    val byte2Raw = stream.peekByte(baseOffset + __offset).toUByte()
+    val byte2 = WsHeaderByte2(byte2Raw)
+    __offset += 1
+    if (byte2.extended16) {
+      if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+      __offset += 2
+    }
+    if (byte2.extended64) {
+      if (stream.available() - baseOffset < __offset + 8) return PeekResult.NeedsMoreData
+      __offset += 8
+    }
+    if (byte2.masked) {
+      if (stream.available() - baseOffset < __offset + 4) return PeekResult.NeedsMoreData
+      __offset += 4
+    }
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsFramePingCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsFramePingCodec.kt
@@ -1,0 +1,82 @@
+package com.ditchoom.buffer.codec.test.protocols.websocket
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.Decoder
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.Payload
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Long
+import kotlin.UShort
+
+public class WsFramePingCodec<P : Payload>(
+  private val payloadCodec: Codec<P>,
+) : Codec<WsFrame.Ping<P>> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): WsFrame.Ping<P> {
+    val byte1 = FrameHeaderByte1(buffer.readUByte())
+    val byte2 = WsHeaderByte2(buffer.readUByte())
+    val extendedLength16: UShort? = if (byte2.extended16) buffer.readUShort() else null
+    val extendedLength64: Long? = if (byte2.extended64) buffer.readLong() else null
+    val maskingKey: WsMaskingKey? = if (byte2.masked) WsMaskingKey(buffer.readUInt()) else null
+    val payload = payloadCodec.decode(buffer, context)
+    return WsFrame.Ping<P>(byte1 = byte1, byte2 = byte2, extendedLength16 = extendedLength16, extendedLength64 = extendedLength64, maskingKey = maskingKey, payload = payload)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: WsFrame.Ping<P>,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.byte1.raw)
+    buffer.writeUByte(value.byte2.raw)
+    if (value.byte2.extended16) {
+      val extendedLength16Value = value.extendedLength16 ?: throw EncodeException(fieldPath = "Ping.extendedLength16", reason = "@When(\"byte2.extended16\") predicate is true but field is null")
+      buffer.writeUShort(extendedLength16Value)
+    }
+    if (value.byte2.extended64) {
+      val extendedLength64Value = value.extendedLength64 ?: throw EncodeException(fieldPath = "Ping.extendedLength64", reason = "@When(\"byte2.extended64\") predicate is true but field is null")
+      buffer.writeLong(extendedLength64Value)
+    }
+    if (value.byte2.masked) {
+      val maskingKeyValue = value.maskingKey ?: throw EncodeException(fieldPath = "Ping.maskingKey", reason = "@When(\"byte2.masked\") predicate is true but field is null")
+      buffer.writeUInt(maskingKeyValue.raw)
+    }
+    payloadCodec.encode(buffer, value.payload, context)
+  }
+
+  override fun wireSize(`value`: WsFrame.Ping<P>, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+
+  public class Partial<P : Payload> internal constructor(
+    public val byte1: FrameHeaderByte1,
+    public val byte2: WsHeaderByte2,
+    public val extendedLength16: UShort?,
+    public val extendedLength64: Long?,
+    public val maskingKey: WsMaskingKey?,
+    private val buffer: ReadBuffer,
+    private val context: DecodeContext,
+  ) {
+    public fun complete(payloadCodec: Decoder<P>): WsFrame.Ping<P> {
+      val payload = payloadCodec.decode(buffer, context)
+      return WsFrame.Ping<P>(byte1 = byte1, byte2 = byte2, extendedLength16 = extendedLength16, extendedLength64 = extendedLength64, maskingKey = maskingKey, payload = payload)
+    }
+  }
+
+  public companion object {
+    public fun <P : Payload> partial(buffer: ReadBuffer, context: DecodeContext): Partial<P> {
+      val byte1 = FrameHeaderByte1(buffer.readUByte())
+      val byte2 = WsHeaderByte2(buffer.readUByte())
+      val extendedLength16: UShort? = if (byte2.extended16) buffer.readUShort() else null
+      val extendedLength64: Long? = if (byte2.extended64) buffer.readLong() else null
+      val maskingKey: WsMaskingKey? = if (byte2.masked) WsMaskingKey(buffer.readUInt()) else null
+      return Partial<P>(byte1 = byte1, byte2 = byte2, extendedLength16 = extendedLength16, extendedLength64 = extendedLength64, maskingKey = maskingKey, buffer = buffer, context = context)
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsFramePongCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsFramePongCodec.kt
@@ -1,0 +1,82 @@
+package com.ditchoom.buffer.codec.test.protocols.websocket
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.Decoder
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.Payload
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Long
+import kotlin.UShort
+
+public class WsFramePongCodec<P : Payload>(
+  private val payloadCodec: Codec<P>,
+) : Codec<WsFrame.Pong<P>> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): WsFrame.Pong<P> {
+    val byte1 = FrameHeaderByte1(buffer.readUByte())
+    val byte2 = WsHeaderByte2(buffer.readUByte())
+    val extendedLength16: UShort? = if (byte2.extended16) buffer.readUShort() else null
+    val extendedLength64: Long? = if (byte2.extended64) buffer.readLong() else null
+    val maskingKey: WsMaskingKey? = if (byte2.masked) WsMaskingKey(buffer.readUInt()) else null
+    val payload = payloadCodec.decode(buffer, context)
+    return WsFrame.Pong<P>(byte1 = byte1, byte2 = byte2, extendedLength16 = extendedLength16, extendedLength64 = extendedLength64, maskingKey = maskingKey, payload = payload)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: WsFrame.Pong<P>,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.byte1.raw)
+    buffer.writeUByte(value.byte2.raw)
+    if (value.byte2.extended16) {
+      val extendedLength16Value = value.extendedLength16 ?: throw EncodeException(fieldPath = "Pong.extendedLength16", reason = "@When(\"byte2.extended16\") predicate is true but field is null")
+      buffer.writeUShort(extendedLength16Value)
+    }
+    if (value.byte2.extended64) {
+      val extendedLength64Value = value.extendedLength64 ?: throw EncodeException(fieldPath = "Pong.extendedLength64", reason = "@When(\"byte2.extended64\") predicate is true but field is null")
+      buffer.writeLong(extendedLength64Value)
+    }
+    if (value.byte2.masked) {
+      val maskingKeyValue = value.maskingKey ?: throw EncodeException(fieldPath = "Pong.maskingKey", reason = "@When(\"byte2.masked\") predicate is true but field is null")
+      buffer.writeUInt(maskingKeyValue.raw)
+    }
+    payloadCodec.encode(buffer, value.payload, context)
+  }
+
+  override fun wireSize(`value`: WsFrame.Pong<P>, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+
+  public class Partial<P : Payload> internal constructor(
+    public val byte1: FrameHeaderByte1,
+    public val byte2: WsHeaderByte2,
+    public val extendedLength16: UShort?,
+    public val extendedLength64: Long?,
+    public val maskingKey: WsMaskingKey?,
+    private val buffer: ReadBuffer,
+    private val context: DecodeContext,
+  ) {
+    public fun complete(payloadCodec: Decoder<P>): WsFrame.Pong<P> {
+      val payload = payloadCodec.decode(buffer, context)
+      return WsFrame.Pong<P>(byte1 = byte1, byte2 = byte2, extendedLength16 = extendedLength16, extendedLength64 = extendedLength64, maskingKey = maskingKey, payload = payload)
+    }
+  }
+
+  public companion object {
+    public fun <P : Payload> partial(buffer: ReadBuffer, context: DecodeContext): Partial<P> {
+      val byte1 = FrameHeaderByte1(buffer.readUByte())
+      val byte2 = WsHeaderByte2(buffer.readUByte())
+      val extendedLength16: UShort? = if (byte2.extended16) buffer.readUShort() else null
+      val extendedLength64: Long? = if (byte2.extended64) buffer.readLong() else null
+      val maskingKey: WsMaskingKey? = if (byte2.masked) WsMaskingKey(buffer.readUInt()) else null
+      return Partial<P>(byte1 = byte1, byte2 = byte2, extendedLength16 = extendedLength16, extendedLength64 = extendedLength64, maskingKey = maskingKey, buffer = buffer, context = context)
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsFrameTextCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsFrameTextCodec.kt
@@ -1,0 +1,82 @@
+package com.ditchoom.buffer.codec.test.protocols.websocket
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.Decoder
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.Payload
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Long
+import kotlin.UShort
+
+public class WsFrameTextCodec<P : Payload>(
+  private val payloadCodec: Codec<P>,
+) : Codec<WsFrame.Text<P>> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): WsFrame.Text<P> {
+    val byte1 = FrameHeaderByte1(buffer.readUByte())
+    val byte2 = WsHeaderByte2(buffer.readUByte())
+    val extendedLength16: UShort? = if (byte2.extended16) buffer.readUShort() else null
+    val extendedLength64: Long? = if (byte2.extended64) buffer.readLong() else null
+    val maskingKey: WsMaskingKey? = if (byte2.masked) WsMaskingKey(buffer.readUInt()) else null
+    val payload = payloadCodec.decode(buffer, context)
+    return WsFrame.Text<P>(byte1 = byte1, byte2 = byte2, extendedLength16 = extendedLength16, extendedLength64 = extendedLength64, maskingKey = maskingKey, payload = payload)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: WsFrame.Text<P>,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.byte1.raw)
+    buffer.writeUByte(value.byte2.raw)
+    if (value.byte2.extended16) {
+      val extendedLength16Value = value.extendedLength16 ?: throw EncodeException(fieldPath = "Text.extendedLength16", reason = "@When(\"byte2.extended16\") predicate is true but field is null")
+      buffer.writeUShort(extendedLength16Value)
+    }
+    if (value.byte2.extended64) {
+      val extendedLength64Value = value.extendedLength64 ?: throw EncodeException(fieldPath = "Text.extendedLength64", reason = "@When(\"byte2.extended64\") predicate is true but field is null")
+      buffer.writeLong(extendedLength64Value)
+    }
+    if (value.byte2.masked) {
+      val maskingKeyValue = value.maskingKey ?: throw EncodeException(fieldPath = "Text.maskingKey", reason = "@When(\"byte2.masked\") predicate is true but field is null")
+      buffer.writeUInt(maskingKeyValue.raw)
+    }
+    payloadCodec.encode(buffer, value.payload, context)
+  }
+
+  override fun wireSize(`value`: WsFrame.Text<P>, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+
+  public class Partial<P : Payload> internal constructor(
+    public val byte1: FrameHeaderByte1,
+    public val byte2: WsHeaderByte2,
+    public val extendedLength16: UShort?,
+    public val extendedLength64: Long?,
+    public val maskingKey: WsMaskingKey?,
+    private val buffer: ReadBuffer,
+    private val context: DecodeContext,
+  ) {
+    public fun complete(payloadCodec: Decoder<P>): WsFrame.Text<P> {
+      val payload = payloadCodec.decode(buffer, context)
+      return WsFrame.Text<P>(byte1 = byte1, byte2 = byte2, extendedLength16 = extendedLength16, extendedLength64 = extendedLength64, maskingKey = maskingKey, payload = payload)
+    }
+  }
+
+  public companion object {
+    public fun <P : Payload> partial(buffer: ReadBuffer, context: DecodeContext): Partial<P> {
+      val byte1 = FrameHeaderByte1(buffer.readUByte())
+      val byte2 = WsHeaderByte2(buffer.readUByte())
+      val extendedLength16: UShort? = if (byte2.extended16) buffer.readUShort() else null
+      val extendedLength64: Long? = if (byte2.extended64) buffer.readLong() else null
+      val maskingKey: WsMaskingKey? = if (byte2.masked) WsMaskingKey(buffer.readUInt()) else null
+      return Partial<P>(byte1 = byte1, byte2 = byte2, extendedLength16 = extendedLength16, extendedLength64 = extendedLength64, maskingKey = maskingKey, buffer = buffer, context = context)
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsHeaderByte2Codec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsHeaderByte2Codec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.websocket
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object WsHeaderByte2Codec : Codec<WsHeaderByte2> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): WsHeaderByte2 {
+    val raw = buffer.readUByte()
+    return WsHeaderByte2(raw = raw)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: WsHeaderByte2,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.raw)
+  }
+
+  override fun wireSize(`value`: WsHeaderByte2, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsMaskingKeyCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsMaskingKeyCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.websocket
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object WsMaskingKeyCodec : Codec<WsMaskingKey> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): WsMaskingKey {
+    val raw = buffer.readUInt()
+    return WsMaskingKey(raw = raw)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: WsMaskingKey,
+    context: EncodeContext,
+  ) {
+    buffer.writeUInt(value.raw)
+  }
+
+  override fun wireSize(`value`: WsMaskingKey, context: EncodeContext): WireSize = WireSize.Exact(4)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 4) PeekResult.Complete(4) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/wireorderMismatch/BigWireFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/wireorderMismatch/BigWireFrameCodec.kt
@@ -1,0 +1,70 @@
+package com.ditchoom.buffer.codec.test.protocols.wireorderMismatch
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object BigWireFrameCodec : Codec<BigWireFrame> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): BigWireFrame {
+    val discriminatorPosition = buffer.position()
+    val discriminator = buffer.readUByte().toInt()
+    return when (discriminator) {
+      0x01 -> BigWireFrameSampleCodec.decode(buffer, context)
+      0x02 -> BigWireFrameStatusCodec.decode(buffer, context)
+      else -> {
+        throw DecodeException(fieldPath = "BigWireFrame.discriminator", bufferPosition = discriminatorPosition, expected = "one of {0x01, 0x02}", actual = """0x${discriminator.toString(16).padStart(2, '0').uppercase()}""")
+      }
+    }
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: BigWireFrame,
+    context: EncodeContext,
+  ) {
+    when (value) {
+      is BigWireFrame.Sample -> {
+        buffer.writeUByte(0x01.toUByte())
+        BigWireFrameSampleCodec.encode(buffer, value, context)
+      }
+      is BigWireFrame.Status -> {
+        buffer.writeUByte(0x02.toUByte())
+        BigWireFrameStatusCodec.encode(buffer, value, context)
+      }
+    }
+  }
+
+  override fun wireSize(`value`: BigWireFrame, context: EncodeContext): WireSize = when (value) {
+    is BigWireFrame.Sample -> WireSize.Exact(27)
+    is BigWireFrame.Status -> WireSize.Exact(13)
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
+    val discriminator = stream.peekByte(baseOffset).toInt() and 0xFF
+    return when (discriminator) {
+      0x01 -> {
+        when (val inner = BigWireFrameSampleCodec.peekFrameSize(stream, baseOffset + 1)) {
+          is PeekResult.Complete -> PeekResult.Complete(1 + inner.bytes)
+          else -> inner
+        }
+      }
+      0x02 -> {
+        when (val inner = BigWireFrameStatusCodec.peekFrameSize(stream, baseOffset + 1)) {
+          is PeekResult.Complete -> PeekResult.Complete(1 + inner.bytes)
+          else -> inner
+        }
+      }
+      else -> {
+        throw DecodeException(fieldPath = "BigWireFrame.discriminator", bufferPosition = baseOffset, expected = "one of {0x01, 0x02}", actual = """0x${discriminator.toString(16).padStart(2, '0').uppercase()}""")
+      }
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/wireorderMismatch/BigWireFrameSampleCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/wireorderMismatch/BigWireFrameSampleCodec.kt
@@ -1,0 +1,85 @@
+package com.ditchoom.buffer.codec.test.protocols.wireorderMismatch
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object BigWireFrameSampleCodec : Codec<BigWireFrame.Sample> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): BigWireFrame.Sample {
+    val shortB0 = buffer.readUByte().toUInt()
+    val shortB1 = buffer.readUByte().toUInt()
+    val short = ((shortB0 shl 8) or shortB1).toShort()
+    val intB0 = buffer.readUByte().toUInt()
+    val intB1 = buffer.readUByte().toUInt()
+    val intB2 = buffer.readUByte().toUInt()
+    val intB3 = buffer.readUByte().toUInt()
+    val int = ((intB0 shl 24) or (intB1 shl 16) or (intB2 shl 8) or intB3).toInt()
+    val longB0 = buffer.readUByte().toULong()
+    val longB1 = buffer.readUByte().toULong()
+    val longB2 = buffer.readUByte().toULong()
+    val longB3 = buffer.readUByte().toULong()
+    val longB4 = buffer.readUByte().toULong()
+    val longB5 = buffer.readUByte().toULong()
+    val longB6 = buffer.readUByte().toULong()
+    val longB7 = buffer.readUByte().toULong()
+    val long = ((longB0 shl 56) or (longB1 shl 48) or (longB2 shl 40) or (longB3 shl 32) or (longB4 shl 24) or (longB5 shl 16) or (longB6 shl 8) or longB7).toLong()
+    val floatB0 = buffer.readUByte().toUInt()
+    val floatB1 = buffer.readUByte().toUInt()
+    val floatB2 = buffer.readUByte().toUInt()
+    val floatB3 = buffer.readUByte().toUInt()
+    val float = Float.fromBits(((floatB0 shl 24) or (floatB1 shl 16) or (floatB2 shl 8) or floatB3).toInt())
+    val doubleB0 = buffer.readUByte().toULong()
+    val doubleB1 = buffer.readUByte().toULong()
+    val doubleB2 = buffer.readUByte().toULong()
+    val doubleB3 = buffer.readUByte().toULong()
+    val doubleB4 = buffer.readUByte().toULong()
+    val doubleB5 = buffer.readUByte().toULong()
+    val doubleB6 = buffer.readUByte().toULong()
+    val doubleB7 = buffer.readUByte().toULong()
+    val double = Double.fromBits(((doubleB0 shl 56) or (doubleB1 shl 48) or (doubleB2 shl 40) or (doubleB3 shl 32) or (doubleB4 shl 24) or (doubleB5 shl 16) or (doubleB6 shl 8) or doubleB7).toLong())
+    return BigWireFrame.Sample(short = short, int = int, long = long, float = float, double = double)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: BigWireFrame.Sample,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(((value.short.toUShort().toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.short.toUShort().toUInt() and 0xFFu).toUByte())
+    buffer.writeUByte(((value.int.toUInt() shr 24) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.int.toUInt() shr 16) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.int.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.int.toUInt() and 0xFFu).toUByte())
+    buffer.writeUByte(((value.long.toULong() shr 56) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.long.toULong() shr 48) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.long.toULong() shr 40) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.long.toULong() shr 32) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.long.toULong() shr 24) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.long.toULong() shr 16) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.long.toULong() shr 8) and 0xFFuL).toUByte())
+    buffer.writeUByte((value.long.toULong() and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.float.toRawBits().toUInt() shr 24) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.float.toRawBits().toUInt() shr 16) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.float.toRawBits().toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.float.toRawBits().toUInt() and 0xFFu).toUByte())
+    buffer.writeUByte(((value.double.toRawBits().toULong() shr 56) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.double.toRawBits().toULong() shr 48) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.double.toRawBits().toULong() shr 40) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.double.toRawBits().toULong() shr 32) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.double.toRawBits().toULong() shr 24) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.double.toRawBits().toULong() shr 16) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.double.toRawBits().toULong() shr 8) and 0xFFuL).toUByte())
+    buffer.writeUByte((value.double.toRawBits().toULong() and 0xFFuL).toUByte())
+  }
+
+  override fun wireSize(`value`: BigWireFrame.Sample, context: EncodeContext): WireSize = WireSize.Exact(26)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 26) PeekResult.Complete(26) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/wireorderMismatch/BigWireFrameStatusCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/wireorderMismatch/BigWireFrameStatusCodec.kt
@@ -1,0 +1,54 @@
+package com.ditchoom.buffer.codec.test.protocols.wireorderMismatch
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object BigWireFrameStatusCodec : Codec<BigWireFrame.Status> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): BigWireFrame.Status {
+    val flagsB0 = buffer.readUByte().toUInt()
+    val flagsB1 = buffer.readUByte().toUInt()
+    val flagsB2 = buffer.readUByte().toUInt()
+    val flagsB3 = buffer.readUByte().toUInt()
+    val flags = ((flagsB0 shl 24) or (flagsB1 shl 16) or (flagsB2 shl 8) or flagsB3)
+    val ratioB0 = buffer.readUByte().toULong()
+    val ratioB1 = buffer.readUByte().toULong()
+    val ratioB2 = buffer.readUByte().toULong()
+    val ratioB3 = buffer.readUByte().toULong()
+    val ratioB4 = buffer.readUByte().toULong()
+    val ratioB5 = buffer.readUByte().toULong()
+    val ratioB6 = buffer.readUByte().toULong()
+    val ratioB7 = buffer.readUByte().toULong()
+    val ratio = Double.fromBits(((ratioB0 shl 56) or (ratioB1 shl 48) or (ratioB2 shl 40) or (ratioB3 shl 32) or (ratioB4 shl 24) or (ratioB5 shl 16) or (ratioB6 shl 8) or ratioB7).toLong())
+    return BigWireFrame.Status(flags = flags, ratio = ratio)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: BigWireFrame.Status,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(((value.flags shr 24) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.flags shr 16) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.flags shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.flags and 0xFFu).toUByte())
+    buffer.writeUByte(((value.ratio.toRawBits().toULong() shr 56) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.ratio.toRawBits().toULong() shr 48) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.ratio.toRawBits().toULong() shr 40) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.ratio.toRawBits().toULong() shr 32) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.ratio.toRawBits().toULong() shr 24) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.ratio.toRawBits().toULong() shr 16) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.ratio.toRawBits().toULong() shr 8) and 0xFFuL).toUByte())
+    buffer.writeUByte((value.ratio.toRawBits().toULong() and 0xFFuL).toUByte())
+  }
+
+  override fun wireSize(`value`: BigWireFrame.Status, context: EncodeContext): WireSize = WireSize.Exact(12)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 12) PeekResult.Complete(12) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/wireorderMismatch/BigWirePacketCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/wireorderMismatch/BigWirePacketCodec.kt
@@ -1,0 +1,122 @@
+package com.ditchoom.buffer.codec.test.protocols.wireorderMismatch
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object BigWirePacketCodec : Codec<BigWirePacket> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): BigWirePacket {
+    val bool = buffer.readByte() != 0.toByte()
+    val byte = buffer.readByte()
+    val ubyte = buffer.readUByte()
+    val shortB0 = buffer.readUByte().toUInt()
+    val shortB1 = buffer.readUByte().toUInt()
+    val short = ((shortB0 shl 8) or shortB1).toShort()
+    val ushortB0 = buffer.readUByte().toUInt()
+    val ushortB1 = buffer.readUByte().toUInt()
+    val ushort = ((ushortB0 shl 8) or ushortB1).toUShort()
+    val intB0 = buffer.readUByte().toUInt()
+    val intB1 = buffer.readUByte().toUInt()
+    val intB2 = buffer.readUByte().toUInt()
+    val intB3 = buffer.readUByte().toUInt()
+    val int = ((intB0 shl 24) or (intB1 shl 16) or (intB2 shl 8) or intB3).toInt()
+    val uintB0 = buffer.readUByte().toUInt()
+    val uintB1 = buffer.readUByte().toUInt()
+    val uintB2 = buffer.readUByte().toUInt()
+    val uintB3 = buffer.readUByte().toUInt()
+    val uint = ((uintB0 shl 24) or (uintB1 shl 16) or (uintB2 shl 8) or uintB3)
+    val longB0 = buffer.readUByte().toULong()
+    val longB1 = buffer.readUByte().toULong()
+    val longB2 = buffer.readUByte().toULong()
+    val longB3 = buffer.readUByte().toULong()
+    val longB4 = buffer.readUByte().toULong()
+    val longB5 = buffer.readUByte().toULong()
+    val longB6 = buffer.readUByte().toULong()
+    val longB7 = buffer.readUByte().toULong()
+    val long = ((longB0 shl 56) or (longB1 shl 48) or (longB2 shl 40) or (longB3 shl 32) or (longB4 shl 24) or (longB5 shl 16) or (longB6 shl 8) or longB7).toLong()
+    val ulongB0 = buffer.readUByte().toULong()
+    val ulongB1 = buffer.readUByte().toULong()
+    val ulongB2 = buffer.readUByte().toULong()
+    val ulongB3 = buffer.readUByte().toULong()
+    val ulongB4 = buffer.readUByte().toULong()
+    val ulongB5 = buffer.readUByte().toULong()
+    val ulongB6 = buffer.readUByte().toULong()
+    val ulongB7 = buffer.readUByte().toULong()
+    val ulong = ((ulongB0 shl 56) or (ulongB1 shl 48) or (ulongB2 shl 40) or (ulongB3 shl 32) or (ulongB4 shl 24) or (ulongB5 shl 16) or (ulongB6 shl 8) or ulongB7)
+    val floatB0 = buffer.readUByte().toUInt()
+    val floatB1 = buffer.readUByte().toUInt()
+    val floatB2 = buffer.readUByte().toUInt()
+    val floatB3 = buffer.readUByte().toUInt()
+    val float = Float.fromBits(((floatB0 shl 24) or (floatB1 shl 16) or (floatB2 shl 8) or floatB3).toInt())
+    val doubleB0 = buffer.readUByte().toULong()
+    val doubleB1 = buffer.readUByte().toULong()
+    val doubleB2 = buffer.readUByte().toULong()
+    val doubleB3 = buffer.readUByte().toULong()
+    val doubleB4 = buffer.readUByte().toULong()
+    val doubleB5 = buffer.readUByte().toULong()
+    val doubleB6 = buffer.readUByte().toULong()
+    val doubleB7 = buffer.readUByte().toULong()
+    val double = Double.fromBits(((doubleB0 shl 56) or (doubleB1 shl 48) or (doubleB2 shl 40) or (doubleB3 shl 32) or (doubleB4 shl 24) or (doubleB5 shl 16) or (doubleB6 shl 8) or doubleB7).toLong())
+    return BigWirePacket(bool = bool, byte = byte, ubyte = ubyte, short = short, ushort = ushort, int = int, uint = uint, long = long, ulong = ulong, float = float, double = double)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: BigWirePacket,
+    context: EncodeContext,
+  ) {
+    buffer.writeByte(if (value.bool) 1.toByte() else 0.toByte())
+    buffer.writeByte(value.byte)
+    buffer.writeUByte(value.ubyte)
+    buffer.writeUByte(((value.short.toUShort().toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.short.toUShort().toUInt() and 0xFFu).toUByte())
+    buffer.writeUByte(((value.ushort.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.ushort.toUInt() and 0xFFu).toUByte())
+    buffer.writeUByte(((value.int.toUInt() shr 24) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.int.toUInt() shr 16) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.int.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.int.toUInt() and 0xFFu).toUByte())
+    buffer.writeUByte(((value.uint shr 24) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.uint shr 16) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.uint shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.uint and 0xFFu).toUByte())
+    buffer.writeUByte(((value.long.toULong() shr 56) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.long.toULong() shr 48) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.long.toULong() shr 40) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.long.toULong() shr 32) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.long.toULong() shr 24) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.long.toULong() shr 16) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.long.toULong() shr 8) and 0xFFuL).toUByte())
+    buffer.writeUByte((value.long.toULong() and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.ulong shr 56) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.ulong shr 48) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.ulong shr 40) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.ulong shr 32) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.ulong shr 24) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.ulong shr 16) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.ulong shr 8) and 0xFFuL).toUByte())
+    buffer.writeUByte((value.ulong and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.float.toRawBits().toUInt() shr 24) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.float.toRawBits().toUInt() shr 16) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.float.toRawBits().toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.float.toRawBits().toUInt() and 0xFFu).toUByte())
+    buffer.writeUByte(((value.double.toRawBits().toULong() shr 56) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.double.toRawBits().toULong() shr 48) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.double.toRawBits().toULong() shr 40) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.double.toRawBits().toULong() shr 32) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.double.toRawBits().toULong() shr 24) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.double.toRawBits().toULong() shr 16) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.double.toRawBits().toULong() shr 8) and 0xFFuL).toUByte())
+    buffer.writeUByte((value.double.toRawBits().toULong() and 0xFFuL).toUByte())
+  }
+
+  override fun wireSize(`value`: BigWirePacket, context: EncodeContext): WireSize = WireSize.Exact(43)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 43) PeekResult.Complete(43) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/wireorderMismatch/LittleWirePacketCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/wireorderMismatch/LittleWirePacketCodec.kt
@@ -1,0 +1,122 @@
+package com.ditchoom.buffer.codec.test.protocols.wireorderMismatch
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object LittleWirePacketCodec : Codec<LittleWirePacket> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): LittleWirePacket {
+    val bool = buffer.readByte() != 0.toByte()
+    val byte = buffer.readByte()
+    val ubyte = buffer.readUByte()
+    val shortB0 = buffer.readUByte().toUInt()
+    val shortB1 = buffer.readUByte().toUInt()
+    val short = (shortB0 or (shortB1 shl 8)).toShort()
+    val ushortB0 = buffer.readUByte().toUInt()
+    val ushortB1 = buffer.readUByte().toUInt()
+    val ushort = (ushortB0 or (ushortB1 shl 8)).toUShort()
+    val intB0 = buffer.readUByte().toUInt()
+    val intB1 = buffer.readUByte().toUInt()
+    val intB2 = buffer.readUByte().toUInt()
+    val intB3 = buffer.readUByte().toUInt()
+    val int = (intB0 or (intB1 shl 8) or (intB2 shl 16) or (intB3 shl 24)).toInt()
+    val uintB0 = buffer.readUByte().toUInt()
+    val uintB1 = buffer.readUByte().toUInt()
+    val uintB2 = buffer.readUByte().toUInt()
+    val uintB3 = buffer.readUByte().toUInt()
+    val uint = (uintB0 or (uintB1 shl 8) or (uintB2 shl 16) or (uintB3 shl 24))
+    val longB0 = buffer.readUByte().toULong()
+    val longB1 = buffer.readUByte().toULong()
+    val longB2 = buffer.readUByte().toULong()
+    val longB3 = buffer.readUByte().toULong()
+    val longB4 = buffer.readUByte().toULong()
+    val longB5 = buffer.readUByte().toULong()
+    val longB6 = buffer.readUByte().toULong()
+    val longB7 = buffer.readUByte().toULong()
+    val long = (longB0 or (longB1 shl 8) or (longB2 shl 16) or (longB3 shl 24) or (longB4 shl 32) or (longB5 shl 40) or (longB6 shl 48) or (longB7 shl 56)).toLong()
+    val ulongB0 = buffer.readUByte().toULong()
+    val ulongB1 = buffer.readUByte().toULong()
+    val ulongB2 = buffer.readUByte().toULong()
+    val ulongB3 = buffer.readUByte().toULong()
+    val ulongB4 = buffer.readUByte().toULong()
+    val ulongB5 = buffer.readUByte().toULong()
+    val ulongB6 = buffer.readUByte().toULong()
+    val ulongB7 = buffer.readUByte().toULong()
+    val ulong = (ulongB0 or (ulongB1 shl 8) or (ulongB2 shl 16) or (ulongB3 shl 24) or (ulongB4 shl 32) or (ulongB5 shl 40) or (ulongB6 shl 48) or (ulongB7 shl 56))
+    val floatB0 = buffer.readUByte().toUInt()
+    val floatB1 = buffer.readUByte().toUInt()
+    val floatB2 = buffer.readUByte().toUInt()
+    val floatB3 = buffer.readUByte().toUInt()
+    val float = Float.fromBits((floatB0 or (floatB1 shl 8) or (floatB2 shl 16) or (floatB3 shl 24)).toInt())
+    val doubleB0 = buffer.readUByte().toULong()
+    val doubleB1 = buffer.readUByte().toULong()
+    val doubleB2 = buffer.readUByte().toULong()
+    val doubleB3 = buffer.readUByte().toULong()
+    val doubleB4 = buffer.readUByte().toULong()
+    val doubleB5 = buffer.readUByte().toULong()
+    val doubleB6 = buffer.readUByte().toULong()
+    val doubleB7 = buffer.readUByte().toULong()
+    val double = Double.fromBits((doubleB0 or (doubleB1 shl 8) or (doubleB2 shl 16) or (doubleB3 shl 24) or (doubleB4 shl 32) or (doubleB5 shl 40) or (doubleB6 shl 48) or (doubleB7 shl 56)).toLong())
+    return LittleWirePacket(bool = bool, byte = byte, ubyte = ubyte, short = short, ushort = ushort, int = int, uint = uint, long = long, ulong = ulong, float = float, double = double)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: LittleWirePacket,
+    context: EncodeContext,
+  ) {
+    buffer.writeByte(if (value.bool) 1.toByte() else 0.toByte())
+    buffer.writeByte(value.byte)
+    buffer.writeUByte(value.ubyte)
+    buffer.writeUByte((value.short.toUShort().toUInt() and 0xFFu).toUByte())
+    buffer.writeUByte(((value.short.toUShort().toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.ushort.toUInt() and 0xFFu).toUByte())
+    buffer.writeUByte(((value.ushort.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((value.int.toUInt() and 0xFFu).toUByte())
+    buffer.writeUByte(((value.int.toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.int.toUInt() shr 16) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.int.toUInt() shr 24) and 0xFFu).toUByte())
+    buffer.writeUByte((value.uint and 0xFFu).toUByte())
+    buffer.writeUByte(((value.uint shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.uint shr 16) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.uint shr 24) and 0xFFu).toUByte())
+    buffer.writeUByte((value.long.toULong() and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.long.toULong() shr 8) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.long.toULong() shr 16) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.long.toULong() shr 24) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.long.toULong() shr 32) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.long.toULong() shr 40) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.long.toULong() shr 48) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.long.toULong() shr 56) and 0xFFuL).toUByte())
+    buffer.writeUByte((value.ulong and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.ulong shr 8) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.ulong shr 16) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.ulong shr 24) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.ulong shr 32) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.ulong shr 40) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.ulong shr 48) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.ulong shr 56) and 0xFFuL).toUByte())
+    buffer.writeUByte((value.float.toRawBits().toUInt() and 0xFFu).toUByte())
+    buffer.writeUByte(((value.float.toRawBits().toUInt() shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.float.toRawBits().toUInt() shr 16) and 0xFFu).toUByte())
+    buffer.writeUByte(((value.float.toRawBits().toUInt() shr 24) and 0xFFu).toUByte())
+    buffer.writeUByte((value.double.toRawBits().toULong() and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.double.toRawBits().toULong() shr 8) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.double.toRawBits().toULong() shr 16) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.double.toRawBits().toULong() shr 24) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.double.toRawBits().toULong() shr 32) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.double.toRawBits().toULong() shr 40) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.double.toRawBits().toULong() shr 48) and 0xFFuL).toUByte())
+    buffer.writeUByte(((value.double.toRawBits().toULong() shr 56) and 0xFFuL).toUByte())
+  }
+
+  override fun wireSize(`value`: LittleWirePacket, context: EncodeContext): WireSize = WireSize.Exact(43)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 43) PeekResult.Complete(43) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/src/jvmTest/kotlin/com/ditchoom/buffer/codec/test/snapshot/CodecSnapshotTest.kt
+++ b/buffer-codec-test/src/jvmTest/kotlin/com/ditchoom/buffer/codec/test/snapshot/CodecSnapshotTest.kt
@@ -1,0 +1,215 @@
+package com.ditchoom.buffer.codec.test.snapshot
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.fail
+
+/**
+ * Golden-file snapshot of every codec the KSP processor emits for the
+ * fixtures in this module.
+ *
+ * On each run: the test walks `build/generated/ksp/metadata/commonMain/kotlin/`
+ * (which `kspCommonMainKotlinMetadata` populates as part of the normal build),
+ * walks `codec-snapshots/` (checked into git), and compares the two trees
+ * file-by-file with line-ending normalization.
+ *
+ * Why this exists: the v4 → v5.0 strip-and-rebuild of `buffer-codec-processor`
+ * silently changed the emit shape in several places (nested codec naming
+ * regressed → issue #156; the batching optimizer was deleted → silent perf
+ * regression; the SPI was removed → silent source-break for v4 extenders).
+ * Round-trip tests pass on *different but still valid* output, so none of
+ * these surfaced until an external user hit one in production. This test
+ * makes every emit-shape change a reviewable diff at PR time.
+ *
+ * Regen workflow:
+ *   ./gradlew :buffer-codec-test:jvmTest -Dupdate.snapshots=true
+ *   git add buffer-codec-test/codec-snapshots
+ *   git commit
+ *
+ * The diff that lands in the regen commit becomes the change's migration note.
+ */
+class CodecSnapshotTest {
+    private val generatedRoot: File =
+        System
+            .getProperty("codec.snapshot.generated")
+            ?.let(::File)
+            ?: error(
+                "codec.snapshot.generated system property not set — " +
+                    "the gradle test task should pass it. See buffer-codec-test/build.gradle.kts.",
+            )
+
+    private val baselineRoot: File =
+        System
+            .getProperty("codec.snapshot.baseline")
+            ?.let(::File)
+            ?: error(
+                "codec.snapshot.baseline system property not set — " +
+                    "the gradle test task should pass it. See buffer-codec-test/build.gradle.kts.",
+            )
+
+    private val updateMode: Boolean = System.getProperty("update.snapshots", "false") == "true"
+
+    @Test
+    fun `generated codec output matches checked-in baselines`() {
+        if (!generatedRoot.exists()) {
+            fail(
+                "KSP output directory does not exist: $generatedRoot\n" +
+                    "Run `./gradlew :buffer-codec-test:kspCommonMainKotlinMetadata` " +
+                    "to populate it. If that fails, fix the processor first — " +
+                    "this test cannot snapshot what KSP did not generate.",
+            )
+        }
+
+        val generatedByRel = collectKtFiles(generatedRoot)
+        val baselineByRel = if (baselineRoot.exists()) collectKtFiles(baselineRoot) else emptyMap()
+
+        if (generatedByRel.isEmpty()) {
+            fail(
+                "KSP produced zero .kt files under $generatedRoot. " +
+                    "Either KSP silently failed or the fixture set has no @ProtocolMessage classes — investigate.",
+            )
+        }
+
+        val mismatches = mutableListOf<String>()
+        val missing = mutableListOf<String>()
+        val orphans = mutableListOf<String>()
+
+        for ((rel, generated) in generatedByRel) {
+            val generatedContent = normalize(generated.readText())
+            val baseline = baselineByRel[rel]
+            if (baseline == null) {
+                if (updateMode) {
+                    val target = File(baselineRoot, rel)
+                    target.parentFile.mkdirs()
+                    target.writeText(generatedContent)
+                } else {
+                    missing += rel
+                }
+            } else {
+                val baselineContent = normalize(baseline.readText())
+                if (generatedContent != baselineContent) {
+                    if (updateMode) {
+                        baseline.writeText(generatedContent)
+                    } else {
+                        mismatches += rel
+                    }
+                }
+            }
+        }
+
+        for ((rel, baseline) in baselineByRel) {
+            if (rel !in generatedByRel) {
+                if (updateMode) {
+                    baseline.delete()
+                } else {
+                    orphans += rel
+                }
+            }
+        }
+
+        if (updateMode) {
+            println(
+                "codec snapshots updated: ${generatedByRel.size} generated, " +
+                    "${missing.size} new, ${mismatches.size} changed, ${orphans.size} removed.",
+            )
+            return
+        }
+
+        if (mismatches.isEmpty() && missing.isEmpty() && orphans.isEmpty()) return
+
+        fail(buildFailureMessage(generatedByRel, baselineByRel, mismatches, missing, orphans))
+    }
+
+    private fun collectKtFiles(root: File): Map<String, File> =
+        root
+            .walkTopDown()
+            .filter { it.isFile && it.extension == "kt" }
+            .associateBy { it.relativeTo(root).invariantSeparatorsPath }
+
+    private fun normalize(content: String): String = content.replace("\r\n", "\n")
+
+    private fun buildFailureMessage(
+        generated: Map<String, File>,
+        baseline: Map<String, File>,
+        mismatches: List<String>,
+        missing: List<String>,
+        orphans: List<String>,
+    ): String {
+        val sb = StringBuilder()
+        sb.appendLine(
+            "Codec snapshot mismatch: " +
+                "${mismatches.size} changed, ${missing.size} new, ${orphans.size} removed.",
+        )
+        sb.appendLine()
+
+        if (mismatches.isNotEmpty()) {
+            sb.appendLine("=== Changed files ===")
+            for (rel in mismatches.take(MAX_FILES_REPORTED)) {
+                sb.appendLine("- $rel")
+                val expected = normalize(baseline.getValue(rel).readText())
+                val actual = normalize(generated.getValue(rel).readText())
+                sb.append(firstLineDifferences(expected, actual, MAX_DIFF_LINES_PER_FILE))
+            }
+            if (mismatches.size > MAX_FILES_REPORTED) {
+                sb.appendLine("- ... and ${mismatches.size - MAX_FILES_REPORTED} more")
+            }
+            sb.appendLine()
+        }
+
+        if (missing.isNotEmpty()) {
+            sb.appendLine("=== New files (no baseline) ===")
+            missing.take(MAX_FILES_REPORTED).forEach { sb.appendLine("- $it") }
+            if (missing.size > MAX_FILES_REPORTED) {
+                sb.appendLine("- ... and ${missing.size - MAX_FILES_REPORTED} more")
+            }
+            sb.appendLine()
+        }
+
+        if (orphans.isNotEmpty()) {
+            sb.appendLine("=== Removed files (baseline orphaned) ===")
+            orphans.take(MAX_FILES_REPORTED).forEach { sb.appendLine("- $it") }
+            if (orphans.size > MAX_FILES_REPORTED) {
+                sb.appendLine("- ... and ${orphans.size - MAX_FILES_REPORTED} more")
+            }
+            sb.appendLine()
+        }
+
+        sb.appendLine("To accept the current generated output as the new baseline, run:")
+        sb.appendLine("  ./gradlew :buffer-codec-test:jvmTest -Dupdate.snapshots=true")
+        sb.appendLine("Then `git add buffer-codec-test/codec-snapshots` and commit.")
+        sb.appendLine("Review the diff carefully — every change here is a wire-format")
+        sb.appendLine("or codec-shape change that downstream users will see.")
+        return sb.toString()
+    }
+
+    private fun firstLineDifferences(
+        expected: String,
+        actual: String,
+        maxLines: Int,
+    ): String {
+        val sb = StringBuilder()
+        val expectedLines = expected.lines()
+        val actualLines = actual.lines()
+        val limit = maxOf(expectedLines.size, actualLines.size)
+        var emitted = 0
+        for (i in 0 until limit) {
+            val e = expectedLines.getOrNull(i)
+            val a = actualLines.getOrNull(i)
+            if (e != a) {
+                sb.appendLine("    L${i + 1} - ${e ?: "<missing>"}")
+                sb.appendLine("    L${i + 1} + ${a ?: "<missing>"}")
+                emitted++
+                if (emitted >= maxLines) {
+                    sb.appendLine("    ... (more differences truncated)")
+                    break
+                }
+            }
+        }
+        return sb.toString()
+    }
+
+    private companion object {
+        const val MAX_FILES_REPORTED = 10
+        const val MAX_DIFF_LINES_PER_FILE = 20
+    }
+}


### PR DESCRIPTION
## Summary

Adds a JVM-only test (`CodecSnapshotTest`) that walks the live KSP
output at `build/generated/ksp/metadata/commonMain/kotlin/` and
diffs it against a checked-in baseline tree at
`buffer-codec-test/codec-snapshots/`. 278 baseline files cover
every `@ProtocolMessage` fixture in this module: MQTT, MQTT v5,
TLS, PNG, RIFF, WebSocket, DNS, Ethernet, FLV, HTTP/2, MySQL,
QUIC, TCP, slice fixtures, etc.

## Why

The v4 → v5.0 strip-and-rebuild of `buffer-codec-processor`
silently changed several emit shapes:

- Nested codec naming flattening was dropped (issue #156, fixed
  in v5.1.0).
- The batching read/write optimizer was deleted (silent perf
  regression).
- The SPI extension system was removed (silent source-break for
  v4 extenders that built custom `CodecFieldProvider`s).

Round-trip tests pass on *different but still valid* output, so
none of these surfaced until an external user hit one in
production. Locking the emit shape in a checked-in baseline makes
every shape change a reviewable diff at PR time — the diff
becomes the change's migration note.

## How it works

- Compares generated vs baseline file trees with line-ending
  normalization.
- Reports three failure modes: mismatched files, new files
  (no baseline), orphan baselines (no longer generated).
- Truncates output to 10 files / 20 differing lines per file
  with `...and N more` so a wholesale shape change produces a
  useful failure message instead of megabytes of diff.
- Prints the exact regen command on every failure.

## Regen workflow

```
./gradlew :buffer-codec-test:jvmTest -Dupdate.snapshots=true
git add buffer-codec-test/codec-snapshots
git commit
```

The PR diff for the regen commit becomes the change's migration note.

## Verified the trap fires

Sanity-tested by temporarily renaming a hardcoded generated
variable (`__framingOuterLimit` → `__framingSavedLimit`) in
`CodecEmitter.kt`. The snapshot test failed cleanly:

```
Codec snapshot mismatch: 35 changed, 0 new, 0 removed.

=== Changed files ===
- com/ditchoom/buffer/codec/test/protocols/slice14cgeneric/Slice14cGenericFramedDispatchHeaderedCodec.kt
    L20 -     val __framingOuterLimit = buffer.limit()
    L20 +     val __framingSavedLimit = buffer.limit()
    L38 -       buffer.setLimit(__framingOuterLimit)
    L38 +       buffer.setLimit(__framingSavedLimit)
- com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketConnAckCodec.kt
    L21 -     val __framingOuterLimit = buffer.limit()
    [...]
- ... and 25 more

To accept the current generated output as the new baseline, run:
  ./gradlew :buffer-codec-test:jvmTest -Dupdate.snapshots=true
```

Restored and verified green.

## Wiring

- `tasks.named<Test>("jvmTest")` gains three system properties:
  generated path, baseline path, and `update.snapshots` forwarded
  from the gradle command line.
- ktlint filter excludes `**/codec-snapshots/**` — kotlinpoet's
  output is the source of truth, drift means the test caught a
  real change.
- README in `codec-snapshots/` documents the regen workflow and
  warns against editing baselines by hand.

## Why `skip-release`

This PR adds a test harness and 278 baseline files; none of these
ship in the published artifact (`buffer-codec-test` is not
published). No reason to cut a 5.1.1 just to land the safety net.

## Test plan

- [x] `./gradlew :buffer-codec-test:ktlintCheck :buffer-codec-test:jvmTest` — green
- [x] Sanity test: introduced fake regression, snapshot test failed with useful diff and regen instructions
- [x] Restored, snapshot test green
- [x] Regen workflow verified: `-Dupdate.snapshots=true` writes baselines on first run, subsequent runs without the flag pass

## Follow-ups (not in this PR)

- The batching optimizer is still gone — restoration is in flight on a separate branch (held until extended for non-Default `wireOrder` coverage with a corresponding fixture). When that lands, the snapshot diff will make the new bulk-op shape visible.
- Architecture spike for validator/IR extraction is a separate decision.

Recommended for v5.x; lock in before any further emit-shape work.