### PR TITLE
feat(codec): emit Partial for non-terminal @RemainingBytes payloads (#168)

### DIFF
--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
@@ -3233,15 +3233,34 @@ internal class CodecEmitter(
      * and restoring on completion — no consumer-visible API change versus
      * the unbounded path.
      *
-     * When [FieldSpec.RemainingBytesPayload] appears as a *non-terminal*
-     * field (e.g. `PngChunk.data: BinaryData` followed by a 4-byte CRC
-     * trailer), the embedded payload is just a bounded body inside the
-     * packet's structure, not a deferred-decode tail. Emit only the normal
-     * decode/encode; skip Partial. [buildPartialClassTypeSpec] would
-     * otherwise error because it expects the Payload field at
-     * `fields.lastOrNull()`.
+     * Non-terminal payload (issue #168): when [FieldSpec.RemainingBytesPayload]
+     * is followed only by fixed-size trailers (e.g. a `checksum: UShort` after
+     * `@RemainingBytes val payload: P`), Partial still applies — `partial(...)`
+     * reads the header *and* the trailer eagerly (the payload's wire extent is
+     * `limit - reservedTrailingBytes`, computable without decoding it), and
+     * `complete(...)` re-seeks to the payload region and decodes it. This is
+     * gated to the unframed / unbounded case: combining a non-terminal payload
+     * with `@FramedBy` or a bounding `@UseCodec` stays terminal-only (the
+     * payload-region math would have to compose with the external bound, out of
+     * scope here), so those shapes fall back to normal decode/encode.
      */
-    private fun shouldEmitPartial(shape: CodecShape): Boolean = shape.fields.lastOrNull() is FieldSpec.RemainingBytesPayload
+    private fun shouldEmitPartial(shape: CodecShape): Boolean {
+        val payloadIndex = shape.fields.indexOfFirst { it is FieldSpec.RemainingBytesPayload }
+        if (payloadIndex < 0) return false
+        val trailing = shape.fields.subList(payloadIndex + 1, shape.fields.size)
+        // Terminal payload — the original streaming-defer shape.
+        if (trailing.isEmpty()) return true
+        // Non-terminal payload: only when the trailer is fixed-size (so the
+        // payload's end is computable without decoding) and the payload isn't
+        // also externally bounded.
+        if (!trailing.all { it is FieldSpec.FixedSize }) return false
+        if (shape.framedBy != null) return false
+        if (shape.fields.any { it.isBoundingShape() }) return false
+        return true
+    }
+
+    /** Index of the (single) `RemainingBytesPayload` field, or -1. */
+    private fun payloadFieldIndex(shape: CodecShape): Int = shape.fields.indexOfFirst { it is FieldSpec.RemainingBytesPayload }
 
     /**
      * Emit the nested `Partial` class. The `Partial`
@@ -3274,10 +3293,18 @@ internal class CodecEmitter(
         shape: CodecShape,
         payloadTypeParameter: PayloadTypeParameter?,
     ): TypeSpec {
+        val payloadIndex = payloadFieldIndex(shape)
         val payloadField =
-            shape.fields.lastOrNull() as? FieldSpec.RemainingBytesPayload
-                ?: error("buildPartialClassTypeSpec called for shape without trailing RemainingBytesPayload")
-        val headerFields = shape.fields.dropLast(1)
+            (shape.fields.getOrNull(payloadIndex) as? FieldSpec.RemainingBytesPayload)
+                ?: error("buildPartialClassTypeSpec called for shape without a RemainingBytesPayload")
+        // Fields before the payload (decoded eagerly in `partial`) and the
+        // fixed-size trailer after it (also decoded eagerly — non-terminal
+        // payload, issue #168). For the terminal shape `afterFields` is empty
+        // and the behavior is unchanged.
+        val beforeFields = shape.fields.subList(0, payloadIndex)
+        val afterFields = shape.fields.subList(payloadIndex + 1, shape.fields.size)
+        val nonTerminal = afterFields.isNotEmpty()
+        val exposedFields = beforeFields + afterFields
         // When the headers contain a bounding `@UseCodec` field (codec
         // implements `BoundingLengthCodec`), the partial decode mid-walk
         // narrows `buffer.limit()` and stashes the prior limit in
@@ -3285,6 +3312,7 @@ internal class CodecEmitter(
         // `complete()` can restore it. `@FramedBy` inherited from the
         // sealed parent supplies the bound externally (no in-shape field),
         // so we treat it as effectively-bounding for Partial purposes.
+        // (Non-terminal shapes are gated out of both by `shouldEmitPartial`.)
         val hasBoundingField = shape.fields.any { it.isBoundingShape() } || shape.framedBy != null
 
         val classBuilder = TypeSpec.classBuilder("Partial")
@@ -3295,7 +3323,7 @@ internal class CodecEmitter(
         if (typeVar != null) classBuilder.addTypeVariable(typeVar)
 
         val ctorBuilder = FunSpec.constructorBuilder().addModifiers(KModifier.INTERNAL)
-        for (field in headerFields) {
+        for (field in exposedFields) {
             val typeName = partialFieldTypeName(field)
             ctorBuilder.addParameter(field.name, typeName)
             classBuilder.addProperty(
@@ -3307,6 +3335,13 @@ internal class CodecEmitter(
         }
         if (hasBoundingField) {
             ctorBuilder.addParameter("outerLimit", INT)
+        }
+        // Non-terminal payload: capture the payload's wire region so
+        // `complete()` can re-seek to it (the trailer was already consumed
+        // in `partial`, so the buffer position no longer sits at the payload).
+        if (nonTerminal) {
+            ctorBuilder.addParameter("payloadStart", INT)
+            ctorBuilder.addParameter("payloadEnd", INT)
         }
         ctorBuilder.addParameter("buffer", READ_BUFFER_CN)
         ctorBuilder.addParameter("context", DECODE_CONTEXT_CN)
@@ -3320,6 +3355,20 @@ internal class CodecEmitter(
                 com.squareup.kotlinpoet.PropertySpec
                     .builder("outerLimit", INT, KModifier.PRIVATE)
                     .initializer("outerLimit")
+                    .build(),
+            )
+        }
+        if (nonTerminal) {
+            classBuilder.addProperty(
+                com.squareup.kotlinpoet.PropertySpec
+                    .builder("payloadStart", INT, KModifier.PRIVATE)
+                    .initializer("payloadStart")
+                    .build(),
+            )
+            classBuilder.addProperty(
+                com.squareup.kotlinpoet.PropertySpec
+                    .builder("payloadEnd", INT, KModifier.PRIVATE)
+                    .initializer("payloadEnd")
                     .build(),
             )
         }
@@ -3337,7 +3386,7 @@ internal class CodecEmitter(
         )
 
         classBuilder.addFunction(
-            buildPartialCompleteFun(shape, payloadTypeParameter, payloadField, hasBoundingField),
+            buildPartialCompleteFun(shape, payloadTypeParameter, payloadField, hasBoundingField, nonTerminal),
         )
         return classBuilder.build()
     }
@@ -3357,6 +3406,7 @@ internal class CodecEmitter(
         payloadTypeParameter: PayloadTypeParameter?,
         payloadField: FieldSpec.RemainingBytesPayload,
         hasBoundingField: Boolean,
+        nonTerminal: Boolean = false,
     ): FunSpec {
         val funBuilder = FunSpec.builder("complete")
         val returnType =
@@ -3397,7 +3447,21 @@ internal class CodecEmitter(
             }
         val ctorArgs = shape.fields.joinToString(", ") { "${it.name} = ${it.name}" }
         val body = CodeBlock.builder()
-        if (hasBoundingField) {
+        if (nonTerminal) {
+            // The trailer was consumed eagerly in `partial`, so the buffer
+            // position no longer sits at the payload. Re-seek to the captured
+            // payload region, narrow the limit to it, decode, then restore the
+            // limit. `payloadStart`/`payloadEnd` were captured at partial time.
+            body.addStatement("buffer.position(payloadStart)")
+            body.addStatement("val __payloadSavedLimit = buffer.limit()")
+            body.addStatement("buffer.setLimit(payloadEnd)")
+            body.beginControlFlow("return try")
+            body.add(payloadDecodeStmt)
+            body.addStatement("%T(%L)", returnType, ctorArgs)
+            body.nextControlFlow("finally")
+            body.addStatement("buffer.setLimit(__payloadSavedLimit)")
+            body.endControlFlow()
+        } else if (hasBoundingField) {
             // Payload decode runs inside the bounding-field-narrowed
             // limit (correct for payload bounding); the outer limit is
             // restored via try/finally so the caller's outer limit
@@ -3436,7 +3500,11 @@ internal class CodecEmitter(
         shape: CodecShape,
         payloadTypeParameter: PayloadTypeParameter?,
     ): FunSpec {
-        val headerFields = shape.fields.dropLast(1)
+        val payloadIndex = payloadFieldIndex(shape)
+        val payloadField = shape.fields[payloadIndex] as FieldSpec.RemainingBytesPayload
+        val beforeFields = shape.fields.subList(0, payloadIndex)
+        val afterFields = shape.fields.subList(payloadIndex + 1, shape.fields.size)
+        val nonTerminal = afterFields.isNotEmpty()
         val partialClassName = ClassName(shape.packageName, shape.codecSimpleName, "Partial")
         val funBuilder = FunSpec.builder("partial")
         val returnType =
@@ -3456,7 +3524,34 @@ internal class CodecEmitter(
             .returns(returnType)
 
         val body = CodeBlock.builder()
-        // When the parent supplies framing via
+        if (nonTerminal) {
+            // Non-terminal payload (issue #168): read the leading fields, then
+            // skip the payload region (its end is `limit - reservedTrailingBytes`,
+            // computable without decoding) and read the fixed-size trailer
+            // eagerly. `complete()` re-seeks to [payloadStart, payloadEnd) to
+            // decode the deferred payload. Gated to the unframed/unbounded case
+            // by `shouldEmitPartial`, so no framing/bounding handling here.
+            appendDecodeFields(body, beforeFields)
+            body.addStatement("val __payloadStart = buffer.position()")
+            body.addStatement("val __payloadEnd = buffer.limit() - %L", payloadField.reservedTrailingBytes)
+            body.addStatement("buffer.position(__payloadEnd)")
+            appendDecodeFields(body, afterFields)
+            val ctorArgs =
+                (
+                    beforeFields.map { "${it.name} = ${it.name}" } +
+                        afterFields.map { "${it.name} = ${it.name}" } +
+                        listOf(
+                            "payloadStart = __payloadStart",
+                            "payloadEnd = __payloadEnd",
+                            "buffer = buffer",
+                            "context = context",
+                        )
+                ).joinToString(", ")
+            body.addStatement("return %T(%L)", returnType, ctorArgs)
+            funBuilder.addCode(body.build())
+            return funBuilder.build()
+        }
+        // Terminal payload. When the parent supplies framing via
         // `@FramedBy`, the variant's partial decode reads the after-field
         // first, then applies the framing bound (capturing the outer
         // limit), then walks the remaining header fields inside the
@@ -3475,9 +3570,9 @@ internal class CodecEmitter(
                 "%T.applyBound(buffer, __framingLength)",
                 framedBy.codecClassName,
             )
-            appendDecodeFields(body, headerFields.filter { it !== afterField })
+            appendDecodeFields(body, beforeFields.filter { it !== afterField })
         } else {
-            appendDecodeFields(body, headerFields)
+            appendDecodeFields(body, beforeFields)
         }
         val boundingField = shape.fields.firstOrNull { it.isBoundingShape() }
         val outerLimitLocal =
@@ -3494,7 +3589,7 @@ internal class CodecEmitter(
             } ?: emptyList()
         val ctorArgs =
             (
-                headerFields.map { "${it.name} = ${it.name}" } +
+                beforeFields.map { "${it.name} = ${it.name}" } +
                     outerLimitArgs +
                     listOf("buffer = buffer", "context = context")
             ).joinToString(", ")

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/partialnonterminal/CommandFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/partialnonterminal/CommandFrameCodec.kt
@@ -1,0 +1,90 @@
+package com.ditchoom.buffer.codec.test.protocols.partialnonterminal
+
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.Decoder
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.Payload
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import com.ditchoom.buffer.swapBytes
+import kotlin.Int
+import kotlin.UShort
+
+public class CommandFrameCodec<P : Payload>(
+  private val payloadCodec: Codec<P>,
+) : Codec<CommandFrame<P>> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): CommandFrame<P> {
+    val __batch1Raw = buffer.readInt()
+    val __batch1 = if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) __batch1Raw else swapBytes(__batch1Raw)
+    val counter = (__batch1 ushr 16 and 0xFFFF).toUShort()
+    val length = (__batch1 and 0xFFFF).toUShort()
+    val __payloadOuterLimit = buffer.limit()
+    buffer.setLimit(__payloadOuterLimit - 2)
+    val payload = try {
+      payloadCodec.decode(buffer, context)
+    } finally {
+      buffer.setLimit(__payloadOuterLimit)
+    }
+    val checksumRaw = buffer.readShort()
+    val checksum = (if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) checksumRaw else swapBytes(checksumRaw)).toUShort()
+    return CommandFrame<P>(counter = counter, length = length, payload = payload, checksum = checksum)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: CommandFrame<P>,
+    context: EncodeContext,
+  ) {
+    val __batch2 = ((value.counter.toInt() and 0xFFFF) shl 16) or (value.length.toInt() and 0xFFFF)
+    buffer.writeInt(if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) __batch2 else swapBytes(__batch2))
+    payloadCodec.encode(buffer, value.payload, context)
+    val checksumRaw = value.checksum.toShort()
+    buffer.writeShort(if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) checksumRaw else swapBytes(checksumRaw))
+  }
+
+  override fun wireSize(`value`: CommandFrame<P>, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+
+  public class Partial<P : Payload> internal constructor(
+    public val counter: UShort,
+    public val length: UShort,
+    public val checksum: UShort,
+    private val payloadStart: Int,
+    private val payloadEnd: Int,
+    private val buffer: ReadBuffer,
+    private val context: DecodeContext,
+  ) {
+    public fun complete(payloadCodec: Decoder<P>): CommandFrame<P> {
+      buffer.position(payloadStart)
+      val __payloadSavedLimit = buffer.limit()
+      buffer.setLimit(payloadEnd)
+      return try {
+        val payload = payloadCodec.decode(buffer, context)
+        CommandFrame<P>(counter = counter, length = length, payload = payload, checksum = checksum)
+      } finally {
+        buffer.setLimit(__payloadSavedLimit)
+      }
+    }
+  }
+
+  public companion object {
+    public fun <P : Payload> partial(buffer: ReadBuffer, context: DecodeContext): Partial<P> {
+      val __batch3Raw = buffer.readInt()
+      val __batch3 = if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) __batch3Raw else swapBytes(__batch3Raw)
+      val counter = (__batch3 ushr 16 and 0xFFFF).toUShort()
+      val length = (__batch3 and 0xFFFF).toUShort()
+      val __payloadStart = buffer.position()
+      val __payloadEnd = buffer.limit() - 2
+      buffer.position(__payloadEnd)
+      val checksumRaw = buffer.readShort()
+      val checksum = (if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) checksumRaw else swapBytes(checksumRaw)).toUShort()
+      return Partial<P>(counter = counter, length = length, checksum = checksum, payloadStart = __payloadStart, payloadEnd = __payloadEnd, buffer = buffer, context = context)
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/png/PngChunkCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/png/PngChunkCodec.kt
@@ -12,6 +12,7 @@ import com.ditchoom.buffer.codec.test.protocols.payload.BinaryDataCodec
 import com.ditchoom.buffer.stream.StreamProcessor
 import com.ditchoom.buffer.swapBytes
 import kotlin.Int
+import kotlin.UInt
 
 public object PngChunkCodec : Codec<PngChunk> {
   override fun decode(buffer: ReadBuffer, context: DecodeContext): PngChunk {
@@ -46,4 +47,39 @@ public object PngChunkCodec : Codec<PngChunk> {
   override fun wireSize(`value`: PngChunk, context: EncodeContext): WireSize = WireSize.BackPatch
 
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+
+  public fun partial(buffer: ReadBuffer, context: DecodeContext): Partial {
+    val __batch3Raw = buffer.readLong()
+    val __batch3 = if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) __batch3Raw else swapBytes(__batch3Raw)
+    val length = (__batch3 ushr 32 and 0xFFFFFFFFL).toUInt()
+    val type = (__batch3 and 0xFFFFFFFFL).toUInt()
+    val __payloadStart = buffer.position()
+    val __payloadEnd = buffer.limit() - 4
+    buffer.position(__payloadEnd)
+    val crcRaw = buffer.readInt()
+    val crc = (if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) crcRaw else swapBytes(crcRaw)).toUInt()
+    return Partial(length = length, type = type, crc = crc, payloadStart = __payloadStart, payloadEnd = __payloadEnd, buffer = buffer, context = context)
+  }
+
+  public class Partial internal constructor(
+    public val length: UInt,
+    public val type: UInt,
+    public val crc: UInt,
+    private val payloadStart: Int,
+    private val payloadEnd: Int,
+    private val buffer: ReadBuffer,
+    private val context: DecodeContext,
+  ) {
+    public fun complete(): PngChunk {
+      buffer.position(payloadStart)
+      val __payloadSavedLimit = buffer.limit()
+      buffer.setLimit(payloadEnd)
+      return try {
+        val data = BinaryDataCodec.decode(buffer, context)
+        PngChunk(length = length, type = type, data = data, crc = crc)
+      } finally {
+        buffer.setLimit(__payloadSavedLimit)
+      }
+    }
+  }
 }

--- a/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/partialnonterminal/CommandFrame.kt
+++ b/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/partialnonterminal/CommandFrame.kt
@@ -1,0 +1,25 @@
+package com.ditchoom.buffer.codec.test.protocols.partialnonterminal
+
+import com.ditchoom.buffer.codec.Payload
+import com.ditchoom.buffer.codec.annotations.Endianness
+import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+import com.ditchoom.buffer.codec.annotations.RemainingBytes
+
+/**
+ * `@RemainingBytes` payload with a **fixed-size trailer** (issue #168). The
+ * payload is non-terminal — a `checksum` follows it — so before #168 no
+ * `Partial` was generated. Now `CommandFrameCodec<P>` emits a `Partial<P>`:
+ * `partial(...)` reads `counter`/`length`/`checksum` eagerly and defers the
+ * payload; `complete(payloadCodec)` decodes the deferred payload region.
+ *
+ * Wire (big-endian): `counter(2) | length(2) | payload(...) | checksum(2)`.
+ * The payload's extent is `limit - 2` (the trailing checksum), so the frame
+ * is caller-bounded exactly like any other `@RemainingBytes` body.
+ */
+@ProtocolMessage(wireOrder = Endianness.Big)
+data class CommandFrame<P : Payload>(
+    val counter: UShort,
+    val length: UShort,
+    @RemainingBytes val payload: P,
+    val checksum: UShort,
+)

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/partialnonterminal/CommandFrameCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/partialnonterminal/CommandFrameCodecTest.kt
@@ -1,0 +1,84 @@
+package com.ditchoom.buffer.codec.test.protocols.partialnonterminal
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.test.protocols.payload.TextPayload
+import com.ditchoom.buffer.codec.test.protocols.payload.TextPayloadCodec
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * `Partial` generation for a non-terminal `@RemainingBytes` payload (issue
+ * #168): the payload is followed by a fixed-size `checksum` trailer, yet a
+ * `Partial<P>` is still emitted. `partial(...)` reads the header and trailer
+ * eagerly and defers the payload; `complete(payloadCodec)` decodes it.
+ */
+class CommandFrameCodecTest {
+    private val codec = CommandFrameCodec(TextPayloadCodec)
+
+    private fun encode(frame: CommandFrame<TextPayload>): ReadBuffer {
+        val size =
+            2 + 2 +
+                frame.payload.text
+                    .encodeToByteArray()
+                    .size + 2
+        val buffer = BufferFactory.Default.allocate(size, ByteOrder.BIG_ENDIAN)
+        codec.encode(buffer, frame, EncodeContext.Empty)
+        buffer.resetForRead()
+        return buffer
+    }
+
+    private val sample =
+        CommandFrame(
+            counter = 0x0102u,
+            length = 0x0005u,
+            payload = TextPayload("Hello"),
+            checksum = 0xBEEFu,
+        )
+
+    @Test
+    fun fullDecodeRoundTrips() {
+        val decoded = codec.decode(encode(sample), DecodeContext.Empty)
+        assertEquals(sample, decoded)
+    }
+
+    @Test
+    fun partialReadsHeaderAndTrailerEagerlyThenCompletesPayload() {
+        val partial = CommandFrameCodec.partial<TextPayload>(encode(sample), DecodeContext.Empty)
+        // Header + fixed-size trailer are available before decoding the payload.
+        assertEquals(0x0102u.toUShort(), partial.counter)
+        assertEquals(0x0005u.toUShort(), partial.length)
+        assertEquals(0xBEEFu.toUShort(), partial.checksum)
+        // Deferred payload decodes from the captured region.
+        val full = partial.complete(TextPayloadCodec)
+        assertEquals(sample, full)
+    }
+
+    @Test
+    fun partialCompleteMatchesFullDecode() {
+        val viaFull = codec.decode(encode(sample), DecodeContext.Empty)
+        val viaPartial =
+            CommandFrameCodec
+                .partial<TextPayload>(encode(sample), DecodeContext.Empty)
+                .complete(TextPayloadCodec)
+        assertEquals(viaFull, viaPartial)
+    }
+
+    @Test
+    fun handlesEmptyPayload() {
+        val empty =
+            CommandFrame(
+                counter = 0x0001u,
+                length = 0x0000u,
+                payload = TextPayload(""),
+                checksum = 0x1234u,
+            )
+        val partial = CommandFrameCodec.partial<TextPayload>(encode(empty), DecodeContext.Empty)
+        assertEquals(0x1234u.toUShort(), partial.checksum)
+        assertEquals(empty, partial.complete(TextPayloadCodec))
+    }
+}


### PR DESCRIPTION
Closes #168.

## Problem

`Partial` (the "decode the header now, defer the payload" streaming entry point) was only generated when the `@RemainingBytes val payload: P` field was the **last** field. A codec whose payload is followed by a fixed-size trailer — e.g. the reporter's `Frame.Command { counter; length; @RemainingBytes payload: P; checksum }` — got no `Partial`, even though the payload's wire extent is perfectly knowable (`limit - trailerBytes`).

## Change

Generalize the `Partial` emit (`CodecEmitter`): emit it when the payload is followed **only by fixed-size fields** and isn't also externally bounded by `@FramedBy` or a bounding `@UseCodec` (those interactions stay terminal-only).

- `partial(...)` reads the leading fields, captures the payload region `[payloadStart, limit - reservedTrailingBytes)`, skips it, and reads the fixed-size trailer eagerly.
- `complete(...)` re-seeks to that region, narrows the limit, decodes the deferred payload, restores the limit, and constructs the full message.

Terminal-payload codecs are byte-for-byte unchanged.

## For the reporter (#168)

`FrameCommandCodec`/`FrameResponseCodec` now generate a `Partial<P>` + `partial<P>(buffer, context)` because their `@RemainingBytes payload` is followed by fixed-size `status`/`checksum` trailers.

## Tests

New `CommandFrame<P>(counter, length, @RemainingBytes payload, checksum)` fixture mirroring the reporter's shape, with 4 tests: full round-trip, eager header+trailer read + deferred `complete()`, partial-equals-full, and an empty-payload edge case.

## Snapshots

- New `CommandFrameCodec` (generic, `complete(payloadCodec)`).
- `PngChunkCodec` (concrete `BinaryData` payload + 4-byte CRC trailer) now also gains a `Partial` with a no-arg `complete()`. The diff is **purely additive** — `decode`/`encode`/`wireSize`/`peekFrameSize` are untouched.