### PR TITLE
feat(codec): @ForwardCompatible — skip-and-preserve unknown sealed variants

### DIFF
--- a/buffer-codec-processor/FORWARD_COMPATIBLE.md
+++ b/buffer-codec-processor/FORWARD_COMPATIBLE.md
@@ -1,0 +1,205 @@
+# `@ForwardCompatible` — skip-and-preserve unknown sealed variants
+
+> Design spec / PR handoff. Implement against `buffer-codec-processor`. Self-contained:
+> a fresh session should be able to build the feature from this document alone.
+
+## Motivation
+
+Generated sealed-dispatch decoders **throw** `DecodeException` when they hit a
+discriminator they don't recognize. Forward-compatible, length-delimited protocols
+need the opposite: an old decoder must **skip** an op it doesn't know (advance past
+its framed payload) and **preserve** it, so newer ops survive round-trips through
+older clients (relay) and on-disk frames (persistence).
+
+This is a generic engine capability — nothing protocol-specific belongs in
+`buffer-codec`. The driving consumer is an external terminal protocol (`§5` frames:
+`Frame{seq,ts,kind,base,ops}`, each op `opcode(1) + varint(len) + payload`), but the
+feature must not know that.
+
+## Scope
+
+Two protocol-agnostic features are needed for that consumer; **this spec covers
+only the first.** The second is tracked at the end.
+
+1. **`@ForwardCompatible`** — skip + preserve unknown variants. *(this doc)*
+2. **`@Count`** — element-count-prefixed lists. *(separate PR — see "Tracked separately")*
+
+Everything protocol-specific stays consumer-side, authored against existing
+extension points (no buffer changes):
+- framing prefix → a `BoundingLengthCodec<UInt>` (e.g. a full-width LEB128 length
+  codec) wired via `@FramedBy` — exactly how `MqttRemainingLengthCodec` is used,
+  and like it, **lives in the consumer module, not `:buffer-codec`** (the design
+  doc rejects a codec stdlib; each consumer authors the codec it needs).
+- per-field varints → `@UseCodec(...)`.
+- discriminator → `@PacketType` / `@DispatchOn`.
+
+## Current behavior to change
+
+In `buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt`
+(line numbers approximate — verify):
+
+- `buildDispatcherDecodeFun` (~7068) — simple `@PacketType` dispatch. Emits
+  `else -> throw DecodeException(...)`.
+- `buildDispatchOnDecodeFun` (~7709) — `@DispatchOn` dispatch. Same `else -> throw`.
+- `buildDispatcherPeekFrameFun` (~7173) / `buildDispatchOnPeekFun` (~7849) — peek.
+- Encode dispatch (`when (value)` over variants) and the wireSize dispatch — need a
+  new arm for the unknown variant.
+
+Annotation definitions live in
+`buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/annotations/Annotations.kt`.
+
+`@FramedBy` (~523) + `BoundingLengthCodec` (`buffer-codec/.../BoundingLengthCodec.kt`)
+already provide the length-bounded decode/encode and the peek-without-resolving-variant
+machinery we build on (`FramedEncoder`, `applyBound`, `maxWireSize`).
+
+## New API (add to `buffer-codec` Annotations.kt)
+
+```kotlin
+@Target(AnnotationTarget.CLASS) @Retention(AnnotationRetention.BINARY)
+annotation class ForwardCompatible(val unknown: KClass<*>)
+
+@Target(AnnotationTarget.CLASS) @Retention(AnnotationRetention.BINARY)
+annotation class UnknownVariant
+
+// Caller-controlled allocator for preserved (un-deserializable) bytes.
+val ForwardCompatibleFactoryKey = DecodeContext.Key<BufferFactory>("forwardCompatibleFactory")
+```
+
+## The unknown variant (consumer-declared)
+
+```kotlin
+@ProtocolMessage
+@FramedBy(<FramingCodec>::class)
+@ForwardCompatible(unknown = Op.Unknown::class)
+sealed interface Op {
+    @ProtocolMessage @PacketType(0x12)
+    data class Scroll(/* @UseCodec varints */) : Op
+
+    @UnknownVariant
+    data class Unknown(val opcode: Int, val raw: PlatformBuffer) : Op   // raw = opaque payload
+}
+```
+
+Decisions (settled):
+- **`data class`, opcode stored** (not a value class). `opcode` is **required**, not
+  cosmetic: `raw` is the opaque *payload only* (no opcode byte to derive from), and
+  re-encode must write a discriminator that, for an unknown op, is unknowable at
+  compile time — it can only come from this field.
+- `raw` is the **payload** (the framed body, excluding opcode and length prefix).
+- `raw` is a **`PlatformBuffer`**, never `ByteArray` — preserved bytes are destined
+  for the wire (relay/persist), which is a buffer consumer, and generated code must
+  never fabricate a `ByteArray`.
+- Content equality is automatic: data-class equals over `opcode: Int` +
+  `raw: PlatformBuffer` (buffers override `equals`/`hashCode` content-wise via
+  `bufferEquals`/`bufferHashCode`, `ReadBuffer.kt:966`).
+
+## Generated code
+
+`<FramingCodec>` = the codec named in this type's `@FramedBy`. `<DISC>` = the
+discriminator wire byte (for simple dispatch, the read `discriminator`).
+
+### decode — replace the `else -> throw`
+
+```kotlin
+else -> {
+    buffer.position(opcodeStart + 1)                 // past the 1-byte discriminator
+    val len = <FramingCodec>.decode(buffer, context)
+    val frameEnd = buffer.position() + len.toInt()   // position is now at payload start
+
+    val factory = context[ForwardCompatibleFactoryKey] ?: BufferFactory.managed()
+    val raw = factory.allocate(len.toInt())
+    val savedLimit = buffer.limit()
+    buffer.setLimit(frameEnd)
+    raw.write(buffer)                                 // copies payload; advances buffer to frameEnd
+    buffer.setLimit(savedLimit)                       // position now exactly past the op
+    raw.resetForRead()
+    Op.Unknown(discriminator, raw)
+}
+```
+
+`opcodeStart` = the position captured before reading the discriminator (the existing
+generated code already captures `discriminatorPosition` — reuse it). For `@DispatchOn`,
+the discriminator may be wider than 1 byte; advance by the discriminator width, and
+take `opcode`/`discriminator` from the already-decoded dispatch value.
+
+### encode — new arm in the `when (value)` dispatch
+
+Re-emit the discriminator from the stored field, then frame the payload with the same
+`@FramedBy` codec (the path known variants already use via `FramedEncoder`):
+
+```kotlin
+is Op.Unknown -> {
+    buffer.writeUByte(value.opcode.toUByte())              // discriminator from stored field
+    <FramingCodec>.encode(buffer, value.raw.remaining().toUInt(), context)
+    buffer.write(value.raw.slice())                        // slice() = non-consuming, re-entrant
+}
+```
+
+### wireSize — new arm
+
+```kotlin
+is Op.Unknown -> {
+    val p = value.raw.remaining()
+    WireSize.Exact(1 + (<FramingCodec>.wireSize(p.toUInt(), context) as WireSize.Exact).bytes + p)
+}
+```
+
+### peekFrameSize — no change
+
+The existing `@FramedBy` peek derives the total frame size from the prefix **without
+resolving the variant**, so an unknown op already peeks correctly. Confirm with a test;
+write no new peek code.
+
+## Copy / lifetime contract
+
+- **One copy, at decode — mandatory.** The op is opaque: there is no typed form to
+  restructure into, so retaining raw bytes *is* the decode, and they outlive the
+  (often pooled) frame buffer. `slice()` is therefore forbidden here — its contract
+  (`ReadBuffer.kt:83`) says a slice must not outlive the parent's scope. Use
+  `factory.allocate + write`.
+- **Zero copies at encode.** We own `raw`; `slice()` is verified non-consuming
+  (does not move the source position) and zero-copy, and the slice is transient
+  within the encode call — safe and re-entrant.
+- **Default `managed()`**: GC lifetime, no manual free. A caller wanting native/pooled
+  memory injects a pool-backed `BufferFactory` via `ForwardCompatibleFactoryKey` and
+  owns freeing.
+
+## Byte-identity
+
+Required (consumer persists/relays frames). Holds because `Unknown` re-encode reuses
+the same `@FramedBy` framing codec that **known** variants use — both re-derive the
+length prefix rather than preserving original length bytes, so they share one
+byte-identity guarantee (canonical framing-codec encoding). The discriminator is a
+single byte, so no encoding ambiguity.
+
+## Compile-time rules (enforce in the processor)
+
+1. `@ForwardCompatible` **requires** `@FramedBy` on the same type → else error:
+   *"cannot skip an unknown variant without a framing length."* You cannot skip what
+   you cannot measure.
+2. `unknown` must name a member of the sealed type marked `@UnknownVariant`, of shape
+   `(opcode: Int, raw: PlatformBuffer)` (also accept `(Int, ReadBuffer)`).
+3. `@UnknownVariant` must **not** carry `@PacketType` (it is the `else` sink).
+4. Exactly **one** `@UnknownVariant` per `@ForwardCompatible` union.
+5. Generated preserve-paths must allocate through `ForwardCompatibleFactoryKey`
+   (default `managed()`) — never `ByteArray`.
+
+## Test obligations
+
+- Round-trip **byte-identical** for a frame containing an unknown op (decode → encode).
+- Unknown op flanked by known ops in one frame; correct ordering and offsets.
+- `peekFrameSize` correct on an unknown op.
+- Relay identity through both `managed()` and a pooled factory (via context key).
+- Wrapper transparency (`PooledBuffer` / `TrackedSlice`) per `WrapperTransparencyTests`.
+- Negative: `@ForwardCompatible` without `@FramedBy` fails compilation with rule (1)'s
+  message; two `@UnknownVariant`s fail with rule (4).
+
+## Tracked separately — `@Count` (element-count lists)
+
+The driving consumer's lists (`ops`, `runs`, `cells`, `lines`) use an **element-count**
+prefix (`varint(N) + N elements`). buffer-codec currently supports only **byte-length**
+lists (`LengthPrefixedUseCodecList`/`RemainingBytes`/`LengthFrom` — all drain-to-limit;
+the framing codec receives a *byte* count, decode loops until the bound drains; no
+`@Count`, no `repeat(n)`). Byte-identity for that consumer therefore needs a generic
+`@Count(codec)`: encode writes `list.size` via the codec, decode does `repeat(n)`.
+Same factory/copy rules apply if it ever retains bytes. Independent of this PR.

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
@@ -6846,9 +6846,26 @@ internal class CodecEmitter(
 
         val subclasses = symbol.getSealedSubclasses().toList()
         if (subclasses.isEmpty()) return null
+
+        // `@ForwardCompatible` capture. The unknown-variant sink carries
+        // `@UnknownVariant` (not `@PacketType`), so it is excluded from
+        // the dispatch table and drives the skip+preserve emit instead.
+        // Only wired alongside `@FramedBy` — the validator errors on
+        // `@ForwardCompatible` without framing, and without a framing
+        // length there is no payload boundary to skip.
+        val forwardCompatible =
+            symbol.annotations
+                .firstOrNull { it.shortName.asString() == "ForwardCompatible" }
+                ?.takeIf { symbol.annotations.any(::isFramedByAnn) }
+                ?.let { resolveForwardCompatibleConfig(subclasses) }
+
         val variants = mutableListOf<DispatchOnVariantSpec>()
         val seenValues = mutableSetOf<Int>()
         for (sub in subclasses) {
+            // The `@UnknownVariant` sink is handled by the dispatcher's
+            // skip+preserve arms, not the variant table — skip it here so
+            // its missing `@PacketType` doesn't fail dispatcher analysis.
+            if (sub.annotations.any { it.shortName.asString() == "UnknownVariant" }) continue
             // Issue #150 — accept `data object` / `object` variants
             // (classKind == OBJECT). Object variants don't carry the
             // discriminator field (no constructor), so the firstParam
@@ -6949,6 +6966,49 @@ internal class CodecEmitter(
             variants = variants,
             payloadTypeParameter = payloadTypeParameter,
             framedBy = framedBy,
+            forwardCompatible = forwardCompatible,
+        )
+    }
+
+    /**
+     * Resolve the `@ForwardCompatible` unknown-variant sink among the
+     * sealed parent's subclasses: the (single) subclass carrying
+     * `@UnknownVariant`, with its `(Int, PlatformBuffer | ReadBuffer)`
+     * constructor parameter names resolved by type. Returns null when
+     * the shape is malformed (no/duplicate sink, wrong arity, missing
+     * either typed parameter) — the validator surfaces the user-facing
+     * diagnostic; the analyzer stays silent and simply emits the
+     * non-forward-compatible (throwing) dispatcher.
+     */
+    private fun resolveForwardCompatibleConfig(subclasses: List<KSClassDeclaration>): ForwardCompatibleConfig? {
+        val sink =
+            subclasses
+                .filter { sub -> sub.annotations.any { it.shortName.asString() == "UnknownVariant" } }
+                .singleOrNull() ?: return null
+        val ctor = sink.primaryConstructor ?: return null
+        val params = ctor.parameters
+        if (params.size != 2) return null
+        val opcodeParam =
+            params.firstOrNull {
+                it.type
+                    .resolve()
+                    .declaration.qualifiedName
+                    ?.asString() == "kotlin.Int"
+            } ?: return null
+        val rawParam =
+            params.firstOrNull {
+                it.type
+                    .resolve()
+                    .declaration.qualifiedName
+                    ?.asString() in FORWARD_COMPATIBLE_RAW_QNAMES
+            } ?: return null
+        val opcodeName = opcodeParam.name?.asString() ?: return null
+        val rawName = rawParam.name?.asString() ?: return null
+        if (opcodeName == rawName) return null
+        return ForwardCompatibleConfig(
+            unknownClassName = classNameOf(sink),
+            opcodeFieldName = opcodeName,
+            rawFieldName = rawName,
         )
     }
 
@@ -7311,6 +7371,7 @@ internal class CodecEmitter(
                 )
             }
         }
