### PR TITLE
test(codec): protocol spec audit — fix TLS HandshakeType, lock framing, add gRPC

### DIFF
--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/grpc/GrpcLengthPrefixedMessageCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/grpc/GrpcLengthPrefixedMessageCodec.kt
@@ -1,0 +1,76 @@
+package com.ditchoom.buffer.codec.test.protocols.grpc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.codec.test.protocols.payload.BinaryDataCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object GrpcLengthPrefixedMessageCodec : Codec<GrpcLengthPrefixedMessage> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): GrpcLengthPrefixedMessage {
+    val compressedFlag = buffer.readUByte()
+    val messagePrefixB0 = buffer.readUByte().toUInt()
+    val messagePrefixB1 = buffer.readUByte().toUInt()
+    val messagePrefixB2 = buffer.readUByte().toUInt()
+    val messagePrefixB3 = buffer.readUByte().toUInt()
+    val messagePrefix = ((messagePrefixB0 shl 24) or (messagePrefixB1 shl 16) or (messagePrefixB2 shl 8) or messagePrefixB3)
+    if (messagePrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "GrpcLengthPrefixedMessage.message", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = messagePrefix.toString())
+    }
+    val messageLength = messagePrefix.toInt()
+    val __messageOuterLimit = buffer.limit()
+    buffer.setLimit(buffer.position() + messageLength)
+    val message = try {
+      BinaryDataCodec.decode(buffer, context)
+    } finally {
+      buffer.setLimit(__messageOuterLimit)
+    }
+    return GrpcLengthPrefixedMessage(compressedFlag = compressedFlag, message = message)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: GrpcLengthPrefixedMessage,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.compressedFlag)
+    val messageSizePosition = buffer.position()
+    buffer.position(messageSizePosition + 4)
+    val messageBodyStart = buffer.position()
+    BinaryDataCodec.encode(buffer, value.message, context)
+    val messageEndPosition = buffer.position()
+    val messageByteCount = messageEndPosition - messageBodyStart
+    buffer.position(messageSizePosition)
+    val messagePrefix = messageByteCount.toUInt()
+    buffer.writeUByte(((messagePrefix shr 24) and 0xFFu).toUByte())
+    buffer.writeUByte(((messagePrefix shr 16) and 0xFFu).toUByte())
+    buffer.writeUByte(((messagePrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((messagePrefix and 0xFFu).toUByte())
+    buffer.position(messageEndPosition)
+  }
+
+  override fun wireSize(`value`: GrpcLengthPrefixedMessage, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    __offset += 1
+    if (stream.available() - baseOffset < __offset + 4) return PeekResult.NeedsMoreData
+    val messagePrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val messagePrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val messagePrefixB2 = stream.peekByte(baseOffset + __offset + 2).toInt() and 0xFF
+    val messagePrefixB3 = stream.peekByte(baseOffset + __offset + 3).toInt() and 0xFF
+    val messagePrefix = ((messagePrefixB0 shl 24) or (messagePrefixB1 shl 16) or (messagePrefixB2 shl 8) or messagePrefixB3).toUInt()
+    if (messagePrefix > (Int.MAX_VALUE - __offset - 4).toUInt()) {
+      throw DecodeException(fieldPath = "GrpcLengthPrefixedMessage.message", bufferPosition = baseOffset + __offset, expected = "__offset + 4 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 4 + messagePrefix.toInt()}""")
+    }
+    __offset += 4 + messagePrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeSealedBodyCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeSealedBodyCodec.kt
@@ -17,9 +17,9 @@ public object TlsHandshakeSealedBodyCodec : Codec<TlsHandshakeSealedBody> {
     val discriminator = buffer.readUByte().toInt()
     return when (discriminator) {
       0x01 -> TlsHandshakeSealedBodyClientHelloCodec.decode(buffer, context)
-      0x02 -> TlsHandshakeSealedBodyHelloRequestCodec.decode(buffer, context)
+      0x05 -> TlsHandshakeSealedBodyEndOfEarlyDataCodec.decode(buffer, context)
       else -> {
-        throw DecodeException(fieldPath = "TlsHandshakeSealedBody.discriminator", bufferPosition = discriminatorPosition, expected = "one of {0x01, 0x02}", actual = """0x${discriminator.toString(16).padStart(2, '0').uppercase()}""")
+        throw DecodeException(fieldPath = "TlsHandshakeSealedBody.discriminator", bufferPosition = discriminatorPosition, expected = "one of {0x01, 0x05}", actual = """0x${discriminator.toString(16).padStart(2, '0').uppercase()}""")
       }
     }
   }
@@ -34,16 +34,16 @@ public object TlsHandshakeSealedBodyCodec : Codec<TlsHandshakeSealedBody> {
         buffer.writeUByte(0x01.toUByte())
         TlsHandshakeSealedBodyClientHelloCodec.encode(buffer, value, context)
       }
-      is TlsHandshakeSealedBody.HelloRequest -> {
-        buffer.writeUByte(0x02.toUByte())
-        TlsHandshakeSealedBodyHelloRequestCodec.encode(buffer, value, context)
+      is TlsHandshakeSealedBody.EndOfEarlyData -> {
+        buffer.writeUByte(0x05.toUByte())
+        TlsHandshakeSealedBodyEndOfEarlyDataCodec.encode(buffer, value, context)
       }
     }
   }
 
   override fun wireSize(`value`: TlsHandshakeSealedBody, context: EncodeContext): WireSize = when (value) {
     is TlsHandshakeSealedBody.ClientHello -> WireSize.Exact(3)
-    is TlsHandshakeSealedBody.HelloRequest -> WireSize.Exact(1)
+    is TlsHandshakeSealedBody.EndOfEarlyData -> WireSize.Exact(1)
   }
 
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
@@ -56,14 +56,14 @@ public object TlsHandshakeSealedBodyCodec : Codec<TlsHandshakeSealedBody> {
           else -> inner
         }
       }
-      0x02 -> {
-        when (val inner = TlsHandshakeSealedBodyHelloRequestCodec.peekFrameSize(stream, baseOffset + 1)) {
+      0x05 -> {
+        when (val inner = TlsHandshakeSealedBodyEndOfEarlyDataCodec.peekFrameSize(stream, baseOffset + 1)) {
           is PeekResult.Complete -> PeekResult.Complete(1 + inner.bytes)
           else -> inner
         }
       }
       else -> {
-        throw DecodeException(fieldPath = "TlsHandshakeSealedBody.discriminator", bufferPosition = baseOffset, expected = "one of {0x01, 0x02}", actual = """0x${discriminator.toString(16).padStart(2, '0').uppercase()}""")
+        throw DecodeException(fieldPath = "TlsHandshakeSealedBody.discriminator", bufferPosition = baseOffset, expected = "one of {0x01, 0x05}", actual = """0x${discriminator.toString(16).padStart(2, '0').uppercase()}""")
       }
     }
   }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeSealedBodyEndOfEarlyDataCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeSealedBodyEndOfEarlyDataCodec.kt
@@ -10,17 +10,17 @@ import com.ditchoom.buffer.codec.WireSize
 import com.ditchoom.buffer.stream.StreamProcessor
 import kotlin.Int
 
-public object TlsHandshakeSealedBodyHelloRequestCodec : Codec<TlsHandshakeSealedBody.HelloRequest> {
-  override fun decode(buffer: ReadBuffer, context: DecodeContext): TlsHandshakeSealedBody.HelloRequest = TlsHandshakeSealedBody.HelloRequest
+public object TlsHandshakeSealedBodyEndOfEarlyDataCodec : Codec<TlsHandshakeSealedBody.EndOfEarlyData> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): TlsHandshakeSealedBody.EndOfEarlyData = TlsHandshakeSealedBody.EndOfEarlyData
 
   override fun encode(
     buffer: WriteBuffer,
-    `value`: TlsHandshakeSealedBody.HelloRequest,
+    `value`: TlsHandshakeSealedBody.EndOfEarlyData,
     context: EncodeContext,
   ) {
   }
 
-  override fun wireSize(`value`: TlsHandshakeSealedBody.HelloRequest, context: EncodeContext): WireSize = WireSize.Exact(0)
+  override fun wireSize(`value`: TlsHandshakeSealedBody.EndOfEarlyData, context: EncodeContext): WireSize = WireSize.Exact(0)
 
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 0) PeekResult.Complete(0) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/grpc/GrpcLengthPrefixedMessage.kt
+++ b/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/grpc/GrpcLengthPrefixedMessage.kt
@@ -1,0 +1,39 @@
+package com.ditchoom.buffer.codec.test.protocols.grpc
+
+import com.ditchoom.buffer.codec.annotations.Endianness
+import com.ditchoom.buffer.codec.annotations.LengthPrefix
+import com.ditchoom.buffer.codec.annotations.LengthPrefixed
+import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+import com.ditchoom.buffer.codec.annotations.UseCodec
+import com.ditchoom.buffer.codec.test.protocols.payload.BinaryData
+import com.ditchoom.buffer.codec.test.protocols.payload.BinaryDataCodec
+
+/**
+ * gRPC `Length-Prefixed-Message` framing (gRPC over HTTP/2, PROTOCOL-HTTP2.md):
+ *
+ * ```
+ * Length-Prefixed-Message → Compressed-Flag (1 byte) Message-Length (4 bytes BE) Message
+ * Compressed-Flag         → 0 / 1
+ * Message-Length          → uint32 (big-endian / network order)
+ * Message                 → *{binary octet}
+ * ```
+ *
+ * Each gRPC message is carried inside HTTP/2 DATA frames as this self-delimiting
+ * envelope: a 1-byte compression flag, then a 4-byte big-endian length, then
+ * exactly that many opaque (protobuf) message bytes. The length measures the
+ * message only — not the 5-byte prefix.
+ *
+ * Modeled with the framework-owned `@LengthPrefixed(LengthPrefix.Int)` 4-byte
+ * prefix carrying the message's wire size, and the opaque message as a consumer-
+ * decoded [BinaryData] payload (the protobuf body is interpreted by a
+ * message-specific codec a layer up, not by the envelope). The generated
+ * `peekFrameSize` therefore frames the whole envelope —
+ * `Complete(1 + 4 + Message-Length)` — so a streaming reader can size each gRPC
+ * message without consuming bytes. The length is owned by the framework, so the
+ * `compressedFlag` + prefix shape round-trips byte-exactly against the spec.
+ */
+@ProtocolMessage(wireOrder = Endianness.Big)
+data class GrpcLengthPrefixedMessage(
+    val compressedFlag: UByte,
+    @LengthPrefixed(LengthPrefix.Int) @UseCodec(BinaryDataCodec::class) val message: BinaryData,
+)

