### PR TITLE
chore(lint): remove orphaned KDoc unblocking project-wide ktlintCheck

### DIFF
--- a/buffer-compression/src/appleMain/kotlin/com/ditchoom/buffer/compression/AppleCompression.kt
+++ b/buffer-compression/src/appleMain/kotlin/com/ditchoom/buffer/compression/AppleCompression.kt
@@ -71,10 +71,6 @@ private inline fun copyMemory(
 private inline fun getCompressBound(size: Int): Int = compressBound(size.convert()).convert()
 
 /**
- * Window bits for different compression formats.
- */
-
-/**
  * Apple implementation using system zlib with direct buffer access.
  */
 @OptIn(ExperimentalForeignApi::class)


### PR DESCRIPTION
`./gradlew ktlintCheck` on the whole project failed on a single violation:

```
buffer-compression/src/appleMain/.../AppleCompression.kt:77:1
  a KDoc may not be preceded by a KDoc (cannot be auto-corrected)
  (standard:no-consecutive-comments)
```

An orphaned `/** Window bits for different compression formats. */` KDoc sat immediately before the `compress` function's own KDoc, documenting nothing (no declaration followed it). The rule can't auto-correct consecutive KDocs, so `ktlintFormat` couldn't fix it — it needed a manual edit.

Removed the orphaned comment. Project-wide `./gradlew ktlintCheck` is now green.

Pre-existing on `main`; unrelated to the feature PRs (#169 / #170 / #171), which were already ktlint-clean for the files they touch.