+        shape.forwardCompatible?.let { fc -> appendForwardCompatibleEncodeArm(body, shape, fc) }
         body.endControlFlow()
         return FunSpec
             .builder("encode")
@@ -7706,6 +7767,95 @@ internal class CodecEmitter(
     private fun expectedDispatchValueSet(shape: DispatchOnDispatcherShape): String =
         shape.variants.joinToString(prefix = "one of {", postfix = "}") { it.dispatchValue.toString() }
 
+    /**
+     * Emit the `@ForwardCompatible` decode `else` arm: skip an
+     * unrecognized discriminator's framed payload and preserve it
+     * verbatim into the unknown variant, instead of throwing.
+     *
+     * Position on entry is `discriminatorPosition` (the decode rewinds
+     * there before dispatching). We re-read the single discriminator
+     * byte as the opcode — capturing the *full* wire byte rather than
+     * the (possibly sub-byte) dispatch value, which is what makes
+     * re-encode byte-identical — then read the inherited framing prefix
+     * to bound the payload, copy the payload into a caller-controlled
+     * buffer (default `managed()`), and restore the outer limit so the
+     * cursor lands exactly past the op.
+     *
+     * The copy is mandatory (the design's lifetime contract): the
+     * preserved bytes outlive the often-pooled frame buffer, so a
+     * non-consuming `slice()` would dangle. `factory.allocate + write`
+     * gives an independently-owned buffer.
+     */
+    private fun appendForwardCompatibleDecodeElse(
+        body: CodeBlock.Builder,
+        shape: DispatchOnDispatcherShape,
+        fc: ForwardCompatibleConfig,
+    ) {
+        val framedBy =
+            shape.framedBy
+                ?: error("@ForwardCompatible requires @FramedBy; analyzer should not have set forwardCompatible")
+        body.beginControlFlow("else ->")
+        // Cursor is at discriminatorPosition (rewound by decode); set it
+        // explicitly so the read is robust to future reordering.
+        body.addStatement("buffer.position(discriminatorPosition)")
+        body.addStatement("val __fcOpcode = buffer.readUByte().toInt()")
+        body.addStatement(
+            "val __fcLength = %T.decode(buffer, context)",
+            framedBy.codecClassName,
+        )
+        body.addStatement("val __fcFrameEnd = buffer.position() + __fcLength.toInt()")
+        body.addStatement(
+            "val __fcFactory = context[%T] ?: %T.%M()",
+            FORWARD_COMPATIBLE_FACTORY_KEY_CN,
+            BUFFER_FACTORY_CN,
+            BUFFER_FACTORY_MANAGED_MN,
+        )
+        body.addStatement("val __fcRaw = __fcFactory.allocate(__fcLength.toInt())")
+        body.addStatement("val __fcSavedLimit = buffer.limit()")
+        body.addStatement("buffer.setLimit(__fcFrameEnd)")
+        body.addStatement("__fcRaw.write(buffer)")
+        body.addStatement("buffer.setLimit(__fcSavedLimit)")
+        body.addStatement("__fcRaw.resetForRead()")
+        body.addStatement(
+            "%T(%L = __fcOpcode, %L = __fcRaw)",
+            fc.unknownClassName,
+            fc.opcodeFieldName,
+            fc.rawFieldName,
+        )
+        body.endControlFlow()
+    }
+
+    /**
+     * Emit the `@ForwardCompatible` encode arm for an unknown variant:
+     * re-frame the preserved payload with the same inherited framing
+     * codec the known variants use (via [FramedEncoder]), writing the
+     * stored opcode as the single-byte discriminator. Byte-identical to
+     * the original wire bytes — same framing codec re-derives the prefix,
+     * the discriminator is one byte, and the payload is reproduced
+     * verbatim. `raw.slice()` is non-consuming and zero-copy: we own
+     * `raw`, and the slice is transient within the encode call.
+     */
+    private fun appendForwardCompatibleEncodeArm(
+        body: CodeBlock.Builder,
+        shape: DispatchOnDispatcherShape,
+        fc: ForwardCompatibleConfig,
+    ) {
+        val framedBy =
+            shape.framedBy
+                ?: error("@ForwardCompatible requires @FramedBy; analyzer should not have set forwardCompatible")
+        body.add("is %T -> %T.encode(\n", fc.unknownClassName, FRAMED_ENCODER_CN)
+        body.indent()
+        body.add("factory = factory,\n")
+        body.add("framingCodec = %T,\n", framedBy.codecClassName)
+        body.add("context = context,\n")
+        body.add("headerWireWidth = 1,\n")
+        body.add("writeHeader = { __fcBuf -> __fcBuf.writeUByte(value.%L.toUByte()) },\n", fc.opcodeFieldName)
+        body.unindent()
+        body.beginControlFlow(") { __fcBuf ->")
+        body.addStatement("__fcBuf.write(value.%L.slice())", fc.rawFieldName)
+        body.endControlFlow()
+    }
+
     private fun buildDispatchOnDecodeFun(
         shape: DispatchOnDispatcherShape,
         parentTypeRef: TypeName,
@@ -7734,15 +7884,20 @@ internal class CodecEmitter(
                 variant.codecReceiver(),
             )
         }
-        body.beginControlFlow("else ->")
-        body.addStatement(
-            "throw %T(fieldPath = %S, bufferPosition = discriminatorPosition, expected = %S, actual = %P)",
-            DECODE_EXCEPTION_CN,
-            "${shape.parentSimpleName}.discriminator",
-            expectedDispatchValueSet(shape),
-            "\${__dispatchValue}",
-        )
-        body.endControlFlow()
+        val fc = shape.forwardCompatible
+        if (fc != null) {
+            appendForwardCompatibleDecodeElse(body, shape, fc)
+        } else {
+            body.beginControlFlow("else ->")
+            body.addStatement(
+                "throw %T(fieldPath = %S, bufferPosition = discriminatorPosition, expected = %S, actual = %P)",
+                DECODE_EXCEPTION_CN,
+                "${shape.parentSimpleName}.discriminator",
+                expectedDispatchValueSet(shape),
+                "\${__dispatchValue}",
+            )
+            body.endControlFlow()
+        }
         body.endControlFlow()
         // `@FramedBy` dispatchers don't
         // implement `Codec<T>` (the encode contract differs), so
@@ -7977,6 +8132,17 @@ internal class CodecEmitter(
          * inner scalar width.
          */
         val framedBy: FramedByConfig? = null,
+        /**
+         * Present when the sealed parent carries `@ForwardCompatible`
+         * (only meaningful alongside [framedBy]). When set, the decode
+         * `else` arm skips an unrecognized discriminator's framed
+         * payload and preserves it into the unknown variant rather than
+         * throwing, and the framed encode gains an `is <Unknown> ->` arm
+         * that re-frames the preserved bytes with the inherited framing
+         * codec. The discriminator is validator-constrained to a single
+         * byte so the stored opcode re-encodes byte-identically.
+         */
+        val forwardCompatible: ForwardCompatibleConfig? = null,
     )
 
     /**
@@ -8097,6 +8263,25 @@ internal class CodecEmitter(
     private data class FramedByConfig(
         val codecClassName: ClassName,
         val afterFieldName: String,
+    )
+
+    /**
+     * `@ForwardCompatible` configuration captured off a `@DispatchOn`
+     * framed sealed parent. The unknown-variant sink is excluded from
+     * the dispatcher's variant table (it carries no `@PacketType`) and
+     * instead drives the decode `else` (skip + preserve) and encode
+     * (`is Unknown ->` re-frame) arms.
+     *
+     * [opcodeFieldName] / [rawFieldName] are the unknown variant's
+     * constructor parameter names — the validator guarantees the shape
+     * `(Int, PlatformBuffer | ReadBuffer)`, the analyzer resolves the
+     * names by type so emission references `value.<opcode>` /
+     * `value.<raw>` regardless of the consumer's chosen identifiers.
+     */
+    private data class ForwardCompatibleConfig(
+        val unknownClassName: ClassName,
+        val opcodeFieldName: String,
+        val rawFieldName: String,
     )
 
     /**
@@ -9034,6 +9219,17 @@ internal class CodecEmitter(
         private val DECODE_EXCEPTION_CN = ClassName("com.ditchoom.buffer.codec", "DecodeException")
         private val ENCODE_EXCEPTION_CN = ClassName("com.ditchoom.buffer.codec", "EncodeException")
         private val FRAMED_ENCODER_CN = ClassName("com.ditchoom.buffer.codec", "FramedEncoder")
+        private val FORWARD_COMPATIBLE_FACTORY_KEY_CN =
+            ClassName("com.ditchoom.buffer.codec", "ForwardCompatibleFactoryKey")
+        private val BUFFER_FACTORY_MANAGED_MN =
+            com.squareup.kotlinpoet.MemberName("com.ditchoom.buffer", "managed")
+
+        // Accepted types for the `@UnknownVariant` `raw` parameter — the
+        // opaque preserved payload. `factory.allocate(...)` yields a
+        // `PlatformBuffer` (assignable to a `ReadBuffer`-typed field too),
+        // so both are valid declared types.
+        private val FORWARD_COMPATIBLE_RAW_QNAMES =
+            setOf("com.ditchoom.buffer.PlatformBuffer", "com.ditchoom.buffer.ReadBuffer")
         private val CHARSET_CN = ClassName("com.ditchoom.buffer", "Charset")
         private val STRING_NULLABLE_TN = ClassName("kotlin", "String").copy(nullable = true)
     }

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/ProtocolMessageProcessor.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/ProtocolMessageProcessor.kt
@@ -137,6 +137,7 @@ class ProtocolMessageProcessor(
                 validateSealedDispatcher(symbol)
                 validateDispatchOnSealed(symbol)
                 validateFramedBy(symbol)
+                validateForwardCompatible(symbol)
                 emitter.tryEmit(symbol)
                 continue
             }
@@ -400,6 +401,12 @@ class ProtocolMessageProcessor(
         val seen = mutableMapOf<Int, String>()
         for (sub in parent.getSealedSubclasses()) {
             val subName = sub.qualifiedName?.asString() ?: sub.simpleName.asString()
+            // The `@ForwardCompatible` unknown-variant sink is the `else`
+            // arm of dispatch — it carries no `@PacketType` and its first
+            // constructor parameter is `opcode: Int`, not the
+            // discriminator. The dispatch-shape rules below don't apply
+            // to it; `validateForwardCompatible` checks its shape instead.
+            if (sub.hasAnnotation(UNKNOWN_VARIANT_SHORT, UNKNOWN_VARIANT_QNAME)) continue
             // Issue #150 — `data object` / `object` variants are valid
             // here (they emit empty-fields singleton codecs). Reject only
             // non-data, non-object subclasses.
@@ -1737,9 +1744,15 @@ class ProtocolMessageProcessor(
         // E2/E3 — `after = "X"`: X exists with Exact wire width on every primary constructor.
         val targets: List<Pair<KSClassDeclaration, List<KSValueParameter>>> =
             if (isSealedParent) {
-                owner.getSealedSubclasses().toList().mapNotNull { variant ->
-                    variant.primaryConstructor?.let { variant to it.parameters }
-                }
+                // The `@ForwardCompatible` unknown-variant sink carries no
+                // discriminator/header field — the dispatcher writes the
+                // discriminator itself on the preserve path — so it is
+                // exempt from the `after`-field requirement.
+                val dispatchVariants =
+                    owner.getSealedSubclasses().toList().filterNot {
+                        it.hasAnnotation(UNKNOWN_VARIANT_SHORT, UNKNOWN_VARIANT_QNAME)
+                    }
+                dispatchVariants.mapNotNull { variant -> variant.primaryConstructor?.let { variant to it.parameters } }
             } else {
                 listOf(owner to (ctor?.parameters ?: emptyList()))
             }
@@ -1784,6 +1797,179 @@ class ProtocolMessageProcessor(
                     target,
                 )
             }
+        }
+    }
+
+    private fun KSClassDeclaration.hasAnnotation(
+        short: String,
+        qname: String,
+    ): Boolean =
+        annotations.any { ann ->
+            ann.shortName.asString() == short &&
+                ann.annotationType
+                    .resolve()
+                    .declaration.qualifiedName
+                    ?.asString() == qname
+        }
+
+    /**
+     * `@ForwardCompatible` validator. Enforces the skip-and-preserve
+     * contract's compile-time rules (spec §"Compile-time rules"):
+     *
+     *   - **F1** — requires `@FramedBy` on the same type. You cannot
+     *     skip an unknown variant without a framing length to measure
+     *     its payload.
+     *   - **F2** — requires `@DispatchOn` with a single-byte
+     *     discriminator. Framed sealed dispatch routes exclusively
+     *     through `@DispatchOn`; a single-byte discriminator guarantees
+     *     the preserved opcode re-encodes byte-identically (the design's
+     *     byte-identity requirement).
+     *   - **F3** — exactly one `@UnknownVariant` sealed member, and it
+     *     must be the type named by `unknown`.
+     *   - **F4** — the `@UnknownVariant` member must not carry
+     *     `@PacketType` (it is the `else` sink, never value-matched).
+     *   - **F5** — the `@UnknownVariant` member's primary constructor
+     *     must be shaped `(opcode: Int, raw: PlatformBuffer)` (a
+     *     `ReadBuffer`-typed `raw` is also accepted).
+     *
+     * Only runs on sealed interfaces (the dispatch parents); a
+     * `@ForwardCompatible` on any other target is a no-op here (the
+     * annotation `@Target(CLASS)` admits it, but it has no meaning
+     * without sealed dispatch — caught as F2's missing `@DispatchOn`).
+     */
+    private fun validateForwardCompatible(owner: KSClassDeclaration) {
+        val ann =
+            owner.annotations.firstOrNull { a ->
+                a.shortName.asString() == FORWARD_COMPATIBLE_SHORT &&
+                    a.annotationType
+                        .resolve()
+                        .declaration.qualifiedName
+                        ?.asString() == FORWARD_COMPATIBLE_QNAME
+            } ?: return
+        val ownerName = owner.qualifiedName?.asString() ?: owner.simpleName.asString()
+
+        // F1 — requires @FramedBy.
+        if (!owner.hasAnnotation(FRAMED_BY_SHORT, FRAMED_BY_QNAME)) {
+            logger.error(
+                "@ForwardCompatible on $ownerName requires @FramedBy on the same type: cannot " +
+                    "skip an unknown variant without a framing length. Add " +
+                    "@FramedBy(<LengthCodec>::class, after = \"<discriminatorField>\").",
+                owner,
+            )
+        }
+
+        // F2 — requires @DispatchOn with a single-byte discriminator.
+        val dispatchOn =
+            owner.annotations.firstOrNull { a ->
+                a.shortName.asString() == DISPATCH_ON_SHORT &&
+                    a.annotationType
+                        .resolve()
+                        .declaration.qualifiedName
+                        ?.asString() == DISPATCH_ON_QNAME
+            }
+        if (dispatchOn == null) {
+            logger.error(
+                "@ForwardCompatible on $ownerName requires @DispatchOn dispatch with a single-byte " +
+                    "discriminator. Framed sealed dispatch routes through @DispatchOn; wrap the " +
+                    "opcode in a `@JvmInline value class` carrying a @DispatchValue and annotate the " +
+                    "parent with @DispatchOn(<OpCode>::class).",
+                owner,
+            )
+        } else {
+            val discriminatorType =
+                dispatchOn.arguments
+                    .firstOrNull { it.name?.asString() == "type" }
+                    ?.value as? KSType
+            val discriminatorDecl = discriminatorType?.declaration as? KSClassDeclaration
+            val innerQname =
+                discriminatorDecl
+                    ?.primaryConstructor
+                    ?.parameters
+                    ?.singleOrNull()
+                    ?.type
+                    ?.resolve()
+                    ?.declaration
+                    ?.qualifiedName
+                    ?.asString()
+            // Single-byte inner scalars only (Byte / UByte). Wider
+            // discriminators would need a multi-byte opcode store + a
+            // byte-order-aware re-encode, neither of which the preserve
+            // path emits today.
+            if (innerQname != null && innerQname !in SINGLE_BYTE_SCALAR_QNAMES) {
+                logger.error(
+                    "@ForwardCompatible on $ownerName requires a single-byte @DispatchOn " +
+                        "discriminator (Byte / UByte inner scalar), but the discriminator's inner " +
+                        "type is `$innerQname`. The preserved opcode is stored as one byte and " +
+                        "re-encoded with writeUByte, so a wider discriminator cannot round-trip " +
+                        "byte-identically.",
+                    owner,
+                )
+            }
+        }
+
+        // F3 — exactly one @UnknownVariant sealed member, matching `unknown`.
+        val unknownMembers =
+            owner.getSealedSubclasses().filter { it.hasAnnotation(UNKNOWN_VARIANT_SHORT, UNKNOWN_VARIANT_QNAME) }.toList()
+        if (unknownMembers.size != 1) {
+            logger.error(
+                "@ForwardCompatible on $ownerName requires exactly one sealed member marked " +
+                    "@UnknownVariant, but found ${unknownMembers.size}. The unknown variant is the " +
+                    "single sink that unrecognized discriminators are preserved into.",
+                owner,
+            )
+            return
+        }
+        val sink = unknownMembers[0]
+        val sinkName = sink.qualifiedName?.asString() ?: sink.simpleName.asString()
+
+        val declaredUnknown =
+            ann.arguments
+                .firstOrNull { it.name?.asString() == "unknown" }
+                ?.value as? KSType
+        val declaredUnknownQname = declaredUnknown?.declaration?.qualifiedName?.asString()
+        if (declaredUnknownQname != null && declaredUnknownQname != sink.qualifiedName?.asString()) {
+            logger.error(
+                "@ForwardCompatible(unknown = ...) on $ownerName names `$declaredUnknownQname`, but " +
+                    "the @UnknownVariant member is `$sinkName`. `unknown` must name the " +
+                    "@UnknownVariant-marked member.",
+                owner,
+            )
+        }
+
+        // F4 — @UnknownVariant must not carry @PacketType.
+        if (sink.hasAnnotation(PACKET_TYPE_SHORT, PACKET_TYPE_QNAME)) {
+            logger.error(
+                "@UnknownVariant $sinkName must not carry @PacketType — it is the `else` sink of " +
+                    "forward-compatible dispatch and is never matched by discriminator value.",
+                sink,
+            )
+        }
+
+        // F5 — (opcode: Int, raw: PlatformBuffer | ReadBuffer).
+        val params = sink.primaryConstructor?.parameters.orEmpty()
+        val hasInt =
+            params.any {
+                it.type
+                    .resolve()
+                    .declaration.qualifiedName
+                    ?.asString() == INT_QNAME
+            }
+        val hasRawBuffer =
+            params.any {
+                it.type
+                    .resolve()
+                    .declaration.qualifiedName
+                    ?.asString() in
+                    setOf(PLATFORM_BUFFER_QNAME, READ_BUFFER_QNAME)
+            }
+        if (params.size != 2 || !hasInt || !hasRawBuffer) {
+            logger.error(
+                "@UnknownVariant $sinkName must have a primary constructor shaped " +
+                    "`(opcode: Int, raw: PlatformBuffer)` (a ReadBuffer-typed `raw` is also " +
+                    "accepted): `opcode` carries the discriminator byte and `raw` carries the " +
+                    "opaque preserved payload.",
+                sink,
+            )
         }
     }
 
@@ -2155,6 +2341,14 @@ class ProtocolMessageProcessor(
         private const val DERIVED_LENGTH_SHORT = "DerivedLength"
         private const val FRAMED_BY_QNAME = "com.ditchoom.buffer.codec.annotations.FramedBy"
         private const val FRAMED_BY_SHORT = "FramedBy"
+        private const val FORWARD_COMPATIBLE_QNAME = "com.ditchoom.buffer.codec.annotations.ForwardCompatible"
+        private const val FORWARD_COMPATIBLE_SHORT = "ForwardCompatible"
+        private const val UNKNOWN_VARIANT_QNAME = "com.ditchoom.buffer.codec.annotations.UnknownVariant"
+        private const val UNKNOWN_VARIANT_SHORT = "UnknownVariant"
+        private const val PLATFORM_BUFFER_QNAME = "com.ditchoom.buffer.PlatformBuffer"
+        private const val READ_BUFFER_QNAME = "com.ditchoom.buffer.ReadBuffer"
+        private const val INT_QNAME = "kotlin.Int"
+        private val SINGLE_BYTE_SCALAR_QNAMES = setOf("kotlin.Byte", "kotlin.UByte")
         private const val REMAINING_BYTES_QNAME = "com.ditchoom.buffer.codec.annotations.RemainingBytes"
         private const val REMAINING_BYTES_SHORT = "RemainingBytes"
         private const val CODEC_QNAME = "com.ditchoom.buffer.codec.Codec"

--- a/buffer-codec-processor/src/test/kotlin/com/ditchoom/buffer/codec/processor/ForwardCompatibleValidatorTest.kt
+++ b/buffer-codec-processor/src/test/kotlin/com/ditchoom/buffer/codec/processor/ForwardCompatibleValidatorTest.kt
@@ -1,0 +1,224 @@
+package com.ditchoom.buffer.codec.processor
+
+import com.tschuchort.compiletesting.JvmCompilationResult
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import com.tschuchort.compiletesting.configureKsp
+import com.tschuchort.compiletesting.useKsp2
+import org.intellij.lang.annotations.Language
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * `@ForwardCompatible` validator coverage:
+ *
+ *   - **F1** — requires `@FramedBy` on the same type.
+ *   - **F2** — requires `@DispatchOn` with a single-byte discriminator.
+ *   - **F3** — exactly one `@UnknownVariant` sealed member.
+ *   - **F4** — the `@UnknownVariant` member must not carry `@PacketType`.
+ *   - **F5** — the `@UnknownVariant` member must be `(opcode: Int, raw: PlatformBuffer)`.
+ *
+ * Plus an acceptance test: a well-formed forward-compatible union compiles
+ * cleanly and emits its dispatcher.
+ */
+class ForwardCompatibleValidatorTest {
+    // Shared preamble: a BoundingLengthCodec<UInt> framing codec and a
+    // single-byte @DispatchOn discriminator value class.
+    private val preamble =
+        """
+        package test
+
+        import com.ditchoom.buffer.PlatformBuffer
+        import com.ditchoom.buffer.ReadBuffer
+        import com.ditchoom.buffer.WriteBuffer
+        import com.ditchoom.buffer.codec.BoundingLengthCodec
+        import com.ditchoom.buffer.codec.DecodeContext
+        import com.ditchoom.buffer.codec.EncodeContext
+        import com.ditchoom.buffer.codec.WireSize
+        import com.ditchoom.buffer.codec.annotations.DispatchOn
+        import com.ditchoom.buffer.codec.annotations.DispatchValue
+        import com.ditchoom.buffer.codec.annotations.ForwardCompatible
+        import com.ditchoom.buffer.codec.annotations.FramedBy
+        import com.ditchoom.buffer.codec.annotations.PacketType
+        import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+        import com.ditchoom.buffer.codec.annotations.UnknownVariant
+
+        object LenCodec : BoundingLengthCodec<UInt> {
+            override val maxWireSize: Int = 4
+            override fun decode(buffer: ReadBuffer, context: DecodeContext): UInt = buffer.readUByte().toUInt()
+            override fun encode(buffer: WriteBuffer, value: UInt, context: EncodeContext) {
+                buffer.writeUByte(value.toUByte())
+            }
+            override fun wireSize(value: UInt, context: EncodeContext): WireSize = WireSize.Exact(1)
+            override fun applyBound(buffer: ReadBuffer, decodedValue: UInt) {
+                buffer.setLimit(buffer.position() + decodedValue.toInt())
+            }
+        }
+
+        @JvmInline
+        @ProtocolMessage
+        value class Op8(val raw: UByte) {
+            @DispatchValue
+            val code: Int get() = raw.toInt()
+        }
+
+        """.trimIndent()
+
+    @Test
+    fun acceptsWellFormedForwardCompatibleUnion() {
+        val result =
+            compile(
+                preamble +
+                    """
+
+                    @ProtocolMessage
+                    @DispatchOn(Op8::class)
+                    @FramedBy(LenCodec::class, after = "header")
+                    @ForwardCompatible(unknown = Frame.Unknown::class)
+                    sealed interface Frame {
+                        @ProtocolMessage
+                        @PacketType(value = 0x12)
+                        data class Known(val header: Op8, val a: UByte) : Frame
+
+                        @UnknownVariant
+                        data class Unknown(val opcode: Int, val raw: PlatformBuffer) : Frame
+                    }
+                    """.trimIndent(),
+            )
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+    }
+
+    @Test
+    fun rejectsForwardCompatibleWithoutFramedBy() {
+        // F1
+        val result =
+            compile(
+                preamble +
+                    """
+
+                    @ProtocolMessage
+                    @DispatchOn(Op8::class)
+                    @ForwardCompatible(unknown = Frame.Unknown::class)
+                    sealed interface Frame {
+                        @ProtocolMessage
+                        @PacketType(value = 0x12)
+                        data class Known(val header: Op8, val a: UByte) : Frame
+
+                        @UnknownVariant
+                        data class Unknown(val opcode: Int, val raw: PlatformBuffer) : Frame
+                    }
+                    """.trimIndent(),
+            )
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode, result.messages)
+        assertTrue(
+            result.messages.contains("framing length"),
+            "expected the rule-1 (no framing) diagnostic, got:\n${result.messages}",
+        )
+    }
+
+    @Test
+    fun rejectsTwoUnknownVariants() {
+        // F3
+        val result =
+            compile(
+                preamble +
+                    """
+
+                    @ProtocolMessage
+                    @DispatchOn(Op8::class)
+                    @FramedBy(LenCodec::class, after = "header")
+                    @ForwardCompatible(unknown = Frame.UnknownA::class)
+                    sealed interface Frame {
+                        @ProtocolMessage
+                        @PacketType(value = 0x12)
+                        data class Known(val header: Op8, val a: UByte) : Frame
+
+                        @UnknownVariant
+                        data class UnknownA(val opcode: Int, val raw: PlatformBuffer) : Frame
+
+                        @UnknownVariant
+                        data class UnknownB(val opcode: Int, val raw: PlatformBuffer) : Frame
+                    }
+                    """.trimIndent(),
+            )
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode, result.messages)
+        assertTrue(
+            result.messages.contains("exactly one sealed member marked @UnknownVariant"),
+            "expected the rule-4 (one unknown variant) diagnostic, got:\n${result.messages}",
+        )
+    }
+
+    @Test
+    fun rejectsUnknownVariantCarryingPacketType() {
+        // F4
+        val result =
+            compile(
+                preamble +
+                    """
+
+                    @ProtocolMessage
+                    @DispatchOn(Op8::class)
+                    @FramedBy(LenCodec::class, after = "header")
+                    @ForwardCompatible(unknown = Frame.Unknown::class)
+                    sealed interface Frame {
+                        @ProtocolMessage
+                        @PacketType(value = 0x12)
+                        data class Known(val header: Op8, val a: UByte) : Frame
+
+                        @UnknownVariant
+                        @PacketType(value = 0x99)
+                        data class Unknown(val opcode: Int, val raw: PlatformBuffer) : Frame
+                    }
+                    """.trimIndent(),
+            )
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode, result.messages)
+        assertTrue(
+            result.messages.contains("must not carry @PacketType"),
+            "expected the rule-3 (@UnknownVariant has @PacketType) diagnostic, got:\n${result.messages}",
+        )
+    }
+
+    @Test
+    fun rejectsMalformedUnknownVariantShape() {
+        // F5 — raw is a ByteArray, not a buffer.
+        val result =
+            compile(
+                preamble +
+                    """
+
+                    @ProtocolMessage
+                    @DispatchOn(Op8::class)
+                    @FramedBy(LenCodec::class, after = "header")
+                    @ForwardCompatible(unknown = Frame.Unknown::class)
+                    sealed interface Frame {
+                        @ProtocolMessage
+                        @PacketType(value = 0x12)
+                        data class Known(val header: Op8, val a: UByte) : Frame
+
+                        @UnknownVariant
+                        data class Unknown(val opcode: Int, val raw: ByteArray) : Frame
+                    }
+                    """.trimIndent(),
+            )
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode, result.messages)
+        assertTrue(
+            result.messages.contains("opcode: Int, raw: PlatformBuffer"),
+            "expected the rule-2 (unknown variant shape) diagnostic, got:\n${result.messages}",
+        )
+    }
+
+    private fun compile(
+        @Language("kotlin") source: String,
+    ): JvmCompilationResult =
+        KotlinCompilation()
+            .apply {
+                sources = listOf(SourceFile.kotlin("Test.kt", source))
+                inheritClassPath = true
+                messageOutputStream = System.out
+                useKsp2()
+                configureKsp {
+                    symbolProcessorProviders += ProtocolMessageProcessorProvider()
+                }
+            }.compile()
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/forwardcompat/ForwardCompatibleOpCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/forwardcompat/ForwardCompatibleOpCodec.kt
@@ -1,0 +1,81 @@
+package com.ditchoom.buffer.codec.test.protocols.forwardcompat
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.ForwardCompatibleFactoryKey
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttRemainingLengthCodec
+import com.ditchoom.buffer.managed
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object ForwardCompatibleOpCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): ForwardCompatibleOp {
+    val discriminatorPosition = buffer.position()
+    val __discriminator = OpCodeCodec.decode(buffer, context)
+    buffer.position(discriminatorPosition)
+    val __dispatchValue = __discriminator.code
+    return when (__dispatchValue) {
+      18 -> ForwardCompatibleOpScrollCodec.decode(buffer, context)
+      52 -> ForwardCompatibleOpSetTitleCodec.decode(buffer, context)
+      else -> {
+        buffer.position(discriminatorPosition)
+        val __fcOpcode = buffer.readUByte().toInt()
+        val __fcLength = MqttRemainingLengthCodec.decode(buffer, context)
+        val __fcFrameEnd = buffer.position() + __fcLength.toInt()
+        val __fcFactory = context[ForwardCompatibleFactoryKey] ?: BufferFactory.managed()
+        val __fcRaw = __fcFactory.allocate(__fcLength.toInt())
+        val __fcSavedLimit = buffer.limit()
+        buffer.setLimit(__fcFrameEnd)
+        __fcRaw.write(buffer)
+        buffer.setLimit(__fcSavedLimit)
+        __fcRaw.resetForRead()
+        ForwardCompatibleOp.Unknown(opcode = __fcOpcode, raw = __fcRaw)
+      }
+    }
+  }
+
+  public fun encode(
+    `value`: ForwardCompatibleOp,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = when (value) {
+    is ForwardCompatibleOp.Scroll -> ForwardCompatibleOpScrollCodec.encode(value, context, factory)
+    is ForwardCompatibleOp.SetTitle -> ForwardCompatibleOpSetTitleCodec.encode(value, context, factory)
+    is ForwardCompatibleOp.Unknown -> FramedEncoder.encode(
+      factory = factory,
+      framingCodec = MqttRemainingLengthCodec,
+      context = context,
+      headerWireWidth = 1,
+      writeHeader = { __fcBuf -> __fcBuf.writeUByte(value.opcode.toUByte()) },
+    ) { __fcBuf ->
+      __fcBuf.write(value.raw.slice())
+    }
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/forwardcompat/ForwardCompatibleOpScrollCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/forwardcompat/ForwardCompatibleOpScrollCodec.kt
@@ -1,0 +1,76 @@
+package com.ditchoom.buffer.codec.test.protocols.forwardcompat
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttRemainingLengthCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object ForwardCompatibleOpScrollCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): ForwardCompatibleOp.Scroll {
+    val header = OpCode(buffer.readUByte())
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val delta = buffer.readShort()
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "Scroll.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      ForwardCompatibleOp.Scroll(header = header, delta = delta)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: ForwardCompatibleOp.Scroll,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+    headerWireWidth = 1,
+    writeHeader = { buffer ->
+      buffer.writeUByte(value.header.raw)
+    },
+  ) { buffer ->
+    buffer.writeShort(value.delta)
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/forwardcompat/ForwardCompatibleOpSetTitleCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/forwardcompat/ForwardCompatibleOpSetTitleCodec.kt
@@ -1,0 +1,98 @@
+package com.ditchoom.buffer.codec.test.protocols.forwardcompat
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttRemainingLengthCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object ForwardCompatibleOpSetTitleCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): ForwardCompatibleOp.SetTitle {
+    val header = OpCode(buffer.readUByte())
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val titlePrefixB0 = buffer.readUByte().toUInt()
+      val titlePrefixB1 = buffer.readUByte().toUInt()
+      val titlePrefix = ((titlePrefixB0 shl 8) or titlePrefixB1)
+      if (titlePrefix > Int.MAX_VALUE.toUInt()) {
+        throw DecodeException(fieldPath = "SetTitle.title", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = titlePrefix.toString())
+      }
+      val titleLength = titlePrefix.toInt()
+      val title = buffer.readString(titleLength, Charset.UTF8)
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "SetTitle.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      ForwardCompatibleOp.SetTitle(header = header, title = title)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: ForwardCompatibleOp.SetTitle,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = FramedEncoder.encode(
+    factory = factory,
+    framingCodec = MqttRemainingLengthCodec,
+    context = context,
+    headerWireWidth = 1,
+    writeHeader = { buffer ->
+      buffer.writeUByte(value.header.raw)
+    },
+  ) { buffer ->
+    val titleSizePosition = buffer.position()
+    buffer.position(titleSizePosition + 2)
+    val titleBodyStart = buffer.position()
+    buffer.writeString(value.title, Charset.UTF8)
+    val titleEndPosition = buffer.position()
+    val titleByteCount = titleEndPosition - titleBodyStart
+    if (titleByteCount > 65_535) {
+      throw EncodeException(fieldPath = "SetTitle.title", reason = """UTF-8 byte length ${titleByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(titleSizePosition)
+    val titlePrefix = titleByteCount.toUInt()
+    buffer.writeUByte(((titlePrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((titlePrefix and 0xFFu).toUByte())
+    buffer.position(titleEndPosition)
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        MqttRemainingLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = 1 + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/forwardcompat/OpCodeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/forwardcompat/OpCodeCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.forwardcompat
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object OpCodeCodec : Codec<OpCode> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): OpCode {
+    val raw = buffer.readUByte()
+    return OpCode(raw = raw)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: OpCode,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.raw)
+  }
+
+  override fun wireSize(`value`: OpCode, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/forwardcompat/ForwardCompatibleOp.kt
+++ b/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/forwardcompat/ForwardCompatibleOp.kt
@@ -1,0 +1,85 @@
+package com.ditchoom.buffer.codec.test.protocols.forwardcompat
+
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.codec.annotations.DispatchOn
+import com.ditchoom.buffer.codec.annotations.DispatchValue
+import com.ditchoom.buffer.codec.annotations.ForwardCompatible
+import com.ditchoom.buffer.codec.annotations.FramedBy
+import com.ditchoom.buffer.codec.annotations.LengthPrefixed
+import com.ditchoom.buffer.codec.annotations.PacketType
+import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+import com.ditchoom.buffer.codec.annotations.UnknownVariant
+import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttRemainingLengthCodec
+import kotlin.jvm.JvmInline
+
+/**
+ * `@ForwardCompatible` fixture — a length-delimited op stream modeled on the
+ * driving terminal §5 protocol: each op is `opcode(1) + varint(len) + payload`,
+ * where the opcode is a single-byte discriminator and the payload is framed by
+ * a full-width variable-byte-integer length ([MqttRemainingLengthCodec], a
+ * `BoundingLengthCodec<UInt>` reused as the framing length).
+ *
+ * An old decoder that meets an opcode it doesn't recognize must **skip** the
+ * framed payload and **preserve** it into [ForwardCompatibleOp.Unknown], so
+ * newer ops survive a round-trip through it (relay) or an on-disk frame
+ * (persistence). The wire layout each op pins down:
+ *
+ * ```text
+ * Scroll(header = 0x12, delta = 0x0102):
+ *   12          opcode (after-field discriminator, 1 byte)
+ *   02          varint length prefix (= 2 body bytes)
+ *   01 02       body (delta, Short BE)
+ *
+ * SetTitle(header = 0x34, title = "hi"):
+ *   34          opcode
+ *   04          varint length prefix (= 2 length-prefix + 2 body)
+ *   00 02       LengthPrefixed string length
+ *   68 69       "hi"
+ *
+ * Unknown op on the wire (opcode 0x99, payload AA BB CC):
+ *   99          opcode (unrecognized → skip + preserve)
+ *   03          varint length prefix (= 3 payload bytes)
+ *   AA BB CC    opaque payload (preserved verbatim into Unknown.raw)
+ * ```
+ */
+@JvmInline
+@ProtocolMessage
+value class OpCode(
+    val raw: UByte,
+) {
+    @DispatchValue
+    val code: Int get() = raw.toInt()
+}
+
+@ProtocolMessage
+@DispatchOn(OpCode::class)
+@FramedBy(MqttRemainingLengthCodec::class, after = "header")
+@ForwardCompatible(unknown = ForwardCompatibleOp.Unknown::class)
+sealed interface ForwardCompatibleOp {
+    @ProtocolMessage
+    @PacketType(value = 0x12)
+    data class Scroll(
+        val header: OpCode,
+        val delta: Short,
+    ) : ForwardCompatibleOp
+
+    @ProtocolMessage
+    @PacketType(value = 0x34)
+    data class SetTitle(
+        val header: OpCode,
+        @LengthPrefixed val title: String,
+    ) : ForwardCompatibleOp
+
+    /**
+     * The skip-and-preserve sink. [opcode] carries the unrecognized
+     * discriminator byte (the only place it can survive — [raw] is the
+     * payload only), and [raw] holds the opaque framed payload, excluding
+     * the opcode and length prefix. Equality is content-wise: data-class
+     * `equals` over `Int` + `PlatformBuffer` (buffers compare by content).
+     */
+    @UnknownVariant
+    data class Unknown(
+        val opcode: Int,
+        val raw: PlatformBuffer,
+    ) : ForwardCompatibleOp
+}

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/forwardcompat/ForwardCompatibleOpCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/forwardcompat/ForwardCompatibleOpCodecTest.kt
@@ -1,0 +1,200 @@
+package com.ditchoom.buffer.codec.test.protocols.forwardcompat
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.ForwardCompatibleFactoryKey
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.managed
+import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.buffer.pool.PoolReleasable
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+/**
+ * `@ForwardCompatible` skip-and-preserve tests. Covers the spec's test
+ * obligations: byte-identical round-trip of an unknown op, an unknown op
+ * flanked by known ops with correct ordering/offsets, `peekFrameSize` on an
+ * unknown op, relay identity through both `managed()` and a pooled factory,
+ * and wrapper transparency (PooledBuffer / TrackedSlice).
+ */
+class ForwardCompatibleOpCodecTest {
+    private fun readAll(buffer: ReadBuffer): ByteArray {
+        val out = ByteArray(buffer.remaining())
+        for (i in out.indices) out[i] = buffer.readByte()
+        return out
+    }
+
+    private fun wireOf(value: ForwardCompatibleOp): ByteArray =
+        readAll(
+            ForwardCompatibleOpCodec.encode(
+                value = value,
+                context = EncodeContext.Empty,
+                factory = BufferFactory.Default,
+            ),
+        )
+
+    private fun bufferOf(bytes: ByteArray): PlatformBuffer {
+        val buffer = BufferFactory.Default.allocate(bytes.size, ByteOrder.BIG_ENDIAN)
+        buffer.writeBytes(bytes)
+        buffer.resetForRead()
+        return buffer
+    }
+
+    // opcode 0x99 (unknown) + varint len 3 + payload AA BB CC.
+    private val unknownWire = byteArrayOf(0x99.toByte(), 0x03, 0xAA.toByte(), 0xBB.toByte(), 0xCC.toByte())
+
+    @Test
+    fun knownVariantsStillRoundTrip() {
+        val scroll = ForwardCompatibleOp.Scroll(OpCode(0x12u), delta = 0x0102)
+        assertContentEquals(byteArrayOf(0x12, 0x02, 0x01, 0x02), wireOf(scroll))
+        assertEquals(
+            scroll,
+            ForwardCompatibleOpCodec.decode(bufferOf(wireOf(scroll)), DecodeContext.Empty),
+        )
+
+        val title = ForwardCompatibleOp.SetTitle(OpCode(0x34u), title = "hi")
+        assertContentEquals(byteArrayOf(0x34, 0x04, 0x00, 0x02, 0x68, 0x69), wireOf(title))
+        assertEquals(
+            title,
+            ForwardCompatibleOpCodec.decode(bufferOf(wireOf(title)), DecodeContext.Empty),
+        )
+    }
+
+    @Test
+    fun unknownOpDecodesToPreservedPayload() {
+        val decoded = ForwardCompatibleOpCodec.decode(bufferOf(unknownWire), DecodeContext.Empty)
+        val unknown = assertIs<ForwardCompatibleOp.Unknown>(decoded)
+        assertEquals(0x99, unknown.opcode)
+        // raw is the payload only — no opcode, no length prefix.
+        assertContentEquals(byteArrayOf(0xAA.toByte(), 0xBB.toByte(), 0xCC.toByte()), readAll(unknown.raw.slice()))
+    }
+
+    @Test
+    fun unknownOpRoundTripsByteIdentical() {
+        val decoded = ForwardCompatibleOpCodec.decode(bufferOf(unknownWire), DecodeContext.Empty)
+        assertContentEquals(unknownWire, wireOf(decoded))
+    }
+
+    @Test
+    fun unknownOpFlankedByKnownOps() {
+        val scroll = ForwardCompatibleOp.Scroll(OpCode(0x12u), delta = 0x0102)
+        val title = ForwardCompatibleOp.SetTitle(OpCode(0x34u), title = "hi")
+        // Concatenate three self-framed ops: known, unknown, known.
+        val frame = wireOf(scroll) + unknownWire + wireOf(title)
+
+        val buffer = bufferOf(frame)
+        val decoded = mutableListOf<ForwardCompatibleOp>()
+        val reencoded = ArrayList<Byte>()
+        while (buffer.remaining() > 0) {
+            val op = ForwardCompatibleOpCodec.decode(buffer, DecodeContext.Empty)
+            decoded += op
+            for (b in wireOf(op)) reencoded += b
+        }
+
+        assertEquals(3, decoded.size)
+        assertEquals(scroll, decoded[0])
+        val unknown = assertIs<ForwardCompatibleOp.Unknown>(decoded[1])
+        assertEquals(0x99, unknown.opcode)
+        assertEquals(title, decoded[2])
+        // Ordering + offsets preserved: re-encoding the whole sequence
+        // reproduces the original frame byte-for-byte.
+        assertContentEquals(frame, reencoded.toByteArray())
+    }
+
+    @Test
+    fun peekFrameSizeForUnknownOp() {
+        val pool = BufferPool()
+        val stream = StreamProcessor.create(pool, ByteOrder.BIG_ENDIAN)
+        try {
+            stream.append(bufferOf(unknownWire))
+            assertEquals(PeekResult.Complete(unknownWire.size), ForwardCompatibleOpCodec.peekFrameSize(stream))
+        } finally {
+            stream.release()
+            pool.clear()
+        }
+    }
+
+    @Test
+    fun peekFrameSizeNeedsMoreDataForTruncatedUnknownOp() {
+        val pool = BufferPool()
+        val stream = StreamProcessor.create(pool, ByteOrder.BIG_ENDIAN)
+        try {
+            // opcode + length prefix present, payload truncated to 1 of 3 bytes.
+            stream.append(bufferOf(byteArrayOf(0x99.toByte(), 0x03, 0xAA.toByte())))
+            assertEquals(PeekResult.NeedsMoreData, ForwardCompatibleOpCodec.peekFrameSize(stream))
+        } finally {
+            stream.release()
+            pool.clear()
+        }
+    }
+
+    @Test
+    fun relayThroughManagedFactory() {
+        val ctx = DecodeContext.Empty.with(ForwardCompatibleFactoryKey, BufferFactory.managed())
+        val decoded = ForwardCompatibleOpCodec.decode(bufferOf(unknownWire), ctx)
+        val unknown = assertIs<ForwardCompatibleOp.Unknown>(decoded)
+        assertContentEquals(byteArrayOf(0xAA.toByte(), 0xBB.toByte(), 0xCC.toByte()), readAll(unknown.raw.slice()))
+        assertContentEquals(unknownWire, wireOf(decoded))
+    }
+
+    @Test
+    fun relayThroughPooledFactory() {
+        // Inject a pool-backed BufferFactory via the context key: the
+        // preserved payload is allocated from the caller's pool, and the
+        // op still relays byte-identically.
+        val pool = BufferPool()
+        try {
+            val ctx = DecodeContext.Empty.with(ForwardCompatibleFactoryKey, pool)
+            val decoded = ForwardCompatibleOpCodec.decode(bufferOf(unknownWire), ctx)
+            val unknown = assertIs<ForwardCompatibleOp.Unknown>(decoded)
+            assertContentEquals(byteArrayOf(0xAA.toByte(), 0xBB.toByte(), 0xCC.toByte()), readAll(unknown.raw.slice()))
+            assertContentEquals(unknownWire, wireOf(decoded))
+        } finally {
+            pool.clear()
+        }
+    }
+
+    @Test
+    fun decodesTransparentlyThroughPooledBufferWrapper() {
+        val pool = BufferPool()
+        val pooled = pool.acquire(unknownWire.size)
+        try {
+            pooled.writeBytes(unknownWire)
+            pooled.resetForRead()
+            val decoded = ForwardCompatibleOpCodec.decode(pooled, DecodeContext.Empty)
+            val unknown = assertIs<ForwardCompatibleOp.Unknown>(decoded)
+            assertEquals(0x99, unknown.opcode)
+            assertContentEquals(unknownWire, wireOf(decoded))
+        } finally {
+            pool.release(pooled)
+            pool.clear()
+        }
+    }
+
+    @Test
+    fun decodesTransparentlyThroughTrackedSliceWrapper() {
+        val pool = BufferPool()
+        val pooled = pool.acquire(unknownWire.size)
+        try {
+            pooled.writeBytes(unknownWire)
+            pooled.resetForRead()
+            val slice = pooled.slice()
+            val decoded = ForwardCompatibleOpCodec.decode(slice, DecodeContext.Empty)
+            val unknown = assertIs<ForwardCompatibleOp.Unknown>(decoded)
+            assertEquals(0x99, unknown.opcode)
+            assertContentEquals(unknownWire, wireOf(decoded))
+            (slice as? PoolReleasable)?.releaseToPool()
+        } finally {
+            pool.release(pooled)
+            pool.clear()
+        }
+    }
+}

--- a/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/ForwardCompatibleFactoryKey.kt
+++ b/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/ForwardCompatibleFactoryKey.kt
@@ -1,0 +1,23 @@
+package com.ditchoom.buffer.codec
+
+import com.ditchoom.buffer.BufferFactory
+
+/**
+ * Caller-controlled allocator for the opaque bytes a `@ForwardCompatible`
+ * decoder preserves when it skips an unknown sealed variant.
+ *
+ * Inject via [DecodeContext.with]; the generated forward-compatible decode
+ * reads `context[ForwardCompatibleFactoryKey] ?: BufferFactory.managed()`.
+ * The default is `managed()` — GC-lifetime heap bytes that need no manual
+ * free. A caller relaying or persisting many frames can supply a pool-backed
+ * or native [BufferFactory] for the preserved payloads and take ownership of
+ * freeing them.
+ *
+ * ```kotlin
+ * val ctx = DecodeContext.Empty.with(ForwardCompatibleFactoryKey, myPool.asFactory())
+ * val op = OpCodec.decode(buffer, ctx)
+ * ```
+ *
+ * @see com.ditchoom.buffer.codec.annotations.ForwardCompatible
+ */
+public object ForwardCompatibleFactoryKey : DecodeKey<BufferFactory>

--- a/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/annotations/Annotations.kt
+++ b/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/annotations/Annotations.kt
@@ -623,3 +623,72 @@ annotation class DispatchOn(
 @Target(AnnotationTarget.PROPERTY)
 @Retention(AnnotationRetention.BINARY)
 annotation class DispatchValue
+
+/**
+ * Marks a `@ProtocolMessage` sealed dispatch parent as **forward compatible**:
+ * a decoder that hits a discriminator it does not recognize **skips** the
+ * unknown variant's framed payload and **preserves** it verbatim into the
+ * [unknown] variant, instead of throwing `DecodeException`.
+ *
+ * This lets newer protocol ops survive a round-trip through an older decoder
+ * (relay) or an on-disk frame (persistence): the bytes are read into an opaque
+ * buffer on decode and re-emitted byte-for-byte on encode.
+ *
+ * ## Requirements (enforced at compile time)
+ *
+ * 1. The annotated type must also carry [FramedBy] — you cannot skip a variant
+ *    whose length you cannot measure. The framing prefix bounds the payload the
+ *    decoder skips.
+ * 2. The annotated type must use [DispatchOn] dispatch with a **single-byte**
+ *    discriminator. (Framed sealed dispatch routes exclusively through
+ *    `@DispatchOn`; a single-byte discriminator guarantees the preserved
+ *    opcode re-encodes byte-identically.)
+ * 3. [unknown] must name a member of the sealed type marked [UnknownVariant],
+ *    whose primary constructor is shaped `(opcode: Int, raw: PlatformBuffer)`
+ *    (a `ReadBuffer`-typed `raw` is also accepted). `opcode` carries the
+ *    discriminator byte (the only place it can survive — `raw` is the payload
+ *    only); `raw` carries the opaque framed payload, excluding the opcode and
+ *    length prefix.
+ *
+ * ```kotlin
+ * @ProtocolMessage
+ * @DispatchOn(OpCode::class)
+ * @FramedBy(OpLengthCodec::class, after = "header")
+ * @ForwardCompatible(unknown = Op.Unknown::class)
+ * sealed interface Op {
+ *     @ProtocolMessage @PacketType(value = 0x12, wire = 0x12)
+ *     data class Scroll(val header: OpCode, /* ... */) : Op
+ *
+ *     @UnknownVariant
+ *     data class Unknown(val opcode: Int, val raw: PlatformBuffer) : Op
+ * }
+ * ```
+ *
+ * Preserved bytes are allocated through [ForwardCompatibleFactoryKey] (default
+ * `BufferFactory.managed()` — GC lifetime, no manual free). A caller wanting
+ * native/pooled memory injects a pool-backed factory via that context key and
+ * owns freeing.
+ *
+ * @param unknown The [UnknownVariant]-marked member of the sealed type that
+ *   receives skipped-and-preserved ops.
+ * @see UnknownVariant
+ * @see ForwardCompatibleFactoryKey
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.BINARY)
+annotation class ForwardCompatible(
+    val unknown: kotlin.reflect.KClass<*>,
+)
+
+/**
+ * Marks the single sealed-variant sink that a [ForwardCompatible] union skips
+ * unknown discriminators into. The marked variant must **not** carry
+ * [PacketType] — it is the `else` arm of dispatch, never matched by value — and
+ * its primary constructor must be `(opcode: Int, raw: PlatformBuffer)` (or
+ * `(opcode: Int, raw: ReadBuffer)`).
+ *
+ * @see ForwardCompatible
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.BINARY)
+annotation class UnknownVariant


### PR DESCRIPTION
## Summary

Generated `@DispatchOn` framed dispatchers currently **throw** `DecodeException` on a discriminator they don't recognize. Forward-compatible, length-delimited protocols need the opposite: an old decoder must **skip** an unknown op (advance past its framed payload) and **preserve** it, so newer ops survive round-trips through older clients (relay) and on-disk frames (persistence).

`@ForwardCompatible` adds that to the engine. It's protocol-agnostic — nothing protocol-specific lives in `buffer-codec`.

## API

```kotlin
@ProtocolMessage
@DispatchOn(OpCode::class)
@FramedBy(OpLengthCodec::class, after = "header")
@ForwardCompatible(unknown = Op.Unknown::class)
sealed interface Op {
    @ProtocolMessage @PacketType(value = 0x12)
    data class Scroll(val header: OpCode, /* ... */) : Op

    @UnknownVariant
    data class Unknown(val opcode: Int, val raw: PlatformBuffer) : Op
}
```

- `@ForwardCompatible(unknown)` / `@UnknownVariant` annotations.
- `ForwardCompatibleFactoryKey` — a `DecodeKey<BufferFactory>` controlling where preserved bytes are allocated (default `BufferFactory.managed()`; inject a pool-backed/native factory for relay/persist).

## Generated code

- **decode** — replaces the `else -> throw` with a skip-and-preserve arm: reads the discriminator byte as `opcode`, reads the inherited framing prefix, copies the payload into a caller-controlled buffer (`factory.allocate + write`, one mandatory copy per the lifetime contract — preserved bytes outlive the often-pooled frame buffer), restores the outer limit so the cursor lands exactly past the op.
- **encode** — new `is Unknown ->` arm re-frames via `FramedEncoder` with the same framing codec known variants use → byte-identical output. `raw.slice()` is non-consuming/zero-copy.
- **peekFrameSize** — unchanged; the framing walker derives the total size from the prefix without resolving the variant, so unknown ops already peek correctly (covered by a test).

## Design note

The spec's illustrative example used simple `@PacketType` dispatch, but that combination can't compile (validator rule **E4** forbids `@FramedBy(after="")` + `@PacketType`, and the simple dispatcher's encode signature is incompatible with framed variant codecs). The only working framed-dispatch path is `@DispatchOn`, so the feature targets it — enforced by validator rule F2.

## Compile-time rules (F1–F5)

Requires `@FramedBy` + single-byte `@DispatchOn`; exactly one `@UnknownVariant` matching `unknown`; the sink must not carry `@PacketType`; its constructor must be `(opcode: Int, raw: PlatformBuffer | ReadBuffer)`.

## Tests

- 10 round-trip/JVM tests: byte-identical unknown round-trip, unknown flanked by known ops (ordering/offsets), `peekFrameSize` complete + needs-more-data, relay through `managed()` and a pooled factory, PooledBuffer + TrackedSlice wrapper transparency.
- 5 processor validator tests (acceptance + F1/F3/F4/F5 negatives).
- New codec snapshots — **purely additive; no existing baselines changed.**

Scope is `@ForwardCompatible` only; `@Count` (element-count lists) is tracked as a separate PR.