### PR TITLE
feat(codec): multi-byte @DispatchOn discriminators (signed Short/Int/Long, unsigned ULong)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,26 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Codec processor: multi-byte `@DispatchOn` discriminators across every
+  integer inner kind** — signed `Short` / `Int` / `Long` and unsigned `ULong`,
+  in addition to the existing single-byte (`UByte` / `Byte`) and 2/4-byte
+  unsigned (`UShort` / `UInt`) kinds. Decode and encode already handled these;
+  the missing piece was the dispatcher's `peekFrameSize` byte-reconstruction,
+  which now assembles the discriminator order-aware (honoring the discriminator
+  value class's `@ProtocolMessage(wireOrder = …)`) in the `Int` domain for
+  2/4-byte inners and the `Long` domain for 8-byte inners, narrowing
+  sign-preservingly to the inner kind. **Wire format and all existing generated
+  codecs are byte-for-byte unchanged.**
+
 ### Changed
 
-- **Codec processor: two previously-silent malformed sealed-dispatch shapes
-  now fail the build with a diagnostic instead of silently generating no
-  codec** (the "Outcome-3 silent gap" class):
-  - A `@PacketType` variant under a *simple* sealed-dispatch parent that is
-    neither a `data class` nor an `object` / `data object`.
-  - A `@DispatchOn` discriminator whose value-class inner scalar is not a
-    supported dispatch width. Only single-byte (`UByte` / `Byte`) and 2/4-byte
-    unsigned (`UShort` / `UInt`) kinds are supported; `Short`, `Int`, `Long`,
-    and `ULong` discriminators now error rather than emitting nothing.
+- **Codec processor: a previously-silent malformed sealed-dispatch shape now
+  fails the build with a diagnostic instead of silently generating no codec**
+  (the "Outcome-3 silent gap" class): a `@PacketType` variant under a *simple*
+  sealed-dispatch parent that is neither a `data class` nor an `object` /
+  `data object`.
 
   Wire format and **all existing generated codecs are byte-for-byte unchanged**
   — only inputs that previously produced no codec are affected.

--- a/buffer-codec-processor/DISPATCH_UNIFICATION_PLAN.md
+++ b/buffer-codec-processor/DISPATCH_UNIFICATION_PLAN.md
@@ -189,10 +189,21 @@ matrix #3/#4.)
 **Tier 1 — safe capability wins (infra exists, one path missing a piece):**
 
 - **#1/#2 — multi-byte `@DispatchOn` discriminators** (signed `Short`/`Int`/`Long`,
-  unsigned `ULong`). Decode/encode already work via the value-class-field path;
-  only the `peekFrameSize` byte-reconstruction is missing (these are *Rejected*
-  today by the stage-9 non-peekable diagnostic — a clean seam to flip). **This is
-  the on-ramp to varint/H3** (variable width is the same machinery one step on).
+  unsigned `ULong`). **DONE** (branch `codec/multibyte-dispatchon-discriminator`).
+  Decode/encode already worked via the value-class-field path; the only gap was
+  the dispatcher's `peekFrameSize` byte-reconstruction. Flipped the clean seam:
+  `peekableDispatcherInnerKinds` now covers every integer kind, and
+  `appendPeekFixedScalar` reconstructs Int-domain (2/4-byte: `Int and 0xFF`
+  shifts) and Long-domain (8-byte: `Long and 0xFFL` shifts) inners, order-aware
+  per the discriminator's `wireOrder`, narrowing sign-preservingly to the inner
+  kind. The stage-9 "non-peekable" diagnostic is now a defensive guard for the
+  non-integer (Float/Double) inners the validator already rejects. New fixture
+  `multibytedisc/MultiByteDispatchFrames` (one frame per inner kind, mixing
+  big/little-endian) + cross-platform round-trip/peek test; stage-9 negative test
+  #17 flipped Rejected→Supported. Byte-identical (305 existing goldens unchanged;
+  16 new goldens added). **This was the on-ramp to varint/H3** (variable width is
+  the same machinery one step on — the Long-domain peek assembly is the shape a
+  QUIC 8-byte varint reuses).
 - **#7/#26 — `@LengthFrom` value-class-wrapped scalar sibling / non-peekable
   inner.** The validator already accepts these; the emitter rejects (drift gap).
   Fix = widen one accepted-kinds set.

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
@@ -2499,18 +2499,32 @@ internal class CodecEmitter(
 
     /**
      * Peek-side reconstruction kinds for `@DispatchOn` value-class
-     * discriminators. Accepts 1/2/4-byte unsigned kinds for real-spec
-     * multi-byte discriminators (e.g., HTTP/2's first 4 bytes packed as
-     * `length<<8 | type`). `appendPeekFixedScalar` with the discriminator
-     * value class's `wireOrder` handles the byte assembly.
+     * discriminators. Accepts every integer scalar kind — 1/2/4/8-byte,
+     * signed and unsigned — so real-spec multi-byte discriminators
+     * (e.g., HTTP/2's first 4 bytes packed as `length<<8 | type`, or a
+     * QUIC-style 8-byte frame type) reconstruct correctly. The byte
+     * assembly is order-aware: `appendPeekFixedScalar` reads the inner
+     * scalar's bytes honoring the discriminator value class's `wireOrder`
+     * and narrows to the inner kind, matching the discriminator codec's
+     * decode/encode wire layout.
      *
-     * `ULong` and signed multi-byte kinds are still rejected — they
-     * would need parallel peek paths (ULong promotion, signed
-     * sign-extension), and no in-scope discriminator vector
-     * requires them.
+     * Int-width kinds (Short / UShort / Int / UInt) assemble in the `Int`
+     * domain; Long-width kinds (Long / ULong) assemble in the `Long`
+     * domain. Float / Double are not integer discriminators and remain
+     * rejected (the validator already restricts inners to
+     * `NUMERIC_SCALAR_QNAMES`).
      */
     private val peekableDispatcherInnerKinds =
-        setOf(ScalarKind.UByte, ScalarKind.Byte, ScalarKind.UShort, ScalarKind.UInt)
+        setOf(
+            ScalarKind.UByte,
+            ScalarKind.Byte,
+            ScalarKind.UShort,
+            ScalarKind.Short,
+            ScalarKind.UInt,
+            ScalarKind.Int,
+            ScalarKind.ULong,
+            ScalarKind.Long,
+        )
 
     /**
      * Typed shape of the `@When("…")` expression
@@ -6358,7 +6372,13 @@ internal class CodecEmitter(
                     targetVar,
                     offsetExpr,
                 )
-            ScalarKind.UShort, ScalarKind.UInt -> {
+            ScalarKind.UShort, ScalarKind.Short, ScalarKind.UInt, ScalarKind.Int -> {
+                // Int-domain assembly: extract each byte as `Int and 0xFF`,
+                // shift into place (big- or little-endian per wireOrder), then
+                // narrow to the inner kind. Signed kinds (Short / Int) narrow
+                // by `.toShort()` / no-op so the high byte's sign bit is
+                // preserved exactly as the discriminator codec's `readShort()`
+                // / `readInt()` would produce it.
                 val width = kind.wireWidth.requireFixed("appendPeekFixedScalar")
                 val bigEndian =
                     when (wireOrder) {
@@ -6383,16 +6403,50 @@ internal class CodecEmitter(
                     when (kind) {
                         ScalarKind.UShort -> "(%L).toUInt().toUShort()"
                         ScalarKind.UInt -> "(%L).toUInt()"
+                        ScalarKind.Short -> "(%L).toShort()"
+                        ScalarKind.Int -> "(%L)"
                         else -> error("unreachable")
                     }
                 body.addStatement("val %L = $narrow", targetVar, parts.joinToString(" or "))
             }
-            ScalarKind.ULong, ScalarKind.Short, ScalarKind.Int, ScalarKind.Long,
-            ScalarKind.Float, ScalarKind.Double,
-            ->
+            ScalarKind.ULong, ScalarKind.Long -> {
+                // Long-domain assembly: an 8-byte inner overflows `Int`, so each
+                // byte is lifted to `Long and 0xFFL` before shifting (up to 56
+                // bits). `ULong` narrows via `.toULong()`; `Long` keeps the
+                // assembled value — matching `readULong()` / `readLong()`.
+                val width = kind.wireWidth.requireFixed("appendPeekFixedScalar")
+                val bigEndian =
+                    when (wireOrder) {
+                        Endianness.Big, Endianness.Default -> true
+                        Endianness.Little -> false
+                    }
+                for (i in 0 until width) {
+                    val byteOffset = if (i == 0) offsetExpr else "$offsetExpr + $i"
+                    body.addStatement(
+                        "val %L = stream.peekByte(baseOffset + %L).toLong() and 0xFFL",
+                        "${targetVar}B$i",
+                        byteOffset,
+                    )
+                }
+                val parts =
+                    (0 until width).map { i ->
+                        val byteName = "${targetVar}B$i"
+                        val shiftBits = if (bigEndian) (width - 1 - i) * 8 else i * 8
+                        if (shiftBits == 0) byteName else "($byteName shl $shiftBits)"
+                    }
+                val narrow =
+                    when (kind) {
+                        ScalarKind.Long -> "(%L)"
+                        ScalarKind.ULong -> "(%L).toULong()"
+                        else -> error("unreachable")
+                    }
+                body.addStatement("val %L = $narrow", targetVar, parts.joinToString(" or "))
+            }
+            ScalarKind.Float, ScalarKind.Double ->
                 error(
                     "peek-side reconstruction for value-class inner kind $kind not implemented; " +
-                        "the analyzer should have rejected this shape until the wider peek path lands.",
+                        "Float / Double are not integer dispatch discriminators and the analyzer " +
+                        "should have rejected this shape.",
                 )
         }
     }
@@ -7737,7 +7791,10 @@ internal class CodecEmitter(
         // at runtime from the value class's own generated codec, so the
         // fixed-width peekable-inner-kind machinery below does not apply.
         // The concrete `Discriminator` (Varint vs ValueClass) is built after
-        // the shared dispatch-value resolution.
+        // the shared dispatch-value resolution. For the non-varint case the
+        // inner-kind resolution + peekable check (now widened to every integer
+        // scalar kind by the multi-byte-discriminator work) live in the
+        // `ValueClass` branch below.
         val varintInner = innerParam.hasVariableLengthUseCodec()
 
         val dispatchProp =
@@ -7908,12 +7965,12 @@ internal class CodecEmitter(
                 val innerKind =
                     SUPPORTED_SCALARS[innerType.declaration.qualifiedName?.asString()]
                         ?: return DispatchAnalysisResult.NotApplicable
-                // True silent gap: validateDispatchOnSealed accepts any numeric
-                // inner (NUMERIC_SCALAR_QNAMES), but peek-side reconstruction only
-                // supports single-byte kinds plus 2/4-byte unsigned kinds. ULong,
-                // Int, and signed multi-byte (Short/Long) discriminators aren't
-                // required by any in-scope vector and would need parallel peek
-                // paths — so they pass validation and are then silently dropped.
+                // Defensive guard: every integer scalar kind (signed/unsigned,
+                // 1/2/4/8-byte) is peekable, so for any inner `validateDispatchOnSealed`
+                // accepts (`NUMERIC_SCALAR_QNAMES`) this never fires. It remains as the
+                // emitter's own check against a non-integer inner (Float / Double) — the
+                // validator reports the user-facing error first, so this is belt-and-
+                // suspenders rather than a silent-gap closer.
                 if (innerKind !in peekableDispatcherInnerKinds) {
                     val innerName = innerType.declaration.simpleName.asString()
                     val peekable = peekableDispatcherInnerKinds.joinToString(", ") { it.name }
@@ -7921,9 +7978,9 @@ internal class CodecEmitter(
                         listOf(
                             Diagnostic(
                                 "@DispatchOn discriminator on ${symbol.simpleName.asString()} has inner scalar " +
-                                    "`$innerName`, which is not a supported dispatch discriminator width. The peek " +
-                                    "path supports only single-byte and 2/4-byte unsigned kinds ($peekable); signed " +
-                                    "multi-byte (Short/Long), Int, and ULong discriminators are not yet supported.",
+                                    "`$innerName`, which is not a supported dispatch discriminator type. The peek " +
+                                    "path supports the integer scalar kinds ($peekable); non-integer inners " +
+                                    "(Float / Double) cannot be dispatch discriminators.",
                                 symbol,
                             ),
                         ),

--- a/buffer-codec-processor/src/test/kotlin/com/ditchoom/buffer/codec/processor/EmitterDiagnosticsValidatorTest.kt
+++ b/buffer-codec-processor/src/test/kotlin/com/ditchoom/buffer/codec/processor/EmitterDiagnosticsValidatorTest.kt
@@ -8,6 +8,7 @@ import com.tschuchort.compiletesting.useKsp2
 import org.intellij.lang.annotations.Language
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
@@ -462,13 +463,17 @@ class EmitterDiagnosticsValidatorTest {
         )
     }
 
-    // 17. @DispatchOn with a non-peekable discriminator inner kind (Short).
-    // validateDispatchOnSealed accepts any numeric inner, so signed
-    // multi-byte / ULong / Int discriminators passed validation and were
-    // then silently dropped until the analyzer started returning Rejected
-    // (plan stage 9).
+    // 17. @DispatchOn with multi-byte discriminator inner kinds (signed
+    // Short / Int / Long, unsigned ULong) now compiles. Decode/encode always
+    // worked; the missing piece was the dispatcher's peekFrameSize byte-
+    // reconstruction, which previously rejected these via the stage-9
+    // "non-peekable @DispatchOn discriminator" diagnostic. Now that
+    // peekableDispatcherInnerKinds covers every integer kind, the peek path
+    // reconstructs Int-domain (2/4-byte) and Long-domain (8-byte) inners
+    // order-aware, so the shape is Supported. (Was: firesOnDispatchOn-
+    // NonPeekableDiscriminator, which asserted COMPILATION_ERROR.)
     @Test
-    fun firesOnDispatchOnNonPeekableDiscriminator() {
+    fun acceptsDispatchOnMultiByteSignedAndULongDiscriminators() {
         val result =
             compile(
                 """
@@ -493,12 +498,57 @@ class EmitterDiagnosticsValidatorTest {
                     @PacketType(1)
                     data class A(val d: ShortDisc, val x: Int) : P
                 }
+
+                @JvmInline
+                @ProtocolMessage
+                value class IntDisc(val raw: Int) {
+                    @DispatchValue
+                    val v: Int get() = raw
+                }
+
+                @DispatchOn(IntDisc::class)
+                @ProtocolMessage
+                sealed interface Q {
+                    @ProtocolMessage
+                    @PacketType(1)
+                    data class A(val d: IntDisc, val x: Int) : Q
+                }
+
+                @JvmInline
+                @ProtocolMessage
+                value class LongDisc(val raw: Long) {
+                    @DispatchValue
+                    val v: Int get() = raw.toInt()
+                }
+
+                @DispatchOn(LongDisc::class)
+                @ProtocolMessage
+                sealed interface R {
+                    @ProtocolMessage
+                    @PacketType(1)
+                    data class A(val d: LongDisc, val x: Int) : R
+                }
+
+                @JvmInline
+                @ProtocolMessage
+                value class ULongDisc(val raw: ULong) {
+                    @DispatchValue
+                    val v: Int get() = raw.toInt()
+                }
+
+                @DispatchOn(ULongDisc::class)
+                @ProtocolMessage
+                sealed interface S {
+                    @ProtocolMessage
+                    @PacketType(1)
+                    data class A(val d: ULongDisc, val x: Int) : S
+                }
                 """.trimIndent(),
             )
-        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode, result.messages)
-        assertTrue(
-            result.messages.contains("is not a supported dispatch discriminator width"),
-            "expected @DispatchOn non-peekable-discriminator diagnostic. Messages:\n${result.messages}",
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        assertFalse(
+            result.messages.contains("not a supported dispatch discriminator"),
+            "multi-byte signed / ULong @DispatchOn discriminators must compile. Messages:\n${result.messages}",
         )
     }
 

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedOpcodeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedOpcodeCodec.kt
@@ -1,0 +1,34 @@
+package com.ditchoom.buffer.codec.test.protocols.multibytedisc
+
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import com.ditchoom.buffer.swapBytes
+import kotlin.Int
+
+public object SignedOpcodeCodec : Codec<SignedOpcode> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): SignedOpcode {
+    val rawRaw = buffer.readShort()
+    val raw = if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) rawRaw else swapBytes(rawRaw)
+    return SignedOpcode(raw = raw)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: SignedOpcode,
+    context: EncodeContext,
+  ) {
+    val rawRaw = value.raw
+    buffer.writeShort(if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) rawRaw else swapBytes(rawRaw))
+  }
+
+  override fun wireSize(`value`: SignedOpcode, context: EncodeContext): WireSize = WireSize.Exact(2)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedOpcodeFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedOpcodeFrameCodec.kt
@@ -1,0 +1,60 @@
+package com.ditchoom.buffer.codec.test.protocols.multibytedisc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object SignedOpcodeFrameCodec : Codec<SignedOpcodeFrame> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): SignedOpcodeFrame {
+    val discriminatorPosition = buffer.position()
+    val __discriminator = SignedOpcodeCodec.decode(buffer, context)
+    buffer.position(discriminatorPosition)
+    val __dispatchValue = __discriminator.code
+    return when (__dispatchValue) {
+      -2 -> SignedOpcodeFrameNegativeCodec.decode(buffer, context)
+      1 -> SignedOpcodeFramePositiveCodec.decode(buffer, context)
+      else -> {
+        throw DecodeException(fieldPath = "SignedOpcodeFrame.discriminator", bufferPosition = discriminatorPosition, expected = "one of {-2, 1}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: SignedOpcodeFrame,
+    context: EncodeContext,
+  ) {
+    when (value) {
+      is SignedOpcodeFrame.Negative -> SignedOpcodeFrameNegativeCodec.encode(buffer, value, context)
+      is SignedOpcodeFrame.Positive -> SignedOpcodeFramePositiveCodec.encode(buffer, value, context)
+    }
+  }
+
+  override fun wireSize(`value`: SignedOpcodeFrame, context: EncodeContext): WireSize = when (value) {
+    is SignedOpcodeFrame.Negative -> SignedOpcodeFrameNegativeCodec.wireSize(value, context)
+    is SignedOpcodeFrame.Positive -> SignedOpcodeFramePositiveCodec.wireSize(value, context)
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+    val __discRawB0 = stream.peekByte(baseOffset + 0).toInt() and 0xFF
+    val __discRawB1 = stream.peekByte(baseOffset + 0 + 1).toInt() and 0xFF
+    val __discRaw = ((__discRawB0 shl 8) or __discRawB1).toShort()
+    val __discriminator = SignedOpcode(__discRaw)
+    val __dispatchValue = __discriminator.code
+    return when (__dispatchValue) {
+      -2 -> SignedOpcodeFrameNegativeCodec.peekFrameSize(stream, baseOffset)
+      1 -> SignedOpcodeFramePositiveCodec.peekFrameSize(stream, baseOffset)
+      else -> {
+        throw DecodeException(fieldPath = "SignedOpcodeFrame.discriminator", bufferPosition = baseOffset, expected = "one of {-2, 1}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedOpcodeFrameNegativeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedOpcodeFrameNegativeCodec.kt
@@ -1,0 +1,36 @@
+package com.ditchoom.buffer.codec.test.protocols.multibytedisc
+
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import com.ditchoom.buffer.swapBytes
+import kotlin.Int
+
+public object SignedOpcodeFrameNegativeCodec : Codec<SignedOpcodeFrame.Negative> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): SignedOpcodeFrame.Negative {
+    val opcodeRaw = buffer.readShort()
+    val opcode = SignedOpcode(if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) opcodeRaw else swapBytes(opcodeRaw))
+    val payload = buffer.readInt()
+    return SignedOpcodeFrame.Negative(opcode = opcode, payload = payload)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: SignedOpcodeFrame.Negative,
+    context: EncodeContext,
+  ) {
+    val opcodeRaw = value.opcode.raw
+    buffer.writeShort(if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) opcodeRaw else swapBytes(opcodeRaw))
+    buffer.writeInt(value.payload)
+  }
+
+  override fun wireSize(`value`: SignedOpcodeFrame.Negative, context: EncodeContext): WireSize = WireSize.Exact(6)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 6) PeekResult.Complete(6) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedOpcodeFramePositiveCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedOpcodeFramePositiveCodec.kt
@@ -1,0 +1,36 @@
+package com.ditchoom.buffer.codec.test.protocols.multibytedisc
+
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import com.ditchoom.buffer.swapBytes
+import kotlin.Int
+
+public object SignedOpcodeFramePositiveCodec : Codec<SignedOpcodeFrame.Positive> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): SignedOpcodeFrame.Positive {
+    val opcodeRaw = buffer.readShort()
+    val opcode = SignedOpcode(if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) opcodeRaw else swapBytes(opcodeRaw))
+    val payload = buffer.readInt()
+    return SignedOpcodeFrame.Positive(opcode = opcode, payload = payload)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: SignedOpcodeFrame.Positive,
+    context: EncodeContext,
+  ) {
+    val opcodeRaw = value.opcode.raw
+    buffer.writeShort(if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) opcodeRaw else swapBytes(opcodeRaw))
+    buffer.writeInt(value.payload)
+  }
+
+  override fun wireSize(`value`: SignedOpcodeFrame.Positive, context: EncodeContext): WireSize = WireSize.Exact(6)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 6) PeekResult.Complete(6) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedSelectorCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedSelectorCodec.kt
@@ -1,0 +1,34 @@
+package com.ditchoom.buffer.codec.test.protocols.multibytedisc
+
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import com.ditchoom.buffer.swapBytes
+import kotlin.Int
+
+public object SignedSelectorCodec : Codec<SignedSelector> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): SignedSelector {
+    val rawRaw = buffer.readLong()
+    val raw = if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) rawRaw else swapBytes(rawRaw)
+    return SignedSelector(raw = raw)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: SignedSelector,
+    context: EncodeContext,
+  ) {
+    val rawRaw = value.raw
+    buffer.writeLong(if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) rawRaw else swapBytes(rawRaw))
+  }
+
+  override fun wireSize(`value`: SignedSelector, context: EncodeContext): WireSize = WireSize.Exact(8)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 8) PeekResult.Complete(8) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedSelectorFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedSelectorFrameCodec.kt
@@ -1,0 +1,66 @@
+package com.ditchoom.buffer.codec.test.protocols.multibytedisc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object SignedSelectorFrameCodec : Codec<SignedSelectorFrame> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): SignedSelectorFrame {
+    val discriminatorPosition = buffer.position()
+    val __discriminator = SignedSelectorCodec.decode(buffer, context)
+    buffer.position(discriminatorPosition)
+    val __dispatchValue = __discriminator.kind
+    return when (__dispatchValue) {
+      2 -> SignedSelectorFrameTwoCodec.decode(buffer, context)
+      9 -> SignedSelectorFrameNineCodec.decode(buffer, context)
+      else -> {
+        throw DecodeException(fieldPath = "SignedSelectorFrame.discriminator", bufferPosition = discriminatorPosition, expected = "one of {2, 9}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: SignedSelectorFrame,
+    context: EncodeContext,
+  ) {
+    when (value) {
+      is SignedSelectorFrame.Two -> SignedSelectorFrameTwoCodec.encode(buffer, value, context)
+      is SignedSelectorFrame.Nine -> SignedSelectorFrameNineCodec.encode(buffer, value, context)
+    }
+  }
+
+  override fun wireSize(`value`: SignedSelectorFrame, context: EncodeContext): WireSize = when (value) {
+    is SignedSelectorFrame.Two -> SignedSelectorFrameTwoCodec.wireSize(value, context)
+    is SignedSelectorFrame.Nine -> SignedSelectorFrameNineCodec.wireSize(value, context)
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    if (stream.available() - baseOffset < 8) return PeekResult.NeedsMoreData
+    val __discRawB0 = stream.peekByte(baseOffset + 0).toLong() and 0xFFL
+    val __discRawB1 = stream.peekByte(baseOffset + 0 + 1).toLong() and 0xFFL
+    val __discRawB2 = stream.peekByte(baseOffset + 0 + 2).toLong() and 0xFFL
+    val __discRawB3 = stream.peekByte(baseOffset + 0 + 3).toLong() and 0xFFL
+    val __discRawB4 = stream.peekByte(baseOffset + 0 + 4).toLong() and 0xFFL
+    val __discRawB5 = stream.peekByte(baseOffset + 0 + 5).toLong() and 0xFFL
+    val __discRawB6 = stream.peekByte(baseOffset + 0 + 6).toLong() and 0xFFL
+    val __discRawB7 = stream.peekByte(baseOffset + 0 + 7).toLong() and 0xFFL
+    val __discRaw = ((__discRawB0 shl 56) or (__discRawB1 shl 48) or (__discRawB2 shl 40) or (__discRawB3 shl 32) or (__discRawB4 shl 24) or (__discRawB5 shl 16) or (__discRawB6 shl 8) or __discRawB7)
+    val __discriminator = SignedSelector(__discRaw)
+    val __dispatchValue = __discriminator.kind
+    return when (__dispatchValue) {
+      2 -> SignedSelectorFrameTwoCodec.peekFrameSize(stream, baseOffset)
+      9 -> SignedSelectorFrameNineCodec.peekFrameSize(stream, baseOffset)
+      else -> {
+        throw DecodeException(fieldPath = "SignedSelectorFrame.discriminator", bufferPosition = baseOffset, expected = "one of {2, 9}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedSelectorFrameNineCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedSelectorFrameNineCodec.kt
@@ -1,0 +1,36 @@
+package com.ditchoom.buffer.codec.test.protocols.multibytedisc
+
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import com.ditchoom.buffer.swapBytes
+import kotlin.Int
+
+public object SignedSelectorFrameNineCodec : Codec<SignedSelectorFrame.Nine> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): SignedSelectorFrame.Nine {
+    val selectorRaw = buffer.readLong()
+    val selector = SignedSelector(if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) selectorRaw else swapBytes(selectorRaw))
+    val payload = buffer.readInt()
+    return SignedSelectorFrame.Nine(selector = selector, payload = payload)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: SignedSelectorFrame.Nine,
+    context: EncodeContext,
+  ) {
+    val selectorRaw = value.selector.raw
+    buffer.writeLong(if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) selectorRaw else swapBytes(selectorRaw))
+    buffer.writeInt(value.payload)
+  }
+
+  override fun wireSize(`value`: SignedSelectorFrame.Nine, context: EncodeContext): WireSize = WireSize.Exact(12)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 12) PeekResult.Complete(12) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedSelectorFrameTwoCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedSelectorFrameTwoCodec.kt
@@ -1,0 +1,36 @@
+package com.ditchoom.buffer.codec.test.protocols.multibytedisc
+
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import com.ditchoom.buffer.swapBytes
+import kotlin.Int
+
+public object SignedSelectorFrameTwoCodec : Codec<SignedSelectorFrame.Two> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): SignedSelectorFrame.Two {
+    val selectorRaw = buffer.readLong()
+    val selector = SignedSelector(if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) selectorRaw else swapBytes(selectorRaw))
+    val payload = buffer.readInt()
+    return SignedSelectorFrame.Two(selector = selector, payload = payload)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: SignedSelectorFrame.Two,
+    context: EncodeContext,
+  ) {
+    val selectorRaw = value.selector.raw
+    buffer.writeLong(if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) selectorRaw else swapBytes(selectorRaw))
+    buffer.writeInt(value.payload)
+  }
+
+  override fun wireSize(`value`: SignedSelectorFrame.Two, context: EncodeContext): WireSize = WireSize.Exact(12)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 12) PeekResult.Complete(12) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedTagCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedTagCodec.kt
@@ -1,0 +1,34 @@
+package com.ditchoom.buffer.codec.test.protocols.multibytedisc
+
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import com.ditchoom.buffer.swapBytes
+import kotlin.Int
+
+public object SignedTagCodec : Codec<SignedTag> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): SignedTag {
+    val rawRaw = buffer.readInt()
+    val raw = if (buffer.byteOrder == ByteOrder.LITTLE_ENDIAN) rawRaw else swapBytes(rawRaw)
+    return SignedTag(raw = raw)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: SignedTag,
+    context: EncodeContext,
+  ) {
+    val rawRaw = value.raw
+    buffer.writeInt(if (buffer.byteOrder == ByteOrder.LITTLE_ENDIAN) rawRaw else swapBytes(rawRaw))
+  }
+
+  override fun wireSize(`value`: SignedTag, context: EncodeContext): WireSize = WireSize.Exact(4)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 4) PeekResult.Complete(4) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedTagFrameAlphaCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedTagFrameAlphaCodec.kt
@@ -1,0 +1,36 @@
+package com.ditchoom.buffer.codec.test.protocols.multibytedisc
+
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import com.ditchoom.buffer.swapBytes
+import kotlin.Int
+
+public object SignedTagFrameAlphaCodec : Codec<SignedTagFrame.Alpha> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): SignedTagFrame.Alpha {
+    val tagRaw = buffer.readInt()
+    val tag = SignedTag(if (buffer.byteOrder == ByteOrder.LITTLE_ENDIAN) tagRaw else swapBytes(tagRaw))
+    val value = buffer.readShort()
+    return SignedTagFrame.Alpha(tag = tag, value = value)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: SignedTagFrame.Alpha,
+    context: EncodeContext,
+  ) {
+    val tagRaw = value.tag.raw
+    buffer.writeInt(if (buffer.byteOrder == ByteOrder.LITTLE_ENDIAN) tagRaw else swapBytes(tagRaw))
+    buffer.writeShort(value.value)
+  }
+
+  override fun wireSize(`value`: SignedTagFrame.Alpha, context: EncodeContext): WireSize = WireSize.Exact(6)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 6) PeekResult.Complete(6) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedTagFrameBetaCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedTagFrameBetaCodec.kt
@@ -1,0 +1,36 @@
+package com.ditchoom.buffer.codec.test.protocols.multibytedisc
+
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import com.ditchoom.buffer.swapBytes
+import kotlin.Int
+
+public object SignedTagFrameBetaCodec : Codec<SignedTagFrame.Beta> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): SignedTagFrame.Beta {
+    val tagRaw = buffer.readInt()
+    val tag = SignedTag(if (buffer.byteOrder == ByteOrder.LITTLE_ENDIAN) tagRaw else swapBytes(tagRaw))
+    val value = buffer.readShort()
+    return SignedTagFrame.Beta(tag = tag, value = value)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: SignedTagFrame.Beta,
+    context: EncodeContext,
+  ) {
+    val tagRaw = value.tag.raw
+    buffer.writeInt(if (buffer.byteOrder == ByteOrder.LITTLE_ENDIAN) tagRaw else swapBytes(tagRaw))
+    buffer.writeShort(value.value)
+  }
+
+  override fun wireSize(`value`: SignedTagFrame.Beta, context: EncodeContext): WireSize = WireSize.Exact(6)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 6) PeekResult.Complete(6) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedTagFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedTagFrameCodec.kt
@@ -1,0 +1,62 @@
+package com.ditchoom.buffer.codec.test.protocols.multibytedisc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object SignedTagFrameCodec : Codec<SignedTagFrame> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): SignedTagFrame {
+    val discriminatorPosition = buffer.position()
+    val __discriminator = SignedTagCodec.decode(buffer, context)
+    buffer.position(discriminatorPosition)
+    val __dispatchValue = __discriminator.tag
+    return when (__dispatchValue) {
+      -1 -> SignedTagFrameAlphaCodec.decode(buffer, context)
+      7 -> SignedTagFrameBetaCodec.decode(buffer, context)
+      else -> {
+        throw DecodeException(fieldPath = "SignedTagFrame.discriminator", bufferPosition = discriminatorPosition, expected = "one of {-1, 7}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: SignedTagFrame,
+    context: EncodeContext,
+  ) {
+    when (value) {
+      is SignedTagFrame.Alpha -> SignedTagFrameAlphaCodec.encode(buffer, value, context)
+      is SignedTagFrame.Beta -> SignedTagFrameBetaCodec.encode(buffer, value, context)
+    }
+  }
+
+  override fun wireSize(`value`: SignedTagFrame, context: EncodeContext): WireSize = when (value) {
+    is SignedTagFrame.Alpha -> SignedTagFrameAlphaCodec.wireSize(value, context)
+    is SignedTagFrame.Beta -> SignedTagFrameBetaCodec.wireSize(value, context)
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    if (stream.available() - baseOffset < 4) return PeekResult.NeedsMoreData
+    val __discRawB0 = stream.peekByte(baseOffset + 0).toInt() and 0xFF
+    val __discRawB1 = stream.peekByte(baseOffset + 0 + 1).toInt() and 0xFF
+    val __discRawB2 = stream.peekByte(baseOffset + 0 + 2).toInt() and 0xFF
+    val __discRawB3 = stream.peekByte(baseOffset + 0 + 3).toInt() and 0xFF
+    val __discRaw = (__discRawB0 or (__discRawB1 shl 8) or (__discRawB2 shl 16) or (__discRawB3 shl 24))
+    val __discriminator = SignedTag(__discRaw)
+    val __dispatchValue = __discriminator.tag
+    return when (__dispatchValue) {
+      -1 -> SignedTagFrameAlphaCodec.peekFrameSize(stream, baseOffset)
+      7 -> SignedTagFrameBetaCodec.peekFrameSize(stream, baseOffset)
+      else -> {
+        throw DecodeException(fieldPath = "SignedTagFrame.discriminator", bufferPosition = baseOffset, expected = "one of {-1, 7}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/UnsignedMagicCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/UnsignedMagicCodec.kt
@@ -1,0 +1,34 @@
+package com.ditchoom.buffer.codec.test.protocols.multibytedisc
+
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import com.ditchoom.buffer.swapBytes
+import kotlin.Int
+
+public object UnsignedMagicCodec : Codec<UnsignedMagic> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): UnsignedMagic {
+    val rawRaw = buffer.readLong()
+    val raw = (if (buffer.byteOrder == ByteOrder.LITTLE_ENDIAN) rawRaw else swapBytes(rawRaw)).toULong()
+    return UnsignedMagic(raw = raw)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: UnsignedMagic,
+    context: EncodeContext,
+  ) {
+    val rawRaw = value.raw.toLong()
+    buffer.writeLong(if (buffer.byteOrder == ByteOrder.LITTLE_ENDIAN) rawRaw else swapBytes(rawRaw))
+  }
+
+  override fun wireSize(`value`: UnsignedMagic, context: EncodeContext): WireSize = WireSize.Exact(8)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 8) PeekResult.Complete(8) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/UnsignedMagicFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/UnsignedMagicFrameCodec.kt
@@ -1,0 +1,66 @@
+package com.ditchoom.buffer.codec.test.protocols.multibytedisc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object UnsignedMagicFrameCodec : Codec<UnsignedMagicFrame> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): UnsignedMagicFrame {
+    val discriminatorPosition = buffer.position()
+    val __discriminator = UnsignedMagicCodec.decode(buffer, context)
+    buffer.position(discriminatorPosition)
+    val __dispatchValue = __discriminator.tag
+    return when (__dispatchValue) {
+      17 -> UnsignedMagicFrameFirstCodec.decode(buffer, context)
+      34 -> UnsignedMagicFrameSecondCodec.decode(buffer, context)
+      else -> {
+        throw DecodeException(fieldPath = "UnsignedMagicFrame.discriminator", bufferPosition = discriminatorPosition, expected = "one of {17, 34}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: UnsignedMagicFrame,
+    context: EncodeContext,
+  ) {
+    when (value) {
+      is UnsignedMagicFrame.First -> UnsignedMagicFrameFirstCodec.encode(buffer, value, context)
+      is UnsignedMagicFrame.Second -> UnsignedMagicFrameSecondCodec.encode(buffer, value, context)
+    }
+  }
+
+  override fun wireSize(`value`: UnsignedMagicFrame, context: EncodeContext): WireSize = when (value) {
+    is UnsignedMagicFrame.First -> UnsignedMagicFrameFirstCodec.wireSize(value, context)
+    is UnsignedMagicFrame.Second -> UnsignedMagicFrameSecondCodec.wireSize(value, context)
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    if (stream.available() - baseOffset < 8) return PeekResult.NeedsMoreData
+    val __discRawB0 = stream.peekByte(baseOffset + 0).toLong() and 0xFFL
+    val __discRawB1 = stream.peekByte(baseOffset + 0 + 1).toLong() and 0xFFL
+    val __discRawB2 = stream.peekByte(baseOffset + 0 + 2).toLong() and 0xFFL
+    val __discRawB3 = stream.peekByte(baseOffset + 0 + 3).toLong() and 0xFFL
+    val __discRawB4 = stream.peekByte(baseOffset + 0 + 4).toLong() and 0xFFL
+    val __discRawB5 = stream.peekByte(baseOffset + 0 + 5).toLong() and 0xFFL
+    val __discRawB6 = stream.peekByte(baseOffset + 0 + 6).toLong() and 0xFFL
+    val __discRawB7 = stream.peekByte(baseOffset + 0 + 7).toLong() and 0xFFL
+    val __discRaw = (__discRawB0 or (__discRawB1 shl 8) or (__discRawB2 shl 16) or (__discRawB3 shl 24) or (__discRawB4 shl 32) or (__discRawB5 shl 40) or (__discRawB6 shl 48) or (__discRawB7 shl 56)).toULong()
+    val __discriminator = UnsignedMagic(__discRaw)
+    val __dispatchValue = __discriminator.tag
+    return when (__dispatchValue) {
+      17 -> UnsignedMagicFrameFirstCodec.peekFrameSize(stream, baseOffset)
+      34 -> UnsignedMagicFrameSecondCodec.peekFrameSize(stream, baseOffset)
+      else -> {
+        throw DecodeException(fieldPath = "UnsignedMagicFrame.discriminator", bufferPosition = baseOffset, expected = "one of {17, 34}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/UnsignedMagicFrameFirstCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/UnsignedMagicFrameFirstCodec.kt
@@ -1,0 +1,36 @@
+package com.ditchoom.buffer.codec.test.protocols.multibytedisc
+
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import com.ditchoom.buffer.swapBytes
+import kotlin.Int
+
+public object UnsignedMagicFrameFirstCodec : Codec<UnsignedMagicFrame.First> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): UnsignedMagicFrame.First {
+    val magicRaw = buffer.readLong()
+    val magic = UnsignedMagic((if (buffer.byteOrder == ByteOrder.LITTLE_ENDIAN) magicRaw else swapBytes(magicRaw)).toULong())
+    val payload = buffer.readInt()
+    return UnsignedMagicFrame.First(magic = magic, payload = payload)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: UnsignedMagicFrame.First,
+    context: EncodeContext,
+  ) {
+    val magicRaw = value.magic.raw.toLong()
+    buffer.writeLong(if (buffer.byteOrder == ByteOrder.LITTLE_ENDIAN) magicRaw else swapBytes(magicRaw))
+    buffer.writeInt(value.payload)
+  }
+
+  override fun wireSize(`value`: UnsignedMagicFrame.First, context: EncodeContext): WireSize = WireSize.Exact(12)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 12) PeekResult.Complete(12) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/UnsignedMagicFrameSecondCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/UnsignedMagicFrameSecondCodec.kt
@@ -1,0 +1,36 @@
+package com.ditchoom.buffer.codec.test.protocols.multibytedisc
+
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import com.ditchoom.buffer.swapBytes
+import kotlin.Int
+
+public object UnsignedMagicFrameSecondCodec : Codec<UnsignedMagicFrame.Second> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): UnsignedMagicFrame.Second {
+    val magicRaw = buffer.readLong()
+    val magic = UnsignedMagic((if (buffer.byteOrder == ByteOrder.LITTLE_ENDIAN) magicRaw else swapBytes(magicRaw)).toULong())
+    val payload = buffer.readInt()
+    return UnsignedMagicFrame.Second(magic = magic, payload = payload)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: UnsignedMagicFrame.Second,
+    context: EncodeContext,
+  ) {
+    val magicRaw = value.magic.raw.toLong()
+    buffer.writeLong(if (buffer.byteOrder == ByteOrder.LITTLE_ENDIAN) magicRaw else swapBytes(magicRaw))
+    buffer.writeInt(value.payload)
+  }
+
+  override fun wireSize(`value`: UnsignedMagicFrame.Second, context: EncodeContext): WireSize = WireSize.Exact(12)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 12) PeekResult.Complete(12) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/multibytedisc/MultiByteDispatchFrames.kt
+++ b/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/multibytedisc/MultiByteDispatchFrames.kt
@@ -1,0 +1,157 @@
+package com.ditchoom.buffer.codec.test.protocols.multibytedisc
+
+import com.ditchoom.buffer.codec.annotations.DispatchOn
+import com.ditchoom.buffer.codec.annotations.DispatchValue
+import com.ditchoom.buffer.codec.annotations.Endianness
+import com.ditchoom.buffer.codec.annotations.PacketType
+import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+import kotlin.jvm.JvmInline
+
+/*
+ * Multi-byte `@DispatchOn` discriminator vectors covering the four inner
+ * scalar kinds whose `peekFrameSize` byte-reconstruction was the last
+ * missing piece: signed `Short` / `Int` / `Long` and unsigned `ULong`.
+ *
+ * Decode and encode already worked for these inners (the discriminator's
+ * own value-class codec reads/writes the scalar, and the variant re-reads
+ * it as its first field). The only gap was the dispatcher's `peekFrameSize`,
+ * which reconstructs the discriminator value class from raw peeked bytes
+ * without consuming the stream — it previously supported only 1/2/4-byte
+ * unsigned kinds and rejected everything here via the stage-9
+ * "non-peekable @DispatchOn discriminator" diagnostic.
+ *
+ * Each frame deliberately picks a byte order (mixing big- and little-endian
+ * across the widths) so the order-aware reconstruction is exercised in both
+ * directions, and each uses a discriminator value that stresses the kind:
+ * negative values for the signed inners (proving sign-preserving narrowing),
+ * an 8-byte value for the 64-bit inners (proving `Long`-domain assembly).
+ */
+
+/** Signed 16-bit opcode, big-endian (2-byte discriminator). */
+@JvmInline
+@ProtocolMessage(wireOrder = Endianness.Big)
+value class SignedOpcode(
+    val raw: Short,
+) {
+    @DispatchValue
+    val code: Int get() = raw.toInt()
+}
+
+/**
+ * `Short` inner. `Negative` uses opcode `-2` (wire `0xFFFE`), exercising
+ * sign extension through `.toShort()` on the peek-reconstructed bytes.
+ */
+@DispatchOn(SignedOpcode::class)
+@ProtocolMessage(wireOrder = Endianness.Big)
+sealed interface SignedOpcodeFrame {
+    @ProtocolMessage
+    @PacketType(-2)
+    data class Negative(
+        val opcode: SignedOpcode = SignedOpcode((-2).toShort()),
+        val payload: Int,
+    ) : SignedOpcodeFrame
+
+    @ProtocolMessage
+    @PacketType(1)
+    data class Positive(
+        val opcode: SignedOpcode = SignedOpcode(1),
+        val payload: Int,
+    ) : SignedOpcodeFrame
+}
+
+/** Signed 32-bit tag, little-endian (4-byte discriminator). */
+@JvmInline
+@ProtocolMessage(wireOrder = Endianness.Little)
+value class SignedTag(
+    val raw: Int,
+) {
+    @DispatchValue
+    val tag: Int get() = raw
+}
+
+/**
+ * `Int` inner with little-endian assembly. `Alpha` uses tag `-1`
+ * (wire `FF FF FF FF`), proving the LE shift path narrows to `Int`.
+ */
+@DispatchOn(SignedTag::class)
+@ProtocolMessage(wireOrder = Endianness.Little)
+sealed interface SignedTagFrame {
+    @ProtocolMessage
+    @PacketType(-1)
+    data class Alpha(
+        val tag: SignedTag = SignedTag(-1),
+        val value: Short,
+    ) : SignedTagFrame
+
+    @ProtocolMessage
+    @PacketType(7)
+    data class Beta(
+        val tag: SignedTag = SignedTag(7),
+        val value: Short,
+    ) : SignedTagFrame
+}
+
+/** Signed 64-bit selector, big-endian (8-byte discriminator). */
+@JvmInline
+@ProtocolMessage(wireOrder = Endianness.Big)
+value class SignedSelector(
+    val raw: Long,
+) {
+    @DispatchValue
+    val kind: Int get() = raw.toInt()
+}
+
+/**
+ * `Long` inner. The 8-byte big-endian assembly overflows `Int`, so peek
+ * lifts each byte to `Long` before shifting (up to 56 bits).
+ */
+@DispatchOn(SignedSelector::class)
+@ProtocolMessage(wireOrder = Endianness.Big)
+sealed interface SignedSelectorFrame {
+    @ProtocolMessage
+    @PacketType(2)
+    data class Two(
+        val selector: SignedSelector = SignedSelector(2L),
+        val payload: Int,
+    ) : SignedSelectorFrame
+
+    @ProtocolMessage
+    @PacketType(9)
+    data class Nine(
+        val selector: SignedSelector = SignedSelector(9L),
+        val payload: Int,
+    ) : SignedSelectorFrame
+}
+
+/** Unsigned 64-bit magic, little-endian (8-byte discriminator). */
+@JvmInline
+@ProtocolMessage(wireOrder = Endianness.Little)
+value class UnsignedMagic(
+    val raw: ULong,
+) {
+    @DispatchValue
+    val tag: Int get() = (raw and 0xFFuL).toInt()
+}
+
+/**
+ * `ULong` inner with little-endian assembly. Proves the `Long`-domain
+ * path narrows to `ULong` via `.toULong()` and that the low-byte
+ * `@DispatchValue` coercion routes correctly.
+ */
+@DispatchOn(UnsignedMagic::class)
+@ProtocolMessage(wireOrder = Endianness.Little)
+sealed interface UnsignedMagicFrame {
+    @ProtocolMessage
+    @PacketType(0x11)
+    data class First(
+        val magic: UnsignedMagic = UnsignedMagic(0x11uL),
+        val payload: Int,
+    ) : UnsignedMagicFrame
+
+    @ProtocolMessage
+    @PacketType(0x22)
+    data class Second(
+        val magic: UnsignedMagic = UnsignedMagic(0x22uL),
+        val payload: Int,
+    ) : UnsignedMagicFrame
+}

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/multibytedisc/MultiByteDispatchCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/multibytedisc/MultiByteDispatchCodecTest.kt
@@ -1,0 +1,231 @@
+package com.ditchoom.buffer.codec.test.protocols.multibytedisc
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+
+/**
+ * Cross-platform round-trip + `peekFrameSize` coverage for multi-byte
+ * `@DispatchOn` discriminators across all four newly-supported inner kinds:
+ * signed `Short` / `Int` / `Long` and unsigned `ULong`.
+ *
+ * The discriminator's decode/encode always worked; what these vectors pin
+ * is the dispatcher's order-aware `peekFrameSize` reconstruction — which
+ * was previously rejected for every kind here. Each test exercises:
+ *
+ *   1. encode → decode round-trip through the dispatcher;
+ *   2. the physical discriminator bytes (proving the declared `wireOrder`);
+ *   3. `peekFrameSize` returning `Complete(totalBytes)` once the frame is
+ *      fully buffered, and `NeedsMoreData` before the discriminator's own
+ *      bytes have arrived (the reconstruction never reads past the stream);
+ *   4. `wireSize` pure-delegation (the variant counts its re-read
+ *      discriminator; the dispatcher does not add a `1 +`);
+ *   5. the unmatched-discriminator failure mode.
+ */
+class MultiByteDispatchCodecTest {
+    // — Short inner, big-endian (2-byte discriminator) —
+
+    @Test
+    fun shortDiscriminatorNegativeRoundTrips() {
+        val original = SignedOpcodeFrame.Negative(payload = 0x0A0B0C0D)
+        val buf = encode { SignedOpcodeFrameCodec.encode(it, original, EncodeContext.Empty) }
+        val decoded = SignedOpcodeFrameCodec.decode(buf, DecodeContext.Empty)
+        assertIs<SignedOpcodeFrame.Negative>(decoded)
+        assertEquals(original, decoded)
+        assertEquals((-2).toShort(), decoded.opcode.raw)
+        // BE -2 → 0xFF 0xFE (decode consumed the whole frame, flip restores it).
+        buf.resetForRead()
+        assertEquals(0xFF, buf.readUByte().toInt(), "opcode hi byte")
+        assertEquals(0xFE, buf.readUByte().toInt(), "opcode lo byte (BE)")
+    }
+
+    @Test
+    fun shortDiscriminatorPositiveRoundTrips() {
+        val original = SignedOpcodeFrame.Positive(payload = 7)
+        val buf = encode { SignedOpcodeFrameCodec.encode(it, original, EncodeContext.Empty) }
+        assertEquals(original, SignedOpcodeFrameCodec.decode(buf, DecodeContext.Empty))
+    }
+
+    @Test
+    fun shortDiscriminatorWireSizeDelegates() {
+        // 2 (discriminator) + 4 (payload Int) = 6; dispatcher does NOT add the
+        // discriminator a second time (ReReadByVariant ownership).
+        assertEquals(
+            WireSize.Exact(6),
+            SignedOpcodeFrameCodec.wireSize(SignedOpcodeFrame.Positive(payload = 0), EncodeContext.Empty),
+        )
+    }
+
+    @Test
+    fun shortDiscriminatorPeekFrameSize() =
+        peekDripFeed({ SignedOpcodeFrameCodec.peekFrameSize(it) }) {
+            SignedOpcodeFrameCodec.encode(it, SignedOpcodeFrame.Negative(payload = 1), EncodeContext.Empty)
+        }
+
+    // — Int inner, little-endian (4-byte discriminator) —
+
+    @Test
+    fun intDiscriminatorBetaRoundTripsLittleEndian() {
+        val original = SignedTagFrame.Beta(value = 0x1234)
+        val buf = encode { SignedTagFrameCodec.encode(it, original, EncodeContext.Empty) }
+        assertEquals(original, SignedTagFrameCodec.decode(buf, DecodeContext.Empty))
+        // LE 7 → 0x07 0x00 0x00 0x00.
+        buf.resetForRead()
+        assertEquals(0x07, buf.readUByte().toInt(), "tag byte 0 (LE low)")
+        assertEquals(0x00, buf.readUByte().toInt(), "tag byte 1")
+        assertEquals(0x00, buf.readUByte().toInt(), "tag byte 2")
+        assertEquals(0x00, buf.readUByte().toInt(), "tag byte 3 (LE high)")
+    }
+
+    @Test
+    fun intDiscriminatorAlphaRoundTripsNegative() {
+        val original = SignedTagFrame.Alpha(value = -3)
+        val buf = encode { SignedTagFrameCodec.encode(it, original, EncodeContext.Empty) }
+        val decoded = SignedTagFrameCodec.decode(buf, DecodeContext.Empty)
+        assertIs<SignedTagFrame.Alpha>(decoded)
+        assertEquals(-1, decoded.tag.raw)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun intDiscriminatorPeekFrameSize() =
+        peekDripFeed({ SignedTagFrameCodec.peekFrameSize(it) }) {
+            SignedTagFrameCodec.encode(it, SignedTagFrame.Alpha(value = 9), EncodeContext.Empty)
+        }
+
+    // — Long inner, big-endian (8-byte discriminator) —
+
+    @Test
+    fun longDiscriminatorRoundTripsBigEndian() {
+        val original = SignedSelectorFrame.Nine(payload = 0x7F00FF01)
+        val buf = encode { SignedSelectorFrameCodec.encode(it, original, EncodeContext.Empty) }
+        val decoded = SignedSelectorFrameCodec.decode(buf, DecodeContext.Empty)
+        assertIs<SignedSelectorFrame.Nine>(decoded)
+        assertEquals(9L, decoded.selector.raw)
+        assertEquals(original, decoded)
+        // BE 9 → seven 0x00 then 0x09.
+        buf.resetForRead()
+        repeat(7) { i -> assertEquals(0x00, buf.readUByte().toInt(), "selector byte $i") }
+        assertEquals(0x09, buf.readUByte().toInt(), "selector byte 7 (BE low)")
+    }
+
+    @Test
+    fun longDiscriminatorWireSizeDelegates() {
+        // 8 (discriminator Long) + 4 (payload Int) = 12, no dispatcher `1 +`.
+        assertEquals(
+            WireSize.Exact(12),
+            SignedSelectorFrameCodec.wireSize(SignedSelectorFrame.Two(payload = 0), EncodeContext.Empty),
+        )
+    }
+
+    @Test
+    fun longDiscriminatorPeekFrameSize() =
+        peekDripFeed({ SignedSelectorFrameCodec.peekFrameSize(it) }) {
+            SignedSelectorFrameCodec.encode(it, SignedSelectorFrame.Two(payload = 1), EncodeContext.Empty)
+        }
+
+    // — ULong inner, little-endian (8-byte discriminator) —
+
+    @Test
+    fun uLongDiscriminatorRoundTripsLittleEndian() {
+        val original = UnsignedMagicFrame.First(payload = 0x0BADF00D)
+        val buf = encode { UnsignedMagicFrameCodec.encode(it, original, EncodeContext.Empty) }
+        val decoded = UnsignedMagicFrameCodec.decode(buf, DecodeContext.Empty)
+        assertIs<UnsignedMagicFrame.First>(decoded)
+        assertEquals(0x11uL, decoded.magic.raw)
+        assertEquals(original, decoded)
+        // LE 0x11 → 0x11 then seven 0x00.
+        buf.resetForRead()
+        assertEquals(0x11, buf.readUByte().toInt(), "magic byte 0 (LE low)")
+        repeat(7) { i -> assertEquals(0x00, buf.readUByte().toInt(), "magic byte ${i + 1}") }
+    }
+
+    @Test
+    fun uLongDiscriminatorSecondRoundTrips() {
+        val original = UnsignedMagicFrame.Second(payload = -1)
+        val buf = encode { UnsignedMagicFrameCodec.encode(it, original, EncodeContext.Empty) }
+        assertEquals(original, UnsignedMagicFrameCodec.decode(buf, DecodeContext.Empty))
+    }
+
+    @Test
+    fun uLongDiscriminatorPeekFrameSize() =
+        peekDripFeed({ UnsignedMagicFrameCodec.peekFrameSize(it) }) {
+            UnsignedMagicFrameCodec.encode(it, UnsignedMagicFrame.Second(payload = 5), EncodeContext.Empty)
+        }
+
+    @Test
+    fun unmatchedDiscriminatorThrows() {
+        // 0x00000000_00000099 — low byte 0x99 is not a named variant; the
+        // dispatcher else-branch fires after reconstructing the ULong.
+        val buf = BufferFactory.Default.allocate(12)
+        repeat(7) { buf.writeByte(0x00) }
+        buf.writeByte(0x99.toByte())
+        buf.writeInt(0)
+        buf.resetForRead()
+        val ex =
+            assertFailsWith<DecodeException> {
+                UnsignedMagicFrameCodec.decode(buf, DecodeContext.Empty)
+            }
+        assertEquals("UnsignedMagicFrame.discriminator", ex.fieldPath)
+    }
+
+    // — helpers —
+
+    private fun encode(block: (PlatformBuffer) -> Unit): PlatformBuffer {
+        val buf = BufferFactory.Default.allocate(64)
+        block(buf)
+        buf.resetForRead()
+        return buf
+    }
+
+    /**
+     * Drip-feeds an encoded frame one byte at a time, asserting
+     * `NeedsMoreData` for every prefix shorter than the whole frame and
+     * `Complete(total)` once the last byte arrives. Proves the order-aware
+     * discriminator reconstruction never reads past the available stream.
+     */
+    private fun peekDripFeed(
+        peek: (StreamProcessor) -> PeekResult,
+        encodeBlock: (PlatformBuffer) -> Unit,
+    ) {
+        val pool = BufferPool()
+        val source = BufferFactory.Default.allocate(64)
+        encodeBlock(source)
+        source.resetForRead()
+        val total = source.remaining()
+        val stream = StreamProcessor.create(pool, ByteOrder.BIG_ENDIAN)
+        try {
+            for (i in 0 until total - 1) {
+                val one = BufferFactory.Default.allocate(1)
+                one.writeByte(source.readByte())
+                one.resetForRead()
+                stream.append(one)
+                assertEquals(
+                    PeekResult.NeedsMoreData,
+                    peek(stream),
+                    "after ${i + 1}/$total bytes",
+                )
+            }
+            val last = BufferFactory.Default.allocate(1)
+            last.writeByte(source.readByte())
+            last.resetForRead()
+            stream.append(last)
+            assertEquals(PeekResult.Complete(total), peek(stream), "fully buffered")
+        } finally {
+            stream.release()
+            pool.clear()
+        }
+    }
+}


### PR DESCRIPTION
## What

Supports **signed `Short` / `Int` / `Long` and unsigned `ULong`** as `@DispatchOn`
discriminator inner kinds, alongside the existing single-byte (`UByte` / `Byte`)
and 2/4-byte unsigned (`UShort` / `UInt`) kinds.

Tier-1 follow-up #1/#2 from `buffer-codec-processor/DISPATCH_UNIFICATION_PLAN.md`,
unlocked by the dispatch-path unification (#177) and the generics-under-simple-
`@PacketType` win (#178).

## Why it was a clean, small change

Decode and encode already worked for these inners (the discriminator's own
value-class codec reads/writes the scalar; the variant re-reads it as its first
field). The only gap was the dispatcher's `peekFrameSize` byte-reconstruction,
which previously **rejected** these via the stage-9 "non-peekable `@DispatchOn`
discriminator" diagnostic. This PR flips that seam:

- `peekableDispatcherInnerKinds` widens from `{UByte, Byte, UShort, UInt}` to all
  eight integer kinds.
- `appendPeekFixedScalar` gains **Int-domain** assembly for 2/4-byte inners
  (`Short`/`Int`: `.toInt() and 0xFF` shifts, sign-preserving narrow) and a new
  **Long-domain** branch for 8-byte inners (`Long`/`ULong`: `.toLong() and 0xFFL`
  shifts). Both honor the discriminator value class's
  `@ProtocolMessage(wireOrder = …)`, matching the discriminator codec's
  decode/encode wire layout on both endiannesses.

The stage-9 diagnostic becomes a defensive guard for the non-integer
(`Float`/`Double`) inners the validator already rejects.

## Tests

- New fixture `multibytedisc/MultiByteDispatchFrames` — one frame per inner kind,
  deliberately mixing big- and little-endian, using negative discriminator values
  (sign-preservation) and 8-byte values (Long-domain assembly).
- New cross-platform `MultiByteDispatchCodecTest` — round-trip, physical
  wire-byte, `wireSize` delegation, drip-fed `peekFrameSize`, and
  unmatched-discriminator coverage.
- `EmitterDiagnosticsValidatorTest` #17 flipped Rejected → Supported.

## Byte-identity

**305 existing codec-snapshot goldens unchanged**; 16 new goldens added for the
new fixture. `git status --short codec-snapshots/` shows only additions, zero
modifications.

## Release

Labeled `skip-release` to match the rest of the dispatch track (#177/#178), which
has been accumulating in `[Unreleased]`. This is a real user-facing feature —
relabel to `minor` if you want to cut a Maven release.

## Next

This is the on-ramp to the QUIC-varint / HTTP/3 discriminator: the Long-domain
8-byte peek assembly added here is the exact shape a QUIC 8-byte varint reuses.

Addresses `SUPPORT_MATRIX.md` rows #1/#2 (the inventory's own row numbers — not GitHub issues; GH #1/#2 are unrelated ancient PRs).
