### PR TITLE
feat(codec): real HTTP/3 + WebSocket peekFrameSize (drop fake WsbFrame)

### DIFF
--- a/buffer-codec-processor/CUSTOM_FRAME_PEEK_DESIGN.md
+++ b/buffer-codec-processor/CUSTOM_FRAME_PEEK_DESIGN.md
@@ -1,0 +1,164 @@
+# Custom frame-size peek — consumer-supplied framing override
+
+**Status:** design (for review) · **Track:** `codec/varint-h3` · **Date:** 2026-06-05
+
+## Problem
+
+Some protocols carry a frame size in a shape the processor cannot derive
+declaratively. The motivating case is **RFC 6455 WebSocket** (`websocket/WsFrame.kt`):
+
+```text
+byte1 | byte2 | [ext-len 16 if ind==126 | ext-len 64 if ind==127] | [mask 4 if MASK] | payload
+```
+
+The payload length is **escape-coded** across header fields —
+`payloadLen = extLen64 ?: extLen16 ?: (byte2 & 0x7F)` — and a 4-byte masking key
+folds **between** the length and the payload. There is no single length field a
+`BoundingLengthCodec`/`@LengthFrom` can point at, and the 126/127 escape is not a
+shape the generated peek walker models. So `WsFrameCodec.peekFrameSize` falls back
+to `NoFraming`, and the websocket repo hand-writes the peek in
+`WebSocketCodec.readNextFrame` (`WsFrame.kt:93-99`).
+
+Decode/encode are **already fine** — the header fields decode via `@When` grammar-1
+predicates. The gap is **only** the generated `peekFrameSize`.
+
+## Non-goal
+
+Teaching the IR the 126/127 escape table. That over-fits the processor to one
+protocol. The escape is protocol-specific; it belongs with the protocol's model.
+
+## Mechanism — companion object implements the existing `FrameDetector`
+
+No new interface needed. `buffer-codec` already defines (`Codec.kt:106`):
+
+```kotlin
+interface FrameDetector {
+    fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult = PeekResult.NoFraming
+}
+// Codec<T> : Encoder<T>, Decoder<T>, FrameDetector  — generated codecs already are FrameDetectors.
+```
+
+The consumer declares a companion object on the `@ProtocolMessage` type that
+implements `FrameDetector`. When present, the generated codec's `peekFrameSize`
+delegates to it instead of the derived walker / `NoFraming` fallback. The
+companion owns ONLY framing (the total byte count) — field decode/encode stay
+generated.
+
+**Load-bearing contract** (the same one generated peeks satisfy by construction;
+here the consumer preserves it by hand):
+
+```
+peekFrameSize(stream, base) is Complete  ⇒  Complete.bytes == (bytes decode consumes)
+```
+
+for any fully-buffered frame, and `NeedsMoreData` for every shorter prefix. A
+single drip-feed test locks it (see WsFrameCodecTest).
+
+The consumer adds a companion to their existing model — no annotation, the logic
+lives next to the wire layout it mirrors:
+
+```kotlin
+@DispatchOn(FrameHeaderByte1::class)
+@ProtocolMessage(wireOrder = Endianness.Big)
+sealed interface WsFrame<out P : Payload> {
+    // ... variants unchanged ...
+
+    companion object : FrameDetector {
+        override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+            if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+            val byte2 = stream.peekByte(baseOffset + 1).toInt() and 0xFF
+            val masked = (byte2 and 0x80) != 0
+            val indicator = byte2 and 0x7F
+            var offset = 2
+            val payloadLen: Long = when (indicator) {
+                126 -> {
+                    if (stream.available() - baseOffset < offset + 2) return PeekResult.NeedsMoreData
+                    val v = ((stream.peekByte(baseOffset + offset).toInt() and 0xFF) shl 8) or
+                        (stream.peekByte(baseOffset + offset + 1).toInt() and 0xFF)
+                    offset += 2; v.toLong()
+                }
+                127 -> {
+                    if (stream.available() - baseOffset < offset + 8) return PeekResult.NeedsMoreData
+                    var v = 0L
+                    for (i in 0 until 8) v = (v shl 8) or (stream.peekByte(baseOffset + offset + i).toLong() and 0xFF)
+                    offset += 8; v
+                }
+                else -> indicator.toLong()
+            }
+            if (masked) offset += 4
+            val total = offset + payloadLen.toInt()
+            return if (stream.available() - baseOffset >= total) PeekResult.Complete(total)
+                   else PeekResult.NeedsMoreData
+        }
+    }
+}
+```
+
+## What the generated codec emits
+
+When the analyzer sees the `@ProtocolMessage` type (or sealed parent) declares a
+companion implementing `FrameSizePeek`, the emitter replaces the derived
+`peekFrameSize` body with a single delegation:
+
+```kotlin
+// WsFrameCodec<P> (the dispatcher codec)
+override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult =
+    WsFrame.peekFrameSize(stream, baseOffset)
+```
+
+This wins over the derived walker (and over the `NoFraming` fallback) whenever the
+companion is present. It applies uniformly to:
+- a plain message codec (companion on the data class), and
+- a sealed dispatcher codec (companion on the sealed parent) — the WS case, where
+  framing is opcode-independent so the override sits at the parent.
+
+## Processor changes (scope)
+
+1. **buffer-codec:** add `FrameSizePeek` (≈ the snippet above).
+2. **Analyzer (`ProtocolMessageProcessor`):** resolve whether the message type's
+   companion object implements `FrameSizePeek`; record `customPeek: ClassName?`
+   (the companion's reference) on `CodecShape`.
+3. **Emitter (`CodecEmitter`):** at the top of `buildPeekFrameFun` **and**
+   `buildDispatchPeekFun`, if `customPeek != null` emit the one-line delegation and
+   return — skipping the derived walker entirely. Everything else (decode, encode,
+   `Partial`, dispatch routing) is untouched.
+
+No change to decode/encode codegen. No new annotation. Existing goldens stay
+byte-identical (no type gains a `FrameSizePeek` companion except the WS fixture).
+
+## Contract & risk
+
+The one risk a hand-written peek introduces is **drift**: the consumer's size math
+could disagree with what the generated decode consumes. Mitigations:
+- The interface KDoc states the `peek.bytes == decode consumption` invariant.
+- The WS fixture test drip-feeds one byte at a time (`NeedsMoreData` until the last
+  byte → `Complete(n)`), then asserts `n == decodeBuffer.position()` — the exact
+  invariant, locked for masked/unmasked × 7-bit/16/64-bit length. Any drift fails
+  loudly. This is the same assertion the HTTP/3 and (former) bounding tests use.
+
+The override covers **only** sizing; field decode stays generated, so drift is
+confined to "is the byte count right," which one test catches — not to field
+layout, types, or order.
+
+## Alternatives considered
+
+- **`@ProtocolMessage(framing = WsFraming::class)`** (annotation pointing at a
+  consumer object). Equivalent power; anticipated in `WsFrame.kt:195`. The companion
+  approach is preferred: no annotation, the framing lives on the type it frames, and
+  it can't be attached to the wrong type. (If a type genuinely can't host a
+  companion, the annotation remains a clean fallback — both can coexist, companion
+  taking precedence.)
+- **Declarative escape-length IR** (model 126/127 in the walker). Rejected:
+  over-fits the processor to RFC 6455; the next protocol's escape table differs.
+- **Hand-write the entire `Codec`** (no codegen). Rejected: throws away the
+  generated decode/encode/`Partial`/dispatch the fixture exists to exercise, just to
+  customize sizing.
+
+## Open questions for review
+
+1. **Interface name** — `FrameSizePeek` vs `FramePeek` vs `CustomFraming`.
+2. **Companion vs annotation as the primary surface** (design assumes companion).
+3. Should the override be allowed on a **variant** (per-opcode framing), or only on
+   the message/sealed-parent? WS only needs parent-level; restricting to
+   message/parent keeps it simple. Variant-level can be added later if a protocol
+   needs per-type framing.

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
@@ -1077,6 +1077,30 @@ internal class CodecEmitter(
             return FieldAnalysis.Err(Diagnostic("value class must have exactly one constructor parameter", param))
         }
         val innerParam = ctor.parameters[0]
+        // Varint discriminator field: the value class's inner scalar carries
+        // `@UseCodec(VariableLengthCodec)`, so its wire form is variable-width
+        // and not an inline fixed scalar. Re-read it through the value class's
+        // own generated codec (which delegates to the consumer's variable-length
+        // codec) — the same UseCodecScalar machinery a bare varint field uses,
+        // so decode/encode/peek all compose. Only varint inners take this path;
+        // every existing value class stays on the inline-scalar path below,
+        // keeping its goldens byte-identical.
+        if (innerParam.hasVariableLengthUseCodec()) {
+            return FieldAnalysis.Ok(
+                FieldSpec.UseCodecScalar(
+                    name = name,
+                    ownerSimpleName = ownerSimpleName,
+                    fieldType = classNameOf(decl),
+                    codecType =
+                        ClassName(
+                            decl.packageName.asString(),
+                            decl.flattenedCodecName(),
+                        ),
+                    isBounding = false,
+                    isVariableLength = true,
+                ),
+            )
+        }
         val innerName =
             innerParam.name?.asString()
                 ?: return FieldAnalysis.Err(Diagnostic("value class inner parameter has no name", param))
