### PR TITLE
fix(android): migrate LockFreeBufferPool off atomicfu to fix NoClassDefFoundError (#164)

### DIFF
--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/LockFreeBufferPool.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/LockFreeBufferPool.kt
@@ -4,7 +4,10 @@ import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.ByteOrder
 import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.ReadWriteBuffer
-import kotlinx.atomicfu.atomic
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.AtomicLong
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
 /**
  * Thread-safe buffer pool using lock-free algorithms (Treiber stack).
@@ -13,7 +16,14 @@ import kotlinx.atomicfu.atomic
  * Suitable for concurrent access from multiple threads/coroutines.
  *
  * For single-threaded use, prefer [SingleThreadedBufferPool] for better performance.
+ *
+ * Uses `kotlin.concurrent.atomics` (stdlib) rather than the atomicfu plugin so the
+ * bytecode is portable to Android without a build-time transform step — the atomicfu
+ * transform didn't run for the `-android` variant, leaving `kotlinx.atomicfu.AtomicFU`
+ * referenced at runtime with no declared dependency (NoClassDefFoundError). Mirrors
+ * [com.ditchoom.buffer.codec.GrowableWriteBufferPool].
  */
+@OptIn(ExperimentalAtomicApi::class)
 internal class LockFreeBufferPool(
     private val maxPoolSize: Int,
     private val defaultBufferSize: Int,
@@ -25,17 +35,17 @@ internal class LockFreeBufferPool(
         val next: Node?,
     )
 
-    // Lock-free stack head using atomicfu
-    private val head = atomic<Node?>(null)
+    // Lock-free stack head
+    private val head = AtomicReference<Node?>(null)
 
     // Atomic size counter to avoid traversing the list
-    private val poolSize = atomic(0)
+    private val poolSize = AtomicInt(0)
 
     // Atomic statistics
-    private val totalAllocations = atomic(0L)
-    private val poolHits = atomic(0L)
-    private val poolMisses = atomic(0L)
-    private val peakPoolSize = atomic(0)
+    private val totalAllocations = AtomicLong(0L)
+    private val poolHits = AtomicLong(0L)
+    private val poolMisses = AtomicLong(0L)
+    private val peakPoolSize = AtomicInt(0)
 
     override fun allocate(
         size: Int,
@@ -53,7 +63,7 @@ internal class LockFreeBufferPool(
     ): PlatformBuffer = factory.wrap(array, byteOrder)
 
     override fun acquire(minSize: Int): ReadWriteBuffer {
-        totalAllocations.incrementAndGet()
+        totalAllocations.update { it + 1 }
         val size = maxOf(minSize, defaultBufferSize)
 
         // Try to pop from stack (lock-free)
@@ -61,11 +71,11 @@ internal class LockFreeBufferPool(
 
         val raw =
             if (buffer != null && buffer.capacity >= size) {
-                poolHits.incrementAndGet()
+                poolHits.update { it + 1 }
                 buffer.resetForWrite()
                 buffer
             } else {
-                poolMisses.incrementAndGet()
+                poolMisses.update { it + 1 }
                 // A too-small popped buffer was removed from the pool; free its native
                 // memory before allocating fresh, otherwise it leaks (Arena.ofShared
                 // never closes, FfmAutoBuffer waits on GC).
@@ -89,10 +99,10 @@ internal class LockFreeBufferPool(
             }
 
         // Only push if under max size (check first to avoid unnecessary work)
-        if (poolSize.value < maxPoolSize) {
+        if (poolSize.load() < maxPoolSize) {
             if (push(raw)) {
                 // Update peak if needed
-                val currentSize = poolSize.value
+                val currentSize = poolSize.load()
                 updatePeak(currentSize)
             } else {
                 // CAS push failed because pool became full - free the buffer
@@ -105,11 +115,11 @@ internal class LockFreeBufferPool(
 
     override fun stats(): PoolStats =
         PoolStats(
-            totalAllocations = totalAllocations.value,
-            poolHits = poolHits.value,
-            poolMisses = poolMisses.value,
-            currentPoolSize = poolSize.value,
-            peakPoolSize = peakPoolSize.value,
+            totalAllocations = totalAllocations.load(),
+            poolHits = poolHits.load(),
+            poolMisses = poolMisses.load(),
+            currentPoolSize = poolSize.load(),
+            peakPoolSize = peakPoolSize.load(),
         )
 
     override fun clear() {
@@ -127,17 +137,17 @@ internal class LockFreeBufferPool(
     private fun push(buffer: PlatformBuffer): Boolean {
         while (true) {
             // Check size limit before attempting push
-            val currentSize = poolSize.value
+            val currentSize = poolSize.load()
             if (currentSize >= maxPoolSize) {
                 return false
             }
 
-            val oldHead = head.value
+            val oldHead = head.load()
             val newNode = Node(buffer, oldHead)
 
             // CAS: if head hasn't changed, update it
             if (head.compareAndSet(oldHead, newNode)) {
-                poolSize.incrementAndGet()
+                poolSize.update { it + 1 }
                 return true
             }
             // CAS failed, retry
@@ -150,12 +160,12 @@ internal class LockFreeBufferPool(
      */
     private fun pop(): PlatformBuffer? {
         while (true) {
-            val oldHead = head.value ?: return null
+            val oldHead = head.load() ?: return null
             val newHead = oldHead.next
 
             // CAS: if head hasn't changed, update it
             if (head.compareAndSet(oldHead, newHead)) {
-                poolSize.decrementAndGet()
+                poolSize.update { it - 1 }
                 return oldHead.buffer
             }
             // CAS failed, retry
@@ -167,9 +177,23 @@ internal class LockFreeBufferPool(
      */
     private fun updatePeak(currentSize: Int) {
         while (true) {
-            val peak = peakPoolSize.value
+            val peak = peakPoolSize.load()
             if (currentSize <= peak) return
             if (peakPoolSize.compareAndSet(peak, currentSize)) return
+        }
+    }
+
+    private inline fun AtomicInt.update(transform: (Int) -> Int) {
+        while (true) {
+            val current = load()
+            if (compareAndSet(current, transform(current))) return
+        }
+    }
+
+    private inline fun AtomicLong.update(transform: (Long) -> Long) {
+        while (true) {
+            val current = load()
+            if (compareAndSet(current, transform(current))) return
         }
     }
 }


### PR DESCRIPTION
Fixes #164.

## Problem

`LockFreeBufferPool` used `kotlinx.atomicfu`, whose gradle-plugin bytecode transform compiles away the `kotlinx.atomicfu.AtomicFU` reference on plain JVM but **did not run for the Android (`-android`) variant**. atomicfu is also absent from `buffer-android`'s module metadata, so any Android consumer of `BufferPool` crashed at runtime:

```
java.lang.NoClassDefFoundError: kotlinx.atomicfu.AtomicFU
```

`LockFreeBufferPool` was the only class in the AAR referencing it.

## Fix

Migrate the pool to the stdlib `kotlin.concurrent.atomics` (`AtomicReference` / `AtomicInt` / `AtomicLong`, under `@OptIn(ExperimentalAtomicApi::class)`). It needs no transform and no runtime dependency, so the compiled bytecode no longer references `kotlinx.atomicfu.AtomicFU` on **any** platform, including Android. This finishes the migration `GrowableWriteBufferPool` (buffer-codec) already made for exactly this reason. The stdlib has no `incrementAndFetch` on Kotlin 2.3.x, so increments reuse the same `compareAndSet`-based `update {}` helper as `GrowableWriteBufferPool`. Treiber-stack CAS semantics unchanged.

## Why the atomicfu plugin is intentionally KEPT applied

First cut removed the plugin entirely; CI caught that this broke `:buffer:jvmTest` — `FfmBuffer`/`FfmAutoBuffer` (the JDK-21 FFM classes from the `jvm21` compilation) dropped off the `jvmTest` runtime classpath, failing `FfmBufferTest`/`FfmAutoBufferTest` with `NoClassDefFoundError`. The atomicfu plugin is **load-bearing for the multi-release JVM test wiring** (`buffer/build.gradle.kts:560-596`: the jvmTest classpath that exposes the FFM classes goes through the plugin's transform; `jvmFfmTest` depends on `transformJvmTestAtomicfu`).

With **zero atomicfu usage left in code**, the plugin is a no-op for emitted output, so #164 stays fixed while the JVM test wiring is preserved. Fully excising the plugin requires reworking that test wiring — left as separate cleanup (not blocking a crash-fix patch).

## Verification

- `:buffer:jvmTest --tests "*FfmBufferTest" "*FfmAutoBufferTest" "*BufferPoolTests"` ✅ locally (the previously-failing FFM tests now pass with plugin restored + code migrated)
- Full CI matrix re-running on this revision.

Patch release (per maintainer decision) — consumer-facing Android crash fix.