### PR TITLE
ci: fix flaky Android INCONSISTENT_CERTIFICATES by keying AVD cache on keystore

### DIFF
--- a/.github/workflows/android_integration.yaml
+++ b/.github/workflows/android_integration.yaml
@@ -66,7 +66,14 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-${{ matrix.api-level }}-${{ matrix.target }}-${{ matrix.arch }}
+          # The cached AVD userdata retains test APKs installed by the run that
+          # populated it, signed with that run's keystore. If the current
+          # .ci/debug.keystore differs (e.g. the cache predates the keystore pin),
+          # installing the freshly-signed APK over the stale one fails with
+          # INSTALL_PARSE_FAILED_INCONSISTENT_CERTIFICATES before any test runs.
+          # Hashing the keystore into the key ties the cached install set to the
+          # signing key, so any keystore change invalidates the stale AVD cache.
+          key: avd-${{ matrix.api-level }}-${{ matrix.target }}-${{ matrix.arch }}-${{ hashFiles('.ci/debug.keystore') }}
 
       - name: create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Problem

The Android API-21 emulator job intermittently fails with:

```
INSTALL_PARSE_FAILED_INCONSISTENT_CERTIFICATES: New package has a different signature: com.ditchoom.buffer.flow.test
> Task :buffer-flow:connectedDebugAndroidTest FAILED
```

This is **not flaky in the random sense** — it's deterministic cache poisoning. The actual tests run and pass (`Finished 167 tests`, `Finished 9 tests`); the build only dies when installing a later module's test APK.

## Root cause

The job already pins `.ci/debug.keystore` to make APK signing deterministic. But the **AVD cache key omits the keystore**:

```yaml
key: avd-${{ matrix.api-level }}-${{ matrix.target }}-${{ matrix.arch }}
```

The cache stores `~/.android/avd/*`, whose userdata retains the **test APKs installed by the run that populated it** (saved at job end). If that cache was populated by a run using a *different* keystore (e.g. before the keystore pin existed), the stale APK's cert won't match the current pinned key, and the install fails. The pin makes signing deterministic but nothing invalidates the poisoned cache.

## Fix

Hash the keystore into the cache key:

```yaml
key: avd-…-${{ hashFiles('.ci/debug.keystore') }}
```

This (1) busts the currently-poisoned cache one time, and (2) ties the cached install set to the signing key going forward, so any keystore change invalidates the AVD cache automatically. The populating run and consuming run always agree on the cert.

First run after merge is a cache miss per matrix entry (fresh AVD created), green thereafter.