### PR TITLE
Support generic payloads under simple @PacketType dispatch (closes #176 gap #4)

### DIFF
--- a/buffer-codec-processor/DISPATCH_UNIFICATION_PLAN.md
+++ b/buffer-codec-processor/DISPATCH_UNIFICATION_PLAN.md
@@ -170,6 +170,59 @@ runtime-measured branch (this is the documented Phase-2 attach point for the
 `WireWidth.Variable` stub). encode/wireSize/file-shell need no changes because
 Varint is `ReReadByVariant` (the variant counts it, dispatcher pure-delegates).
 
+## Post-unification: safe-to-add follow-ups (roadmap)
+
+Now that both dispatch paths share one `DispatchShape` + one emit builder set,
+several `SUPPORT_MATRIX.md` backlog rows became *safe* to add — meaning
+byte-identical for existing goldens (snapshot-gated), leveraging infra that
+already exists on a parallel path, with a round-trip test as the correctness
+gate. `SUPPORT_MATRIX.md` stays the canonical gap inventory; this is the
+prioritization lens (row numbers reference it).
+
+The template the unification establishes: a feature already working on one path
+becomes a small, byte-identical change on the other because
+`branchTypeName(Monomorphic) == className` and `codecReceiver(StaticObject)`
+equals the old static ref — so generic/feature code emits *only* when the new
+shape is present. (Proven by the generics-under-simple-`@PacketType` win,
+matrix #3/#4.)
+
+**Tier 1 — safe capability wins (infra exists, one path missing a piece):**
+
+- **#1/#2 — multi-byte `@DispatchOn` discriminators** (signed `Short`/`Int`/`Long`,
+  unsigned `ULong`). Decode/encode already work via the value-class-field path;
+  only the `peekFrameSize` byte-reconstruction is missing (these are *Rejected*
+  today by the stage-9 non-peekable diagnostic — a clean seam to flip). **This is
+  the on-ramp to varint/H3** (variable width is the same machinery one step on).
+- **#7/#26 — `@LengthFrom` value-class-wrapped scalar sibling / non-peekable
+  inner.** The validator already accepts these; the emitter rejects (drift gap).
+  Fix = widen one accepted-kinds set.
+- **#28 — bare nested `@RemainingBytes val: SomeMessage`** (not `List`). Mirrors
+  the existing `List<@ProtocolMessage>` path.
+- **#22/#23 — data-object variant under simple `@PacketType` + peek/wireSize
+  asymmetry.** Almost certainly already closed structurally by the one-builder
+  set; near-zero-risk "add a fixture + round-trip test to prove and lock it".
+
+**Tier 2 — loudness, not capability (cheap DX):** convert remaining silent gaps
+to diagnostics (#8–#12, #16, #36–#38). Trivially safe (fire only on
+already-broken shapes). NB: the `AnalysisResult` diagnostics pass + stage 9
+already closed many — audit `EmitterDiagnosticsValidatorTest` first to find the
+genuine stragglers.
+
+**Tier 3 — NOT safe yet (design work / fragile paths):**
+
+- **#6 — generic + `@FramedBy` on the simple path.** Framed-encode infra is
+  still `@DispatchOn`-only; re-introduces path-specific feature code.
+- **#14/#15 — signed scalar with explicit `@WireOrder` (#154).** Touches the
+  fragile manual byte-assembly path (sign handling); flagged risky in-code.
+- **#24 — `@ForwardCompatible` + generic framed round-trip.** Unchecked
+  star-projected casts + `payloadCodec` injection into the Unknown re-frame;
+  compiles but runtime-fragile.
+- **Supporting (vs rejecting) non-terminal length fields** — needs wireSize
+  composition that doesn't exist; a design project, not an add.
+
+Recommended next: **#1/#2** (highest leverage — also the varint on-ramp), then
+**#22/#23** (cheapest — likely just prove-and-lock).
+
 ## Top byte-identity risks
 
 1. **Discriminator-counted-once** (`1 +` only under ConsumedByDispatcher) — the

--- a/buffer-codec-processor/SUPPORT_MATRIX.md
+++ b/buffer-codec-processor/SUPPORT_MATRIX.md
@@ -367,10 +367,10 @@ Every Outcome-3 row across all axes, deduplicated and tagged with the recommende
 |---|-------|------|----------------|-------|
 | 1 | Signed multi-byte discriminators (Short/Long) in `@DispatchOn` | dispatch | `add-support` (#176) | Extend `peekableDispatcherInnerKinds`; add parallel signed peek paths. |
 | 2 | Unsigned multi-byte (ULong) discriminators in `@DispatchOn` | dispatch | `add-support` (#176) | Same set, ULong peek path. |
-| 3 | Generic `<P: Payload>` under **simple** `@PacketType` dispatcher | dispatch / genericity | `unify-dispatch` (#176) | Simple path has no `payloadTypeParameter`; merge with `@DispatchOn` path. |
-| 4 | Generic sealed parent `<out P>` emitted as `object`, not `class<P>` | genericity | `unify-dispatch` (#176) | `buildSealedDispatcherFileSpec` always `object`. |
-| 5 | Generic variant under non-generic simple sealed parent | genericity | `unify-dispatch` (#176) | Simple path lacks the `:7061` parent-generic check the `@DispatchOn` path has. |
-| 6 | Generic sealed parent w/ `@PacketType` + `@FramedBy`, no `@DispatchOn` | genericity | `unify-dispatch` (#176) | Framed encode infra exists only on the `@DispatchOn` path. |
+| 3 | Generic `<P: Payload>` under **simple** `@PacketType` dispatcher | dispatch / genericity | ✅ **RESOLVED** | `analyzeSealedDispatcher` now detects the parent payload type param and sets `Genericity.Generic`; the unified emit builders handle `Generic × FixedByte`. Fixture `simplegeneric/SimpleGenericFrame`. |
+| 4 | Generic sealed parent `<out P>` emitted as `object`, not `class<P>` | genericity | ✅ **RESOLVED** | `buildDispatchFileSpec` emits `class FooCodec<P>(payloadCodec)` for any `Genericity.Generic`, including `FixedByte`. |
+| 5 | Generic variant under non-generic simple sealed parent | genericity | ✅ rejected (loud) | The type-unsafe shape is reported by `validateGenericPayloadVariantShape` on the simple path (issue #176). Stays a diagnostic, not silent. |
+| 6 | Generic sealed parent w/ `@PacketType` + `@FramedBy`, no `@DispatchOn` | genericity | `add-support` | Generic + **non-framed** simple dispatch now works (#3/#4); generic + `@FramedBy` on the simple path is still unimplemented (framed encode infra remains `@DispatchOn`-only). |
 | 7 | `@LengthFrom` on value-class-wrapped scalar sibling (non-dotted) | length | `reject-with-diagnostic` or `add-support` (#163) | Validator passes value-class sibling; emitter rejects. |
 | 8 | `@LengthPrefixed val: @ProtocolMessage` non-terminal | length | `reject-with-diagnostic` | Add terminal-position validator error. |
 | 9 | `@LengthFrom on @ProtocolMessage` non-terminal | length | `reject-with-diagnostic` | Same terminal check. |
@@ -394,7 +394,7 @@ Every Outcome-3 row across all axes, deduplicated and tagged with the recommende
 | 22 | Data object variant under simple `@PacketType` w/ variable peekFrameSize | dispatch | `unify-dispatch` (unified peek walk) + add test coverage |
 | 23 | Asymmetric wireSize (simple aggregates discriminator, `@DispatchOn` doesn't) | dispatch | `unify-dispatch` (single wireSize builder) |
 | 24 | `@DispatchOn` framed generic variant + `@ForwardCompatible` round-trip | dispatch | `add-support` (thread `payloadCodec` into Unknown re-frame) + test |
-| 25 | `Partial<P>` aggregator: generic variant under non-generic simple parent | genericity | `unify-dispatch` (#176) |
+| 25 | `Partial<P>` aggregator: generic variant under non-generic simple parent | genericity | ✅ rejected (loud) — the non-generic-parent shape is the #176 diagnostic. For a *correctly* generic parent under simple `@PacketType`, the dispatcher omits the `decodeAggregating` companion by design (it's a `@DispatchOn` peek+rewind construct); the variant codec's own `Partial<P>` is still generated. |
 | 26 | `@LengthFrom` value-class property w/ non-peekable inner (ULong/Long) | length | `reject-with-diagnostic` or `add-support` (#163) |
 | 27 | `@When @LengthPrefixed` on inner `@ProtocolMessage` (non-String) | length | `reject-with-diagnostic` or `add-support` |
 | 28 | `@RemainingBytes @ProtocolMessage` (bare nested, not List) | length | `add-support` (#151) |

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
@@ -7265,6 +7265,12 @@ internal class CodecEmitter(
         }
         val subclasses = symbol.getSealedSubclasses().toList()
         if (subclasses.isEmpty()) return DispatchAnalysisResult.NotApplicable
+        // Generic-payload parity with the @DispatchOn path: a sealed parent
+        // declaring `<out P : Payload>` emits as `class FooCodec<P>(payloadCodec)`
+        // and threads the codec to generic variants. A non-generic parent
+        // stays Monomorphic and every variant uses a static-object codec ref —
+        // byte-identical to the pre-generics simple dispatcher.
+        val payloadTypeParameter = detectPayloadTypeParameter(symbol)
         val variants = mutableListOf<DispatchVariant>()
         val seenValues = mutableSetOf<Int>()
         for (sub in subclasses) {
@@ -7306,9 +7312,23 @@ internal class CodecEmitter(
                 (analyze(sub) as? AnalysisResult.Supported)?.shape
                     ?: return DispatchAnalysisResult.NotApplicable
             val variantWireSize = classifyVariantWireSize(variantShape)
+            // A variant declaring its own `<P : Payload>` needs a
+            // constructor-injected `payloadCodec`, so the dispatcher holds the
+            // variant codec as a generic instance (mirrors the @DispatchOn
+            // path). A generic variant under a NON-generic parent is the #176
+            // type-unsafe shape, reported by validateGenericPayloadVariantShape
+            // (ProtocolMessageProcessor.kt:213) — stay silent here.
+            val variantSimpleName = sub.simpleName.asString()
+            val genericInstanceFieldName =
+                if (detectPayloadTypeParameter(sub) != null) {
+                    if (payloadTypeParameter == null) return DispatchAnalysisResult.NotApplicable
+                    "${variantSimpleName.replaceFirstChar { it.lowercase() }}Codec"
+                } else {
+                    null
+                }
             variants +=
                 DispatchVariant(
-                    simpleName = sub.simpleName.asString(),
+                    simpleName = variantSimpleName,
                     className = classNameOf(sub),
                     codecClassName =
                         ClassName(
@@ -7316,7 +7336,10 @@ internal class CodecEmitter(
                             sub.flattenedCodecName(),
                         ),
                     dispatchValue = rawValue,
-                    codecRef = VariantCodecRef.StaticObject,
+                    codecRef =
+                        genericInstanceFieldName
+                            ?.let { VariantCodecRef.GenericInstance(it) }
+                            ?: VariantCodecRef.StaticObject,
                     wireSize = variantWireSize,
                 )
         }
@@ -7334,7 +7357,10 @@ internal class CodecEmitter(
                 codecSimpleName = symbol.flattenedCodecName(),
                 discriminator = Discriminator.FixedByte,
                 variants = variants,
-                genericity = Genericity.Monomorphic,
+                genericity =
+                    payloadTypeParameter
+                        ?.let { Genericity.Generic(it) }
+                        ?: Genericity.Monomorphic,
                 framing = Framing.Unframed,
                 forwardCompat = ForwardCompat.Disabled,
                 visibility = codecVisibilityModifier(symbol).toCodecVisibility(),
@@ -7936,9 +7962,21 @@ internal class CodecEmitter(
 
         when (shape.discriminator.ownership) {
             DiscriminatorOwnership.ConsumedByDispatcher -> {
+                // Generic variants (a `<P : Payload>` parent under simple
+                // @PacketType) star-project their `is X<*>` branch and cast
+                // `value as X<P>` so the injected variant codec instance
+                // accepts it — identical machinery to the ReReadByVariant
+                // branch below. For monomorphic shapes `branchTypeName` is the
+                // bare class and `codecReceiver` the static object, so the
+                // output is byte-identical to the pre-generics simple path.
+                val anyGeneric =
+                    shape.variants.any { it.codecRef is VariantCodecRef.GenericInstance }
+                if (anyGeneric) {
+                    body.add("@Suppress(%S)\n", "UNCHECKED_CAST")
+                }
                 body.beginControlFlow("when (value)")
                 for (variant in shape.variants) {
-                    body.beginControlFlow("is %T ->", variant.className)
+                    body.beginControlFlow("is %T ->", variant.branchTypeName(shape.genericity))
                     // The discriminator literal is ALWAYS hex (risk #2).
                     body.addStatement(
                         "buffer.writeUByte(0x%L.toUByte())",
@@ -7947,10 +7985,18 @@ internal class CodecEmitter(
                             .padStart(2, '0')
                             .uppercase(),
                     )
-                    body.addStatement(
-                        "%L.encode(buffer, value, context)",
-                        variant.codecReceiver(),
-                    )
+                    if (variant.codecRef is VariantCodecRef.GenericInstance) {
+                        body.addStatement(
+                            "%L.encode(buffer, value as %T, context)",
+                            variant.codecReceiver(),
+                            variant.typedRef(shape.genericity),
+                        )
+                    } else {
+                        body.addStatement(
+                            "%L.encode(buffer, value, context)",
+                            variant.codecReceiver(),
+                        )
+                    }
                     body.endControlFlow()
                 }
                 body.endControlFlow()
@@ -8024,25 +8070,34 @@ internal class CodecEmitter(
             DiscriminatorOwnership.ConsumedByDispatcher -> {
                 body.beginControlFlow("return when (value)")
                 for (variant in shape.variants) {
+                    // Generic variants (a `<P : Payload>` parent under simple
+                    // @PacketType) need the star-projected `is X<*>` branch so
+                    // the runtime match succeeds. For monomorphic shapes
+                    // `branchTypeName` is the bare class, so existing output is
+                    // unchanged. A generic variant always carries
+                    // `@RemainingBytes val: P`, which classifyVariantWireSize
+                    // maps to BackPatch — so the RuntimeExact static-codec call
+                    // below is only ever reached by monomorphic variants.
+                    val branchType = variant.branchTypeName(shape.genericity)
                     when (val ws = variant.wireSize) {
                         is VariantWireSize.LiteralExact ->
                             body.addStatement(
                                 "is %T -> %T.Exact(%L)",
-                                variant.className,
+                                branchType,
                                 WIRE_SIZE_CN,
                                 1 + ws.bytes,
                             )
                         is VariantWireSize.BackPatch ->
                             body.addStatement(
                                 "is %T -> %T.BackPatch",
-                                variant.className,
+                                branchType,
                                 WIRE_SIZE_CN,
                             )
                         is VariantWireSize.RuntimeExact -> {
-                            body.beginControlFlow("is %T ->", variant.className)
+                            body.beginControlFlow("is %T ->", branchType)
                             body.addStatement(
-                                "val inner = (%T.wireSize(value, context) as %T.Exact).bytes",
-                                variant.codecClassName,
+                                "val inner = (%L.wireSize(value, context) as %T.Exact).bytes",
+                                variant.codecReceiver(),
                                 WIRE_SIZE_CN,
                             )
                             body.addStatement("%T.Exact(1 + inner)", WIRE_SIZE_CN)
@@ -8314,7 +8369,16 @@ internal class CodecEmitter(
                         builder.addFunction(buildDispatchWireSizeFun(shape))
                         builder.addFunction(buildDispatchPeekFun(shape))
                     }
-                    builder.addType(buildDispatchOnAggregatorCompanion(shape, binding))
+                    // The `decodeAggregating` companion (per-call payload-codec
+                    // selection) is a ReReadByVariant/@DispatchOn construct — it
+                    // peeks+rewinds the discriminator. A simple @PacketType
+                    // (FixedByte) generic dispatcher consumes the byte and relies
+                    // on the constructor-injected payloadCodec, so it omits the
+                    // aggregator. (buildDispatchOnAggregatorCompanion requires a
+                    // ValueClass discriminator and would otherwise error.)
+                    if (shape.discriminator is Discriminator.ValueClass) {
+                        builder.addType(buildDispatchOnAggregatorCompanion(shape, binding))
+                    }
                     builder.build()
                 }
             }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simplegeneric/SimpleGenericFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simplegeneric/SimpleGenericFrameCodec.kt
@@ -1,0 +1,77 @@
+package com.ditchoom.buffer.codec.test.protocols.simplegeneric
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.Payload
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public class SimpleGenericFrameCodec<P : Payload>(
+  private val payloadCodec: Codec<P>,
+) : Codec<SimpleGenericFrame<P>> {
+  private val commandCodec: SimpleGenericFrameCommandCodec<P> =
+      SimpleGenericFrameCommandCodec(payloadCodec)
+
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): SimpleGenericFrame<P> {
+    val discriminatorPosition = buffer.position()
+    val discriminator = buffer.readUByte().toInt()
+    return when (discriminator) {
+      0x0A -> commandCodec.decode(buffer, context)
+      0xA0 -> SimpleGenericFrameStatusCodec.decode(buffer, context)
+      else -> {
+        throw DecodeException(fieldPath = "SimpleGenericFrame.discriminator", bufferPosition = discriminatorPosition, expected = "one of {0x0A, 0xA0}", actual = """0x${discriminator.toString(16).padStart(2, '0').uppercase()}""")
+      }
+    }
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: SimpleGenericFrame<P>,
+    context: EncodeContext,
+  ) {
+    @Suppress("UNCHECKED_CAST")
+    when (value) {
+      is SimpleGenericFrame.Command<*> -> {
+        buffer.writeUByte(0x0A.toUByte())
+        commandCodec.encode(buffer, value as SimpleGenericFrame.Command<P>, context)
+      }
+      is SimpleGenericFrame.Status -> {
+        buffer.writeUByte(0xA0.toUByte())
+        SimpleGenericFrameStatusCodec.encode(buffer, value, context)
+      }
+    }
+  }
+
+  override fun wireSize(`value`: SimpleGenericFrame<P>, context: EncodeContext): WireSize = when (value) {
+    is SimpleGenericFrame.Command<*> -> WireSize.BackPatch
+    is SimpleGenericFrame.Status -> WireSize.Exact(2)
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
+    val discriminator = stream.peekByte(baseOffset).toInt() and 0xFF
+    return when (discriminator) {
+      0x0A -> {
+        when (val inner = commandCodec.peekFrameSize(stream, baseOffset + 1)) {
+          is PeekResult.Complete -> PeekResult.Complete(1 + inner.bytes)
+          else -> inner
+        }
+      }
+      0xA0 -> {
+        when (val inner = SimpleGenericFrameStatusCodec.peekFrameSize(stream, baseOffset + 1)) {
+          is PeekResult.Complete -> PeekResult.Complete(1 + inner.bytes)
+          else -> inner
+        }
+      }
+      else -> {
+        throw DecodeException(fieldPath = "SimpleGenericFrame.discriminator", bufferPosition = baseOffset, expected = "one of {0x0A, 0xA0}", actual = """0x${discriminator.toString(16).padStart(2, '0').uppercase()}""")
+      }
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simplegeneric/SimpleGenericFrameCommandCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simplegeneric/SimpleGenericFrameCommandCodec.kt
@@ -1,0 +1,55 @@
+package com.ditchoom.buffer.codec.test.protocols.simplegeneric
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.Decoder
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.Payload
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.UByte
+
+public class SimpleGenericFrameCommandCodec<P : Payload>(
+  private val payloadCodec: Codec<P>,
+) : Codec<SimpleGenericFrame.Command<P>> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): SimpleGenericFrame.Command<P> {
+    val counter = buffer.readUByte()
+    val payload = payloadCodec.decode(buffer, context)
+    return SimpleGenericFrame.Command<P>(counter = counter, payload = payload)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: SimpleGenericFrame.Command<P>,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.counter)
+    payloadCodec.encode(buffer, value.payload, context)
+  }
+
+  override fun wireSize(`value`: SimpleGenericFrame.Command<P>, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+
+  public class Partial<P : Payload> internal constructor(
+    public val counter: UByte,
+    private val buffer: ReadBuffer,
+    private val context: DecodeContext,
+  ) {
+    public fun complete(payloadCodec: Decoder<P>): SimpleGenericFrame.Command<P> {
+      val payload = payloadCodec.decode(buffer, context)
+      return SimpleGenericFrame.Command<P>(counter = counter, payload = payload)
+    }
+  }
+
+  public companion object {
+    public fun <P : Payload> partial(buffer: ReadBuffer, context: DecodeContext): Partial<P> {
+      val counter = buffer.readUByte()
+      return Partial<P>(counter = counter, buffer = buffer, context = context)
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simplegeneric/SimpleGenericFrameStatusCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simplegeneric/SimpleGenericFrameStatusCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.simplegeneric
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object SimpleGenericFrameStatusCodec : Codec<SimpleGenericFrame.Status> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): SimpleGenericFrame.Status {
+    val code = buffer.readUByte()
+    return SimpleGenericFrame.Status(code = code)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: SimpleGenericFrame.Status,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.code)
+  }
+
+  override fun wireSize(`value`: SimpleGenericFrame.Status, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/simplegeneric/SimpleGenericFrame.kt
+++ b/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/simplegeneric/SimpleGenericFrame.kt
@@ -1,0 +1,54 @@
+package com.ditchoom.buffer.codec.test.protocols.simplegeneric
+
+import com.ditchoom.buffer.codec.Payload
+import com.ditchoom.buffer.codec.annotations.PacketType
+import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+import com.ditchoom.buffer.codec.annotations.RemainingBytes
+
+/**
+ * Generic payload under a **simple `@PacketType`** dispatcher (no
+ * `@DispatchOn`, no `@FramedBy`).
+ *
+ * This is the shape from issue #176, declared correctly: the sealed parent
+ * carries `<out P : Payload>` so the dispatcher can bind `P` and thread a
+ * constructor-injected `payloadCodec: Codec<P>` to its generic variants. The
+ * issue's original (raw, non-generic parent) form is rejected by
+ * `validateGenericPayloadVariantShape`; this form is the one that works.
+ *
+ * Until now this exact combination — a generic parent under simple
+ * `@PacketType` (`Generic × FixedByte`) — silently emitted broken monomorphic
+ * code (SUPPORT_MATRIX backlog #4/#6: the dispatcher was always an `object`,
+ * erasing `P`). It now generates
+ * `class SimpleGenericFrameCodec<P>(payloadCodec: Codec<P>)`, threading the
+ * codec to the generic [Command] variant while the non-generic [Status]
+ * variant (extending `SimpleGenericFrame<Nothing>`) keeps a static codec ref.
+ *
+ * Wire layout this probe pins down (single-byte fields, so no byte-order
+ * concern):
+ *
+ * ```text
+ * Command<TextPayload>(counter = 0x42, payload = "hi"):
+ *   0A          discriminator (consumed by the dispatcher)
+ *   42          counter
+ *   68 69       @RemainingBytes payload "hi"
+ *
+ * Status(code = 0x7F):
+ *   A0          discriminator
+ *   7F          code
+ * ```
+ */
+@ProtocolMessage
+sealed interface SimpleGenericFrame<out P : Payload> {
+    @ProtocolMessage
+    @PacketType(0x0A)
+    data class Command<P : Payload>(
+        val counter: UByte,
+        @RemainingBytes val payload: P,
+    ) : SimpleGenericFrame<P>
+
+    @ProtocolMessage
+    @PacketType(0xA0)
+    data class Status(
+        val code: UByte,
+    ) : SimpleGenericFrame<Nothing>
+}

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/simplegeneric/SimpleGenericFrameCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/simplegeneric/SimpleGenericFrameCodecTest.kt
@@ -1,0 +1,103 @@
+package com.ditchoom.buffer.codec.test.protocols.simplegeneric
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.codec.test.protocols.payload.TextPayload
+import com.ditchoom.buffer.codec.test.protocols.payload.TextPayloadCodec
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+/**
+ * Round-trip + wire-format coverage for a generic payload under a **simple
+ * `@PacketType`** dispatcher (no `@DispatchOn`) — the `Generic × FixedByte`
+ * combination that previously emitted broken monomorphic code (issue #176 /
+ * SUPPORT_MATRIX backlog #4/#6) and now generates
+ * `class SimpleGenericFrameCodec<P>(payloadCodec)`.
+ *
+ * The checks prove the generated generic dispatcher actually works at
+ * runtime, not just that it compiles:
+ *   1. the generic [Command] variant round-trips through the
+ *      constructor-injected `payloadCodec` after the dispatcher consumes the
+ *      discriminator byte;
+ *   2. the non-generic [Status] variant (extending `<Nothing>`) round-trips
+ *      via its static codec ref;
+ *   3. the discriminator byte is written/consumed by the dispatcher
+ *      (FixedByte ownership) — asserted on the wire;
+ *   4. dispatch routes to the correct variant;
+ *   5. `wireSize` aggregates the discriminator byte (`Status → Exact(2)`).
+ */
+class SimpleGenericFrameCodecTest {
+    private val codec = SimpleGenericFrameCodec(TextPayloadCodec)
+
+    @Test
+    fun commandRoundTripsThroughInjectedPayloadCodec() {
+        val original =
+            SimpleGenericFrame.Command(
+                counter = 0x42u,
+                payload = TextPayload("hi"),
+            )
+        val buffer = BufferFactory.Default.allocate(64)
+        codec.encode(buffer, original, EncodeContext.Empty)
+        // 0A (discriminator) + 42 (counter) + 68 69 ("hi") = 4 bytes.
+        assertEquals(4, buffer.position(), "encoded byte count")
+        buffer.resetForRead()
+        assertEquals(0x0A, buffer.readUByte().toInt(), "discriminator byte (consumed by dispatcher)")
+        assertEquals(0x42, buffer.readUByte().toInt(), "counter")
+        assertEquals(0x68, buffer.readUByte().toInt(), "payload[0] = 'h'")
+        assertEquals(0x69, buffer.readUByte().toInt(), "payload[1] = 'i'")
+        buffer.resetForRead()
+        val decoded = codec.decode(buffer, DecodeContext.Empty)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun statusVariantRoundTrips() {
+        val original = SimpleGenericFrame.Status(code = 0x7Fu)
+        val buffer = BufferFactory.Default.allocate(64)
+        codec.encode(buffer, original, EncodeContext.Empty)
+        assertEquals(2, buffer.position(), "encoded byte count")
+        buffer.resetForRead()
+        assertEquals(0xA0, buffer.readUByte().toInt(), "discriminator byte")
+        assertEquals(0x7F, buffer.readUByte().toInt(), "code")
+        buffer.resetForRead()
+        val decoded = codec.decode(buffer, DecodeContext.Empty)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun dispatchRoutesToCorrectVariant() {
+        val command =
+            SimpleGenericFrame.Command(counter = 0x01u, payload = TextPayload("payload"))
+        val buffer = BufferFactory.Default.allocate(64)
+        codec.encode(buffer, command, EncodeContext.Empty)
+        buffer.resetForRead()
+        assertIs<SimpleGenericFrame.Command<TextPayload>>(codec.decode(buffer, DecodeContext.Empty))
+
+        val status = SimpleGenericFrame.Status(code = 0x10u)
+        val statusBuffer = BufferFactory.Default.allocate(64)
+        codec.encode(statusBuffer, status, EncodeContext.Empty)
+        statusBuffer.resetForRead()
+        assertIs<SimpleGenericFrame.Status>(codec.decode(statusBuffer, DecodeContext.Empty))
+    }
+
+    @Test
+    fun wireSizeAggregatesDiscriminatorByte() {
+        // Status body is a single UByte; the dispatcher adds the discriminator
+        // byte → Exact(2). Command carries @RemainingBytes payload → BackPatch.
+        assertEquals(
+            WireSize.Exact(2),
+            codec.wireSize(SimpleGenericFrame.Status(code = 0u), EncodeContext.Empty),
+        )
+        assertEquals(
+            WireSize.BackPatch,
+            codec.wireSize(
+                SimpleGenericFrame.Command(counter = 0u, payload = TextPayload("x")),
+                EncodeContext.Empty,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Closes the `Generic × FixedByte` gap (SUPPORT_MATRIX backlog #3/#4): a sealed parent declaring `<out P : Payload>` under a **simple `@PacketType`** dispatcher (no `@DispatchOn`) now generates `class FooCodec<P>(payloadCodec: Codec<P>)` that threads the injected codec to its generic variants — instead of silently emitting broken monomorphic `object` code.

This is the natural follow-up to the dispatch-path unification (#177): because both dispatch paths now feed one `DispatchShape` + one emit builder set, generics on the simple path became a small, byte-identical-safe change rather than a second feature implementation.

## Why it's safe (existing output unchanged)

`branchTypeName(Monomorphic)` returns exactly `variant.className`, and `codecReceiver()` for a `StaticObject` is the same static ref the old code emitted. So routing the `FixedByte` encode/wireSize branches through the generic-aware helpers is a **no-op for every existing monomorphic fixture** — the generic-only code (the `value as X<P>` cast, `@Suppress`, the `class<P>` shell, the injected variant-codec fields) emits *only* when a generic variant is actually present, which no existing `@PacketType` fixture has. **All 305 codec-snapshot goldens are unchanged** (verified: `git status` on `codec-snapshots/` shows only the new `simplegeneric/` baselines as additions, nothing modified).

## Changes

- **`analyzeSealedDispatcher`** detects the parent payload type parameter → `Genericity.Generic`, and marks generic variants with `GenericInstance` codecRefs (mirrors `analyzeDispatchOnSealedDispatcher`). A generic variant under a *non-generic* parent stays the #176 validator rejection.
- **`buildDispatchEncodeFun` / `buildDispatchWireSizeFun`**: the `ConsumedByDispatcher` branch uses `branchTypeName(shape.genericity)` + the generic cast/`@Suppress` the `ReReadByVariant` branch already had.
- **`buildDispatchFileSpec`**: gates the `decodeAggregating` companion on `ValueClass` — it's a `@DispatchOn` peek+rewind construct; a `FixedByte` generic dispatcher uses constructor injection and omits it.

## Test coverage

- New fixture `simplegeneric/SimpleGenericFrame` — the issue #176 shape, declared correctly with a generic parent, under plain `@PacketType` (a generic `Command<P>` variant + a non-generic `Status` variant extending `<Nothing>`).
- New cross-platform round-trip test (`SimpleGenericFrameCodecTest`): generic variant round-trips through the injected `payloadCodec`, non-generic variant via its static ref, discriminator byte written/consumed on the wire, dispatch routing, and `wireSize` discriminator aggregation (`Status → Exact(2)`).
- 3 reviewed snapshot goldens.
- Verified on JVM / JS / WasmJS / Linux-native (`./gradlew allTests`), plus `:buffer-codec-processor:test` and `ktlintCheck`.

## Still open

- **#6**: generic + `@FramedBy` on the simple path — the framed-encode infra remains `@DispatchOn`-only. Out of scope here; tracked in SUPPORT_MATRIX.

skip-release.