--- a/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshake.kt
+++ b/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshake.kt
@@ -70,13 +70,19 @@ data class TlsHandshakeWithSealedBody(
 
 @ProtocolMessage(wireOrder = Endianness.Big)
 sealed interface TlsHandshakeSealedBody {
+    /** RFC 8446 §4 HandshakeType `client_hello(1)` — a data-class body. */
     @PacketType(0x01)
     @ProtocolMessage
     data class ClientHello(
         val legacyVersion: UShort,
     ) : TlsHandshakeSealedBody
 
-    @PacketType(0x02)
+    /**
+     * RFC 8446 §4.5 HandshakeType `end_of_early_data(5)` — `struct {} EndOfEarlyData`,
+     * an empty body. Exercises the empty `data object` singleton-dispatch path under a
+     * `@LengthFrom`-bounded sealed parent with a spec-faithful HandshakeType value.
+     */
+    @PacketType(0x05)
     @ProtocolMessage
-    data object HelloRequest : TlsHandshakeSealedBody
+    data object EndOfEarlyData : TlsHandshakeSealedBody
 }

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/ethernet/EthernetFrameByEtherTypePeekTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/ethernet/EthernetFrameByEtherTypePeekTest.kt
@@ -1,0 +1,66 @@
+package com.ditchoom.buffer.codec.test.protocols.ethernet
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The fixture models exactly the 2-byte EtherType dispatch slice (IEEE 802.3,
+ * offset 12-13 of an Ethernet II frame), so each variant's wire form is 2 bytes.
+ * `peekFrameSize` framing that 2-byte message as `Complete(2)` is correct and
+ * honest — it frames exactly the bytes the fixture decodes (it does not claim to
+ * frame a whole, externally-delimited Ethernet frame). This locks
+ * `peek.bytes == decode consumption`.
+ */
+class EthernetFrameByEtherTypePeekTest {
+    @Test
+    fun peekFramesTwoByteEtherTypeDispatch() {
+        for (frame in listOf(
+            EthernetFrameByEtherType.Ipv4(),
+            EthernetFrameByEtherType.Arp(),
+            EthernetFrameByEtherType.Ipv6(),
+            EthernetFrameByEtherType.VlanTag(),
+        )) {
+            val pool = BufferPool()
+            val source = BufferFactory.Default.allocate(8, ByteOrder.BIG_ENDIAN)
+            EthernetFrameByEtherTypeCodec.encode(source, frame, EncodeContext.Empty)
+            source.resetForRead()
+            val total = source.remaining()
+            assertEquals(2, total, "EtherType dispatch slice is 2 bytes")
+            val stream = StreamProcessor.create(pool, ByteOrder.BIG_ENDIAN)
+            try {
+                appendByte(stream, source.readByte())
+                assertEquals(PeekResult.NeedsMoreData, EthernetFrameByEtherTypeCodec.peekFrameSize(stream), "1/2 bytes")
+                appendByte(stream, source.readByte())
+                assertEquals(PeekResult.Complete(2), EthernetFrameByEtherTypeCodec.peekFrameSize(stream), "fully buffered")
+
+                val decodeBuffer = BufferFactory.Default.allocate(8, ByteOrder.BIG_ENDIAN)
+                EthernetFrameByEtherTypeCodec.encode(decodeBuffer, frame, EncodeContext.Empty)
+                decodeBuffer.resetForRead()
+                EthernetFrameByEtherTypeCodec.decode(decodeBuffer, DecodeContext.Empty)
+                assertEquals(2, decodeBuffer.position(), "decode consumed exactly the peeked frame size")
+            } finally {
+                stream.release()
+                pool.clear()
+            }
+        }
+    }
+
+    private fun appendByte(
+        stream: StreamProcessor,
+        byte: Byte,
+    ) {
+        val one: PlatformBuffer = BufferFactory.Default.allocate(1)
+        one.writeByte(byte)
+        one.resetForRead()
+        stream.append(one)
+    }
+}

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/grpc/GrpcLengthPrefixedMessageCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/grpc/GrpcLengthPrefixedMessageCodecTest.kt
@@ -1,0 +1,119 @@
+package com.ditchoom.buffer.codec.test.protocols.grpc
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.byteSize
+import com.ditchoom.buffer.codec.handleEquals
+import com.ditchoom.buffer.codec.ownedBytesFrom
+import com.ditchoom.buffer.codec.test.protocols.payload.BinaryData
+import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * gRPC `Length-Prefixed-Message` framing: `Compressed-Flag(1) + Message-Length(4
+ * BE) + Message`. Self-delimiting via the 4-byte length, so `peekFrameSize`
+ * frames the whole envelope as `Complete(1 + 4 + length)`.
+ *
+ * Pins round-trip plus the `peek.bytes == decode consumption` invariant across
+ * message sizes (including a length needing the upper prefix bytes), byte-at-a-
+ * time: `NeedsMoreData` until the full envelope is buffered, then `Complete(total)`.
+ */
+class GrpcLengthPrefixedMessageCodecTest {
+    private fun message(size: Int): BinaryData {
+        // byteSize() == buffer capacity, so allocate exactly `size` (0 allowed —
+        // an empty gRPC message is valid).
+        val buf = BufferFactory.Default.allocate(size, ByteOrder.BIG_ENDIAN)
+        for (i in 0 until size) buf.writeByte((i and 0x7F).toByte())
+        buf.resetForRead()
+        return BinaryData(ownedBytesFrom(buf))
+    }
+
+    private fun frame(
+        compressed: Boolean,
+        size: Int,
+    ): GrpcLengthPrefixedMessage =
+        GrpcLengthPrefixedMessage(
+            compressedFlag = if (compressed) 1u else 0u,
+            message = message(size),
+        )
+
+    @Test
+    fun roundTripsAcrossFlagAndMessageSizes() {
+        for (size in listOf(0, 5, 300)) {
+            for (compressed in listOf(false, true)) {
+                val original = frame(compressed, size)
+                val buf = BufferFactory.Default.allocate(size + 16, ByteOrder.BIG_ENDIAN)
+                GrpcLengthPrefixedMessageCodec.encode(buf, original, EncodeContext.Empty)
+                assertEquals(1 + 4 + size, buf.position(), "envelope size (compressed=$compressed, size=$size)")
+                buf.resetForRead()
+                val decoded = GrpcLengthPrefixedMessageCodec.decode(buf, DecodeContext.Empty)
+                assertEquals(original.compressedFlag, decoded.compressedFlag, "flag")
+                assertEquals(size, decoded.message.data.byteSize(), "message length")
+                assertTrue(original.message.data.handleEquals(decoded.message.data), "message bytes")
+            }
+        }
+    }
+
+    @Test
+    fun peekFramesEnvelopeByLengthPrefix() {
+        // size 5 → length fits one byte; size 300 → length spills into upper prefix bytes.
+        for (size in listOf(0, 5, 300)) {
+            assertDripPeek(frame(compressed = false, size = size), expectedTotal = 1 + 4 + size)
+        }
+    }
+
+    private fun assertDripPeek(
+        frame: GrpcLengthPrefixedMessage,
+        expectedTotal: Int,
+    ) {
+        val pool = BufferPool()
+        val source = BufferFactory.Default.allocate(expectedTotal + 16, ByteOrder.BIG_ENDIAN)
+        GrpcLengthPrefixedMessageCodec.encode(source, frame, EncodeContext.Empty)
+        source.resetForRead()
+        val total = source.remaining()
+        assertEquals(expectedTotal, total, "encoded total")
+        val stream = StreamProcessor.create(pool, ByteOrder.BIG_ENDIAN)
+        try {
+            for (i in 0 until total - 1) {
+                appendByte(stream, source.readByte())
+                assertEquals(
+                    PeekResult.NeedsMoreData,
+                    GrpcLengthPrefixedMessageCodec.peekFrameSize(stream),
+                    "after ${i + 1}/$total bytes",
+                )
+            }
+            appendByte(stream, source.readByte())
+            assertEquals(
+                PeekResult.Complete(total),
+                GrpcLengthPrefixedMessageCodec.peekFrameSize(stream),
+                "fully buffered",
+            )
+            val decodeBuffer = BufferFactory.Default.allocate(total + 16, ByteOrder.BIG_ENDIAN)
+            GrpcLengthPrefixedMessageCodec.encode(decodeBuffer, frame, EncodeContext.Empty)
+            decodeBuffer.resetForRead()
+            GrpcLengthPrefixedMessageCodec.decode(decodeBuffer, DecodeContext.Empty)
+            assertEquals(total, decodeBuffer.position(), "decode consumed exactly the peeked frame size")
+        } finally {
+            stream.release()
+            pool.clear()
+        }
+    }
+
+    private fun appendByte(
+        stream: StreamProcessor,
+        byte: Byte,
+    ) {
+        val one: PlatformBuffer = BufferFactory.Default.allocate(1)
+        one.writeByte(byte)
+        one.resetForRead()
+        stream.append(one)
+    }
+}

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/png/PngChunkPeekTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/png/PngChunkPeekTest.kt
@@ -1,0 +1,87 @@
+package com.ditchoom.buffer.codec.test.protocols.png
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.ownedBytesFrom
+import com.ditchoom.buffer.codec.test.protocols.payload.BinaryData
+import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The PNG fixture models `data` as a consumer-bounded `@RemainingBytes` field
+ * (the outer reader bounds the buffer to the chunk extent before decode), so the
+ * codec deliberately does NOT self-frame: `peekFrameSize` returns `NoFraming`.
+ * That is the honest claim for this modeling — the codec must not pretend to know
+ * the chunk size it was never told to read.
+ *
+ * This locks two things: (1) the peek stays `NoFraming` no matter how many bytes
+ * are buffered (it never falsely upgrades to `Complete`), and (2) when the caller
+ * bounds the buffer to the chunk extent, decode consumes exactly to that limit.
+ *
+ * (The genuinely self-delimiting PNG framing — `Complete(length + 12)` via
+ * `@LengthFrom("length")` — is a separate reference-fixture upgrade, not this
+ * consumer-bounded probe.)
+ */
+class PngChunkPeekTest {
+    private fun data(size: Int): BinaryData {
+        val buf = BufferFactory.Default.allocate(maxOf(size, 1), ByteOrder.BIG_ENDIAN)
+        for (i in 0 until size) buf.writeByte((i and 0x7F).toByte())
+        buf.resetForRead()
+        return BinaryData(ownedBytesFrom(buf))
+    }
+
+    @Test
+    fun peekStaysNoFramingRegardlessOfBufferedBytes() {
+        val chunk = PngChunk(length = 4u, type = 0x49444154u, data = data(4), crc = 0xDEADBEEFu)
+        val total = 4 + 4 + 4 + 4 // length + type + data + crc
+        val pool = BufferPool()
+        val source = BufferFactory.Default.allocate(total + 8, ByteOrder.BIG_ENDIAN)
+        PngChunkCodec.encode(source, chunk, EncodeContext.Empty)
+        source.resetForRead()
+        val stream = StreamProcessor.create(pool, ByteOrder.BIG_ENDIAN)
+        try {
+            // NoFraming at every prefix length, including fully buffered — the
+            // codec never claims a frame size it was not given.
+            for (i in 0 until total) {
+                appendByte(stream, source.readByte())
+                assertEquals(
+                    PeekResult.NoFraming,
+                    PngChunkCodec.peekFrameSize(stream),
+                    "after ${i + 1}/$total bytes",
+                )
+            }
+        } finally {
+            stream.release()
+            pool.clear()
+        }
+    }
+
+    @Test
+    fun decodeConsumesToCallerBoundedLimit() {
+        val chunk = PngChunk(length = 4u, type = 0x49444154u, data = data(4), crc = 0xDEADBEEFu)
+        val total = 4 + 4 + 4 + 4
+        val buf = BufferFactory.Default.allocate(total + 8, ByteOrder.BIG_ENDIAN)
+        PngChunkCodec.encode(buf, chunk, EncodeContext.Empty)
+        buf.resetForRead()
+        buf.setLimit(total) // the caller bounds the buffer to the chunk extent
+        PngChunkCodec.decode(buf, DecodeContext.Empty)
+        assertEquals(total, buf.position(), "decode consumes exactly the caller-bounded chunk extent")
+    }
+
+    private fun appendByte(
+        stream: StreamProcessor,
+        byte: Byte,
+    ) {
+        val one: PlatformBuffer = BufferFactory.Default.allocate(1)
+        one.writeByte(byte)
+        one.resetForRead()
+        stream.append(one)
+    }
+}

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/quic/QuicPacketHeaderPeekTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/quic/QuicPacketHeaderPeekTest.kt
@@ -1,0 +1,61 @@
+package com.ditchoom.buffer.codec.test.protocols.quic
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The fixture models exactly the 1-byte QUIC first byte (RFC 9000 §17.2/§17.3),
+ * dispatching on the header-form bit. Each variant's wire form is a single byte,
+ * so `peekFrameSize` framing it as `Complete(1)` is correct and honest. The
+ * sibling [QuicVarintCodec] peek is tested separately; this locks the packet-
+ * header dispatch peek's `peek.bytes == decode consumption`.
+ */
+class QuicPacketHeaderPeekTest {
+    @Test
+    fun peekFramesSingleFirstByteDispatch() {
+        for (frame in listOf(
+            QuicPacketHeader.ShortHeader(),
+            QuicPacketHeader.LongHeader(),
+        )) {
+            val pool = BufferPool()
+            val source = BufferFactory.Default.allocate(8, ByteOrder.BIG_ENDIAN)
+            QuicPacketHeaderCodec.encode(source, frame, EncodeContext.Empty)
+            source.resetForRead()
+            assertEquals(1, source.remaining(), "first-byte dispatch slice is 1 byte")
+            val stream = StreamProcessor.create(pool, ByteOrder.BIG_ENDIAN)
+            try {
+                assertEquals(PeekResult.NeedsMoreData, QuicPacketHeaderCodec.peekFrameSize(stream), "no bytes")
+                appendByte(stream, source.readByte())
+                assertEquals(PeekResult.Complete(1), QuicPacketHeaderCodec.peekFrameSize(stream), "fully buffered")
+
+                val decodeBuffer = BufferFactory.Default.allocate(8, ByteOrder.BIG_ENDIAN)
+                QuicPacketHeaderCodec.encode(decodeBuffer, frame, EncodeContext.Empty)
+                decodeBuffer.resetForRead()
+                QuicPacketHeaderCodec.decode(decodeBuffer, DecodeContext.Empty)
+                assertEquals(1, decodeBuffer.position(), "decode consumed exactly the peeked frame size")
+            } finally {
+                stream.release()
+                pool.clear()
+            }
+        }
+    }
+
+    private fun appendByte(
+        stream: StreamProcessor,
+        byte: Byte,
+    ) {
+        val one: PlatformBuffer = BufferFactory.Default.allocate(1)
+        one.writeByte(byte)
+        one.resetForRead()
+        stream.append(one)
+    }
+}

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/tcp/TcpSegmentByFlagsPeekTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/tcp/TcpSegmentByFlagsPeekTest.kt
@@ -1,0 +1,64 @@
+package com.ditchoom.buffer.codec.test.protocols.tcp
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The fixture models exactly the 1-byte TCP control-bits dispatch slice (RFC 793
+ * §3.1, byte 13 of the TCP header), so each variant's wire form is a single byte.
+ * `peekFrameSize` framing that as `Complete(1)` is correct and honest — it frames
+ * exactly the byte the fixture decodes. This locks `peek.bytes == decode
+ * consumption`; with no buffered bytes the peek is `NeedsMoreData`.
+ */
+class TcpSegmentByFlagsPeekTest {
+    @Test
+    fun peekFramesSingleFlagsByteDispatch() {
+        for (frame in listOf(
+            TcpSegmentByFlags.Syn(),
+            TcpSegmentByFlags.SynAck(),
+            TcpSegmentByFlags.Ack(),
+            TcpSegmentByFlags.FinAck(),
+            TcpSegmentByFlags.Rst(),
+        )) {
+            val pool = BufferPool()
+            val source = BufferFactory.Default.allocate(8, ByteOrder.BIG_ENDIAN)
+            TcpSegmentByFlagsCodec.encode(source, frame, EncodeContext.Empty)
+            source.resetForRead()
+            assertEquals(1, source.remaining(), "flags dispatch slice is 1 byte")
+            val stream = StreamProcessor.create(pool, ByteOrder.BIG_ENDIAN)
+            try {
+                assertEquals(PeekResult.NeedsMoreData, TcpSegmentByFlagsCodec.peekFrameSize(stream), "no bytes")
+                appendByte(stream, source.readByte())
+                assertEquals(PeekResult.Complete(1), TcpSegmentByFlagsCodec.peekFrameSize(stream), "fully buffered")
+
+                val decodeBuffer = BufferFactory.Default.allocate(8, ByteOrder.BIG_ENDIAN)
+                TcpSegmentByFlagsCodec.encode(decodeBuffer, frame, EncodeContext.Empty)
+                decodeBuffer.resetForRead()
+                TcpSegmentByFlagsCodec.decode(decodeBuffer, DecodeContext.Empty)
+                assertEquals(1, decodeBuffer.position(), "decode consumed exactly the peeked frame size")
+            } finally {
+                stream.release()
+                pool.clear()
+            }
+        }
+    }
+
+    private fun appendByte(
+        stream: StreamProcessor,
+        byte: Byte,
+    ) {
+        val one: PlatformBuffer = BufferFactory.Default.allocate(1)
+        one.writeByte(byte)
+        one.resetForRead()
+        stream.append(one)
+    }
+}

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakePeekTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakePeekTest.kt
@@ -1,0 +1,98 @@
+package com.ditchoom.buffer.codec.test.protocols.tls
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.ownedBytesFrom
+import com.ditchoom.buffer.codec.test.protocols.payload.BinaryData
+import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * TLS 1.3 handshake-message framing (RFC 8446 §4): `HandshakeType msg_type (1)`
+ * + `uint24 length (3)` + `body[length]`. The handshake message is self-
+ * delimiting via the `uint24` length, so `TlsHandshakeCodec.peekFrameSize`
+ * frames the whole message — `Complete(1 + 3 + length)`.
+ *
+ * This pins the load-bearing invariant `peek.bytes == decode consumption` across
+ * the `uint24` length range (small body → length < 256; large body → length
+ * spilling into the upper length bytes), byte-at-a-time: `NeedsMoreData` for
+ * every prefix shorter than the full message, then `Complete(total)`.
+ */
+class TlsHandshakePeekTest {
+    private fun payload(size: Int): BinaryData {
+        val buf = BufferFactory.Default.allocate(size, ByteOrder.BIG_ENDIAN)
+        for (i in 0 until size) buf.writeByte((i and 0x7F).toByte())
+        buf.resetForRead()
+        return BinaryData(ownedBytesFrom(buf))
+    }
+
+    private fun handshake(randomSize: Int): TlsHandshake {
+        val body = TlsHandshakeBody(legacyVersion = 0x0303u, random = payload(randomSize))
+        val bodyBytes = 2 + randomSize // legacyVersion(2) + random[randomSize]
+        return TlsHandshake(msgType = 0x01u, length = bodyBytes.toUInt(), body = body)
+    }
+
+    @Test
+    fun peekFramesHandshakeAcrossUint24LengthRange() {
+        // randomSize 4 → length 6 (single low byte); randomSize 300 → length 302
+        // (0x00012E — exercises the middle uint24 byte). total = 1 + 3 + 2 + randomSize.
+        for (randomSize in listOf(4, 300)) {
+            assertDripPeek(handshake(randomSize), expectedTotal = 6 + randomSize)
+        }
+    }
+
+    private fun assertDripPeek(
+        frame: TlsHandshake,
+        expectedTotal: Int,
+    ) {
+        val pool = BufferPool()
+        val source = BufferFactory.Default.allocate(expectedTotal + 16, ByteOrder.BIG_ENDIAN)
+        TlsHandshakeCodec.encode(source, frame, EncodeContext.Empty)
+        source.resetForRead()
+        val total = source.remaining()
+        assertEquals(expectedTotal, total, "encoded total")
+        val stream = StreamProcessor.create(pool, ByteOrder.BIG_ENDIAN)
+        try {
+            for (i in 0 until total - 1) {
+                appendByte(stream, source.readByte())
+                assertEquals(
+                    PeekResult.NeedsMoreData,
+                    TlsHandshakeCodec.peekFrameSize(stream),
+                    "after ${i + 1}/$total bytes",
+                )
+            }
+            appendByte(stream, source.readByte())
+            assertEquals(
+                PeekResult.Complete(total),
+                TlsHandshakeCodec.peekFrameSize(stream),
+                "fully buffered",
+            )
+            // The peeked frame size must equal what decode actually consumes.
+            val decodeBuffer = BufferFactory.Default.allocate(total + 16, ByteOrder.BIG_ENDIAN)
+            TlsHandshakeCodec.encode(decodeBuffer, frame, EncodeContext.Empty)
+            decodeBuffer.resetForRead()
+            TlsHandshakeCodec.decode(decodeBuffer, DecodeContext.Empty)
+            assertEquals(total, decodeBuffer.position(), "decode consumed exactly the peeked frame size")
+        } finally {
+            stream.release()
+            pool.clear()
+        }
+    }
+
+    private fun appendByte(
+        stream: StreamProcessor,
+        byte: Byte,
+    ) {
+        val one: PlatformBuffer = BufferFactory.Default.allocate(1)
+        one.writeByte(byte)
+        one.resetForRead()
+        stream.append(one)
+    }
+}

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeRoundTripTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeRoundTripTest.kt
@@ -95,19 +95,20 @@ class TlsHandshakeRoundTripTest {
     }
 
     @Test
-    fun handshakeWithSealedHelloRequestDataObjectRoundTrips() {
-        val body = TlsHandshakeSealedBody.HelloRequest
+    fun handshakeWithSealedEndOfEarlyDataDataObjectRoundTrips() {
+        val body = TlsHandshakeSealedBody.EndOfEarlyData
         // Sealed-body wire = 1 (PacketType discriminator) + 0 (singleton) = 1
         val bodyBytes = 1
         val original =
             TlsHandshakeWithSealedBody(
-                msgType = 0x00u,
+                msgType = 0x05u,
                 length = bodyBytes.toUInt(),
                 body = body,
             )
-        val expected = byteArrayOf(0x00, 0x00, 0x00, 0x01, 0x02)
+        // msgType 0x05 + uint24 length 0x000001 + body discriminator 0x05 (end_of_early_data).
+        val expected = byteArrayOf(0x05, 0x00, 0x00, 0x01, 0x05)
         val decoded = roundTripHandshakeWithSealed(original, expected)
-        assertSame(TlsHandshakeSealedBody.HelloRequest, decoded.body)
+        assertSame(TlsHandshakeSealedBody.EndOfEarlyData, decoded.body)
     }
 
     private fun bodyWireBytes(body: TlsHandshakeBody): Int = 2 + body.random.bytes.size


### PR DESCRIPTION
## Summary

A spec-compliance pass over the protocol codec fixtures, focused on **framing** (`peekFrameSize`). Verifies that every fixture either frames its wire genuinely correctly or is an honest probe — no misleading spec claims (the WsbFrame failure mode). Test-only: no production code changes (all in `buffer-codec-test`).

## What this contains

**Spec audit (14 real-protocol fixtures, multi-agent).** Result: **no fakes** — zero `false_complete` peeks, zero misleading fixtures, no field-layout/byte-order errors that would mis-decode real wire. dns/flv/http2/http3/mqtt/mqttv5/mysql/riff/tls/websocket all check out against their specs.

**One genuine spec error fixed:**
- **TLS (RFC 8446)** — `TlsHandshakeSealedBody` used `@PacketType(0x02) → HelloRequest`, but HandshakeType `2 = server_hello` and `hello_request` is removed in 1.3. Replaced with the spec-faithful empty singleton `end_of_early_data(5)`, so the discriminator values now match the RFC (`client_hello=1`, `end_of_early_data=5`).

**Framing locked with `peek == decode consumption` tests:**
- TLS handshake (`Complete(1 + 3 + length)`, RFC 8446 §4).
- ethernet / tcp / quic-header — honest dispatch-slice probes (real wire values), `Complete(2)`/`Complete(1)` for their actual tiny message; verified peek == decode.
- png — consumer-bounded `@RemainingBytes`; verified peek stays `NoFraming` (never falsely upgrades to `Complete`) and decode consumes to the bounded limit.

**New framing reference:**
- **gRPC** `Length-Prefixed-Message` (`Compressed-Flag(1) + Message-Length(4 BE) + Message`) — a real, ubiquitous self-delimiting envelope, expressed with the shipped `@LengthPrefixed(Int) @UseCodec` shape; generated peek frames `Complete(1 + 4 + length)`. Round-trip + drip-peek across flag/size (incl. empty message).

## Documented future work (not in this PR)
- **PNG promotion to faithful self-framing** — needs `@LengthFrom` on a *non-terminal* `@UseCodec` payload (length-bounded body + fixed CRC trailer). Real emitter feature.
- **CoAP (RFC 7252)** — faithful version needs #163 (token length from the header TKL nibble = scalar `@LengthFrom`); base CoAP is UDP-datagram-framed.
- **Kafka** — intentionally skipped: `length(4)+payload` is structurally identical to existing coverage (gRPC minus the flag byte); adds no new capability.

Local: full `:buffer-codec-test:jvmTest` (snapshot test confirms baseline==generated) + ktlint green.