### PR TITLE
ci(android): uninstall stale test APKs before connectedAndroidTest (kills recurring INCONSISTENT_CERTIFICATES)

### DIFF
--- a/.github/workflows/android_integration.yaml
+++ b/.github/workflows/android_integration.yaml
@@ -96,7 +96,18 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: ./gradlew connectedAndroidTest -x connectedBenchmarkAndroidTest
+          script: |
+            # The cached AVD's userdata retains test APKs installed by the run
+            # that populated it. If any was signed with a different debug key
+            # than the current build (cache poisoning across a keystore /
+            # emulator / module-signing change — the keystore-hash cache key in
+            # #183 only invalidates on keystore changes, not these), reinstalling
+            # over it fails with INSTALL_PARSE_FAILED_INCONSISTENT_CERTIFICATES
+            # before any test runs. Uninstalling every pre-existing ditchoom
+            # package first makes the install clean and idempotent regardless of
+            # what signature the cached copy carried.
+            adb shell pm list packages -3 | sed 's/^package://' | grep -i '\.ditchoom\.' | xargs -r -n1 adb uninstall || true
+            ./gradlew connectedAndroidTest -x connectedBenchmarkAndroidTest
 
       - name: Kill emulator processes
         if: always()


### PR DESCRIPTION
## Problem

PR #182's API-21 matrix leg failed with:

```
INSTALL_PARSE_FAILED_INCONSISTENT_CERTIFICATES: New package has a different signature: com.ditchoom.buffer.flow.test
```

Only `com.ditchoom.buffer.flow.test` collided — `buffer-codec` and `buffer-compression` installed fine in the same run, using the *same* default debug keystore. A manual re-run hit the same cached AVD and **failed identically**, so this is **deterministic cache poisoning, not a transient flake.**

### Root cause

The AVD cache stores `~/.android/avd/*`, whose userdata image retains the test APKs installed by the run that populated it. That API-21 cache entry held a `buffer-flow` test APK signed with a debug key that no longer matches the current build, so reinstalling over it is rejected before any test runs. (The healthy API-35 cache, populated by a run that signed everything with the pinned key, passes.)

#183 keyed the cache on `hashFiles('.ci/debug.keystore')`, but that only invalidates the cache when the **keystore file** changes — it can't catch an entry poisoned *before* the pin took effect, or one where a module was signed off a different default debug key. The prior remedy was to manually `gh cache delete` the poisoned entry — a per-incident band-aid.

## Fix

Uninstall every pre-existing `com.ditchoom.*` package before `connectedAndroidTest`, so the install is always clean and idempotent regardless of what signature the cached copy carried:

```bash
adb shell pm list packages -3 | sed 's/^package://' | grep -i '\.ditchoom\.' | xargs -r -n1 adb uninstall || true
./gradlew connectedAndroidTest -x connectedBenchmarkAndroidTest
```

This kills the failure **class** permanently rather than one cache entry at a time, and keeps the AVD snapshot-caching optimization intact. `xargs -r` no-ops when nothing is installed; `|| true` keeps an empty/clean device from failing the step.

## Also done out-of-band

Deleted the two poisoned API-21 cache entries so #182 (and `main`) get a clean repopulate immediately, without waiting for this to merge.