@@ -1885,6 +1909,25 @@ internal class CodecEmitter(
         getAllSuperTypes().any { st ->
             st.declaration.qualifiedName?.asString() == VARIABLE_LENGTH_CODEC_QNAME
         }
+
+    /**
+     * Does this parameter carry `@UseCodec(C::class)` where `C` implements
+     * `VariableLengthCodec`? Used in two places to recognize a self-delimiting
+     * variable-width scalar:
+     *  - on a `@DispatchOn` discriminator value class's inner constructor
+     *    parameter → the dispatcher is a [Discriminator.Varint];
+     *  - on the inner of a variant's value-class discriminator field → that
+     *    field re-reads the discriminator through the value class's own codec
+     *    rather than an inline fixed-width scalar read.
+     */
+    private fun KSValueParameter.hasVariableLengthUseCodec(): Boolean {
+        val useCodecAnn =
+            annotations.firstOrNull { it.shortName.asString() == "UseCodec" } ?: return false
+        val codecDecl =
+            (useCodecAnn.arguments.firstOrNull { it.name?.asString() == "codec" }?.value as? KSType)
+                ?.declaration as? KSClassDeclaration ?: return false
+        return codecDecl.implementsVariableLengthCodec()
+    }
 
     /**
      * Per-field-type peek-budget table.
@@ -7514,37 +7557,16 @@ internal class CodecEmitter(
         val discriminatorCtor =
             discriminatorDecl.primaryConstructor ?: return DispatchAnalysisResult.NotApplicable
         if (discriminatorCtor.parameters.size != 1) return DispatchAnalysisResult.NotApplicable
-        val innerType = discriminatorCtor.parameters[0].type.resolve()
+        val innerParam = discriminatorCtor.parameters[0]
+        val innerType = innerParam.type.resolve()
         if (innerType.isError || innerType.isMarkedNullable) return DispatchAnalysisResult.NotApplicable
-        val innerKind =
-            SUPPORTED_SCALARS[innerType.declaration.qualifiedName?.asString()]
-                ?: return DispatchAnalysisResult.NotApplicable
-        // True silent gap: validateDispatchOnSealed accepts any numeric
-        // inner (NUMERIC_SCALAR_QNAMES), but peek-side reconstruction only
-        // supports single-byte kinds plus 2/4-byte unsigned kinds. ULong,
-        // Int, and signed multi-byte (Short/Long) discriminators aren't
-        // required by any in-scope vector and would need parallel peek
-        // paths — so they pass validation and are then silently dropped.
-        if (innerKind !in peekableDispatcherInnerKinds) {
-            val innerName =
-                innerType.declaration.simpleName.asString()
-            val peekable = peekableDispatcherInnerKinds.joinToString(", ") { it.name }
-            return DispatchAnalysisResult.Rejected(
-                listOf(
-                    Diagnostic(
-                        "@DispatchOn discriminator on ${symbol.simpleName.asString()} has inner scalar " +
-                            "`$innerName`, which is not a supported dispatch discriminator width. The peek " +
-                            "path supports only single-byte and 2/4-byte unsigned kinds ($peekable); signed " +
-                            "multi-byte (Short/Long), Int, and ULong discriminators are not yet supported.",
-                        symbol,
-                    ),
-                ),
-            )
-        }
-        // Read the discriminator value class's `@ProtocolMessage(
-        // wireOrder = ...)` so multi-byte byte assembly during peek matches
-        // the encode/decode wire layout. Single-byte kinds ignore this.
-        val discriminatorWireOrder = readMessageWireOrder(discriminatorDecl)
+        // Varint discriminator: the value class's inner scalar carries
+        // `@UseCodec(VariableLengthCodec)`. Width is variable and recovered
+        // at runtime from the value class's own generated codec, so the
+        // fixed-width peekable-inner-kind machinery below does not apply.
+        // The concrete `Discriminator` (Varint vs ValueClass) is built after
+        // the shared dispatch-value resolution.
+        val varintInner = innerParam.hasVariableLengthUseCodec()
 
         val dispatchProp =
             discriminatorDecl
@@ -7697,25 +7719,64 @@ internal class CodecEmitter(
         // a single header+prefix walker rather than per-variant
         // dispatch, and `wireSize` is omitted.
         val framedBy = symbol.annotations.firstOrNull(::isFramedByAnn)?.let(::parseFramedBy)
+        val discriminatorCodecClassName =
+            ClassName(
+                discriminatorDecl.packageName.asString(),
+                discriminatorDecl.flattenedCodecName(),
+            )
+        val discriminator: Discriminator =
+            if (varintInner) {
+                Discriminator.Varint(
+                    className = classNameOf(discriminatorDecl),
+                    codecClassName = discriminatorCodecClassName,
+                    dispatchValueProperty = dispatchValuePropertyName,
+                    dispatchValueKind = dispatchValueKind,
+                )
+            } else {
+                val innerKind =
+                    SUPPORTED_SCALARS[innerType.declaration.qualifiedName?.asString()]
+                        ?: return DispatchAnalysisResult.NotApplicable
+                // True silent gap: validateDispatchOnSealed accepts any numeric
+                // inner (NUMERIC_SCALAR_QNAMES), but peek-side reconstruction only
+                // supports single-byte kinds plus 2/4-byte unsigned kinds. ULong,
+                // Int, and signed multi-byte (Short/Long) discriminators aren't
+                // required by any in-scope vector and would need parallel peek
+                // paths — so they pass validation and are then silently dropped.
+                if (innerKind !in peekableDispatcherInnerKinds) {
+                    val innerName = innerType.declaration.simpleName.asString()
+                    val peekable = peekableDispatcherInnerKinds.joinToString(", ") { it.name }
+                    return DispatchAnalysisResult.Rejected(
+                        listOf(
+                            Diagnostic(
+                                "@DispatchOn discriminator on ${symbol.simpleName.asString()} has inner scalar " +
+                                    "`$innerName`, which is not a supported dispatch discriminator width. The peek " +
+                                    "path supports only single-byte and 2/4-byte unsigned kinds ($peekable); signed " +
+                                    "multi-byte (Short/Long), Int, and ULong discriminators are not yet supported.",
+                                symbol,
+                            ),
+                        ),
+                    )
+                }
+                Discriminator.ValueClass(
+                    className = classNameOf(discriminatorDecl),
+                    codecClassName = discriminatorCodecClassName,
+                    innerKind = innerKind,
+                    // Read the discriminator value class's `@ProtocolMessage(
+                    // wireOrder = ...)` so multi-byte byte assembly during peek
+                    // matches the encode/decode wire layout. Single-byte kinds
+                    // ignore this.
+                    innerWireOrder = readMessageWireOrder(discriminatorDecl),
+                    dispatchValueProperty = dispatchValuePropertyName,
+                    dispatchValueKind = dispatchValueKind,
+                )
+            }
         return DispatchAnalysisResult.Supported(
             DispatchShape(
                 packageName = pkg,
                 parentClassName = ClassName(pkg, parentSimpleName),
                 parentSimpleName = parentSimpleName,
                 codecSimpleName = symbol.flattenedCodecName(),
-                discriminator =
-                    Discriminator.ValueClass(
-                        className = classNameOf(discriminatorDecl),
-                        codecClassName =
-                            ClassName(
-                                discriminatorDecl.packageName.asString(),
-                                discriminatorDecl.flattenedCodecName(),
-                            ),
-                        innerKind = innerKind,
-                        innerWireOrder = discriminatorWireOrder,
-                        dispatchValueProperty = dispatchValuePropertyName,
-                        dispatchValueKind = dispatchValueKind,
-                    ),
+                discriminator = discriminator,
                 variants = variants,
                 genericity =
                     payloadTypeParameter
@@ -7965,8 +8026,27 @@ internal class CodecEmitter(
                 actualFormat = "\${__dispatchValue}"
                 body.beginControlFlow("return when (__dispatchValue)")
             }
-            is Discriminator.Varint ->
-                error("Discriminator.Varint decode is not reachable yet — no shape produces it")
+            is Discriminator.Varint -> {
+                // Varint @DispatchOn: identical decode shape to ValueClass —
+                // peek the variable-width discriminator via the value class's
+                // codec, rewind, and let the variant re-read it. The codec
+                // (not a fixed inner-scalar read) does the self-delimiting read.
+                body.addStatement("val discriminatorPosition = buffer.position()")
+                body.addStatement(
+                    "val __discriminator = %T.decode(buffer, context)",
+                    disc.codecClassName,
+                )
+                body.addStatement("buffer.position(discriminatorPosition)")
+                body.addStatement(
+                    "val __dispatchValue = %L",
+                    dispatchValueIntCoercion(
+                        disc.dispatchValueKind,
+                        "__discriminator.${disc.dispatchValueProperty}",
+                    ),
+                )
+                actualFormat = "\${__dispatchValue}"
+                body.beginControlFlow("return when (__dispatchValue)")
+            }
         }
 
         for (variant in shape.variants) {
@@ -8282,13 +8362,12 @@ internal class CodecEmitter(
      */
     private fun buildDispatchPeekFun(shape: DispatchShape): FunSpec {
         val body = CodeBlock.builder()
-        val discriminatorBytes = shape.discriminator.wireWidth.requireFixed("dispatch peek")
 
         when (val disc = shape.discriminator) {
             Discriminator.FixedByte -> {
                 body.addStatement(
                     "if (stream.available() - baseOffset < %L) return %T.NeedsMoreData",
-                    discriminatorBytes,
+                    disc.wireWidth.requireFixed("dispatch peek"),
                     PEEK_RESULT_CN,
                 )
                 body.addStatement(
@@ -8327,7 +8406,7 @@ internal class CodecEmitter(
             is Discriminator.ValueClass -> {
                 body.addStatement(
                     "if (stream.available() - baseOffset < %L) return %T.NeedsMoreData",
-                    discriminatorBytes,
+                    disc.wireWidth.requireFixed("dispatch peek"),
                     PEEK_RESULT_CN,
                 )
                 // Peek the discriminator's inner-scalar bytes at baseOffset and
@@ -8372,8 +8451,65 @@ internal class CodecEmitter(
                 body.endControlFlow()
                 body.endControlFlow()
             }
-            is Discriminator.Varint ->
-                error("Discriminator.Varint peek is not reachable yet — no shape produces it")
+            is Discriminator.Varint -> {
+                // Variable-width discriminator: its byte count isn't known
+                // statically, so measure it via the value class codec's own
+                // peekFrameSize (which delegates to the consumer's
+                // VariableLengthCodec). If the prefix is too short to frame the
+                // discriminator, propagate NeedsMoreData / NoFraming unchanged.
+                body.addStatement(
+                    "val __discFrame = %T.peekFrameSize(stream, baseOffset)",
+                    disc.codecClassName,
+                )
+                body.beginControlFlow("if (__discFrame !is %T.Complete)", PEEK_RESULT_CN)
+                body.addStatement("return __discFrame")
+                body.endControlFlow()
+                // Decode the discriminator from a non-consuming view of exactly
+                // its measured width to recover the dispatch value, then PURE-
+                // DELEGATE to the variant at baseOffset (the variant re-reads the
+                // self-delimiting discriminator as its first field, so no `1 +`).
+                body.addStatement(
+                    "val __discView = stream.peekBuffer(baseOffset, __discFrame.bytes) ?: return %T.NeedsMoreData",
+                    PEEK_RESULT_CN,
+                )
+                body.beginControlFlow("val __dispatchValue = try")
+                body.addStatement(
+                    "val __discriminator = %T.decode(__discView, %T.Empty)",
+                    disc.codecClassName,
+                    DECODE_CONTEXT_CN,
+                )
+                body.addStatement(
+                    "%L",
+                    dispatchValueIntCoercion(
+                        disc.dispatchValueKind,
+                        "__discriminator.${disc.dispatchValueProperty}",
+                    ),
+                )
+                body.nextControlFlow("finally")
+                body.addStatement(
+                    "(__discView as? %T)?.freeNativeMemory()",
+                    PLATFORM_BUFFER_CN,
+                )
+                body.endControlFlow()
+                body.beginControlFlow("return when (__dispatchValue)")
+                for (variant in shape.variants) {
+                    body.addStatement(
+                        "%L -> %L.peekFrameSize(stream, baseOffset)",
+                        variant.dispatchLabel(shape.discriminator.labelFormat),
+                        variant.codecReceiver(),
+                    )
+                }
+                body.beginControlFlow("else ->")
+                body.addStatement(
+                    "throw %T(fieldPath = %S, bufferPosition = baseOffset, expected = %S, actual = %P)",
+                    DECODE_EXCEPTION_CN,
+                    "${shape.parentSimpleName}.discriminator",
+                    expectedDispatchSet(shape),
+                    "\${__dispatchValue}",
+                )
+                body.endControlFlow()
+                body.endControlFlow()
+            }
         }
 
         return FunSpec

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
@@ -1638,6 +1638,7 @@ internal class CodecEmitter(
                 fieldType = fieldTypeName,
                 codecType = codecClassName,
                 isBounding = codecDecl.implementsBoundingLengthCodec(),
+                isVariableLength = codecDecl.implementsVariableLengthCodec(),
             ),
         )
     }
@@ -1869,6 +1870,20 @@ internal class CodecEmitter(
     private fun KSClassDeclaration.implementsBoundingLengthCodec(): Boolean =
         getAllSuperTypes().any { st ->
             st.declaration.qualifiedName?.asString() == BOUNDING_LENGTH_CODEC_QNAME
+        }
+
+    /**
+     * Does this codec class implement
+     * `com.ditchoom.buffer.codec.VariableLengthCodec`? Marks a bare-`@UseCodec`
+     * scalar field as self-delimiting / variable-width: decode/encode already
+     * delegate to the codec, and this flag drives the variable-width
+     * `peekFrameSize` branch (`total = prior + observed-width`, no value term —
+     * unlike the bounding case). Walks the full supertype chain so an indirect
+     * implementer (intermediate interface) is still detected.
+     */
+    private fun KSClassDeclaration.implementsVariableLengthCodec(): Boolean =
+        getAllSuperTypes().any { st ->
+            st.declaration.qualifiedName?.asString() == VARIABLE_LENGTH_CODEC_QNAME
         }
 
     /**
@@ -4337,11 +4352,46 @@ internal class CodecEmitter(
                 shape.fields
                     .takeWhile { it !== ucsField }
                     .all { it is FieldSpec.FixedSize }
-            if (!ucsField.isBounding || budget == null || !priorAreFixed) {
+            // A non-statically-sized prior field → out of the walker's reach
+            // (the walker assumes a statically-known prior byte count).
+            if (!priorAreFixed) {
                 builder.addStatement("return %T.NoFraming", PEEK_RESULT_CN)
                 return builder.build()
             }
-            appendPeekUseCodecScalar(builder, shape, ucsField, budget)
+            // Bounding length: the decoded value IS the body byte count, so
+            // total = prior + width + value (existing walker). Needs a peek
+            // budget to size the materialize-and-decode view; no budget entry
+            // (value-class / non-scalar field) → NoFraming.
+            if (ucsField.isBounding) {
+                if (budget == null) {
+                    builder.addStatement("return %T.NoFraming", PEEK_RESULT_CN)
+                    return builder.build()
+                }
+                appendPeekUseCodecScalar(builder, shape, ucsField, budget)
+                return builder.build()
+            }
+            // Self-delimiting variable-width value (VariableLengthCodec): the
+            // value occupies only its own bytes, so total = prior + width +
+            // fixed-suffix — provided every field after it is FixedSize (a
+            // variable suffix would desync the byte count). Width comes from the
+            // codec's own peekFrameSize (no peek budget needed), so this also
+            // composes through a value-class codec whose inner is a varint.
+            if (ucsField.isVariableLength) {
+                val suffixAreFixed =
+                    shape.fields
+                        .dropWhile { it !== ucsField }
+                        .drop(1)
+                        .all { it is FieldSpec.FixedSize }
+                if (!suffixAreFixed) {
+                    builder.addStatement("return %T.NoFraming", PEEK_RESULT_CN)
+                    return builder.build()
+                }
+                appendPeekVariableLengthUseCodecScalar(builder, shape, ucsField)
+                return builder.build()
+            }
+            // Non-bounding, non-variable-length @UseCodec: no value-to-byte
+            // mapping the walker can use.
+            builder.addStatement("return %T.NoFraming", PEEK_RESULT_CN)
             return builder.build()
         }
         // `@LengthPrefixed @UseCodec val: List<E>`
@@ -4553,6 +4603,64 @@ internal class CodecEmitter(
             PLATFORM_BUFFER_CN,
         )
         body.endControlFlow()
+        builder.addCode(body.build())
+    }
+
+    /**
+     * Emit peek for a shape carrying a non-bounding, **variable-length**
+     * `@UseCodec val: <scalar>` field (codec implements `VariableLengthCodec`).
+     * The decoded value is *not* a body length, so the frame total is
+     * `priorBytes + codecWidth + fixedSuffixBytes` — no value term.
+     *
+     * Width comes from the codec's own `peekFrameSize` (every
+     * `VariableLengthCodec` derives it from `peekValue`): `Complete(width)` once
+     * the self-delimiting value is fully buffered, `NeedsMoreData` otherwise.
+     * Delegating to the codec means no peek budget is needed and the same path
+     * composes through a generated value-class codec whose inner is a varint.
+     *
+     * Caller guarantees (in [buildPeekFrameFun]): every prior and suffix field
+     * is `FixedSize`.
+     */
+    private fun appendPeekVariableLengthUseCodecScalar(
+        builder: FunSpec.Builder,
+        shape: CodecShape,
+        field: FieldSpec.UseCodecScalar,
+    ) {
+        val priorBytes =
+            shape.fields
+                .takeWhile { it !== field }
+                .filterIsInstance<FieldSpec.FixedSize>()
+                .sumOf { it.wireBytes }
+        val suffixBytes =
+            shape.fields
+                .dropWhile { it !== field }
+                .drop(1)
+                .filterIsInstance<FieldSpec.FixedSize>()
+                .sumOf { it.wireBytes }
+        val body = CodeBlock.builder()
+        val frameVar = "__${field.name}Frame"
+        body.addStatement(
+            "val %L = %T.peekFrameSize(stream, baseOffset + %L)",
+            frameVar,
+            field.codecType,
+            priorBytes,
+        )
+        // Propagate NeedsMoreData / NoFraming unchanged; only a Complete width
+        // lets us size the whole frame.
+        body.beginControlFlow("if (%L !is %T.Complete)", frameVar, PEEK_RESULT_CN)
+        body.addStatement("return %L", frameVar)
+        body.endControlFlow()
+        body.addStatement(
+            "val __total = %L + %L.bytes + %L",
+            priorBytes,
+            frameVar,
+            suffixBytes,
+        )
+        body.addStatement(
+            "return if (stream.available() - baseOffset >= __total) %T.Complete(__total) else %T.NeedsMoreData",
+            PEEK_RESULT_CN,
+            PEEK_RESULT_CN,
+        )
         builder.addCode(body.build())
     }
 
@@ -8895,6 +9003,7 @@ internal class CodecEmitter(
         private const val PAYLOAD_SIMPLE = "Payload"
         private const val OWNED_BYTES_HANDLE_QNAME = "com.ditchoom.buffer.codec.OwnedBytesHandle"
         private const val BOUNDING_LENGTH_CODEC_QNAME = "com.ditchoom.buffer.codec.BoundingLengthCodec"
+        private const val VARIABLE_LENGTH_CODEC_QNAME = "com.ditchoom.buffer.codec.VariableLengthCodec"
         private const val FRAMED_BY_QNAME = "com.ditchoom.buffer.codec.annotations.FramedBy"
 
         // Batching gate. A coalesced read targets exactly 2, 4, or 8 bytes —

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
@@ -471,6 +471,7 @@ internal class CodecEmitter(
                 visibility = codecVisibilityModifier(symbol),
                 payloadTypeParameter = payloadTypeParameter,
                 framedBy = detectFramedBy(symbol),
+                customPeek = detectCustomFramePeek(symbol),
             ),
         )
     }
@@ -1909,6 +1910,35 @@ internal class CodecEmitter(
         getAllSuperTypes().any { st ->
             st.declaration.qualifiedName?.asString() == VARIABLE_LENGTH_CODEC_QNAME
         }
+
+    /**
+     * Consumer-supplied frame-size override: when a `@ProtocolMessage` type
+     * declares a companion object implementing
+     * `com.ditchoom.buffer.codec.FrameDetector`, the generated codec's
+     * `peekFrameSize` delegates to it instead of running the derived walker (or
+     * collapsing to `NoFraming`). The escape hatch for wire shapes the walker
+     * can't express — RFC 6455 WebSocket's escape-coded payload length with a
+     * masking key folded between the length and the body.
+     *
+     * Returns the type whose companion to call (`<Type>.peekFrameSize(...)` —
+     * companion members are referenced through the enclosing class name, so this
+     * is the message/parent [ClassName] itself, raw of any type arguments), or
+     * `null` when there is no such companion. Walks the full supertype chain of
+     * the companion so an indirect `FrameDetector` (e.g. via `Codec`) still
+     * counts.
+     */
+    private fun detectCustomFramePeek(symbol: KSClassDeclaration): ClassName? {
+        val companion =
+            symbol.declarations
+                .filterIsInstance<KSClassDeclaration>()
+                .firstOrNull { it.isCompanionObject }
+                ?: return null
+        val implementsFrameDetector =
+            companion.getAllSuperTypes().any { st ->
+                st.declaration.qualifiedName?.asString() == FRAME_DETECTOR_QNAME
+            }
+        return if (implementsFrameDetector) classNameOf(symbol) else null
+    }
 
     /**
      * Does this parameter carry `@UseCodec(C::class)` where `C` implements
@@ -4371,6 +4401,13 @@ internal class CodecEmitter(
                 .addParameter("stream", STREAM_PROCESSOR_CN)
                 .addParameter("baseOffset", INT)
                 .returns(PEEK_RESULT_CN)
+        // Consumer-supplied frame-size override: a companion object implementing
+        // `FrameDetector` takes over framing wholesale (the escape hatch for
+        // wire shapes the walker can't express). Delegate and return.
+        shape.customPeek?.let { customPeek ->
+            builder.addStatement("return %T.peekFrameSize(stream, baseOffset)", customPeek)
+            return builder.build()
+        }
         // Generic `@UseCodec` peek walker. When a
         // bounding `UseCodecScalar` field is present, the framework drives
         // the user codec against a non-consuming `stream.peekBuffer(...)`
@@ -4390,27 +4427,53 @@ internal class CodecEmitter(
         val ucsField =
             shape.fields.firstOrNull { it is FieldSpec.UseCodecScalar } as? FieldSpec.UseCodecScalar
         if (ucsField != null) {
-            val budget = peekBudgetFor(ucsField.fieldType)
+            // A bounding length anchors framing wherever it sits: the decoded
+            // value IS the bounded body's byte count, so
+            // total = priorBytes + lengthWidth + value. The priors before it may
+            // themselves be variable-width as long as each is *self-framing* —
+            // fixed-width, a nested-message/value-class `ProtocolMessageScalar`,
+            // or a self-delimiting variable-length `@UseCodec` (a varint). This
+            // is the real HTTP/3 frame shape: a QUIC-varint `Type` discriminator
+            // precedes the QUIC-varint bounding `Length`.
+            val boundingField =
+                shape.fields
+                    .firstOrNull { it is FieldSpec.UseCodecScalar && it.isBounding }
+                    as? FieldSpec.UseCodecScalar
+            if (boundingField != null) {
+                val budget = peekBudgetFor(boundingField.fieldType)
+                val priors = shape.fields.takeWhile { it !== boundingField }
+                val priorAreFixed = priors.all { it is FieldSpec.FixedSize }
+                val priorAreFramable =
+                    priors.all {
+                        it is FieldSpec.FixedSize ||
+                            it is FieldSpec.ProtocolMessageScalar ||
+                            (it is FieldSpec.UseCodecScalar && it.isVariableLength)
+                    }
+                // No peek budget for the length field (value-class / non-scalar),
+                // or a prior the walker can't size → NoFraming.
+                if (budget == null || !priorAreFramable) {
+                    builder.addStatement("return %T.NoFraming", PEEK_RESULT_CN)
+                    return builder.build()
+                }
+                if (priorAreFixed) {
+                    // All-fixed priors: the static-offset walker (byte-identical
+                    // to every pre-existing bounding fixture).
+                    appendPeekUseCodecScalar(builder, shape, boundingField, budget)
+                } else {
+                    // A self-framing variable-width prior is present (varint
+                    // discriminator): measure prior offsets at runtime.
+                    appendPeekBoundingDynamicPrior(builder, shape, boundingField, budget)
+                }
+                return builder.build()
+            }
+            // No bounding length: the remaining cases key off the first
+            // `@UseCodec` field and require statically-sized priors.
             val priorAreFixed =
                 shape.fields
                     .takeWhile { it !== ucsField }
                     .all { it is FieldSpec.FixedSize }
-            // A non-statically-sized prior field → out of the walker's reach
-            // (the walker assumes a statically-known prior byte count).
             if (!priorAreFixed) {
                 builder.addStatement("return %T.NoFraming", PEEK_RESULT_CN)
-                return builder.build()
-            }
-            // Bounding length: the decoded value IS the body byte count, so
-            // total = prior + width + value (existing walker). Needs a peek
-            // budget to size the materialize-and-decode view; no budget entry
-            // (value-class / non-scalar field) → NoFraming.
-            if (ucsField.isBounding) {
-                if (budget == null) {
-                    builder.addStatement("return %T.NoFraming", PEEK_RESULT_CN)
-                    return builder.build()
-                }
-                appendPeekUseCodecScalar(builder, shape, ucsField, budget)
                 return builder.build()
             }
             // Self-delimiting variable-width value (VariableLengthCodec): the
@@ -4634,6 +4697,114 @@ internal class CodecEmitter(
             widthVar,
             field.name,
         )
+        body.addStatement(
+            "return if (stream.available() - baseOffset >= __total) %T.Complete(__total) else %T.NeedsMoreData",
+            PEEK_RESULT_CN,
+            PEEK_RESULT_CN,
+        )
+        body.nextControlFlow("finally")
+        body.addStatement(
+            "(%L as? %T)?.freeNativeMemory()",
+            peekViewVar,
+            PLATFORM_BUFFER_CN,
+        )
+        body.endControlFlow()
+        builder.addCode(body.build())
+    }
+
+    /**
+     * Bounding `@UseCodec` peek where one or more prior fields are **not**
+     * fixed-width but are self-framing — most importantly a dispatch variant's
+     * re-read varint discriminator (the HTTP/3 frame's QUIC-varint `Type` before
+     * the bounding `Length`). The fixed-prior sibling [appendPeekUseCodecScalar]
+     * sums a compile-time `priorBytes`; here that sum is accumulated at runtime
+     * into `__priorBytes`:
+     *
+     *  - a `FixedSize` prior contributes its constant `wireBytes`;
+     *  - a `ProtocolMessageScalar` or self-delimiting variable-length
+     *    `UseCodecScalar` prior contributes the width its own codec's
+     *    `peekFrameSize` reports — measured at `baseOffset + __priorBytes`,
+     *    exactly the dispatcher's discriminator-framing idiom, so peek and decode
+     *    read the same bytes. A non-`Complete` prior result (the discriminator
+     *    isn't fully buffered, or itself yields `NoFraming`) propagates straight
+     *    out.
+     *
+     * After the priors, the bounded length is materialized and decoded against a
+     * non-consuming `peekBuffer` view (underflow → `NeedsMoreData`, the same
+     * contract as [appendPeekUseCodecScalar]) and the frame total is
+     * `__priorBytes + lengthWidth + value`.
+     */
+    private fun appendPeekBoundingDynamicPrior(
+        builder: FunSpec.Builder,
+        shape: CodecShape,
+        field: FieldSpec.UseCodecScalar,
+        peekBudget: Int,
+    ) {
+        val priors = shape.fields.takeWhile { it !== field }
+        val body = CodeBlock.builder()
+        body.addStatement("var __priorBytes = 0")
+        for (prior in priors) {
+            val priorCodec: ClassName? =
+                when (prior) {
+                    is FieldSpec.ProtocolMessageScalar -> prior.codecType
+                    is FieldSpec.UseCodecScalar -> prior.codecType
+                    else -> null
+                }
+            when {
+                prior is FieldSpec.FixedSize ->
+                    body.addStatement("__priorBytes += %L", prior.wireBytes)
+                priorCodec != null -> {
+                    val frameVar = "__${prior.name}Frame"
+                    body.addStatement(
+                        "val %L = %T.peekFrameSize(stream, baseOffset + __priorBytes)",
+                        frameVar,
+                        priorCodec,
+                    )
+                    body.beginControlFlow("if (%L !is %T.Complete)", frameVar, PEEK_RESULT_CN)
+                    body.addStatement("return %L", frameVar)
+                    body.endControlFlow()
+                    body.addStatement("__priorBytes += %L.bytes", frameVar)
+                }
+                else ->
+                    error("priorAreFramable should have excluded ${prior::class.simpleName}")
+            }
+        }
+        body.addStatement(
+            "if (stream.available() - baseOffset < __priorBytes + 1) return %T.NeedsMoreData",
+            PEEK_RESULT_CN,
+        )
+        val peekViewVar = "__${field.name}PeekView"
+        body.addStatement(
+            "val %L = stream.peekBuffer(baseOffset + __priorBytes, %L) ?: return %T.NeedsMoreData",
+            peekViewVar,
+            peekBudget,
+            PEEK_RESULT_CN,
+        )
+        body.beginControlFlow("try")
+        val priorPosVar = "__${field.name}PriorPos"
+        body.addStatement("val %L = %L.position()", priorPosVar, peekViewVar)
+        body.beginControlFlow("val %L = try", field.name)
+        body.addStatement(
+            "%T.decode(%L, %T.Empty)",
+            field.codecType,
+            peekViewVar,
+            DECODE_CONTEXT_CN,
+        )
+        body.nextControlFlow("catch (__e: %T)", ClassName("kotlin", "Throwable"))
+        body.beginControlFlow("when (__e::class.simpleName)")
+        body.addStatement(
+            "%S, %S, %S -> return %T.NeedsMoreData",
+            "BufferUnderflowException",
+            "IndexOutOfBoundsException",
+            "ArrayIndexOutOfBoundsException",
+            PEEK_RESULT_CN,
+        )
+        body.addStatement("else -> throw __e")
+        body.endControlFlow()
+        body.endControlFlow()
+        val widthVar = "__${field.name}Width"
+        body.addStatement("val %L = %L.position() - %L", widthVar, peekViewVar, priorPosVar)
+        body.addStatement("val __total = __priorBytes + %L + %L.toInt()", widthVar, field.name)
         body.addStatement(
             "return if (stream.available() - baseOffset >= __total) %T.Complete(__total) else %T.NeedsMoreData",
             PEEK_RESULT_CN,
@@ -7515,6 +7686,7 @@ internal class CodecEmitter(
                 framing = Framing.Unframed,
                 forwardCompat = ForwardCompat.Disabled,
                 visibility = codecVisibilityModifier(symbol).toCodecVisibility(),
+                customPeek = detectCustomFramePeek(symbol),
             ),
         )
     }
@@ -7788,6 +7960,7 @@ internal class CodecEmitter(
                         ?.let { ForwardCompat.Enabled(it) }
                         ?: ForwardCompat.Disabled,
                 visibility = codecVisibilityModifier(symbol).toCodecVisibility(),
+                customPeek = detectCustomFramePeek(symbol),
             ),
         )
     }
@@ -8362,6 +8535,22 @@ internal class CodecEmitter(
      */
     private fun buildDispatchPeekFun(shape: DispatchShape): FunSpec {
         val body = CodeBlock.builder()
+
+        // Consumer-supplied frame-size override: a companion object on the sealed
+        // parent implementing `FrameDetector` frames the whole dispatch wholesale
+        // (RFC 6455 WebSocket: opcode-independent bit-packed escape length +
+        // folded mask, which the per-variant peek walk can't derive). Delegate
+        // and return, bypassing discriminator routing.
+        shape.customPeek?.let { customPeek ->
+            return FunSpec
+                .builder("peekFrameSize")
+                .addModifiers(KModifier.OVERRIDE)
+                .addParameter("stream", STREAM_PROCESSOR_CN)
+                .addParameter("baseOffset", INT)
+                .returns(PEEK_RESULT_CN)
+                .addStatement("return %T.peekFrameSize(stream, baseOffset)", customPeek)
+                .build()
+        }
 
         when (val disc = shape.discriminator) {
             Discriminator.FixedByte -> {
@@ -9141,6 +9330,7 @@ internal class CodecEmitter(
         private const val BOUNDING_LENGTH_CODEC_QNAME = "com.ditchoom.buffer.codec.BoundingLengthCodec"
         private const val VARIABLE_LENGTH_CODEC_QNAME = "com.ditchoom.buffer.codec.VariableLengthCodec"
         private const val FRAMED_BY_QNAME = "com.ditchoom.buffer.codec.annotations.FramedBy"
+        private const val FRAME_DETECTOR_QNAME = "com.ditchoom.buffer.codec.FrameDetector"
 
         // Batching gate. A coalesced read targets exactly 2, 4, or 8 bytes —
         // the natural-width reads on `ReadBuffer`. 3/5/6/7 prefixes are

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecIr.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecIr.kt
@@ -536,6 +536,17 @@ internal sealed interface FieldSpec {
         val fieldType: TypeName,
         val codecType: ClassName,
         val isBounding: Boolean,
+        /**
+         * `true` when `C` implements
+         * `com.ditchoom.buffer.codec.VariableLengthCodec<T>` — a
+         * self-delimiting, variable-width encoding (QUIC varint, LEB128, …).
+         * Decode/encode are unchanged (they already delegate to `C`); this
+         * flag makes `peekFrameSize` framable via the codec's observed width
+         * (`total = prior + width + fixed-suffix`) instead of collapsing to
+         * `NoFraming`. Mutually exclusive with [isBounding] (a bounding length
+         * adds its value to the total; a self-delimiting value does not).
+         */
+        val isVariableLength: Boolean,
     ) : FieldSpec
 
     /**

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecIr.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecIr.kt
@@ -184,8 +184,20 @@ internal sealed interface Discriminator {
         override val wireWidth: WireWidth get() = innerKind.wireWidth
     }
 
-    /** Reserved — HTTP/3 QUIC varint discriminator (variable wire width). */
+    /**
+     * `@DispatchOn(value class)` whose inner scalar carries
+     * `@UseCodec(VariableLengthCodec)` — an HTTP/3 QUIC-varint-style
+     * self-delimiting discriminator. Wire width is variable, recovered at
+     * runtime from the value class's own generated codec ([codecClassName],
+     * which delegates to the consumer's `VariableLengthCodec`). Like
+     * [ValueClass] this is peek/rewind + re-read-by-variant with decimal
+     * labels; it differs only in that the dispatcher can't pre-compute a
+     * fixed discriminator width, so peek measures it via the codec instead
+     * of reconstructing fixed inner-scalar bytes.
+     */
     data class Varint(
+        val className: ClassName,
+        val codecClassName: ClassName,
         val dispatchValueProperty: String,
         val dispatchValueKind: ScalarKind,
     ) : Discriminator {

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecIr.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecIr.kt
@@ -128,6 +128,17 @@ internal data class DispatchShape(
     val framing: Framing,
     val forwardCompat: ForwardCompat,
     val visibility: CodecVisibility,
+    /**
+     * Consumer-supplied frame-size override for the dispatcher. Non-null when
+     * the sealed parent declares a companion object implementing
+     * `com.ditchoom.buffer.codec.FrameDetector`; holds the parent type whose
+     * companion to call. The dispatcher's `peekFrameSize` delegates to
+     * `<customPeek>.peekFrameSize(stream, baseOffset)` instead of routing through
+     * per-variant peeks — for frames whose size is opcode-independent and not
+     * walker-derivable (RFC 6455 WebSocket: bit-packed escape length + folded
+     * mask). See [CodecShape.customPeek].
+     */
+    val customPeek: ClassName? = null,
 )
 
 internal data class DispatchVariant(
@@ -315,6 +326,16 @@ internal data class CodecShape(
      * literal drives the encode-side write.
      */
     val singletonDispatchDiscriminator: SingletonDispatchDiscriminator? = null,
+    /**
+     * Consumer-supplied frame-size override. Non-null when the
+     * `@ProtocolMessage` type declares a companion object implementing
+     * `com.ditchoom.buffer.codec.FrameDetector`; holds the type whose companion
+     * to call. The emitter makes `peekFrameSize` delegate to
+     * `<customPeek>.peekFrameSize(stream, baseOffset)` instead of running the
+     * derived walker — the escape hatch for framings the walker can't express
+     * (e.g. RFC 6455 WebSocket's escape-coded length + folded mask).
+     */
+    val customPeek: ClassName? = null,
 )
 
 /**

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/ProtocolMessageProcessor.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/ProtocolMessageProcessor.kt
@@ -2128,9 +2128,9 @@ class ProtocolMessageProcessor(
         fieldType: KSType,
     ): Boolean {
         val expectedQname = fieldType.declaration.qualifiedName?.asString() ?: return false
-        // Walk the full supertype chain so a `BoundingLengthCodec<T>` impl
-        // (which transitively implements `Codec<T>`) is also recognized.
-        // Both `Codec<T>` and `BoundingLengthCodec<T>` are accepted: KSP's
+        // Walk the full supertype chain so a `BoundingLengthCodec<T>` or
+        // `VariableLengthCodec<T>` impl (each transitively implements
+        // `Codec<T>`) is also recognized. All three are accepted: KSP's
         // `getAllSuperTypes()` doesn't substitute the type variable from the
         // intermediate interface declaration, so the transitive `Codec<T>`
         // entry still carries the unsubstituted T. The concrete type arg is
@@ -2138,7 +2138,7 @@ class ProtocolMessageProcessor(
         for (st in codecDecl.getAllSuperTypes()) {
             if (st.isError) continue
             val q = st.declaration.qualifiedName?.asString()
-            if (q != CODEC_QNAME && q != BOUNDING_LENGTH_CODEC_QNAME) continue
+            if (q != CODEC_QNAME && q != BOUNDING_LENGTH_CODEC_QNAME && q != VARIABLE_LENGTH_CODEC_QNAME) continue
             val arg =
                 st.arguments
                     .firstOrNull()
@@ -2402,6 +2402,7 @@ class ProtocolMessageProcessor(
         private const val REMAINING_BYTES_SHORT = "RemainingBytes"
         private const val CODEC_QNAME = "com.ditchoom.buffer.codec.Codec"
         private const val BOUNDING_LENGTH_CODEC_QNAME = "com.ditchoom.buffer.codec.BoundingLengthCodec"
+        private const val VARIABLE_LENGTH_CODEC_QNAME = "com.ditchoom.buffer.codec.VariableLengthCodec"
         private const val BOOLEAN_QNAME = "kotlin.Boolean"
         private const val STRING_QNAME = "kotlin.String"
         private const val OWNED_BYTES_HANDLE_QNAME = "com.ditchoom.buffer.codec.OwnedBytesHandle"

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameCodec.kt
@@ -1,0 +1,74 @@
+package com.ditchoom.buffer.codec.test.protocols.http3
+
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object Http3FrameCodec : Codec<Http3Frame> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): Http3Frame {
+    val discriminatorPosition = buffer.position()
+    val __discriminator = Http3FrameTypeCodec.decode(buffer, context)
+    buffer.position(discriminatorPosition)
+    val __dispatchValue = __discriminator.type
+    return when (__dispatchValue) {
+      0 -> Http3FrameDataCodec.decode(buffer, context)
+      1 -> Http3FrameHeadersCodec.decode(buffer, context)
+      4 -> Http3FrameSettingsCodec.decode(buffer, context)
+      64 -> Http3FrameExtensionCodec.decode(buffer, context)
+      else -> {
+        throw DecodeException(fieldPath = "Http3Frame.discriminator", bufferPosition = discriminatorPosition, expected = "one of {0, 1, 4, 64}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: Http3Frame,
+    context: EncodeContext,
+  ) {
+    when (value) {
+      is Http3Frame.Data -> Http3FrameDataCodec.encode(buffer, value, context)
+      is Http3Frame.Headers -> Http3FrameHeadersCodec.encode(buffer, value, context)
+      is Http3Frame.Settings -> Http3FrameSettingsCodec.encode(buffer, value, context)
+      is Http3Frame.Extension -> Http3FrameExtensionCodec.encode(buffer, value, context)
+    }
+  }
+
+  override fun wireSize(`value`: Http3Frame, context: EncodeContext): WireSize = when (value) {
+    is Http3Frame.Data -> Http3FrameDataCodec.wireSize(value, context)
+    is Http3Frame.Headers -> Http3FrameHeadersCodec.wireSize(value, context)
+    is Http3Frame.Settings -> Http3FrameSettingsCodec.wireSize(value, context)
+    is Http3Frame.Extension -> Http3FrameExtensionCodec.wireSize(value, context)
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    val __discFrame = Http3FrameTypeCodec.peekFrameSize(stream, baseOffset)
+    if (__discFrame !is PeekResult.Complete) {
+      return __discFrame
+    }
+    val __discView = stream.peekBuffer(baseOffset, __discFrame.bytes) ?: return PeekResult.NeedsMoreData
+    val __dispatchValue = try {
+      val __discriminator = Http3FrameTypeCodec.decode(__discView, DecodeContext.Empty)
+      __discriminator.type
+    } finally {
+      (__discView as? PlatformBuffer)?.freeNativeMemory()
+    }
+    return when (__dispatchValue) {
+      0 -> Http3FrameDataCodec.peekFrameSize(stream, baseOffset)
+      1 -> Http3FrameHeadersCodec.peekFrameSize(stream, baseOffset)
+      4 -> Http3FrameSettingsCodec.peekFrameSize(stream, baseOffset)
+      64 -> Http3FrameExtensionCodec.peekFrameSize(stream, baseOffset)
+      else -> {
+        throw DecodeException(fieldPath = "Http3Frame.discriminator", bufferPosition = baseOffset, expected = "one of {0, 1, 4, 64}", actual = """${__dispatchValue}""")
+      }
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameDataCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameDataCodec.kt
@@ -1,5 +1,6 @@
 package com.ditchoom.buffer.codec.test.protocols.http3
 
+import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.WriteBuffer
 import com.ditchoom.buffer.codec.Codec
@@ -7,14 +8,24 @@ import com.ditchoom.buffer.codec.DecodeContext
 import com.ditchoom.buffer.codec.EncodeContext
 import com.ditchoom.buffer.codec.PeekResult
 import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.codec.test.protocols.payload.BinaryDataCodec
 import com.ditchoom.buffer.stream.StreamProcessor
 import kotlin.Int
+import kotlin.Throwable
+import kotlin.ULong
 
 public object Http3FrameDataCodec : Codec<Http3Frame.Data> {
   override fun decode(buffer: ReadBuffer, context: DecodeContext): Http3Frame.Data {
     val frameType = Http3FrameTypeCodec.decode(buffer, context)
-    val firstByte = buffer.readUByte()
-    return Http3Frame.Data(frameType = frameType, firstByte = firstByte)
+    val __lengthOuterLimit = buffer.limit()
+    val length = Http3LengthCodec.decode(buffer, context)
+    Http3LengthCodec.applyBound(buffer, length)
+    return try {
+      val payload = BinaryDataCodec.decode(buffer, context)
+      Http3Frame.Data(frameType = frameType, length = length, payload = payload)
+    } finally {
+      buffer.setLimit(__lengthOuterLimit)
+    }
   }
 
   override fun encode(
@@ -23,17 +34,59 @@ public object Http3FrameDataCodec : Codec<Http3Frame.Data> {
     context: EncodeContext,
   ) {
     Http3FrameTypeCodec.encode(buffer, value.frameType, context)
-    buffer.writeUByte(value.firstByte)
+    Http3LengthCodec.encode(buffer, value.length, context)
+    BinaryDataCodec.encode(buffer, value.payload, context)
   }
 
   override fun wireSize(`value`: Http3Frame.Data, context: EncodeContext): WireSize = WireSize.BackPatch
 
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
-    val __frameTypeFrame = Http3FrameTypeCodec.peekFrameSize(stream, baseOffset + 0)
+    var __priorBytes = 0
+    val __frameTypeFrame = Http3FrameTypeCodec.peekFrameSize(stream, baseOffset + __priorBytes)
     if (__frameTypeFrame !is PeekResult.Complete) {
       return __frameTypeFrame
     }
-    val __total = 0 + __frameTypeFrame.bytes + 1
-    return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    __priorBytes += __frameTypeFrame.bytes
+    if (stream.available() - baseOffset < __priorBytes + 1) return PeekResult.NeedsMoreData
+    val __lengthPeekView = stream.peekBuffer(baseOffset + __priorBytes, 10) ?: return PeekResult.NeedsMoreData
+    try {
+      val __lengthPriorPos = __lengthPeekView.position()
+      val length = try {
+        Http3LengthCodec.decode(__lengthPeekView, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __lengthWidth = __lengthPeekView.position() - __lengthPriorPos
+      val __total = __priorBytes + __lengthWidth + length.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__lengthPeekView as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+
+  public fun partial(buffer: ReadBuffer, context: DecodeContext): Partial {
+    val frameType = Http3FrameTypeCodec.decode(buffer, context)
+    val __lengthOuterLimit = buffer.limit()
+    val length = Http3LengthCodec.decode(buffer, context)
+    Http3LengthCodec.applyBound(buffer, length)
+    return Partial(frameType = frameType, length = length, outerLimit = __lengthOuterLimit, buffer = buffer, context = context)
+  }
+
+  public class Partial internal constructor(
+    public val frameType: Http3FrameType,
+    public val length: ULong,
+    private val outerLimit: Int,
+    private val buffer: ReadBuffer,
+    private val context: DecodeContext,
+  ) {
+    public fun complete(): Http3Frame.Data = try {
+      val payload = BinaryDataCodec.decode(buffer, context)
+      Http3Frame.Data(frameType = frameType, length = length, payload = payload)
+    } finally {
+      buffer.setLimit(outerLimit)
+    }
   }
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameDataCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameDataCodec.kt
@@ -1,0 +1,39 @@
+package com.ditchoom.buffer.codec.test.protocols.http3
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object Http3FrameDataCodec : Codec<Http3Frame.Data> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): Http3Frame.Data {
+    val frameType = Http3FrameTypeCodec.decode(buffer, context)
+    val firstByte = buffer.readUByte()
+    return Http3Frame.Data(frameType = frameType, firstByte = firstByte)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: Http3Frame.Data,
+    context: EncodeContext,
+  ) {
+    Http3FrameTypeCodec.encode(buffer, value.frameType, context)
+    buffer.writeUByte(value.firstByte)
+  }
+
+  override fun wireSize(`value`: Http3Frame.Data, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    val __frameTypeFrame = Http3FrameTypeCodec.peekFrameSize(stream, baseOffset + 0)
+    if (__frameTypeFrame !is PeekResult.Complete) {
+      return __frameTypeFrame
+    }
+    val __total = 0 + __frameTypeFrame.bytes + 1
+    return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameExtensionCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameExtensionCodec.kt
@@ -1,5 +1,6 @@
 package com.ditchoom.buffer.codec.test.protocols.http3
 
+import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.WriteBuffer
 import com.ditchoom.buffer.codec.Codec
@@ -7,14 +8,24 @@ import com.ditchoom.buffer.codec.DecodeContext
 import com.ditchoom.buffer.codec.EncodeContext
 import com.ditchoom.buffer.codec.PeekResult
 import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.codec.test.protocols.payload.BinaryDataCodec
 import com.ditchoom.buffer.stream.StreamProcessor
 import kotlin.Int
+import kotlin.Throwable
+import kotlin.ULong
 
 public object Http3FrameExtensionCodec : Codec<Http3Frame.Extension> {
   override fun decode(buffer: ReadBuffer, context: DecodeContext): Http3Frame.Extension {
     val frameType = Http3FrameTypeCodec.decode(buffer, context)
-    val payload = buffer.readUByte()
-    return Http3Frame.Extension(frameType = frameType, payload = payload)
+    val __lengthOuterLimit = buffer.limit()
+    val length = Http3LengthCodec.decode(buffer, context)
+    Http3LengthCodec.applyBound(buffer, length)
+    return try {
+      val payload = BinaryDataCodec.decode(buffer, context)
+      Http3Frame.Extension(frameType = frameType, length = length, payload = payload)
+    } finally {
+      buffer.setLimit(__lengthOuterLimit)
+    }
   }
 
   override fun encode(
@@ -23,17 +34,59 @@ public object Http3FrameExtensionCodec : Codec<Http3Frame.Extension> {
     context: EncodeContext,
   ) {
     Http3FrameTypeCodec.encode(buffer, value.frameType, context)
-    buffer.writeUByte(value.payload)
+    Http3LengthCodec.encode(buffer, value.length, context)
+    BinaryDataCodec.encode(buffer, value.payload, context)
   }
 
   override fun wireSize(`value`: Http3Frame.Extension, context: EncodeContext): WireSize = WireSize.BackPatch
 
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
-    val __frameTypeFrame = Http3FrameTypeCodec.peekFrameSize(stream, baseOffset + 0)
+    var __priorBytes = 0
+    val __frameTypeFrame = Http3FrameTypeCodec.peekFrameSize(stream, baseOffset + __priorBytes)
     if (__frameTypeFrame !is PeekResult.Complete) {
       return __frameTypeFrame
     }
-    val __total = 0 + __frameTypeFrame.bytes + 1
-    return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    __priorBytes += __frameTypeFrame.bytes
+    if (stream.available() - baseOffset < __priorBytes + 1) return PeekResult.NeedsMoreData
+    val __lengthPeekView = stream.peekBuffer(baseOffset + __priorBytes, 10) ?: return PeekResult.NeedsMoreData
+    try {
+      val __lengthPriorPos = __lengthPeekView.position()
+      val length = try {
+        Http3LengthCodec.decode(__lengthPeekView, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __lengthWidth = __lengthPeekView.position() - __lengthPriorPos
+      val __total = __priorBytes + __lengthWidth + length.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__lengthPeekView as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+
+  public fun partial(buffer: ReadBuffer, context: DecodeContext): Partial {
+    val frameType = Http3FrameTypeCodec.decode(buffer, context)
+    val __lengthOuterLimit = buffer.limit()
+    val length = Http3LengthCodec.decode(buffer, context)
+    Http3LengthCodec.applyBound(buffer, length)
+    return Partial(frameType = frameType, length = length, outerLimit = __lengthOuterLimit, buffer = buffer, context = context)
+  }
+
+  public class Partial internal constructor(
+    public val frameType: Http3FrameType,
+    public val length: ULong,
+    private val outerLimit: Int,
+    private val buffer: ReadBuffer,
+    private val context: DecodeContext,
+  ) {
+    public fun complete(): Http3Frame.Extension = try {
+      val payload = BinaryDataCodec.decode(buffer, context)
+      Http3Frame.Extension(frameType = frameType, length = length, payload = payload)
+    } finally {
+      buffer.setLimit(outerLimit)
+    }
   }
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameExtensionCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameExtensionCodec.kt
@@ -1,0 +1,39 @@
+package com.ditchoom.buffer.codec.test.protocols.http3
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object Http3FrameExtensionCodec : Codec<Http3Frame.Extension> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): Http3Frame.Extension {
+    val frameType = Http3FrameTypeCodec.decode(buffer, context)
+    val payload = buffer.readUByte()
+    return Http3Frame.Extension(frameType = frameType, payload = payload)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: Http3Frame.Extension,
+    context: EncodeContext,
+  ) {
+    Http3FrameTypeCodec.encode(buffer, value.frameType, context)
+    buffer.writeUByte(value.payload)
+  }
+
+  override fun wireSize(`value`: Http3Frame.Extension, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    val __frameTypeFrame = Http3FrameTypeCodec.peekFrameSize(stream, baseOffset + 0)
+    if (__frameTypeFrame !is PeekResult.Complete) {
+      return __frameTypeFrame
+    }
+    val __total = 0 + __frameTypeFrame.bytes + 1
+    return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameHeadersCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameHeadersCodec.kt
@@ -1,0 +1,39 @@
+package com.ditchoom.buffer.codec.test.protocols.http3
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object Http3FrameHeadersCodec : Codec<Http3Frame.Headers> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): Http3Frame.Headers {
+    val frameType = Http3FrameTypeCodec.decode(buffer, context)
+    val fieldSectionTag = buffer.readUShort()
+    return Http3Frame.Headers(frameType = frameType, fieldSectionTag = fieldSectionTag)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: Http3Frame.Headers,
+    context: EncodeContext,
+  ) {
+    Http3FrameTypeCodec.encode(buffer, value.frameType, context)
+    buffer.writeUShort(value.fieldSectionTag)
+  }
+
+  override fun wireSize(`value`: Http3Frame.Headers, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    val __frameTypeFrame = Http3FrameTypeCodec.peekFrameSize(stream, baseOffset + 0)
+    if (__frameTypeFrame !is PeekResult.Complete) {
+      return __frameTypeFrame
+    }
+    val __total = 0 + __frameTypeFrame.bytes + 2
+    return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameHeadersCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameHeadersCodec.kt
@@ -1,5 +1,6 @@
 package com.ditchoom.buffer.codec.test.protocols.http3
 
+import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.WriteBuffer
 import com.ditchoom.buffer.codec.Codec
@@ -7,14 +8,24 @@ import com.ditchoom.buffer.codec.DecodeContext
 import com.ditchoom.buffer.codec.EncodeContext
 import com.ditchoom.buffer.codec.PeekResult
 import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.codec.test.protocols.payload.BinaryDataCodec
 import com.ditchoom.buffer.stream.StreamProcessor
 import kotlin.Int
+import kotlin.Throwable
+import kotlin.ULong
 
 public object Http3FrameHeadersCodec : Codec<Http3Frame.Headers> {
   override fun decode(buffer: ReadBuffer, context: DecodeContext): Http3Frame.Headers {
     val frameType = Http3FrameTypeCodec.decode(buffer, context)
-    val fieldSectionTag = buffer.readUShort()
-    return Http3Frame.Headers(frameType = frameType, fieldSectionTag = fieldSectionTag)
+    val __lengthOuterLimit = buffer.limit()
+    val length = Http3LengthCodec.decode(buffer, context)
+    Http3LengthCodec.applyBound(buffer, length)
+    return try {
+      val fieldSection = BinaryDataCodec.decode(buffer, context)
+      Http3Frame.Headers(frameType = frameType, length = length, fieldSection = fieldSection)
+    } finally {
+      buffer.setLimit(__lengthOuterLimit)
+    }
   }
 
   override fun encode(
@@ -23,17 +34,59 @@ public object Http3FrameHeadersCodec : Codec<Http3Frame.Headers> {
     context: EncodeContext,
   ) {
     Http3FrameTypeCodec.encode(buffer, value.frameType, context)
-    buffer.writeUShort(value.fieldSectionTag)
+    Http3LengthCodec.encode(buffer, value.length, context)
+    BinaryDataCodec.encode(buffer, value.fieldSection, context)
   }
 
   override fun wireSize(`value`: Http3Frame.Headers, context: EncodeContext): WireSize = WireSize.BackPatch
 
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
-    val __frameTypeFrame = Http3FrameTypeCodec.peekFrameSize(stream, baseOffset + 0)
+    var __priorBytes = 0
+    val __frameTypeFrame = Http3FrameTypeCodec.peekFrameSize(stream, baseOffset + __priorBytes)
     if (__frameTypeFrame !is PeekResult.Complete) {
       return __frameTypeFrame
     }
-    val __total = 0 + __frameTypeFrame.bytes + 2
-    return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    __priorBytes += __frameTypeFrame.bytes
+    if (stream.available() - baseOffset < __priorBytes + 1) return PeekResult.NeedsMoreData
+    val __lengthPeekView = stream.peekBuffer(baseOffset + __priorBytes, 10) ?: return PeekResult.NeedsMoreData
+    try {
+      val __lengthPriorPos = __lengthPeekView.position()
+      val length = try {
+        Http3LengthCodec.decode(__lengthPeekView, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __lengthWidth = __lengthPeekView.position() - __lengthPriorPos
+      val __total = __priorBytes + __lengthWidth + length.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__lengthPeekView as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+
+  public fun partial(buffer: ReadBuffer, context: DecodeContext): Partial {
+    val frameType = Http3FrameTypeCodec.decode(buffer, context)
+    val __lengthOuterLimit = buffer.limit()
+    val length = Http3LengthCodec.decode(buffer, context)
+    Http3LengthCodec.applyBound(buffer, length)
+    return Partial(frameType = frameType, length = length, outerLimit = __lengthOuterLimit, buffer = buffer, context = context)
+  }
+
+  public class Partial internal constructor(
+    public val frameType: Http3FrameType,
+    public val length: ULong,
+    private val outerLimit: Int,
+    private val buffer: ReadBuffer,
+    private val context: DecodeContext,
+  ) {
+    public fun complete(): Http3Frame.Headers = try {
+      val fieldSection = BinaryDataCodec.decode(buffer, context)
+      Http3Frame.Headers(frameType = frameType, length = length, fieldSection = fieldSection)
+    } finally {
+      buffer.setLimit(outerLimit)
+    }
   }
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameSettingsCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameSettingsCodec.kt
@@ -1,0 +1,39 @@
+package com.ditchoom.buffer.codec.test.protocols.http3
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object Http3FrameSettingsCodec : Codec<Http3Frame.Settings> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): Http3Frame.Settings {
+    val frameType = Http3FrameTypeCodec.decode(buffer, context)
+    val identifier = buffer.readUInt()
+    return Http3Frame.Settings(frameType = frameType, identifier = identifier)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: Http3Frame.Settings,
+    context: EncodeContext,
+  ) {
+    Http3FrameTypeCodec.encode(buffer, value.frameType, context)
+    buffer.writeUInt(value.identifier)
+  }
+
+  override fun wireSize(`value`: Http3Frame.Settings, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    val __frameTypeFrame = Http3FrameTypeCodec.peekFrameSize(stream, baseOffset + 0)
+    if (__frameTypeFrame !is PeekResult.Complete) {
+      return __frameTypeFrame
+    }
+    val __total = 0 + __frameTypeFrame.bytes + 4
+    return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameSettingsCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameSettingsCodec.kt
@@ -1,5 +1,6 @@
 package com.ditchoom.buffer.codec.test.protocols.http3
 
+import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.WriteBuffer
 import com.ditchoom.buffer.codec.Codec
@@ -7,14 +8,24 @@ import com.ditchoom.buffer.codec.DecodeContext
 import com.ditchoom.buffer.codec.EncodeContext
 import com.ditchoom.buffer.codec.PeekResult
 import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.codec.test.protocols.payload.BinaryDataCodec
 import com.ditchoom.buffer.stream.StreamProcessor
 import kotlin.Int
+import kotlin.Throwable
+import kotlin.ULong
 
 public object Http3FrameSettingsCodec : Codec<Http3Frame.Settings> {
   override fun decode(buffer: ReadBuffer, context: DecodeContext): Http3Frame.Settings {
     val frameType = Http3FrameTypeCodec.decode(buffer, context)
-    val identifier = buffer.readUInt()
-    return Http3Frame.Settings(frameType = frameType, identifier = identifier)
+    val __lengthOuterLimit = buffer.limit()
+    val length = Http3LengthCodec.decode(buffer, context)
+    Http3LengthCodec.applyBound(buffer, length)
+    return try {
+      val parameters = BinaryDataCodec.decode(buffer, context)
+      Http3Frame.Settings(frameType = frameType, length = length, parameters = parameters)
+    } finally {
+      buffer.setLimit(__lengthOuterLimit)
+    }
   }
 
   override fun encode(
@@ -23,17 +34,59 @@ public object Http3FrameSettingsCodec : Codec<Http3Frame.Settings> {
     context: EncodeContext,
   ) {
     Http3FrameTypeCodec.encode(buffer, value.frameType, context)
-    buffer.writeUInt(value.identifier)
+    Http3LengthCodec.encode(buffer, value.length, context)
+    BinaryDataCodec.encode(buffer, value.parameters, context)
   }
 
   override fun wireSize(`value`: Http3Frame.Settings, context: EncodeContext): WireSize = WireSize.BackPatch
 
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
-    val __frameTypeFrame = Http3FrameTypeCodec.peekFrameSize(stream, baseOffset + 0)
+    var __priorBytes = 0
+    val __frameTypeFrame = Http3FrameTypeCodec.peekFrameSize(stream, baseOffset + __priorBytes)
     if (__frameTypeFrame !is PeekResult.Complete) {
       return __frameTypeFrame
     }
-    val __total = 0 + __frameTypeFrame.bytes + 4
-    return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    __priorBytes += __frameTypeFrame.bytes
+    if (stream.available() - baseOffset < __priorBytes + 1) return PeekResult.NeedsMoreData
+    val __lengthPeekView = stream.peekBuffer(baseOffset + __priorBytes, 10) ?: return PeekResult.NeedsMoreData
+    try {
+      val __lengthPriorPos = __lengthPeekView.position()
+      val length = try {
+        Http3LengthCodec.decode(__lengthPeekView, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __lengthWidth = __lengthPeekView.position() - __lengthPriorPos
+      val __total = __priorBytes + __lengthWidth + length.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__lengthPeekView as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+
+  public fun partial(buffer: ReadBuffer, context: DecodeContext): Partial {
+    val frameType = Http3FrameTypeCodec.decode(buffer, context)
+    val __lengthOuterLimit = buffer.limit()
+    val length = Http3LengthCodec.decode(buffer, context)
+    Http3LengthCodec.applyBound(buffer, length)
+    return Partial(frameType = frameType, length = length, outerLimit = __lengthOuterLimit, buffer = buffer, context = context)
+  }
+
+  public class Partial internal constructor(
+    public val frameType: Http3FrameType,
+    public val length: ULong,
+    private val outerLimit: Int,
+    private val buffer: ReadBuffer,
+    private val context: DecodeContext,
+  ) {
+    public fun complete(): Http3Frame.Settings = try {
+      val parameters = BinaryDataCodec.decode(buffer, context)
+      Http3Frame.Settings(frameType = frameType, length = length, parameters = parameters)
+    } finally {
+      buffer.setLimit(outerLimit)
+    }
   }
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameTypeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameTypeCodec.kt
@@ -1,0 +1,38 @@
+package com.ditchoom.buffer.codec.test.protocols.http3
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.codec.test.protocols.quic.QuicVarintCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object Http3FrameTypeCodec : Codec<Http3FrameType> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): Http3FrameType {
+    val raw = QuicVarintCodec.decode(buffer, context)
+    return Http3FrameType(raw = raw)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: Http3FrameType,
+    context: EncodeContext,
+  ) {
+    QuicVarintCodec.encode(buffer, value.raw, context)
+  }
+
+  override fun wireSize(`value`: Http3FrameType, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    val __rawFrame = QuicVarintCodec.peekFrameSize(stream, baseOffset + 0)
+    if (__rawFrame !is PeekResult.Complete) {
+      return __rawFrame
+    }
+    val __total = 0 + __rawFrame.bytes + 0
+    return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/varintfield/VarintLengthFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/varintfield/VarintLengthFrameCodec.kt
@@ -1,0 +1,40 @@
+package com.ditchoom.buffer.codec.test.protocols.varintfield
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.codec.test.protocols.quic.QuicVarintCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object VarintLengthFrameCodec : Codec<VarintLengthFrame> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): VarintLengthFrame {
+    val value = QuicVarintCodec.decode(buffer, context)
+    val tag = buffer.readUByte()
+    return VarintLengthFrame(value = value, tag = tag)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: VarintLengthFrame,
+    context: EncodeContext,
+  ) {
+    QuicVarintCodec.encode(buffer, value.value, context)
+    buffer.writeUByte(value.tag)
+  }
+
+  override fun wireSize(`value`: VarintLengthFrame, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    val __valueFrame = QuicVarintCodec.peekFrameSize(stream, baseOffset + 0)
+    if (__valueFrame !is PeekResult.Complete) {
+      return __valueFrame
+    }
+    val __total = 0 + __valueFrame.bytes + 1
+    return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsFrameCodec.kt
@@ -72,23 +72,7 @@ public class WsFrameCodec<P : Payload>(
     }
   }
 
-  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
-    if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
-    val __discRaw = stream.peekByte(baseOffset + 0).toUByte()
-    val __discriminator = FrameHeaderByte1(__discRaw)
-    val __dispatchValue = __discriminator.opcode
-    return when (__dispatchValue) {
-      0 -> continuationCodec.peekFrameSize(stream, baseOffset)
-      1 -> textCodec.peekFrameSize(stream, baseOffset)
-      2 -> binaryCodec.peekFrameSize(stream, baseOffset)
-      8 -> WsFrameCloseCodec.peekFrameSize(stream, baseOffset)
-      9 -> pingCodec.peekFrameSize(stream, baseOffset)
-      10 -> pongCodec.peekFrameSize(stream, baseOffset)
-      else -> {
-        throw DecodeException(fieldPath = "WsFrame.discriminator", bufferPosition = baseOffset, expected = "one of {0, 1, 2, 8, 9, 10}", actual = """${__dispatchValue}""")
-      }
-    }
-  }
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = WsFrame.peekFrameSize(stream, baseOffset)
 
   public companion object {
     public fun <P : Payload> decodeAggregating(

--- a/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/http3/Http3Frame.kt
+++ b/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/http3/Http3Frame.kt
@@ -1,0 +1,76 @@
+package com.ditchoom.buffer.codec.test.protocols.http3
+
+import com.ditchoom.buffer.codec.annotations.DispatchOn
+import com.ditchoom.buffer.codec.annotations.DispatchValue
+import com.ditchoom.buffer.codec.annotations.PacketType
+import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+import com.ditchoom.buffer.codec.annotations.UseCodec
+import com.ditchoom.buffer.codec.test.protocols.quic.QuicVarintCodec
+import kotlin.jvm.JvmInline
+
+/**
+ * Stage 3/4a — the variable-width **dispatcher** vector: a `@DispatchOn`
+ * discriminator whose wire width is itself variable.
+ *
+ * The HTTP/3 frame layout (RFC 9114 §7.1) is `Type (varint)` + `Length
+ * (varint)` + `Frame Payload`, where `Type` is a QUIC variable-length integer
+ * (RFC 9000 §16). [Http3FrameType] models that discriminator: its inner scalar
+ * carries `@UseCodec(QuicVarintCodec)`, so the dispatcher is a
+ * `Discriminator.Varint` — it can't pre-compute a fixed discriminator width and
+ * instead measures it at runtime via the value class's own codec.
+ *
+ * The buffer library ships no QUIC encoding; [QuicVarintCodec] is test-support
+ * (RFC 9000 §16) and the processor stays encoding-agnostic. Frame *bodies* are
+ * fixed-size scalars here (not the real HTTP/3 length-prefixed payloads) so the
+ * generated `peekFrameSize` is exactly testable: total = varint-type-width +
+ * fixed-suffix.
+ *
+ * [Extension] uses frame type `0x40` (64), which needs a 2-byte QUIC varint, so
+ * the suite exercises a discriminator wider than one byte on both decode and
+ * peek — the property that distinguishes this from the fixed-width
+ * `Discriminator.ValueClass` path.
+ */
+@JvmInline
+@ProtocolMessage
+value class Http3FrameType(
+    @UseCodec(QuicVarintCodec::class) val raw: ULong,
+) {
+    @DispatchValue
+    val type: Int get() = raw.toInt()
+}
+
+@DispatchOn(Http3FrameType::class)
+@ProtocolMessage
+sealed interface Http3Frame {
+    /** DATA — RFC 9114 §7.2.1, frame type 0x00. */
+    @PacketType(value = 0x00)
+    @ProtocolMessage
+    data class Data(
+        val frameType: Http3FrameType = Http3FrameType(0x00uL),
+        val firstByte: UByte,
+    ) : Http3Frame
+
+    /** HEADERS — RFC 9114 §7.2.2, frame type 0x01. */
+    @PacketType(value = 0x01)
+    @ProtocolMessage
+    data class Headers(
+        val frameType: Http3FrameType = Http3FrameType(0x01uL),
+        val fieldSectionTag: UShort,
+    ) : Http3Frame
+
+    /** SETTINGS — RFC 9114 §7.2.4, frame type 0x04. */
+    @PacketType(value = 0x04)
+    @ProtocolMessage
+    data class Settings(
+        val frameType: Http3FrameType = Http3FrameType(0x04uL),
+        val identifier: UInt,
+    ) : Http3Frame
+
+    /** A reserved/greased extension frame whose type needs a 2-byte varint. */
+    @PacketType(value = 0x40)
+    @ProtocolMessage
+    data class Extension(
+        val frameType: Http3FrameType = Http3FrameType(0x40uL),
+        val payload: UByte,
+    ) : Http3Frame
+}

--- a/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/http3/Http3Frame.kt
+++ b/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/http3/Http3Frame.kt
@@ -4,31 +4,40 @@ import com.ditchoom.buffer.codec.annotations.DispatchOn
 import com.ditchoom.buffer.codec.annotations.DispatchValue
 import com.ditchoom.buffer.codec.annotations.PacketType
 import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+import com.ditchoom.buffer.codec.annotations.RemainingBytes
 import com.ditchoom.buffer.codec.annotations.UseCodec
+import com.ditchoom.buffer.codec.test.protocols.payload.BinaryData
+import com.ditchoom.buffer.codec.test.protocols.payload.BinaryDataCodec
 import com.ditchoom.buffer.codec.test.protocols.quic.QuicVarintCodec
 import kotlin.jvm.JvmInline
 
 /**
- * Stage 3/4a — the variable-width **dispatcher** vector: a `@DispatchOn`
- * discriminator whose wire width is itself variable.
+ * The real HTTP/3 frame (RFC 9114 §7.1): `Type (varint)` + `Length (varint)` +
+ * `Frame Payload`. This fixture exercises two variable-width mechanisms at once,
+ * both keyed off the QUIC variable-length integer (RFC 9000 §16):
  *
- * The HTTP/3 frame layout (RFC 9114 §7.1) is `Type (varint)` + `Length
- * (varint)` + `Frame Payload`, where `Type` is a QUIC variable-length integer
- * (RFC 9000 §16). [Http3FrameType] models that discriminator: its inner scalar
- * carries `@UseCodec(QuicVarintCodec)`, so the dispatcher is a
- * `Discriminator.Varint` — it can't pre-compute a fixed discriminator width and
- * instead measures it at runtime via the value class's own codec.
+ *  - **A variable-width dispatcher.** [Http3FrameType] is the `@DispatchOn`
+ *    discriminator; its inner scalar carries `@UseCodec(QuicVarintCodec)`, so
+ *    the dispatcher is a `Discriminator.Varint` — it measures the discriminator
+ *    width at runtime rather than assuming one byte. Frame types `0x00`/`0x01`/
+ *    `0x04` are 1-byte varints; [Extension] (type `0x40` = 64) needs 2 bytes.
  *
- * The buffer library ships no QUIC encoding; [QuicVarintCodec] is test-support
- * (RFC 9000 §16) and the processor stays encoding-agnostic. Frame *bodies* are
- * fixed-size scalars here (not the real HTTP/3 length-prefixed payloads) so the
- * generated `peekFrameSize` is exactly testable: total = varint-type-width +
- * fixed-suffix.
+ *  - **A variable-width bounding length.** Each variant's `length` field is the
+ *    real RFC 9114 §7.1 Length, modeled as [Http3LengthCodec] (a
+ *    `BoundingLengthCodec`). It narrows `buffer.limit()` to the payload extent so
+ *    the trailing `@RemainingBytes payload` reads exactly `length` bytes — and
+ *    the generated `peekFrameSize` sizes the whole frame as
+ *    `typeWidth + lengthWidth + length`.
  *
- * [Extension] uses frame type `0x40` (64), which needs a 2-byte QUIC varint, so
- * the suite exercises a discriminator wider than one byte on both decode and
- * peek — the property that distinguishes this from the fixed-width
- * `Discriminator.ValueClass` path.
+ * The length sits immediately before the payload (no field folds between them),
+ * which is the common bounding shape; the WebSocket frame is the contrasting
+ * case where a masking key folds between the length and the body.
+ *
+ * The buffer library ships no QUIC encoding; [QuicVarintCodec] / [Http3LengthCodec]
+ * are test-support and the processor stays encoding-agnostic. Frame payloads are
+ * opaque [BinaryData] here — RFC 9114 §7.1 defines the generic frame as
+ * Type + Length + opaque Frame Payload; per-type payload structure (QPACK field
+ * sections, SETTINGS id/value pairs) is a nested concern above the framing layer.
  */
 @JvmInline
 @ProtocolMessage
@@ -42,28 +51,31 @@ value class Http3FrameType(
 @DispatchOn(Http3FrameType::class)
 @ProtocolMessage
 sealed interface Http3Frame {
-    /** DATA — RFC 9114 §7.2.1, frame type 0x00. */
+    /** DATA — RFC 9114 §7.2.1, frame type 0x00. Payload is opaque application data. */
     @PacketType(value = 0x00)
     @ProtocolMessage
     data class Data(
         val frameType: Http3FrameType = Http3FrameType(0x00uL),
-        val firstByte: UByte,
+        @UseCodec(Http3LengthCodec::class) val length: ULong,
+        @RemainingBytes @UseCodec(BinaryDataCodec::class) val payload: BinaryData,
     ) : Http3Frame
 
-    /** HEADERS — RFC 9114 §7.2.2, frame type 0x01. */
+    /** HEADERS — RFC 9114 §7.2.2, frame type 0x01. Payload is a QPACK field section. */
     @PacketType(value = 0x01)
     @ProtocolMessage
     data class Headers(
         val frameType: Http3FrameType = Http3FrameType(0x01uL),
-        val fieldSectionTag: UShort,
+        @UseCodec(Http3LengthCodec::class) val length: ULong,
+        @RemainingBytes @UseCodec(BinaryDataCodec::class) val fieldSection: BinaryData,
     ) : Http3Frame
 
-    /** SETTINGS — RFC 9114 §7.2.4, frame type 0x04. */
+    /** SETTINGS — RFC 9114 §7.2.4, frame type 0x04. Payload is a sequence of id/value pairs. */
     @PacketType(value = 0x04)
     @ProtocolMessage
     data class Settings(
         val frameType: Http3FrameType = Http3FrameType(0x04uL),
-        val identifier: UInt,
+        @UseCodec(Http3LengthCodec::class) val length: ULong,
+        @RemainingBytes @UseCodec(BinaryDataCodec::class) val parameters: BinaryData,
     ) : Http3Frame
 
     /** A reserved/greased extension frame whose type needs a 2-byte varint. */
@@ -71,6 +83,7 @@ sealed interface Http3Frame {
     @ProtocolMessage
     data class Extension(
         val frameType: Http3FrameType = Http3FrameType(0x40uL),
-        val payload: UByte,
+        @UseCodec(Http3LengthCodec::class) val length: ULong,
+        @RemainingBytes @UseCodec(BinaryDataCodec::class) val payload: BinaryData,
     ) : Http3Frame
 }

--- a/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/http3/Http3LengthCodec.kt
+++ b/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/http3/Http3LengthCodec.kt
@@ -1,0 +1,54 @@
+package com.ditchoom.buffer.codec.test.protocols.http3
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.BoundingLengthCodec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.codec.test.protocols.quic.QuicVarintCodec
+
+/**
+ * The HTTP/3 frame **Length** field (RFC 9114 §7.1) as a [BoundingLengthCodec].
+ *
+ * Every HTTP/3 frame is `Type (varint)` + `Length (varint)` + `Frame Payload`,
+ * where `Length` is a QUIC variable-length integer (RFC 9000 §16) giving the
+ * byte count of the payload that follows. That is the textbook bounding-length
+ * shape: [decode] reads the varint, [applyBound] narrows `buffer.limit()` to
+ * `position + value`, and a trailing `@RemainingBytes` payload field reads
+ * exactly that many bytes.
+ *
+ * Distinct from [QuicVarintCodec] used as the frame-*type* discriminator
+ * ([Http3FrameType]): there the varint is self-delimiting (its width is the
+ * whole contribution); here the varint *bounds* the body, so the frame total is
+ * `typeWidth + lengthWidth + value`. Both roles wrap the same QUIC varint wire
+ * format — this codec delegates the encoding to [QuicVarintCodec] so the two
+ * share one source of truth; the buffer library itself ships no QUIC encoding.
+ */
+object Http3LengthCodec : BoundingLengthCodec<ULong> {
+    /** A QUIC varint is at most 8 bytes (the 62-bit length class). */
+    override val maxWireSize: Int = 8
+
+    override fun decode(
+        buffer: ReadBuffer,
+        context: DecodeContext,
+    ): ULong = QuicVarintCodec.decode(buffer, context)
+
+    override fun encode(
+        buffer: WriteBuffer,
+        value: ULong,
+        context: EncodeContext,
+    ) = QuicVarintCodec.encode(buffer, value, context)
+
+    override fun wireSize(
+        value: ULong,
+        context: EncodeContext,
+    ): WireSize = WireSize.Exact(QuicVarintCodec.encodedLength(value))
+
+    override fun applyBound(
+        buffer: ReadBuffer,
+        decodedValue: ULong,
+    ) {
+        buffer.setLimit(buffer.position() + decodedValue.toInt())
+    }
+}

--- a/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/quic/QuicVarintCodec.kt
+++ b/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/quic/QuicVarintCodec.kt
@@ -1,0 +1,103 @@
+package com.ditchoom.buffer.codec.test.protocols.quic
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.VarLenPeek
+import com.ditchoom.buffer.codec.VariableLengthCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+
+/**
+ * QUIC variable-length integer codec — RFC 9000 §16. **Test-support only**:
+ * the buffer library ships no protocol encodings; this lives in the test
+ * module to exercise the generic [VariableLengthCodec] plumbing on a real
+ * self-delimiting encoding.
+ *
+ * The two most-significant bits of the first byte name the length class — 1, 2,
+ * 4, or 8 bytes — and the remaining 6/14/30/62 bits carry the value big-endian:
+ *
+ * ```text
+ *   2MSB  bytes  usable bits  max value
+ *   00      1       6         2^6  - 1 = 63
+ *   01      2      14         2^14 - 1 = 16383
+ *   10      4      30         2^30 - 1
+ *   11      8      62         2^62 - 1
+ * ```
+ *
+ * Encoding is minimal (smallest length class that fits). Decoding accepts
+ * non-minimal encodings per spec (e.g. `0x40 0x25` → 37), so a decode of
+ * non-minimal input followed by a re-encode is *not* byte-identical — the
+ * value round-trips, the bytes do not.
+ */
+object QuicVarintCodec : VariableLengthCodec<ULong> {
+    /** Largest value a QUIC varint can represent: 2^62 - 1. */
+    const val MAX_VALUE: ULong = 0x3FFF_FFFF_FFFF_FFFFuL
+
+    private const val ONE_BYTE_MAX: ULong = 0x3FuL // 2^6 - 1
+    private const val TWO_BYTE_MAX: ULong = 0x3FFFuL // 2^14 - 1
+    private const val FOUR_BYTE_MAX: ULong = 0x3FFF_FFFFuL // 2^30 - 1
+
+    override fun encodedLength(value: ULong): Int =
+        when {
+            value <= ONE_BYTE_MAX -> 1
+            value <= TWO_BYTE_MAX -> 2
+            value <= FOUR_BYTE_MAX -> 4
+            value <= MAX_VALUE -> 8
+            else -> throw IllegalArgumentException(
+                "value $value exceeds the QUIC varint range 0..$MAX_VALUE (RFC 9000 §16)",
+            )
+        }
+
+    override fun encode(
+        buffer: WriteBuffer,
+        value: ULong,
+        context: EncodeContext,
+    ) {
+        val length = encodedLength(value)
+        // Length class encoded in the 2 high bits of byte 0: log2(length).
+        val lengthClass =
+            when (length) {
+                1 -> 0
+                2 -> 1
+                4 -> 2
+                else -> 3
+            }
+        for (i in 0 until length) {
+            val shift = (length - 1 - i) * 8
+            var b = ((value shr shift) and 0xFFuL).toInt()
+            // The value occupies length*8 - 2 bits, so byte 0's top 2 bits are
+            // free for the length class.
+            if (i == 0) b = b or (lengthClass shl 6)
+            buffer.writeByte(b.toByte())
+        }
+    }
+
+    override fun decode(
+        buffer: ReadBuffer,
+        context: DecodeContext,
+    ): ULong {
+        val first = buffer.readUByte().toInt()
+        val length = 1 shl (first shr 6)
+        var value = (first and 0x3F).toULong()
+        for (i in 1 until length) {
+            value = (value shl 8) or buffer.readUByte().toULong()
+        }
+        return value
+    }
+
+    override fun peekValue(
+        stream: StreamProcessor,
+        baseOffset: Int,
+    ): VarLenPeek<ULong> {
+        if (stream.available() - baseOffset < 1) return VarLenPeek.NeedsMoreData
+        val first = stream.peekByte(baseOffset).toInt() and 0xFF
+        val length = 1 shl (first shr 6)
+        if (stream.available() - baseOffset < length) return VarLenPeek.NeedsMoreData
+        var value = (first and 0x3F).toULong()
+        for (i in 1 until length) {
+            value = (value shl 8) or (stream.peekByte(baseOffset + i).toInt() and 0xFF).toULong()
+        }
+        return VarLenPeek.Decoded(value, length)
+    }
+}

--- a/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/varintfield/VarintLengthFrame.kt
+++ b/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/varintfield/VarintLengthFrame.kt
@@ -1,0 +1,22 @@
+package com.ditchoom.buffer.codec.test.protocols.varintfield
+
+import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+import com.ditchoom.buffer.codec.annotations.UseCodec
+import com.ditchoom.buffer.codec.test.protocols.quic.QuicVarintCodec
+
+/**
+ * Field-level variable-width vector (stage 2): a `@UseCodec` scalar whose codec
+ * implements `VariableLengthCodec` (the test-support [QuicVarintCodec]),
+ * followed by a fixed-size suffix.
+ *
+ * Proves the generic, encoding-agnostic plumbing: decode/encode delegate to the
+ * codec (already worked), and `peekFrameSize` now frames the message as
+ * `width(value) + 1` — the self-delimiting width read from the leading bytes
+ * plus the trailing `tag` byte — instead of collapsing to `NoFraming`. No QUIC
+ * knowledge is in the processor; the encoding is entirely in the consumer codec.
+ */
+@ProtocolMessage
+data class VarintLengthFrame(
+    @UseCodec(QuicVarintCodec::class) val value: ULong,
+    val tag: UByte,
+)

--- a/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/websocket/WsFrame.kt
+++ b/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/websocket/WsFrame.kt
@@ -1,6 +1,8 @@
 package com.ditchoom.buffer.codec.test.protocols.websocket
 
+import com.ditchoom.buffer.codec.FrameDetector
 import com.ditchoom.buffer.codec.Payload
+import com.ditchoom.buffer.codec.PeekResult
 import com.ditchoom.buffer.codec.annotations.DispatchOn
 import com.ditchoom.buffer.codec.annotations.DispatchValue
 import com.ditchoom.buffer.codec.annotations.Endianness
@@ -8,6 +10,7 @@ import com.ditchoom.buffer.codec.annotations.PacketType
 import com.ditchoom.buffer.codec.annotations.ProtocolMessage
 import com.ditchoom.buffer.codec.annotations.RemainingBytes
 import com.ditchoom.buffer.codec.annotations.When
+import com.ditchoom.buffer.stream.StreamProcessor
 import kotlin.jvm.JvmInline
 
 /*
@@ -342,4 +345,68 @@ sealed interface WsFrame<out P : Payload> {
         @When("byte2.masked") val maskingKey: WsMaskingKey? = null,
         @RemainingBytes val payload: P,
     ) : WsFrame<P>
+
+    /**
+     * Consumer-supplied frame sizing — the piece RFC 6455 framing needs that the
+     * generated peek walker cannot derive. The payload length is **escape-coded**
+     * across header fields (`byte2.lengthIndicator`, escaping to a 16- or 64-bit
+     * extended length at 126/127), and a masking key folds **between** the length
+     * and the payload — neither a `@LengthPrefixed`/`@LengthFrom` nor a bounding
+     * codec can express that, so `WsFrameCodec.peekFrameSize` would otherwise fall
+     * back to `NoFraming` (and the websocket repo hand-writes this in
+     * `WebSocketCodec.readNextFrame`).
+     *
+     * Because this companion implements [FrameDetector], the processor makes the
+     * generated `WsFrameCodec.peekFrameSize` delegate here instead. The companion
+     * owns ONLY framing (the total byte count); field decode/encode stay
+     * generated. The load-bearing contract — `peek.bytes == decode consumption`
+     * for any fully-buffered frame, `NeedsMoreData` for every shorter prefix — is
+     * locked by `WsFramePeekCodecTest`'s drip-feed across all three length classes
+     * (7-bit / 16-bit / 64-bit), masked and unmasked.
+     *
+     * Wire walked (RFC 6455 §5.2): `byte1 | byte2 | [ext-len 16 if ind==126 |
+     * ext-len 64 if ind==127] | [mask 4 if MASK] | payload[len]`. Extended lengths
+     * are network (big-endian) order; the 64-bit length's MSB is 0 by spec, so it
+     * fits a non-negative `Long`.
+     */
+    companion object : FrameDetector {
+        override fun peekFrameSize(
+            stream: StreamProcessor,
+            baseOffset: Int,
+        ): PeekResult {
+            // byte1 + byte2 are needed before the length shape is known.
+            if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
+            val byte2 = stream.peekByte(baseOffset + 1).toInt() and 0xFF
+            val masked = (byte2 and 0x80) != 0
+            val indicator = byte2 and 0x7F
+            var offset = 2
+            val payloadLength: Long =
+                when (indicator) {
+                    126 -> {
+                        if (stream.available() - baseOffset < offset + 2) return PeekResult.NeedsMoreData
+                        val hi = stream.peekByte(baseOffset + offset).toInt() and 0xFF
+                        val lo = stream.peekByte(baseOffset + offset + 1).toInt() and 0xFF
+                        offset += 2
+                        ((hi shl 8) or lo).toLong()
+                    }
+                    127 -> {
+                        if (stream.available() - baseOffset < offset + 8) return PeekResult.NeedsMoreData
+                        var v = 0L
+                        for (i in 0 until 8) {
+                            v = (v shl 8) or (stream.peekByte(baseOffset + offset + i).toLong() and 0xFF)
+                        }
+                        offset += 8
+                        v
+                    }
+                    else -> indicator.toLong()
+                }
+            if (masked) offset += 4
+            val total = offset + payloadLength.toInt()
+            return if (stream.available() - baseOffset >= total) {
+                PeekResult.Complete(total)
+            } else {
+                PeekResult.NeedsMoreData
+            }
+        }
+    }
 }

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameCodecTest.kt
@@ -1,0 +1,100 @@
+package com.ditchoom.buffer.codec.test.protocols.http3
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Stage 3/4a — the variable-width **dispatcher**.
+ *
+ * `Http3Frame` dispatches on [Http3FrameType], a value class whose inner scalar
+ * is a QUIC varint (`@UseCodec(QuicVarintCodec)`). The discriminator's wire
+ * width therefore isn't fixed: frame types `0x00`/`0x01`/`0x04` are 1-byte
+ * varints, while `Extension` (type `0x40` = 64) is a 2-byte varint. The
+ * dispatcher must measure that width at runtime — via the value class's own
+ * codec — both to rewind on decode and to frame on peek.
+ *
+ * What this pins:
+ *  - round-trip through `Http3FrameCodec` for every variant, including the
+ *    multi-byte discriminator, and
+ *  - `peekFrameSize` drip-feeding one byte at a time: `NeedsMoreData` until the
+ *    full frame (varint type + fixed body) is buffered, then `Complete(total)`.
+ */
+class Http3FrameCodecTest {
+    @Test
+    fun roundTripsEveryVariantIncludingMultiByteDiscriminator() {
+        // (frame, total wire bytes) — type-varint-width + fixed body.
+        for ((frame, total) in listOf(
+            Http3Frame.Data(firstByte = 0xABu) to 2, // 1-byte type + 1
+            Http3Frame.Headers(fieldSectionTag = 0x1234u) to 3, // 1-byte type + 2
+            Http3Frame.Settings(identifier = 0xDEAD_BEEFu) to 5, // 1-byte type + 4
+            Http3Frame.Extension(payload = 0x7Fu) to 3, // 2-byte type + 1
+        )) {
+            val buf = BufferFactory.Default.allocate(16)
+            Http3FrameCodec.encode(buf, frame, EncodeContext.Empty)
+            assertEquals(total, buf.position(), "encoded size for $frame")
+            buf.resetForRead()
+            assertEquals(frame, Http3FrameCodec.decode(buf, DecodeContext.Empty), "round-trip $frame")
+        }
+    }
+
+    @Test
+    fun peekFramesByVariableDiscriminatorWidthPlusBody() {
+        // 1-byte discriminator variants.
+        assertDripPeek(Http3Frame.Data(firstByte = 0x01u), expectedTotal = 2)
+        assertDripPeek(Http3Frame.Settings(identifier = 0x01020304u), expectedTotal = 5)
+        // 2-byte discriminator (type 0x40): proves the dispatcher measures the
+        // varint width rather than assuming one byte.
+        assertDripPeek(Http3Frame.Extension(payload = 0x55u), expectedTotal = 3)
+    }
+
+    private fun assertDripPeek(
+        frame: Http3Frame,
+        expectedTotal: Int,
+    ) {
+        val pool = BufferPool()
+        val source = BufferFactory.Default.allocate(16)
+        Http3FrameCodec.encode(source, frame, EncodeContext.Empty)
+        source.resetForRead()
+        val total = source.remaining()
+        assertEquals(expectedTotal, total, "encoded total for $frame")
+        val stream = StreamProcessor.create(pool, ByteOrder.BIG_ENDIAN)
+        try {
+            for (i in 0 until total - 1) {
+                appendByte(stream, source.readByte())
+                assertEquals(
+                    PeekResult.NeedsMoreData,
+                    Http3FrameCodec.peekFrameSize(stream),
+                    "after ${i + 1}/$total bytes of $frame",
+                )
+            }
+            appendByte(stream, source.readByte())
+            assertEquals(
+                PeekResult.Complete(total),
+                Http3FrameCodec.peekFrameSize(stream),
+                "fully buffered $frame",
+            )
+        } finally {
+            stream.release()
+            pool.clear()
+        }
+    }
+
+    private fun appendByte(
+        stream: StreamProcessor,
+        byte: Byte,
+    ) {
+        val one: PlatformBuffer = BufferFactory.Default.allocate(1)
+        one.writeByte(byte)
+        one.resetForRead()
+        stream.append(one)
+    }
+}

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameCodecTest.kt
@@ -6,54 +6,108 @@ import com.ditchoom.buffer.Default
 import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.codec.DecodeContext
 import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.OwnedBytesHandle
 import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.byteSize
+import com.ditchoom.buffer.codec.handleEquals
+import com.ditchoom.buffer.codec.ownedBytesFrom
+import com.ditchoom.buffer.codec.test.protocols.payload.BinaryData
 import com.ditchoom.buffer.pool.BufferPool
 import com.ditchoom.buffer.stream.StreamProcessor
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
- * Stage 3/4a — the variable-width **dispatcher**.
+ * The real HTTP/3 frame (RFC 9114 §7.1): `Type (varint)` + `Length (varint)` +
+ * `Frame Payload`. This pins two variable-width mechanisms composing in one
+ * codec:
  *
- * `Http3Frame` dispatches on [Http3FrameType], a value class whose inner scalar
- * is a QUIC varint (`@UseCodec(QuicVarintCodec)`). The discriminator's wire
- * width therefore isn't fixed: frame types `0x00`/`0x01`/`0x04` are 1-byte
- * varints, while `Extension` (type `0x40` = 64) is a 2-byte varint. The
- * dispatcher must measure that width at runtime — via the value class's own
- * codec — both to rewind on decode and to frame on peek.
+ *  - the **variable-width dispatcher** ([Http3FrameType], a `@DispatchOn`
+ *    discriminator whose QUIC-varint width is 1 byte for types `0x00`/`0x01`/
+ *    `0x04` and 2 bytes for [Http3Frame.Extension] = `0x40`), and
+ *  - the **variable-width bounding length** ([Http3LengthCodec], the RFC 9114
+ *    §7.1 Length): 1-byte varint for payloads ≤63, 2-byte for larger.
  *
  * What this pins:
- *  - round-trip through `Http3FrameCodec` for every variant, including the
- *    multi-byte discriminator, and
+ *  - round-trip through `Http3FrameCodec` for every variant across the
+ *    discriminator-width × length-width cross product;
+ *  - `applyBound` caps the `@RemainingBytes` payload at exactly `length` bytes,
+ *    so trailing bytes past the frame don't bleed into the payload;
  *  - `peekFrameSize` drip-feeding one byte at a time: `NeedsMoreData` until the
- *    full frame (varint type + fixed body) is buffered, then `Complete(total)`.
+ *    whole frame (`typeWidth + lengthWidth + length`) is buffered, then
+ *    `Complete(total)` — and `total` equals what `decode` consumes.
  */
 class Http3FrameCodecTest {
+    // Short payload → 1-byte varint length; long payload (>63) → 2-byte varint.
+    private val short = 3
+    private val long = 200
+
+    private fun payload(size: Int): BinaryData {
+        val buf = BufferFactory.Default.allocate(size)
+        for (i in 0 until size) buf.writeByte((i and 0x7F).toByte())
+        buf.resetForRead()
+        return BinaryData(ownedBytesFrom(buf))
+    }
+
+    /** (frameType, length, payload-handle) projected uniformly across variants. */
+    private fun parts(frame: Http3Frame): Triple<Http3FrameType, ULong, OwnedBytesHandle> =
+        when (frame) {
+            is Http3Frame.Data -> Triple(frame.frameType, frame.length, frame.payload.data)
+            is Http3Frame.Headers -> Triple(frame.frameType, frame.length, frame.fieldSection.data)
+            is Http3Frame.Settings -> Triple(frame.frameType, frame.length, frame.parameters.data)
+            is Http3Frame.Extension -> Triple(frame.frameType, frame.length, frame.payload.data)
+        }
+
+    private fun cases(): List<Pair<Http3Frame, Int>> =
+        listOf(
+            // (frame, expected total wire bytes = typeWidth + lengthWidth + payload)
+            Http3Frame.Data(length = short.toULong(), payload = payload(short)) to (1 + 1 + short),
+            Http3Frame.Data(length = long.toULong(), payload = payload(long)) to (1 + 2 + long),
+            Http3Frame.Headers(length = short.toULong(), fieldSection = payload(short)) to (1 + 1 + short),
+            Http3Frame.Settings(length = short.toULong(), parameters = payload(short)) to (1 + 1 + short),
+            // 2-byte discriminator (type 0x40) × both length widths.
+            Http3Frame.Extension(length = short.toULong(), payload = payload(short)) to (2 + 1 + short),
+            Http3Frame.Extension(length = long.toULong(), payload = payload(long)) to (2 + 2 + long),
+        )
+
     @Test
-    fun roundTripsEveryVariantIncludingMultiByteDiscriminator() {
-        // (frame, total wire bytes) — type-varint-width + fixed body.
-        for ((frame, total) in listOf(
-            Http3Frame.Data(firstByte = 0xABu) to 2, // 1-byte type + 1
-            Http3Frame.Headers(fieldSectionTag = 0x1234u) to 3, // 1-byte type + 2
-            Http3Frame.Settings(identifier = 0xDEAD_BEEFu) to 5, // 1-byte type + 4
-            Http3Frame.Extension(payload = 0x7Fu) to 3, // 2-byte type + 1
-        )) {
-            val buf = BufferFactory.Default.allocate(16)
+    fun roundTripsEveryVariantAcrossDiscriminatorAndLengthWidths() {
+        for ((frame, total) in cases()) {
+            val buf = BufferFactory.Default.allocate(256)
             Http3FrameCodec.encode(buf, frame, EncodeContext.Empty)
             assertEquals(total, buf.position(), "encoded size for $frame")
             buf.resetForRead()
-            assertEquals(frame, Http3FrameCodec.decode(buf, DecodeContext.Empty), "round-trip $frame")
+            val decoded = Http3FrameCodec.decode(buf, DecodeContext.Empty)
+            assertEquals(frame::class, decoded::class, "variant for $frame")
+            val (type, length, payload) = parts(frame)
+            val (dType, dLength, dPayload) = parts(decoded)
+            assertEquals(type, dType, "frameType for $frame")
+            assertEquals(length, dLength, "length for $frame")
+            assertTrue(payload.handleEquals(dPayload), "payload bytes for $frame")
         }
     }
 
     @Test
-    fun peekFramesByVariableDiscriminatorWidthPlusBody() {
-        // 1-byte discriminator variants.
-        assertDripPeek(Http3Frame.Data(firstByte = 0x01u), expectedTotal = 2)
-        assertDripPeek(Http3Frame.Settings(identifier = 0x01020304u), expectedTotal = 5)
-        // 2-byte discriminator (type 0x40): proves the dispatcher measures the
-        // varint width rather than assuming one byte.
-        assertDripPeek(Http3Frame.Extension(payload = 0x55u), expectedTotal = 3)
+    fun applyBoundCapsPayloadEvenWithTrailingBytes() {
+        // The Length varint bounds the payload; bytes appended past the frame
+        // must not be swallowed by the trailing @RemainingBytes field.
+        val frame = Http3Frame.Data(length = short.toULong(), payload = payload(short))
+        val buf = BufferFactory.Default.allocate(64)
+        Http3FrameCodec.encode(buf, frame, EncodeContext.Empty)
+        buf.writeByte(0x7F) // trailing bytes past the frame
+        buf.writeByte(0x7E)
+        buf.resetForRead()
+        val decoded = Http3FrameCodec.decode(buf, DecodeContext.Empty)
+        assertEquals(short, parts(decoded).third.byteSize(), "payload capped at length")
+        assertTrue(parts(frame).third.handleEquals(parts(decoded).third), "payload bytes")
+    }
+
+    @Test
+    fun peekFramesByVariableDiscriminatorWidthPlusBoundedBody() {
+        for ((frame, total) in cases()) {
+            assertDripPeek(frame, expectedTotal = total)
+        }
     }
 
     private fun assertDripPeek(
@@ -61,7 +115,7 @@ class Http3FrameCodecTest {
         expectedTotal: Int,
     ) {
         val pool = BufferPool()
-        val source = BufferFactory.Default.allocate(16)
+        val source = BufferFactory.Default.allocate(256)
         Http3FrameCodec.encode(source, frame, EncodeContext.Empty)
         source.resetForRead()
         val total = source.remaining()
@@ -82,6 +136,12 @@ class Http3FrameCodecTest {
                 Http3FrameCodec.peekFrameSize(stream),
                 "fully buffered $frame",
             )
+            // Peeked frame size must equal what decode consumes.
+            val decodeBuffer = BufferFactory.Default.allocate(256)
+            Http3FrameCodec.encode(decodeBuffer, frame, EncodeContext.Empty)
+            decodeBuffer.resetForRead()
+            Http3FrameCodec.decode(decodeBuffer, DecodeContext.Empty)
+            assertEquals(total, decodeBuffer.position(), "decode consumed the peeked frame size for $frame")
         } finally {
             stream.release()
             pool.clear()

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/quic/QuicVarintCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/quic/QuicVarintCodecTest.kt
@@ -1,0 +1,145 @@
+package com.ditchoom.buffer.codec.test.protocols.quic
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.VarLenPeek
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * RFC 9000 §16 conformance for the test-support [QuicVarintCodec], and the
+ * cross-method invariants the [com.ditchoom.buffer.codec.VariableLengthCodec]
+ * contract promises: `encode` writes exactly `encodedLength` bytes, `decode`
+ * recovers the value, and `peekValue` reports the same value + byte count
+ * without consuming the stream.
+ */
+class QuicVarintCodecTest {
+    // The four worked vectors from RFC 9000 Appendix A.1, plus length-class
+    // boundaries. Each pair is (value, canonical minimal wire bytes).
+    private val vectors: List<Pair<ULong, List<Int>>> =
+        listOf(
+            0uL to listOf(0x00),
+            37uL to listOf(0x25), // RFC A.1
+            63uL to listOf(0x3F), // 1-byte max
+            64uL to listOf(0x40, 0x40), // first 2-byte
+            15293uL to listOf(0x7B, 0xBD), // RFC A.1
+            16383uL to listOf(0x7F, 0xFF), // 2-byte max
+            16384uL to listOf(0x80, 0x00, 0x40, 0x00), // first 4-byte
+            494878333uL to listOf(0x9D, 0x7F, 0x3E, 0x7D), // RFC A.1
+            0x3FFF_FFFFuL to listOf(0xBF, 0xFF, 0xFF, 0xFF), // 4-byte max
+            0x4000_0000uL to listOf(0xC0, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00), // first 8-byte (class 11)
+            151288809941952652uL to listOf(0xC2, 0x19, 0x7C, 0x5E, 0xFF, 0x14, 0xE8, 0x8C), // RFC A.1
+            0x3FFF_FFFF_FFFF_FFFFuL to listOf(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF), // 8-byte max
+        )
+
+    @Test
+    fun encodeMatchesCanonicalBytes() {
+        for ((value, bytes) in vectors) {
+            assertEquals(bytes.size, QuicVarintCodec.encodedLength(value), "encodedLength($value)")
+            val buf = BufferFactory.Default.allocate(8)
+            QuicVarintCodec.encode(buf, value, EncodeContext.Empty)
+            assertEquals(bytes.size, buf.position(), "encoded byte count for $value")
+            buf.resetForRead()
+            for ((i, expected) in bytes.withIndex()) {
+                assertEquals(expected, buf.readUByte().toInt(), "byte $i of $value")
+            }
+        }
+    }
+
+    @Test
+    fun decodeRecoversValue() {
+        for ((value, bytes) in vectors) {
+            val buf = BufferFactory.Default.allocate(bytes.size, ByteOrder.BIG_ENDIAN)
+            bytes.forEach { buf.writeByte(it.toByte()) }
+            buf.resetForRead()
+            assertEquals(value, QuicVarintCodec.decode(buf, DecodeContext.Empty), "decode of $value")
+        }
+    }
+
+    @Test
+    fun wireSizeIsAlwaysExactAndAgreesWithEncodedLength() {
+        for ((value, bytes) in vectors) {
+            assertEquals(
+                WireSize.Exact(bytes.size),
+                QuicVarintCodec.wireSize(value, EncodeContext.Empty),
+                "wireSize($value)",
+            )
+        }
+    }
+
+    @Test
+    fun peekValueReportsValueAndLengthWithoutConsuming() {
+        for ((value, bytes) in vectors) {
+            withStream(bytes) { stream ->
+                val before = stream.available()
+                assertEquals(
+                    VarLenPeek.Decoded(value, bytes.size),
+                    QuicVarintCodec.peekValue(stream),
+                    "peekValue($value)",
+                )
+                assertEquals(before, stream.available(), "peekValue must not consume")
+            }
+        }
+    }
+
+    @Test
+    fun decodeAcceptsNonMinimalEncoding() {
+        // RFC 9000 §16: 0x40 0x25 is a non-minimal 2-byte encoding of 37.
+        val buf = BufferFactory.Default.allocate(2, ByteOrder.BIG_ENDIAN)
+        buf.writeByte(0x40)
+        buf.writeByte(0x25)
+        buf.resetForRead()
+        assertEquals(37uL, QuicVarintCodec.decode(buf, DecodeContext.Empty))
+    }
+
+    @Test
+    fun peekValueNeedsMoreDataOnShortPrefix() {
+        // Empty stream — can't even read byte 0.
+        withStream(emptyList()) { stream ->
+            assertEquals(VarLenPeek.NeedsMoreData, QuicVarintCodec.peekValue(stream))
+        }
+        // First byte announces a 4-byte varint (class 10) but only 1 byte present.
+        withStream(listOf(0x80)) { stream ->
+            assertEquals(VarLenPeek.NeedsMoreData, QuicVarintCodec.peekValue(stream))
+        }
+        // 3 of the 4 bytes present — still short.
+        withStream(listOf(0x80, 0x00, 0x00)) { stream ->
+            assertEquals(VarLenPeek.NeedsMoreData, QuicVarintCodec.peekValue(stream))
+        }
+    }
+
+    @Test
+    fun encodedLengthRejectsOutOfRange() {
+        assertFailsWith<IllegalArgumentException> {
+            // 2^62 — one past the varint maximum.
+            QuicVarintCodec.encodedLength(0x4000_0000_0000_0000uL)
+        }
+    }
+
+    private fun withStream(
+        bytes: List<Int>,
+        block: (StreamProcessor) -> Unit,
+    ) {
+        val pool = BufferPool()
+        val stream = StreamProcessor.create(pool, ByteOrder.BIG_ENDIAN)
+        try {
+            if (bytes.isNotEmpty()) {
+                val buf = BufferFactory.Default.allocate(bytes.size)
+                bytes.forEach { buf.writeByte(it.toByte()) }
+                buf.resetForRead()
+                stream.append(buf)
+            }
+            block(stream)
+        } finally {
+            stream.release()
+            pool.clear()
+        }
+    }
+}

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/varintfield/VarintLengthFrameCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/varintfield/VarintLengthFrameCodecTest.kt
@@ -1,0 +1,99 @@
+package com.ditchoom.buffer.codec.test.protocols.varintfield
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Stage 2 — the generic, encoding-agnostic variable-width **field** path.
+ *
+ * `VarintLengthFrame` carries a `@UseCodec(QuicVarintCodec)` `ULong` (whose
+ * codec implements `VariableLengthCodec`) followed by a fixed `tag` byte.
+ * Decode/encode delegating to the codec already worked; what this pins is that
+ * `peekFrameSize` now frames the message — `width(value) + 1` — instead of
+ * returning `NoFraming`. The frame width changes with the value (1/2/4/8-byte
+ * varint), so the same message type peeks to different totals.
+ */
+class VarintLengthFrameCodecTest {
+    @Test
+    fun roundTripsAcrossVarintWidths() {
+        // (value, varint byte width) — one per QUIC length class.
+        for ((value, varintWidth) in listOf(
+            0uL to 1,
+            63uL to 1,
+            64uL to 2,
+            16383uL to 2,
+            16384uL to 4,
+            0x3FFF_FFFFuL to 4,
+            0x4000_0000uL to 8,
+            0x3FFF_FFFF_FFFF_FFFFuL to 8,
+        )) {
+            val original = VarintLengthFrame(value = value, tag = 0xABu)
+            val buf = BufferFactory.Default.allocate(16)
+            VarintLengthFrameCodec.encode(buf, original, EncodeContext.Empty)
+            assertEquals(varintWidth + 1, buf.position(), "encoded size for value $value")
+            buf.resetForRead()
+            assertEquals(original, VarintLengthFrameCodec.decode(buf, DecodeContext.Empty), "round-trip $value")
+        }
+    }
+
+    @Test
+    fun peekFramesByObservedVarintWidthPlusSuffix() {
+        // 64 → 2-byte varint + 1 tag = 3 bytes total.
+        assertPeekComplete(VarintLengthFrame(value = 64uL, tag = 0x01u), expectedTotal = 3)
+        // 5 → 1-byte varint + 1 tag = 2 bytes.
+        assertPeekComplete(VarintLengthFrame(value = 5uL, tag = 0x02u), expectedTotal = 2)
+        // 0x4000_0000 → 8-byte varint + 1 tag = 9 bytes.
+        assertPeekComplete(VarintLengthFrame(value = 0x4000_0000uL, tag = 0x03u), expectedTotal = 9)
+    }
+
+    private fun assertPeekComplete(
+        original: VarintLengthFrame,
+        expectedTotal: Int,
+    ) {
+        val pool = BufferPool()
+        val source = BufferFactory.Default.allocate(16)
+        VarintLengthFrameCodec.encode(source, original, EncodeContext.Empty)
+        source.resetForRead()
+        val total = source.remaining()
+        assertEquals(expectedTotal, total, "encoded total for $original")
+        val stream = StreamProcessor.create(pool, ByteOrder.BIG_ENDIAN)
+        try {
+            for (i in 0 until total - 1) {
+                appendByte(stream, source.readByte())
+                assertEquals(
+                    PeekResult.NeedsMoreData,
+                    VarintLengthFrameCodec.peekFrameSize(stream),
+                    "after ${i + 1}/$total bytes",
+                )
+            }
+            appendByte(stream, source.readByte())
+            assertEquals(
+                PeekResult.Complete(total),
+                VarintLengthFrameCodec.peekFrameSize(stream),
+                "fully buffered",
+            )
+        } finally {
+            stream.release()
+            pool.clear()
+        }
+    }
+
+    private fun appendByte(
+        stream: StreamProcessor,
+        byte: Byte,
+    ) {
+        val one: PlatformBuffer = BufferFactory.Default.allocate(1)
+        one.writeByte(byte)
+        one.resetForRead()
+        stream.append(one)
+    }
+}

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/websocket/WsFramePeekCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/websocket/WsFramePeekCodecTest.kt
@@ -1,0 +1,170 @@
+package com.ditchoom.buffer.codec.test.protocols.websocket
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.ownedBytesFrom
+import com.ditchoom.buffer.codec.test.protocols.payload.BinaryData
+import com.ditchoom.buffer.codec.test.protocols.payload.BinaryDataCodec
+import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The RFC 6455 framing peek the generated `WsFrameCodec.peekFrameSize` now
+ * delegates to the `WsFrame` companion ([com.ditchoom.buffer.codec.FrameDetector]).
+ * This is the gap `WsFrame.kt` previously documented as "deliberately NOT covered"
+ * (the websocket repo hand-wrote it) — closed via the consumer-supplied framing
+ * override rather than baking RFC 6455's escape-coded length into the processor.
+ *
+ * The load-bearing invariant: a peeked `Complete(n)` must equal exactly what
+ * `decode` consumes, and every shorter prefix must be `NeedsMoreData`. Locked here
+ * across all three length classes (7-bit indicator, 16-bit escape at 126, 64-bit
+ * escape at 127), masked and unmasked — so a drift between the hand-written peek
+ * and the generated decode fails loudly.
+ */
+class WsFramePeekCodecTest {
+    private val codec = WsFrameCodec(BinaryDataCodec)
+
+    private fun payload(size: Int): BinaryData {
+        val buf = BufferFactory.Default.allocate(size)
+        for (i in 0 until size) buf.writeByte((i and 0x7F).toByte())
+        buf.resetForRead()
+        return BinaryData(ownedBytesFrom(buf))
+    }
+
+    private fun binaryFrame(
+        payloadSize: Int,
+        masked: Boolean,
+    ): WsFrame.Binary<BinaryData> {
+        val byte2 = WsHeaderByte2.pack(payloadSize.toLong(), masked = masked)
+        return WsFrame.Binary(
+            byte1 = FrameHeaderByte1.pack(true, rsv1 = false, rsv2 = false, rsv3 = false, opcode = 0x2),
+            byte2 = byte2,
+            extendedLength16 = if (byte2.extended16) payloadSize.toUShort() else null,
+            extendedLength64 = if (byte2.extended64) payloadSize.toLong() else null,
+            maskingKey = if (masked) WsMaskingKey(0xDEAD_BEEFu) else null,
+            payload = payload(payloadSize),
+        )
+    }
+
+    private fun encodeToBuffer(frame: WsFrame.Binary<BinaryData>): PlatformBuffer {
+        val buf = BufferFactory.Default.allocate(payloadFrameCapacity(frame))
+        codec.encode(buf, frame, EncodeContext.Empty)
+        buf.resetForRead()
+        return buf
+    }
+
+    private fun payloadFrameCapacity(frame: WsFrame.Binary<BinaryData>): Int =
+        2 + 8 + 4 + frame.payload.size // header + max ext + mask + payload (upper bound)
+
+    private fun decodeConsumption(frame: WsFrame.Binary<BinaryData>): Int {
+        val buf = encodeToBuffer(frame)
+        val total = buf.remaining()
+        buf.setLimit(total)
+        codec.decode(buf, DecodeContext.Empty)
+        return buf.position()
+    }
+
+    @Test
+    fun peekEqualsDecodeConsumptionAcrossLengthClasses() {
+        // 7-bit indicator (≤125), 16-bit escape (126), 64-bit escape (127),
+        // masked and unmasked. 70000 > 0xFFFF forces the 8-byte extended length.
+        for (size in listOf(5, 256, 70000)) {
+            for (masked in listOf(false, true)) {
+                val frame = binaryFrame(size, masked)
+                val total = decodeConsumption(frame)
+                assertEquals(
+                    PeekResult.Complete(total),
+                    fullyBufferedPeek(frame),
+                    "peek total == decode consumption (size=$size, masked=$masked)",
+                )
+                assertEquals(
+                    PeekResult.NeedsMoreData,
+                    prefixPeek(frame, total - 1),
+                    "one byte short → NeedsMoreData (size=$size, masked=$masked)",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun dripFeedNeedsMoreDataUntilLastByteForSmallFrames() {
+        // Byte-at-a-time across the small length classes (full drip would be
+        // wasteful at 70000 bytes; the cross-class invariant above covers those).
+        assertDripPeek(binaryFrame(5, masked = false))
+        assertDripPeek(binaryFrame(5, masked = true))
+        assertDripPeek(binaryFrame(256, masked = false)) // 16-bit escape
+        assertDripPeek(binaryFrame(256, masked = true))
+    }
+
+    private fun fullyBufferedPeek(frame: WsFrame.Binary<BinaryData>): PeekResult {
+        val source = encodeToBuffer(frame)
+        val pool = BufferPool()
+        val stream = StreamProcessor.create(pool, ByteOrder.BIG_ENDIAN)
+        try {
+            stream.append(source)
+            return codec.peekFrameSize(stream)
+        } finally {
+            stream.release()
+            pool.clear()
+        }
+    }
+
+    private fun prefixPeek(
+        frame: WsFrame.Binary<BinaryData>,
+        prefixLen: Int,
+    ): PeekResult {
+        val source = encodeToBuffer(frame)
+        val pool = BufferPool()
+        val stream = StreamProcessor.create(pool, ByteOrder.BIG_ENDIAN)
+        try {
+            for (i in 0 until prefixLen) appendByte(stream, source.readByte())
+            return codec.peekFrameSize(stream)
+        } finally {
+            stream.release()
+            pool.clear()
+        }
+    }
+
+    private fun assertDripPeek(frame: WsFrame.Binary<BinaryData>) {
+        val pool = BufferPool()
+        val source = encodeToBuffer(frame)
+        val total = source.remaining()
+        val stream = StreamProcessor.create(pool, ByteOrder.BIG_ENDIAN)
+        try {
+            for (i in 0 until total - 1) {
+                appendByte(stream, source.readByte())
+                assertEquals(
+                    PeekResult.NeedsMoreData,
+                    codec.peekFrameSize(stream),
+                    "after ${i + 1}/$total bytes (masked=${frame.byte2.masked})",
+                )
+            }
+            appendByte(stream, source.readByte())
+            assertEquals(
+                PeekResult.Complete(total),
+                codec.peekFrameSize(stream),
+                "fully buffered (masked=${frame.byte2.masked})",
+            )
+        } finally {
+            stream.release()
+            pool.clear()
+        }
+    }
+
+    private fun appendByte(
+        stream: StreamProcessor,
+        byte: Byte,
+    ) {
+        val one: PlatformBuffer = BufferFactory.Default.allocate(1)
+        one.writeByte(byte)
+        one.resetForRead()
+        stream.append(one)
+    }
+}

--- a/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/VariableLengthCodec.kt
+++ b/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/VariableLengthCodec.kt
@@ -1,0 +1,77 @@
+package com.ditchoom.buffer.codec
+
+import com.ditchoom.buffer.stream.StreamProcessor
+
+/**
+ * Result of peeking a self-delimiting value from a [StreamProcessor] prefix
+ * without consuming bytes. Modeled as a sum type (not a nullable) so the two
+ * states are explicit and exhaustive.
+ */
+sealed interface VarLenPeek<out T> {
+    /** Not enough bytes are buffered yet to determine the value or its length. */
+    data object NeedsMoreData : VarLenPeek<Nothing>
+
+    /** The decoded value and the exact number of bytes it occupies on the wire. */
+    data class Decoded<out T>(
+        val value: T,
+        val byteCount: Int,
+    ) : VarLenPeek<T>
+}
+
+/**
+ * A [Codec] for a self-delimiting, variable-width value — one whose encoded
+ * length is not a compile-time constant but is always recoverable from the
+ * value (for sizing) and from the leading wire bytes (for framing). QUIC
+ * varints (RFC 9000 §16), LEB128, protobuf varints, and similar schemes fit;
+ * the buffer library ships none of them — a consumer supplies the encoding and
+ * the KSP processor provides encoding-agnostic variable-width plumbing.
+ *
+ * The contract is narrower than [Codec] on purpose, so illegal states are
+ * unrepresentable:
+ *  - [encodedLength] returns a plain [Int]: the size of a value already in hand
+ *    is *total*, so there is no `BackPatch` to reach for. [wireSize] is derived
+ *    as [WireSize.Exact], keeping enclosing messages on the precompute path
+ *    rather than degrading the whole chain to back-patching.
+ *  - [peekValue] returns [VarLenPeek]: a stream prefix genuinely *can* be
+ *    incomplete, so `NeedsMoreData` is a real state. [peekFrameSize] is derived
+ *    from it.
+ *
+ * A consumer therefore implements exactly four methods — [Decoder.decode],
+ * [Encoder.encode], [encodedLength], and [peekValue] — and the two wider [Codec]
+ * return types ([WireSize], [PeekResult]) are filled in here so they cannot
+ * carry a value this contract forbids.
+ *
+ * One correctness invariant the type system can't express: [Encoder.encode]
+ * must write exactly [encodedLength] bytes, and that count must equal the
+ * [VarLenPeek.Decoded.byteCount] that [peekValue] reports for the same value. A
+ * round-trip test is the right place to pin this down.
+ */
+interface VariableLengthCodec<T> : Codec<T> {
+    /** Bytes [value] encodes to — always known from the value alone. */
+    fun encodedLength(value: T): Int
+
+    /**
+     * Decode the value and its byte length from a [stream] prefix beginning at
+     * [baseOffset], without consuming any bytes. Returns
+     * [VarLenPeek.NeedsMoreData] when the prefix is too short to determine
+     * either.
+     */
+    fun peekValue(
+        stream: StreamProcessor,
+        baseOffset: Int = 0,
+    ): VarLenPeek<T>
+
+    override fun wireSize(
+        value: T,
+        context: EncodeContext,
+    ): WireSize = WireSize.Exact(encodedLength(value))
+
+    override fun peekFrameSize(
+        stream: StreamProcessor,
+        baseOffset: Int,
+    ): PeekResult =
+        when (val peeked = peekValue(stream, baseOffset)) {
+            is VarLenPeek.Decoded -> PeekResult.Complete(peeked.byteCount)
+            VarLenPeek.NeedsMoreData -> PeekResult.NeedsMoreData
+        }
+}


### PR DESCRIPTION
## Summary

Replaces the synthetic `wsbounding/WsbFrame` fixture — a WebSocket-topology + QUIC-varint-length chimera no real protocol uses, which also masked the real HTTP/3 peek gap behind a fixed discriminator — with **real-wire `peekFrameSize` coverage for both HTTP/3 and WebSocket**.

This continues the `codec/varint-h3` track (stages 1–4a already on the branch). It is the "stage 5 + 6" work: real HTTP/3 framing, and a general consumer-supplied framing override that closes the WebSocket peek gap.

## HTTP/3 (RFC 9114 §7.1) — `Type(varint) + Length(varint) + Payload[Length]`
- `Http3LengthCodec`: the real `Length` varint as a `BoundingLengthCodec`.
- `Http3Frame` variants now carry the real length-prefixed payload (decode/encode/bound already worked; the gap was peek).
- **Emitter fix:** the bounding-length peek required *fixed-width* priors, but a real HTTP/3 frame's prior is a *variable-width* varint discriminator. `buildPeekFrameFun` now anchors framing on the bounding field and measures self-framing priors at runtime via their own `peekFrameSize` (new `appendPeekBoundingDynamicPrior`). → `Complete(typeWidth + lengthWidth + length)`.

## WebSocket (RFC 6455 §5.2) — escape-coded length + folded mask
- Reuses the **existing `FrameDetector` interface** (the `peekFrameSize` slice of `Codec`) as a consumer-supplied framing override: a `@ProtocolMessage` type whose companion implements `FrameDetector` gets its generated `peekFrameSize` delegated to that companion. `detectCustomFramePeek` + a `customPeek` field threaded onto `CodecShape`/`DispatchShape`; short-circuit in `buildPeekFrameFun` and `buildDispatchPeekFun`.
- `WsFrame` gains a `FrameDetector` companion encoding the 7-bit/16-bit/64-bit length escape + optional mask. Closes the gap `WsFrame.kt` previously documented as deliberately uncovered.
- This is a **general escape hatch** for any walker-`NoFraming` shape — documented as escape-hatch-not-default; the declarative path still covers most protocols.

## Spec compliance / testing
Both new tests assert `peek.bytes == decode consumption` — the structural spec-compliance lock — across all length classes, masked and unmasked. Since decode is RFC-driven, agreeing with it makes peek spec-faithful.

## Blast radius
Only the 4 HTTP/3 variant goldens + `WsFrameCodec`'s peek delegation regenerated; no unrelated fixture moved.

Local: `:buffer-codec-processor:test`, full `:buffer-codec-test:jvmTest` (snapshot test confirms baseline==generated), and ktlint all green.

Design doc: `buffer-codec-processor/CUSTOM_FRAME_PEEK_DESIGN.md`.