### PR TITLE
feat(codec): @FramedBy + @ForwardCompatible over varint discriminators + ViewCodec zero-copy escape

### DIFF
--- a/.github/workflows/android_integration.yaml
+++ b/.github/workflows/android_integration.yaml
@@ -59,20 +59,25 @@ jobs:
           mkdir -p ~/.android
           cp .ci/debug.keystore ~/.android/debug.keystore
 
-      - name: AVD cache
-        uses: actions/cache@v5
+      # restore/save are deliberately SPLIT (not actions/cache@v5): the unified
+      # action saves at job END, i.e. AFTER `run tests` — capturing AVD userdata
+      # with the test APKs installed, possibly torn from the emulator teardown
+      # mid-write. Every cache-miss run then poisons the cache for the next run:
+      # the stale/corrupt install can neither be uninstalled
+      # (DELETE_FAILED_INTERNAL_ERROR on API 21) nor reinstalled over
+      # (INSTALL_PARSE_FAILED_INCONSISTENT_CERTIFICATES), even with the pinned
+      # keystore. Saving explicitly right after the create-AVD step caches the
+      # PRISTINE snapshot — no package ever installed — and the post-test state
+      # is never cached.
+      - name: AVD cache (restore)
+        uses: actions/cache/restore@v5
         id: avd-cache
         with:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          # The cached AVD userdata retains test APKs installed by the run that
-          # populated it, signed with that run's keystore. If the current
-          # .ci/debug.keystore differs (e.g. the cache predates the keystore pin),
-          # installing the freshly-signed APK over the stale one fails with
-          # INSTALL_PARSE_FAILED_INCONSISTENT_CERTIFICATES before any test runs.
-          # Hashing the keystore into the key ties the cached install set to the
-          # signing key, so any keystore change invalidates the stale AVD cache.
+          # The keystore hash stays in the key so a keystore change still
+          # invalidates any cache created under the old key (see #183).
           key: avd-${{ matrix.api-level }}-${{ matrix.target }}-${{ matrix.arch }}-${{ hashFiles('.ci/debug.keystore') }}
 
       - name: create AVD and generate snapshot for caching
@@ -86,6 +91,15 @@ jobs:
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
           script: echo "Generated AVD snapshot for caching."
+
+      - name: AVD cache (save pristine snapshot)
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ matrix.api-level }}-${{ matrix.target }}-${{ matrix.arch }}-${{ hashFiles('.ci/debug.keystore') }}
 
       - name: run tests
         uses: reactivecircus/android-emulator-runner@v2

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ docs/build/
 docs/.docusaurus/
 docs/.cache-loader/
 docs/static/api/
+# Android NDK / CMake native build outputs
+.cxx/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Codec processor: `@FramedBy` after a varint discriminator** — the `after`
+  framing header may now be a varint value class (inner scalar carrying
+  `@UseCodec(<VariableLengthCodec>)`, e.g. an HTTP/3 frame type). The framed
+  encode measures the header's width per value via the codec's `wireSize`
+  (instead of a compile-time constant), the framed `peekFrameSize` measures it
+  via the codec's own peek, and the peek budget for the framing prefix is the
+  framing codec's declared `maxWireSize` (a QUIC varint length is 1–8 bytes;
+  the fixed path's literal budget is unchanged). Together with
+  `@ForwardCompatible` below this enables a fully **length-free** declarative
+  HTTP/3 frame model: `Type (varint)` + computed `Length (varint)` + payload,
+  with strict body consumption (RFC 9114 §7.1 H3_FRAME_ERROR semantics).
+- **Codec processor: `@ForwardCompatible` over varint discriminators** — the
+  skip-and-preserve contract (F2/F5) now accepts a varint `@DispatchOn`
+  discriminator in addition to single-byte ones. The preserved opcode is the
+  discriminator's full decoded value; the `@UnknownVariant` sink's opcode
+  parameter must be the discriminator's inner type (`Long` / `ULong`) so the
+  preserve→re-encode round trip is lossless (re-encoded through the
+  discriminator's own codec in canonical minimal form). Covers RFC 9114 §9
+  ignore-unknown (reserved/GREASE frame types) for HTTP/3-style unions; the
+  same shape fits QUIC frame types, HTTP/3 stream types, and QPACK opcodes.
+- **`ViewCodec<T>` — explicit zero-copy escape from the raw-bytes lockdown.**
+  `@RemainingBytes @UseCodec(C) val: T` may now carry a **non-`Payload`** type
+  (including `ReadBuffer` itself) when `C` implements the new
+  `com.ditchoom.buffer.codec.ViewCodec` marker: decode returns a borrowed view
+  whose lifetime is tied to the source buffer, encode must be non-consuming.
+  Implementing `ViewCodec` *is* the documented ownership answer the lockdown's
+  prohibition exists to demand; `Payload`-marked self-contained values remain
+  the default for anything that outlives the source buffer.
+
+### Changed
+
+- **Generated varint value-class codecs report Exact `wireSize`.** A
+  `@ProtocolMessage` value class whose single field is a variable-length
+  `@UseCodec` scalar (a varint wrapper) now forwards `wireSize` to the user
+  codec (`VariableLengthCodec.wireSize` is `Exact(encodedLength)` by
+  construction) instead of collapsing to `BackPatch`. Wire format unchanged;
+  required so `@FramedBy`-after-varint can size the framing header per value.
+- The new dispatch-value contract note for varint unions: a `@DispatchValue`
+  projection narrowing a `Long`/`ULong` varint to `Int` should clamp
+  out-of-range values to a sentinel (e.g. `-1`) rather than truncate —
+  truncation can alias a huge unknown type onto a known small `@PacketType`
+  value. The `protocols/http3fc` fixture pins the guard.
+
 ### Fixed
 
 - **`PlatformBuffer.use {}` now releases pooled buffers.** The cleanup was gated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Codec processor: framed-body truncation guard** — generated `@FramedBy`
+  decode (variant arms and the `@ForwardCompatible` preserve arm) now throws a
+  `DecodeException` (`<Owner>.@FramedBy` / `<Unknown>.@ForwardCompatible`)
+  when the declared body length exceeds `buffer.remaining()`, **before**
+  applying the bound or allocating the preserve buffer. Previously a truncated
+  frame failed with platform-dependent buffer errors — or worse, on platforms
+  whose buffers clamp limits past capacity (JS), reads silently fabricated
+  zero bytes for the missing region and the preserve path allocated the
+  attacker-declared length (found by downstream differential fuzzing). Stream
+  readers that gate on `peekFrameSize` never hit the guard; it protects direct
+  `decode` callers and makes truncation behavior identical on every platform.
 - **Codec processor: `@FramedBy` after a varint discriminator** — the `after`
   framing header may now be a varint value class (inner scalar carrying
   `@UseCodec(<VariableLengthCodec>)`, e.g. an HTTP/3 frame type). The framed

--- a/buffer-codec-processor/HTTP3_VARINT_FRAMING_GAPS.md
+++ b/buffer-codec-processor/HTTP3_VARINT_FRAMING_GAPS.md
@@ -1,0 +1,233 @@
+# HTTP/3 varint framing — two declarative gaps blocking the socket migration
+
+**Status:** spec (for implementation) · **Track:** `codec/varint-h3` · **Date:** 2026-06-05
+
+## Context
+
+The `com.ditchoom:socket` library is migrating its hand-written protocol codecs
+onto the buffer-codec KSP processor (socket branch `feat/buffer-codec-migration`).
+The first body — `Http3Setting` (two QUIC varints) — migrated cleanly via
+`@ProtocolMessage` + `@UseCodec(VarIntCodec)`. The next target is the **full
+`Http3FrameCodec`** (the RFC 9114 §7.1 frame envelope: `Type (varint)` +
+`Length (varint)` + payload), and it is **blocked**: two of its load-bearing
+behaviors cannot be expressed declaratively today. This doc specifies both gaps
+and proposes the framework features that would unblock a **byte-identical** full
+migration.
+
+The reference fixture `buffer-codec-test/.../protocols/http3/Http3Frame.kt`
+already exercises varint dispatch + a `BoundingLengthCodec` length — but it keeps
+**every payload opaque** and **stores `length` as a field**, and it has **no
+unknown-frame handling**. socket's real codec is richer than that fixture in
+exactly the two dimensions below, which is why the fixture compiles but the real
+migration cannot.
+
+Both gaps share a root cause: the framework's variable-width (varint) discriminator
+and length support is newer than its fixed-width support, and two features that
+exist for fixed-width discriminators have not been extended to the varint case.
+
+---
+
+## Gap 1 — varint-discriminated unknown-frame capture (skip-and-preserve)
+
+### What socket needs
+
+RFC 9114 §9 requires a receiver to **ignore unknown frame types** (reserved /
+GREASE types of the form `0x1f·N + 0x21`), not fail. socket models this as a
+sealed variant:
+
+```kotlin
+data class Unknown(val type: Long, val payload: ReadBuffer) : Http3Frame
+```
+
+On decode, an unrecognized frame **type** varint + its length-bounded payload are
+captured into `Unknown`; on encode they round-trip byte-for-byte. This is
+**interop-load-bearing** — the socket H3 stack is proven against Cloudflare and
+Google, both of which send GREASE frames. A codec that throws here is a
+functional regression.
+
+### Why it's not expressible
+
+- The generated varint `@DispatchOn` dispatcher's `else` arm **hard-throws**
+  `DecodeException`. Confirmed in the generated reference codec
+  `buffer-codec-test/build/.../http3/Http3FrameCodec.kt`:
+  `else -> throw DecodeException(fieldPath = "Http3Frame.discriminator", ...)`.
+- The only skip-and-preserve mechanism, `@ForwardCompatible`, is validator-gated
+  to a **single-byte** (Byte / UByte) discriminator. See **F2** in
+  `ProtocolMessageProcessor.kt` `validateForwardCompatible` (~line 1910–1957):
+
+  ```
+  // Single-byte inner scalars only (Byte / UByte). Wider discriminators would
+  // need a multi-byte opcode store + a byte-order-aware re-encode, neither of
+  // which the preserve path emits today.
+  if (innerQname != null && innerQname !in SINGLE_BYTE_SCALAR_QNAMES) { logger.error(...) }
+  ```
+
+  HTTP/3 frame types are varints (`@UseCodec(VarIntCodec) raw: Long`), so
+  `@ForwardCompatible` is rejected at compile time.
+
+### Proposed feature
+
+Lift `@ForwardCompatible` to support a **varint `@DispatchOn` discriminator**:
+
+- Store the preserved opcode as the discriminator's **own decoded value**
+  (`Long` / `ULong`) rather than a single byte, and re-encode it through the
+  discriminator's `@UseCodec` codec (here `VarIntCodec`) — so a multi-byte GREASE
+  type round-trips byte-identically. The F2 comment already names this exact
+  missing capability ("multi-byte opcode store + byte-order-aware re-encode").
+- Shape the `@UnknownVariant` sink to carry the wide opcode:
+  `(opcode: Long, raw: ReadBuffer)` (or `ULong`) in addition to the existing
+  `(opcode: Int, raw: PlatformBuffer)` form.
+- This still requires `@FramedBy` (F1) so the skipped payload is length-bounded —
+  which dovetails with Gap 2's computed varint length (below). The framing prefix
+  is the frame's own `Length` varint.
+
+Generalizes beyond H3: QUIC frame types, HTTP/3 **stream** types (§6.2), and
+QPACK instruction opcodes are all varint-discriminated unions that want
+ignore-unknown.
+
+---
+
+## Gap 2 — computed varint length prefix bounding an opaque / structured payload
+
+### What socket needs
+
+socket's model is **length-free**: no `length` field anywhere. The `Length`
+varint is **computed** from the payload on encode and **consumed** (used to bound
+the payload) on decode. The payloads are structured per type:
+
+| Frame                              | Payload model (socket)                       |
+|------------------------------------|----------------------------------------------|
+| DATA / HEADERS                     | opaque `ReadBuffer`                           |
+| SETTINGS                           | `List<Http3Setting>`  ✅ *expressible today*  |
+| GOAWAY / MAX_PUSH_ID / CANCEL_PUSH | a single `Long` varint                       |
+| PUSH_PROMISE                       | `pushId: Long` varint + opaque `ReadBuffer`  |
+| Unknown                            | opaque `ReadBuffer` (+ Gap 1)                |
+
+Keeping the model length-free matters: call sites construct `GoAway(streamId)`,
+`Data(payload)` etc. with no length to compute or keep consistent. Storing a
+`length` field (the reference-fixture shape) ripples length-correctness to every
+call site (`Http3Connection`, `Http3ServerConnection`, `Http3LoopbackServer`) and
+creates an impossible-state class (the stored prefix vs the body's real
+`wireSize` independently encode the same quantity).
+
+### Why it's not expressible (except SETTINGS)
+
+The Length prefix is a **QUIC varint** (variable 1/2/4/8-byte width), and it must
+be **computed from the body**. The available tools each fall short:
+
+- **`@LengthPrefixed` (default)** emits a *fixed* 1/2/4-byte big-endian prefix
+  (`LengthPrefix.Byte`/`Short`/`Int`) — wrong wire format vs a QUIC varint.
+- **`@LengthPrefixed @UseCodec(varintPrefixCodec)`** routes `@UseCodec` to a
+  varint `BoundingLengthCodec<UInt>` **prefix** codec *only for a `List<T>`
+  field* (the MQTT-properties shape). For a single scalar/opaque payload,
+  `@UseCodec` is interpreted as the **payload** codec and the prefix falls back
+  to the fixed default. So:
+  - **SETTINGS** ✅ works:
+    `@LengthPrefixed @UseCodec(Http3VarintLenCodec) val entries: List<Http3Setting>`
+    (computed varint prefix + by-convention `Http3SettingCodec` element).
+  - **DATA / HEADERS / Unknown / GOAWAY / MAX_PUSH_ID / CANCEL_PUSH / PUSH_PROMISE**
+    ❌ — opaque/scalar payloads have no `List` element codec to free up the
+    `@UseCodec` slot for the varint prefix.
+- **`@FramedBy(varintLenCodec, after = "frameType")`** on the sealed parent
+  *would* give a computed, body-bounding prefix (length-free!) and is the natural
+  pairing with Gap 1's `@ForwardCompatible`. But its **E3** validator
+  (`validateFramedBy`, `ProtocolMessageProcessor.kt` ~line 1821–1848) requires the
+  `after` field — the discriminator — to have **Exact wire width**. A varint
+  `frameType` value class is variable-width; the slicing-scheme emitter
+  ("right-flush the prefix against the body without shifting body bytes") assumes
+  a fixed-width header preceding the prefix. So `@FramedBy` after a varint
+  discriminator is untested/unsupported.
+
+### Proposed feature (pick one; **B is preferred**)
+
+**A. Computed varint prefix on a single payload field.** Allow
+`@LengthPrefixed @UseCodec(C)` where `C : BoundingLengthCodec` to mean the
+**prefix** codec even on a non-`List` field, with the payload codec supplied
+separately (a second annotation, or a convention: the field type's by-convention
+codec / a nested `@ProtocolMessage` body). Lets each variant model its payload
+as a nested length-free body bounded by a computed varint.
+
+**B. `@FramedBy` with a variable-width discriminator.** Extend the `@FramedBy`
+slicing scheme (and relax E3) so the `after` discriminator may be a
+variable-width varint value class. The emitter measures the discriminator's
+actual width at encode time (it already does for `Discriminator.Varint`) instead
+of assuming Exact width. This is the cleanest fit: one annotation on the sealed
+parent yields a **computed, body-bounding varint Length** for *every* variant,
+keeps the model length-free, and is exactly what Gap 1's `@ForwardCompatible`
+already requires (`@ForwardCompatible` mandates `@FramedBy`). **B closes most of
+Gap 2 and pairs with Gap 1 in one stroke.**
+
+With B, socket's variants become, e.g.:
+
+```kotlin
+@JvmInline @ProtocolMessage
+value class Http3FrameType(@UseCodec(VarIntCodec::class) val raw: Long) {
+    @DispatchValue val type: Int get() = raw.toInt()
+}
+
+@ProtocolMessage
+@DispatchOn(Http3FrameType::class)
+@FramedBy(Http3VarintLenCodec::class, after = "frameType")     // computed varint Length, body-bounding
+@ForwardCompatible(unknown = Http3Frame.Unknown::class)         // Gap 1
+sealed interface Http3Frame {
+    @PacketType(0x00) @ProtocolMessage
+    data class Data(val frameType: Http3FrameType = Http3FrameType(0),
+                    @RemainingBytes @UseCodec(ReadBufferPayloadCodec::class) val payload: ReadBuffer) : Http3Frame
+
+    @PacketType(0x04) @ProtocolMessage
+    data class Settings(val frameType: Http3FrameType = Http3FrameType(4),
+                        @RemainingBytes val entries: List<Http3Setting>) : Http3Frame
+
+    @PacketType(0x07) @ProtocolMessage
+    data class GoAway(val frameType: Http3FrameType = Http3FrameType(7),
+                      @UseCodec(VarIntCodec::class) val id: Long) : Http3Frame
+
+    @UnknownVariant
+    data class Unknown(val opcode: Long, val raw: ReadBuffer) : Http3Frame
+    // … Headers / MaxPushId / CancelPush / PushPromise analogously
+}
+```
+
+(`Http3VarintLenCodec` is a `BoundingLengthCodec<UInt>` delegating to the QUIC
+varint — socket can supply it; buffer ships no QUIC encoding. Note the `UInt`
+type parameter of `BoundingLengthCodec` vs socket's `VarIntCodec : Codec<Long>`
+is a minor adapter, but confirm `@FramedBy`/`@LengthPrefixed` can carry a
+`ULong`/`Long`-valued length up to 2^62−1, not just `UInt` ≤ 4 GiB — H3 lengths
+are 62-bit on the wire even if practically Int-bounded.)
+
+---
+
+## Acceptance criteria
+
+The features land correctly when socket can, on its `feat/buffer-codec-migration`
+branch:
+
+1. Annotate `Http3Frame` (length-free, structural payloads, varint dispatch,
+   `Unknown` capture) and have KSP generate `Http3FrameCodec`.
+2. Pass a **differential test** vs the current hand-written codec:
+   **byte-identical `encode`** and **decode parity** for every frame type —
+   DATA, HEADERS, SETTINGS (multi-entry), GOAWAY, MAX_PUSH_ID, CANCEL_PUSH,
+   PUSH_PROMISE, and at least two GREASE/Unknown types (1-byte and multi-byte
+   varint type) — plus malformed/bounds edge cases (length past buffer, varint
+   straddling the frame end, zero-length payload, non-minimal varint type).
+3. The generated `peekFrameSize` reports `typeWidth + lengthWidth + length`
+   (matching the hand-written one) so the streaming frame reader is unchanged.
+4. No `length`/`frameType` value leaks to call sites beyond a defaulted
+   discriminator field.
+
+Until then, socket keeps `Http3FrameCodec` hand-written (it is correct and
+interop-proven) and migrates only the clean bodies (`Http3Setting` done).
+
+## Pointers
+
+- socket hand-written codec (the round-trip oracle):
+  `socket-http3/src/commonMain/.../Http3FrameCodec.kt` (283 lines) and its model
+  `Http3Frame.kt`.
+- socket varint codec to delegate to:
+  `socket-http3/src/commonMain/.../VarIntCodec.kt` (`Codec<Long>`, RFC 9000 §16).
+- buffer reference fixture (opaque + stored-length, no Unknown):
+  `buffer-codec-test/.../protocols/http3/{Http3Frame,Http3LengthCodec}.kt`.
+- validators to touch: `ProtocolMessageProcessor.kt` `validateForwardCompatible`
+  (F2, ~1910) and `validateFramedBy` (E3, ~1793); dispatch/`else`-arm emission in
+  `CodecEmitter.kt` (`Discriminator.Varint`, ~1948) and forward-compat capture
+  (~7777).

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecAnalyzer.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecAnalyzer.kt
@@ -546,7 +546,11 @@ internal fun analyzeField(
                 ),
             )
         }
-        if (useCodecAnn != null && type.implementsPayload()) {
+        if (useCodecAnn != null && (type.implementsPayload() || param.hasViewUseCodec())) {
+            // Two typed-payload shapes share one emit: a `Payload`-marked
+            // self-contained value, or a non-`Payload` borrowed view whose
+            // codec opts in via `ViewCodec` (the zero-copy escape — see
+            // [implementsViewCodec]).
             return analyzeRemainingBytesPayloadField(param, type, useCodecAnn, ownerSimpleName)
         }
         if (useCodecAnn == null && payloadTypeParameter != null && type.matchesTypeParameter(payloadTypeParameter)) {
@@ -1766,6 +1770,35 @@ internal fun KSValueParameter.hasVariableLengthUseCodec(): Boolean {
 }
 
 /**
+ * Does this codec class implement `com.ditchoom.buffer.codec.ViewCodec`?
+ * The explicit opt-in that lets a `@RemainingBytes @UseCodec(C) val: T`
+ * field carry a non-`Payload` type (including `ReadBuffer`): the codec's
+ * decode returns a borrowed view into the source buffer, and implementing
+ * `ViewCodec` is the documented ownership contract the lockdown's
+ * raw-bytes prohibition otherwise demands. Walks the full supertype chain
+ * so an indirect implementer is still detected.
+ */
+internal fun KSClassDeclaration.implementsViewCodec(): Boolean =
+    getAllSuperTypes().any { st ->
+        st.declaration.qualifiedName?.asString() == VIEW_CODEC_QNAME
+    }
+
+/**
+ * Does this parameter carry `@UseCodec(C::class)` where `C` implements
+ * `ViewCodec`? See [implementsViewCodec]; used to route a
+ * `@RemainingBytes` non-`Payload` field onto the typed-payload emit path
+ * and to exempt its declared type from the raw-bytes prohibition.
+ */
+internal fun KSValueParameter.hasViewUseCodec(): Boolean {
+    val useCodecAnn =
+        annotations.firstOrNull { it.shortName.asString() == "UseCodec" } ?: return false
+    val codecDecl =
+        (useCodecAnn.arguments.firstOrNull { it.name?.asString() == "codec" }?.value as? KSType)
+            ?.declaration as? KSClassDeclaration ?: return false
+    return codecDecl.implementsViewCodec()
+}
+
+/**
  * Does this type refer to the message's
  * declared `<P : Payload>` type parameter? KSP represents type-
  * parameter references as a `KSTypeParameter` declaration with
@@ -2706,11 +2739,25 @@ internal fun analyzeDispatchOnSealedDispatcher(symbol: KSClassDeclaration): Disp
         )
     val discriminator: Discriminator =
         if (varintInner) {
+            // The inner property's name + scalar kind feed the
+            // `@ForwardCompatible` skip+preserve emit (full-width opcode
+            // capture / re-wrap). A varint inner that isn't a supported
+            // scalar (or has no name) can't carry an opcode — fall back
+            // to NotApplicable; the validator reports the user-facing
+            // diagnostic.
+            val varintInnerName =
+                innerParam.name?.asString()
+                    ?: return DispatchAnalysisResult.NotApplicable
+            val varintInnerKind =
+                SUPPORTED_SCALARS[innerType.declaration.qualifiedName?.asString()]
+                    ?: return DispatchAnalysisResult.NotApplicable
             Discriminator.Varint(
                 className = classNameOf(discriminatorDecl),
                 codecClassName = discriminatorCodecClassName,
                 dispatchValueProperty = dispatchValuePropertyName,
                 dispatchValueKind = dispatchValueKind,
+                innerPropertyName = varintInnerName,
+                innerKind = varintInnerKind,
             )
         } else {
             val innerKind =
@@ -2791,12 +2838,16 @@ internal fun resolveForwardCompatibleConfig(subclasses: List<KSClassDeclaration>
     val ctor = sink.primaryConstructor ?: return null
     val params = ctor.parameters
     if (params.size != 2) return null
+    // Legacy single-byte shape stores the opcode as `Int`; the varint
+    // shapes store the discriminator's full decoded value as `Long` /
+    // `ULong`. F2/F5 enforce kind-vs-discriminator compatibility; the
+    // analyzer only needs the declared kind for emit-side typing.
     val opcodeParam =
         params.firstOrNull {
             it.type
                 .resolve()
                 .declaration.qualifiedName
-                ?.asString() == "kotlin.Int"
+                ?.asString() in FORWARD_COMPATIBLE_OPCODE_QNAMES
         } ?: return null
     val rawParam =
         params.firstOrNull {
@@ -2808,10 +2859,18 @@ internal fun resolveForwardCompatibleConfig(subclasses: List<KSClassDeclaration>
     val opcodeName = opcodeParam.name?.asString() ?: return null
     val rawName = rawParam.name?.asString() ?: return null
     if (opcodeName == rawName) return null
+    val opcodeKind =
+        SUPPORTED_SCALARS[
+            opcodeParam.type
+                .resolve()
+                .declaration.qualifiedName
+                ?.asString(),
+        ] ?: return null
     return ForwardCompatibleConfig(
         unknownClassName = classNameOf(sink),
         opcodeFieldName = opcodeName,
         rawFieldName = rawName,
+        opcodeKind = opcodeKind,
     )
 }
 

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
@@ -238,6 +238,7 @@ internal class CodecEmitter(
             "val __framingLength = %T.decode(buffer, context)",
             framedBy.codecClassName,
         )
+        appendFramedBodyTruncationGuard(body, "__framingLength", "${shape.ownerSimpleName}.@FramedBy")
         body.addStatement("%T.applyBound(buffer, __framingLength)", framedBy.codecClassName)
         body.addStatement("val __framingStart = buffer.position()")
         body.addStatement("val __framingBound = __framingStart + __framingLength.toInt()")
@@ -1693,6 +1694,7 @@ internal class CodecEmitter(
                 "val __framingLength = %T.decode(buffer, context)",
                 framedBy.codecClassName,
             )
+            appendFramedBodyTruncationGuard(body, "__framingLength", "${shape.ownerSimpleName}.@FramedBy")
             body.addStatement(
                 "%T.applyBound(buffer, __framingLength)",
                 framedBy.codecClassName,
@@ -1787,4 +1789,31 @@ internal class CodecEmitter(
             is FieldSpec.Conditional -> field.nullableTypeName
             is FieldSpec.ProtocolMessageScalar -> field.fieldType
         }
+}
+
+/**
+ * Emits the framed-body truncation guard between the framing codec's `decode`
+ * and the body decode: the declared body must be fully buffered. Without it a
+ * truncated frame fails with platform-dependent buffer errors — or worse, on
+ * platforms whose buffers clamp limits past capacity (JS), reads silently
+ * fabricate zero bytes for the missing region (and the @ForwardCompatible
+ * preserve path would even *allocate* the attacker-declared length). Stream
+ * readers that gate on `peekFrameSize` never hit this; it protects direct
+ * `decode` callers.
+ */
+internal fun appendFramedBodyTruncationGuard(
+    body: CodeBlock.Builder,
+    lengthLocal: String,
+    fieldPath: String,
+) {
+    body.beginControlFlow("if (%L.toInt() > buffer.remaining())", lengthLocal)
+    body.addStatement(
+        "throw %T(\n  fieldPath = %S,\n  bufferPosition = buffer.position(),\n" +
+            "  expected = \"a fully-buffered \" + %L + \"-byte framed body\",\n" +
+            "  actual = buffer.remaining().toString() + \" bytes available\",\n)",
+        DECODE_EXCEPTION_CN,
+        fieldPath,
+        lengthLocal,
+    )
+    body.endControlFlow()
 }

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
@@ -272,17 +272,44 @@ internal class CodecEmitter(
         messageType: TypeName = shape.messageClassName,
     ): FunSpec {
         val afterField = framedByAfterField(shape, framedBy)
-        val headerWireWidth =
-            (afterField?.let(::framedByHeaderWireWidth) ?: WireWidth.Zero)
-                .requireFixed("framedByHeaderWireWidth")
         val body = CodeBlock.builder()
+        // Variable-width header (varint discriminator): the header's
+        // width isn't a compile-time constant, so measure it per-value
+        // through the header codec's `wireSize` and pass the runtime
+        // value to FramedEncoder (whose slack arithmetic is already
+        // runtime-`Int`-driven).
+        val variableAfter = afterField as? FieldSpec.UseCodecScalar
+        if (variableAfter != null) {
+            body.addStatement(
+                "val __framingHeaderSize = %T.wireSize(value.%L, context)",
+                variableAfter.codecType,
+                variableAfter.name,
+            )
+            body.beginControlFlow("require(__framingHeaderSize is %T.Exact)", WIRE_SIZE_CN)
+            body.addStatement(
+                "%S",
+                "framing header codec returned a non-Exact wire size for ${shape.ownerSimpleName}.${variableAfter.name}",
+            )
+            body.endControlFlow()
+        }
+        val headerWireWidthLiteral: Int? =
+            if (variableAfter == null) {
+                (afterField?.let(::framedByHeaderWireWidth) ?: WireWidth.Zero)
+                    .requireFixed("framedByHeaderWireWidth")
+            } else {
+                null
+            }
         body.add("return %T.encode(\n", FRAMED_ENCODER_CN)
         body.indent()
         body.add("factory = factory,\n")
         body.add("framingCodec = %T,\n", framedBy.codecClassName)
         body.add("context = context,\n")
         if (afterField != null) {
-            body.add("headerWireWidth = %L,\n", headerWireWidth)
+            if (variableAfter != null) {
+                body.add("headerWireWidth = __framingHeaderSize.bytes,\n")
+            } else {
+                body.add("headerWireWidth = %L,\n", headerWireWidthLiteral)
+            }
             body.add("writeHeader = { buffer ->\n")
             body.indent()
             appendEncodeField(body, afterField, shape)
@@ -316,9 +343,7 @@ internal class CodecEmitter(
         framedBy: FramedByConfig,
     ): FunSpec {
         val afterField = framedByAfterField(shape, framedBy)
-        val headerWireWidth =
-            (afterField?.let(::framedByHeaderWireWidth) ?: WireWidth.Zero)
-                .requireFixed("framedByHeaderWireWidth")
+        val variableAfter = afterField as? FieldSpec.UseCodecScalar
         val builder =
             FunSpec
                 .builder("peekFrameSize")
@@ -330,6 +355,35 @@ internal class CodecEmitter(
                         .build(),
                 ).returns(PEEK_RESULT_CN)
         val body = CodeBlock.builder()
+        if (variableAfter != null) {
+            // Variable-width header (varint discriminator): measure the
+            // header's width via its codec's own peek, then walk the
+            // framing prefix at the measured offset. The peek budget is
+            // the framing codec's declared worst case rather than the
+            // fixed-path literal (a QUIC varint length is 1..8 bytes).
+            body.addStatement(
+                "val __headerFrame = %T.peekFrameSize(stream, baseOffset)",
+                variableAfter.codecType,
+            )
+            body.beginControlFlow("if (__headerFrame !is %T.Complete)", PEEK_RESULT_CN)
+            body.addStatement("return __headerFrame")
+            body.endControlFlow()
+            body.addStatement("val __headerWireWidth = __headerFrame.bytes")
+            body.addStatement(
+                "if (stream.available() - baseOffset < __headerWireWidth + 1) return %T.NeedsMoreData",
+                PEEK_RESULT_CN,
+            )
+            body.addStatement(
+                "val __framingPeek = stream.peekBuffer(baseOffset + __headerWireWidth, %T.maxWireSize) " +
+                    "?: return %T.NeedsMoreData",
+                framedBy.codecClassName,
+                PEEK_RESULT_CN,
+            )
+            return buildFramedByPeekFrameTail(builder, body, framedBy, headerWidthExpr = "__headerWireWidth")
+        }
+        val headerWireWidth =
+            (afterField?.let(::framedByHeaderWireWidth) ?: WireWidth.Zero)
+                .requireFixed("framedByHeaderWireWidth")
         // Need at least the header bytes plus one prefix byte before
         // attempting the codec read. Wider VBI continuations are caught
         // by the codec's underflow → NeedsMoreData fallback below.
@@ -348,6 +402,23 @@ internal class CodecEmitter(
             peekBudget,
             PEEK_RESULT_CN,
         )
+        return buildFramedByPeekFrameTail(builder, body, framedBy, headerWidthExpr = headerWireWidth.toString())
+    }
+
+    /**
+     * Shared tail of the `@FramedBy` `peekFrameSize` emit: decode the
+     * framing prefix against the non-consuming `__framingPeek` view
+     * (underflow → NeedsMoreData), then total = header + observed prefix
+     * width + decoded length. [headerWidthExpr] is either the fixed-path
+     * literal (`"1"`) or the variable-path runtime local
+     * (`"__headerWireWidth"`) — both interpolate into the same shape.
+     */
+    private fun buildFramedByPeekFrameTail(
+        builder: FunSpec.Builder,
+        body: CodeBlock.Builder,
+        framedBy: FramedByConfig,
+        headerWidthExpr: String,
+    ): FunSpec {
         body.beginControlFlow("try")
         body.addStatement("val __framingPeekStart = __framingPeek.position()")
         body.beginControlFlow("val __framingLength = try")
@@ -373,7 +444,7 @@ internal class CodecEmitter(
         )
         body.addStatement(
             "val __total = %L + __framingPrefixWidth + __framingLength.toInt()",
-            headerWireWidth,
+            headerWidthExpr,
         )
         body.addStatement(
             "return if (stream.available() - baseOffset >= __total) %T.Complete(__total) else %T.NeedsMoreData",
@@ -393,9 +464,11 @@ internal class CodecEmitter(
     /**
      * Resolve the `@FramedByafter`-named
      * field to its [FieldSpec], or `null` when the name doesn't match
-     * an analyzed field OR the field shape cannot carry an Exact wire
-     * width (only Scalar / ValueClassScalar are accepted; this mirrors
-     * the validator's E3 acceptance set).
+     * an analyzed field OR the field shape cannot serve as the framing
+     * header (Scalar / ValueClassScalar for the fixed-width emit, plus
+     * a variable-length non-bounding UseCodecScalar — the varint
+     * discriminator — for the runtime-width emit; this mirrors the
+     * validator's E3 acceptance set).
      *
      * Returning `null` for a non-Exact match is a graceful fallback: the
      * validator already logged an `E3` error against the same shape, so
@@ -411,6 +484,15 @@ internal class CodecEmitter(
         val field = shape.fields.firstOrNull { it.name == framedBy.afterFieldName } ?: return null
         return when (field) {
             is FieldSpec.Scalar, is FieldSpec.ValueClassScalar -> field
+            // Varint discriminator header (a value class whose inner
+            // scalar carries `@UseCodec(VariableLengthCodec)`, e.g. an
+            // HTTP/3 frame type). Variable wire width: the encode emit
+            // measures it per-value via the codec's `wireSize` and the
+            // peek emit via the codec's `peekFrameSize`, instead of the
+            // compile-time constant the fixed shapes use. A *bounding*
+            // UseCodecScalar can never be the framing header (its value
+            // is a length, not an opcode) — excluded.
+            is FieldSpec.UseCodecScalar -> field.takeIf { it.isVariableLength && !it.isBounding }
             else -> null
         }
     }

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterConstants.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterConstants.kt
@@ -19,6 +19,7 @@ internal const val PAYLOAD_SIMPLE = "Payload"
 internal const val OWNED_BYTES_HANDLE_QNAME = "com.ditchoom.buffer.codec.OwnedBytesHandle"
 internal const val BOUNDING_LENGTH_CODEC_QNAME = "com.ditchoom.buffer.codec.BoundingLengthCodec"
 internal const val VARIABLE_LENGTH_CODEC_QNAME = "com.ditchoom.buffer.codec.VariableLengthCodec"
+internal const val VIEW_CODEC_QNAME = "com.ditchoom.buffer.codec.ViewCodec"
 internal const val FRAMED_BY_QNAME = "com.ditchoom.buffer.codec.annotations.FramedBy"
 internal const val FRAME_DETECTOR_QNAME = "com.ditchoom.buffer.codec.FrameDetector"
 
@@ -92,5 +93,13 @@ internal val BUFFER_FACTORY_MANAGED_MN =
 // so both are valid declared types.
 internal val FORWARD_COMPATIBLE_RAW_QNAMES =
     setOf("com.ditchoom.buffer.PlatformBuffer", "com.ditchoom.buffer.ReadBuffer")
+
+// Accepted types for the `@UnknownVariant` `opcode` parameter. `Int`
+// is the legacy single-byte-discriminator shape (carries the
+// discriminator byte); `Long` / `ULong` are the varint-discriminator
+// shapes (carry the discriminator's full decoded value) — F2/F5
+// require them to match the discriminator's inner scalar kind.
+internal val FORWARD_COMPATIBLE_OPCODE_QNAMES =
+    setOf("kotlin.Int", "kotlin.Long", "kotlin.ULong")
 internal val CHARSET_CN = ClassName("com.ditchoom.buffer", "Charset")
 internal val STRING_NULLABLE_TN = ClassName("kotlin", "String").copy(nullable = true)

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterDispatch.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterDispatch.kt
@@ -1129,6 +1129,10 @@ internal fun appendForwardCompatibleDecodeElse(
         "val __fcLength = %T.decode(buffer, context)",
         framedBy.codecClassName,
     )
+    // Truncation guard BEFORE the allocate below: __fcRaw is sized by the
+    // *declared* length, so an unguarded truncated frame would allocate an
+    // attacker-controlled amount and (on limit-clamping platforms) zero-fill it.
+    appendFramedBodyTruncationGuard(body, "__fcLength", "${fc.unknownClassName.simpleName}.@ForwardCompatible")
     body.addStatement("val __fcFrameEnd = buffer.position() + __fcLength.toInt()")
     body.addStatement(
         "val __fcFactory = context[%T] ?: %T.%M()",

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterDispatch.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterDispatch.kt
@@ -160,7 +160,7 @@ internal fun buildDispatchDecodeFun(shape: DispatchShape): FunSpec {
             val framedBy =
                 (shape.framing as? Framing.Framed)?.config
                     ?: error("@ForwardCompatible requires @FramedBy; analyzer should not have set forwardCompat")
-            appendForwardCompatibleDecodeElse(body, framedBy, fc.config)
+            appendForwardCompatibleDecodeElse(body, framedBy, fc.config, shape.discriminator)
         }
         ForwardCompat.Disabled -> {
             body.beginControlFlow("else ->")
@@ -794,7 +794,7 @@ internal fun buildFramedByDispatchOnEncodeFun(
             val framedBy =
                 (shape.framing as? Framing.Framed)?.config
                     ?: error("@ForwardCompatible requires @FramedBy; analyzer should not have set forwardCompat")
-            appendForwardCompatibleEncodeArm(body, framedBy, fc.config)
+            appendForwardCompatibleEncodeArm(body, framedBy, fc.config, shape.discriminator)
         }
         ForwardCompat.Disabled -> Unit
     }
@@ -820,7 +820,6 @@ internal fun buildFramedByDispatchOnPeekFun(shape: DispatchShape): FunSpec {
     val framedBy =
         (shape.framing as? Framing.Framed)?.config
             ?: error("buildFramedByDispatchOnPeekFun called on shape without @FramedBy")
-    val headerWireWidth = shape.discriminator.wireWidth.requireFixed("dispatchOnDiscriminator")
     val builder =
         FunSpec
             .builder("peekFrameSize")
@@ -832,18 +831,49 @@ internal fun buildFramedByDispatchOnPeekFun(shape: DispatchShape): FunSpec {
                     .build(),
             ).returns(PEEK_RESULT_CN)
     val body = CodeBlock.builder()
-    body.addStatement(
-        "if (stream.available() - baseOffset < %L) return %T.NeedsMoreData",
-        headerWireWidth + 1,
-        PEEK_RESULT_CN,
-    )
-    val peekBudget = 5
-    body.addStatement(
-        "val __framingPeek = stream.peekBuffer(baseOffset + %L, %L) ?: return %T.NeedsMoreData",
-        headerWireWidth,
-        peekBudget,
-        PEEK_RESULT_CN,
-    )
+    val headerWidthExpr: String
+    if (shape.discriminator is Discriminator.Varint) {
+        // Variable-width discriminator: measure its width via the value
+        // class codec's own peek (works for unknown/GREASE types too —
+        // a varint self-delimits regardless of whether the dispatch
+        // value is recognized), then walk the framing prefix at the
+        // measured offset with the framing codec's worst-case budget.
+        val disc = shape.discriminator as Discriminator.Varint
+        body.addStatement(
+            "val __headerFrame = %T.peekFrameSize(stream, baseOffset)",
+            disc.codecClassName,
+        )
+        body.beginControlFlow("if (__headerFrame !is %T.Complete)", PEEK_RESULT_CN)
+        body.addStatement("return __headerFrame")
+        body.endControlFlow()
+        body.addStatement("val __headerWireWidth = __headerFrame.bytes")
+        body.addStatement(
+            "if (stream.available() - baseOffset < __headerWireWidth + 1) return %T.NeedsMoreData",
+            PEEK_RESULT_CN,
+        )
+        body.addStatement(
+            "val __framingPeek = stream.peekBuffer(baseOffset + __headerWireWidth, %T.maxWireSize) " +
+                "?: return %T.NeedsMoreData",
+            framedBy.codecClassName,
+            PEEK_RESULT_CN,
+        )
+        headerWidthExpr = "__headerWireWidth"
+    } else {
+        val headerWireWidth = shape.discriminator.wireWidth.requireFixed("dispatchOnDiscriminator")
+        body.addStatement(
+            "if (stream.available() - baseOffset < %L) return %T.NeedsMoreData",
+            headerWireWidth + 1,
+            PEEK_RESULT_CN,
+        )
+        val peekBudget = 5
+        body.addStatement(
+            "val __framingPeek = stream.peekBuffer(baseOffset + %L, %L) ?: return %T.NeedsMoreData",
+            headerWireWidth,
+            peekBudget,
+            PEEK_RESULT_CN,
+        )
+        headerWidthExpr = headerWireWidth.toString()
+    }
     body.beginControlFlow("try")
     body.addStatement("val __framingPeekStart = __framingPeek.position()")
     body.beginControlFlow("val __framingLength = try")
@@ -869,7 +899,7 @@ internal fun buildFramedByDispatchOnPeekFun(shape: DispatchShape): FunSpec {
     )
     body.addStatement(
         "val __total = %L + __framingPrefixWidth + __framingLength.toInt()",
-        headerWireWidth,
+        headerWidthExpr,
     )
     body.addStatement(
         "return if (stream.available() - baseOffset >= __total) %T.Complete(__total) else %T.NeedsMoreData",
@@ -1075,12 +1105,26 @@ internal fun appendForwardCompatibleDecodeElse(
     body: CodeBlock.Builder,
     framedBy: FramedByConfig,
     fc: ForwardCompatibleConfig,
+    discriminator: Discriminator,
 ) {
     body.beginControlFlow("else ->")
     // Cursor is at discriminatorPosition (rewound by decode); set it
     // explicitly so the read is robust to future reordering.
     body.addStatement("buffer.position(discriminatorPosition)")
-    body.addStatement("val __fcOpcode = buffer.readUByte().toInt()")
+    when (discriminator) {
+        is Discriminator.Varint ->
+            // Re-read the variable-width discriminator through its own
+            // codec and keep the *inner* decoded value (Long / ULong) —
+            // the dispatch value may be a narrowing projection, but the
+            // inner value is what re-encodes byte-identically.
+            body.addStatement(
+                "val __fcOpcode = %T.decode(buffer, context).%L",
+                discriminator.codecClassName,
+                discriminator.innerPropertyName,
+            )
+        else ->
+            body.addStatement("val __fcOpcode = buffer.readUByte().toInt()")
+    }
     body.addStatement(
         "val __fcLength = %T.decode(buffer, context)",
         framedBy.codecClassName,
@@ -1121,7 +1165,47 @@ internal fun appendForwardCompatibleEncodeArm(
     body: CodeBlock.Builder,
     framedBy: FramedByConfig,
     fc: ForwardCompatibleConfig,
+    discriminator: Discriminator,
 ) {
+    if (discriminator is Discriminator.Varint) {
+        // Re-wrap the preserved full-width opcode in the discriminator
+        // value class and re-encode it through the discriminator's own
+        // codec — width measured per-value, so a multi-byte GREASE-style
+        // type round-trips byte-identically (for the canonical minimal
+        // encoding; a varint has no fixed width to assume).
+        body.beginControlFlow("is %T ->", fc.unknownClassName)
+        body.addStatement(
+            "val __fcHeader = %T(value.%L)",
+            discriminator.className,
+            fc.opcodeFieldName,
+        )
+        body.addStatement(
+            "val __fcHeaderSize = %T.wireSize(__fcHeader, context)",
+            discriminator.codecClassName,
+        )
+        body.beginControlFlow("require(__fcHeaderSize is %T.Exact)", WIRE_SIZE_CN)
+        body.addStatement(
+            "%S",
+            "discriminator codec returned a non-Exact wire size for the preserved opcode",
+        )
+        body.endControlFlow()
+        body.add("%T.encode(\n", FRAMED_ENCODER_CN)
+        body.indent()
+        body.add("factory = factory,\n")
+        body.add("framingCodec = %T,\n", framedBy.codecClassName)
+        body.add("context = context,\n")
+        body.add("headerWireWidth = __fcHeaderSize.bytes,\n")
+        body.add(
+            "writeHeader = { __fcBuf -> %T.encode(__fcBuf, __fcHeader, context) },\n",
+            discriminator.codecClassName,
+        )
+        body.unindent()
+        body.beginControlFlow(") { __fcBuf ->")
+        body.addStatement("__fcBuf.write(value.%L.slice())", fc.rawFieldName)
+        body.endControlFlow()
+        body.endControlFlow()
+        return
+    }
     body.add("is %T -> %T.encode(\n", fc.unknownClassName, FRAMED_ENCODER_CN)
     body.indent()
     body.add("factory = factory,\n")

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterWireSize.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterWireSize.kt
@@ -46,6 +46,23 @@ internal fun buildWireSizeFun(
     // BackPatch unconditionally — runtime-Exact-via-cast (mirroring
     // LengthPrefixedMessage) is a follow-on once a vector measurably
     // benefits.
+    //
+    // The one promoted vector: a **varint value class** — a single
+    // variable-length UseCodecScalar field (an HTTP/3 frame type wrapping
+    // a QUIC varint). Its wire size IS the user codec's
+    // (`VariableLengthCodec.wireSize` is `Exact(encodedLength)` by
+    // construction), and the `@FramedBy`-after-varint emit needs that
+    // Exact answer to size the framing header per value. Forward instead
+    // of collapsing.
+    val soleVarintField = shape.fields.singleOrNull() as? FieldSpec.UseCodecScalar
+    if (soleVarintField != null && soleVarintField.isVariableLength) {
+        builder.addStatement(
+            "return %T.wireSize(value.%L, context)",
+            soleVarintField.codecType,
+            soleVarintField.name,
+        )
+        return builder.build()
+    }
     if (shape.fields.any { it is FieldSpec.UseCodecScalar }) {
         builder.addStatement("return %T.BackPatch", WIRE_SIZE_CN)
         return builder.build()

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecIr.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecIr.kt
@@ -211,6 +211,17 @@ internal sealed interface Discriminator {
         val codecClassName: ClassName,
         val dispatchValueProperty: String,
         val dispatchValueKind: ScalarKind,
+        /**
+         * The value class's single constructor property carrying the
+         * varint-decoded value (e.g. `raw`). The `@ForwardCompatible`
+         * skip+preserve arms read `<decoded>.<innerPropertyName>` to
+         * capture the full-width opcode (the dispatch value may be a
+         * narrowing projection) and re-wrap it (`ValueClass(opcode)`)
+         * on the re-encode path.
+         */
+        val innerPropertyName: String,
+        /** The inner property's scalar kind (Long / ULong for QUIC varints). */
+        val innerKind: ScalarKind,
     ) : Discriminator {
         override val labelFormat: LabelFormat get() = LabelFormat.Decimal
         override val ownership: DiscriminatorOwnership get() = DiscriminatorOwnership.ReReadByVariant
@@ -388,6 +399,15 @@ internal data class ForwardCompatibleConfig(
     val unknownClassName: ClassName,
     val opcodeFieldName: String,
     val rawFieldName: String,
+    /**
+     * The opcode parameter's declared scalar kind. [ScalarKind.Int] is
+     * the legacy single-byte-discriminator shape (the opcode carries the
+     * discriminator *byte*); [ScalarKind.Long] / [ScalarKind.ULong] are
+     * the varint-discriminator shapes, carrying the discriminator's full
+     * decoded value (F2/F5 require it to match the discriminator's inner
+     * scalar kind so the preserve→re-encode round trip is lossless).
+     */
+    val opcodeKind: ScalarKind,
 )
 
 /**

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/ProtocolMessageProcessor.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/ProtocolMessageProcessor.kt
@@ -172,6 +172,16 @@ class ProtocolMessageProcessor(
             }
             val ctor = symbol.primaryConstructor ?: continue
             for (param in ctor.parameters) {
+                // `@RemainingBytes @UseCodec(C)` where `C : ViewCodec` is the
+                // sanctioned zero-copy escape from the raw-bytes prohibition:
+                // the codec's ViewCodec contract documents the borrowed-view
+                // ownership the prohibition exists to demand. The field's
+                // declared type (including `ReadBuffer`) is the codec's
+                // business — skip the walker for this parameter.
+                val isViewPayload =
+                    param.annotations.any { it.shortName.asString() == "RemainingBytes" } &&
+                        param.hasViewUseCodec()
+                if (isViewPayload) continue
                 walkType(
                     type = param.type.resolve(),
                     owner = symbol,
@@ -1361,14 +1371,16 @@ class ProtocolMessageProcessor(
                 )
                 continue
             }
-            if (hasRemainingBytes && !isPayloadField) {
+            if (hasRemainingBytes && !isPayloadField && !param.hasViewUseCodec()) {
                 val displayed = fieldType.declaration.qualifiedName?.asString() ?: "<unresolved>"
                 logger.error(
                     "@RemainingBytes @UseCodec on $ownerName.$fieldName requires the bound " +
                         "field's type to extend `com.ditchoom.buffer.codec.Payload`, but it " +
-                        "is `$displayed`. The typed-payload path is the only " +
-                        "`@UseCodec` composition wired up — wrap the value in a `Payload`-" +
-                        "tagged type.",
+                        "is `$displayed`. Either wrap the value in a `Payload`-tagged type " +
+                        "(consumer-owned copy), or — for a zero-copy borrowed view whose " +
+                        "lifetime is tied to the source buffer — make the codec implement " +
+                        "`com.ditchoom.buffer.codec.ViewCodec` (the explicit ownership " +
+                        "opt-in for non-Payload types).",
                     param,
                 )
                 continue
@@ -1907,7 +1919,7 @@ class ProtocolMessageProcessor(
             )
         }
 
-        // F2 — requires @DispatchOn with a single-byte discriminator.
+        // F2 — requires @DispatchOn with a single-byte or varint discriminator.
         val dispatchOn =
             owner.annotations.firstOrNull { a ->
                 a.shortName.asString() == DISPATCH_ON_SHORT &&
@@ -1916,12 +1928,19 @@ class ProtocolMessageProcessor(
                         .declaration.qualifiedName
                         ?.asString() == DISPATCH_ON_QNAME
             }
+        // Discriminator shape, threaded into F5: the opcode parameter's
+        // required type depends on whether the discriminator is the
+        // legacy single-byte scalar (opcode: Int carrying the byte) or a
+        // varint value class (opcode: Long / ULong carrying the full
+        // decoded value, re-encoded through the discriminator's codec).
+        var discInnerQname: String? = null
+        var discIsVarint = false
         if (dispatchOn == null) {
             logger.error(
                 "@ForwardCompatible on $ownerName requires @DispatchOn dispatch with a single-byte " +
-                    "discriminator. Framed sealed dispatch routes through @DispatchOn; wrap the " +
-                    "opcode in a `@JvmInline value class` carrying a @DispatchValue and annotate the " +
-                    "parent with @DispatchOn(<OpCode>::class).",
+                    "or varint discriminator. Framed sealed dispatch routes through @DispatchOn; " +
+                    "wrap the opcode in a `@JvmInline value class` carrying a @DispatchValue and " +
+                    "annotate the parent with @DispatchOn(<OpCode>::class).",
                 owner,
             )
         } else {
@@ -1930,27 +1949,39 @@ class ProtocolMessageProcessor(
                     .firstOrNull { it.name?.asString() == "type" }
                     ?.value as? KSType
             val discriminatorDecl = discriminatorType?.declaration as? KSClassDeclaration
-            val innerQname =
+            val innerParam =
                 discriminatorDecl
                     ?.primaryConstructor
                     ?.parameters
                     ?.singleOrNull()
+            val innerQname =
+                innerParam
                     ?.type
                     ?.resolve()
                     ?.declaration
                     ?.qualifiedName
                     ?.asString()
-            // Single-byte inner scalars only (Byte / UByte). Wider
-            // discriminators would need a multi-byte opcode store + a
-            // byte-order-aware re-encode, neither of which the preserve
-            // path emits today.
-            if (innerQname != null && innerQname !in SINGLE_BYTE_SCALAR_QNAMES) {
+            discInnerQname = innerQname
+            discIsVarint = innerParam?.hasVariableLengthUseCodec() == true
+            // Two preservable shapes: a single-byte inner scalar (the
+            // opcode byte re-encodes via writeUByte) or a varint inner
+            // (`@UseCodec(VariableLengthCodec)` on a Long / ULong inner —
+            // the opcode value re-encodes through the discriminator's own
+            // codec, so a multi-byte GREASE-style type round-trips).
+            // Fixed multi-byte inners (UShort / UInt / …) remain
+            // unsupported: their preserve path would need a byte-order-
+            // aware re-encode the emit doesn't produce.
+            val singleByte = innerQname in SINGLE_BYTE_SCALAR_QNAMES
+            val varintWide = discIsVarint && innerQname in VARINT_OPCODE_QNAMES
+            if (innerQname != null && !singleByte && !varintWide) {
                 logger.error(
                     "@ForwardCompatible on $ownerName requires a single-byte @DispatchOn " +
-                        "discriminator (Byte / UByte inner scalar), but the discriminator's inner " +
-                        "type is `$innerQname`. The preserved opcode is stored as one byte and " +
-                        "re-encoded with writeUByte, so a wider discriminator cannot round-trip " +
-                        "byte-identically.",
+                        "discriminator (Byte / UByte inner scalar) or a varint discriminator " +
+                        "(`@UseCodec(<VariableLengthCodec>) raw: Long | ULong` inner), but the " +
+                        "discriminator's inner type is `$innerQname`" +
+                        (if (discIsVarint) " (varint)" else "") +
+                        ". A fixed multi-byte discriminator cannot round-trip byte-identically " +
+                        "through the preserve path.",
                     owner,
                 )
             }
@@ -1994,14 +2025,20 @@ class ProtocolMessageProcessor(
             )
         }
 
-        // F5 — (opcode: Int, raw: PlatformBuffer | ReadBuffer).
+        // F5 — (opcode: Int | Long | ULong, raw: PlatformBuffer | ReadBuffer).
+        // The opcode kind must match the discriminator shape: a single-
+        // byte discriminator preserves the discriminator *byte* as `Int`;
+        // a varint discriminator preserves the full decoded value, so the
+        // opcode parameter must be the discriminator's own inner type
+        // (Long / ULong) for a lossless preserve→re-encode round trip.
         val params = sink.primaryConstructor?.parameters.orEmpty()
-        val hasInt =
+        val expectedOpcodeQname = if (discIsVarint) discInnerQname else INT_QNAME
+        val hasOpcode =
             params.any {
                 it.type
                     .resolve()
                     .declaration.qualifiedName
-                    ?.asString() == INT_QNAME
+                    ?.asString() == expectedOpcodeQname
             }
         val hasRawBuffer =
             params.any {
@@ -2011,12 +2048,21 @@ class ProtocolMessageProcessor(
                     ?.asString() in
                     setOf(PLATFORM_BUFFER_QNAME, READ_BUFFER_QNAME)
             }
-        if (params.size != 2 || !hasInt || !hasRawBuffer) {
+        if (params.size != 2 || !hasOpcode || !hasRawBuffer) {
+            val expectedOpcodeSimple = expectedOpcodeQname?.substringAfterLast('.') ?: "Int"
             logger.error(
                 "@UnknownVariant $sinkName must have a primary constructor shaped " +
-                    "`(opcode: Int, raw: PlatformBuffer)` (a ReadBuffer-typed `raw` is also " +
-                    "accepted): `opcode` carries the discriminator byte and `raw` carries the " +
-                    "opaque preserved payload.",
+                    "`(opcode: $expectedOpcodeSimple, raw: PlatformBuffer)` (a ReadBuffer-typed " +
+                    "`raw` is also accepted): `opcode` carries the " +
+                    (
+                        if (discIsVarint) {
+                            "discriminator's full decoded value (its inner type, so the preserve" +
+                                "→re-encode round trip is lossless)"
+                        } else {
+                            "discriminator byte"
+                        }
+                    ) +
+                    " and `raw` carries the opaque preserved payload.",
                 sink,
             )
         }
@@ -2138,7 +2184,13 @@ class ProtocolMessageProcessor(
         for (st in codecDecl.getAllSuperTypes()) {
             if (st.isError) continue
             val q = st.declaration.qualifiedName?.asString()
-            if (q != CODEC_QNAME && q != BOUNDING_LENGTH_CODEC_QNAME && q != VARIABLE_LENGTH_CODEC_QNAME) continue
+            if (q != CODEC_QNAME &&
+                q != BOUNDING_LENGTH_CODEC_QNAME &&
+                q != VARIABLE_LENGTH_CODEC_QNAME &&
+                q != VIEW_CODEC_QNAME
+            ) {
+                continue
+            }
             val arg =
                 st.arguments
                     .firstOrNull()
@@ -2398,6 +2450,10 @@ class ProtocolMessageProcessor(
         private const val READ_BUFFER_QNAME = "com.ditchoom.buffer.ReadBuffer"
         private const val INT_QNAME = "kotlin.Int"
         private val SINGLE_BYTE_SCALAR_QNAMES = setOf("kotlin.Byte", "kotlin.UByte")
+
+        // Inner scalar kinds accepted for a *varint* @ForwardCompatible
+        // discriminator (QUIC varints decode into a 62-bit domain).
+        private val VARINT_OPCODE_QNAMES = setOf("kotlin.Long", "kotlin.ULong")
         private const val REMAINING_BYTES_QNAME = "com.ditchoom.buffer.codec.annotations.RemainingBytes"
         private const val REMAINING_BYTES_SHORT = "RemainingBytes"
         private const val CODEC_QNAME = "com.ditchoom.buffer.codec.Codec"

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/batch/FramedBatchedBodyCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/batch/FramedBatchedBodyCodec.kt
@@ -19,6 +19,14 @@ public object FramedBatchedBodyCodec {
   public fun decode(buffer: ReadBuffer, context: DecodeContext): FramedBatchedBody {
     val __framingOuterLimit = buffer.limit()
     val __framingLength = Le32LengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "FramedBatchedBody.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     Le32LengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/forwardcompat/ForwardCompatibleOpCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/forwardcompat/ForwardCompatibleOpCodec.kt
@@ -4,6 +4,7 @@ import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
 import com.ditchoom.buffer.codec.EncodeContext
 import com.ditchoom.buffer.codec.ForwardCompatibleFactoryKey
 import com.ditchoom.buffer.codec.FramedEncoder
@@ -27,6 +28,14 @@ public object ForwardCompatibleOpCodec {
         buffer.position(discriminatorPosition)
         val __fcOpcode = buffer.readUByte().toInt()
         val __fcLength = MqttRemainingLengthCodec.decode(buffer, context)
+        if (__fcLength.toInt() > buffer.remaining()) {
+          throw DecodeException(
+                fieldPath = "Unknown.@ForwardCompatible",
+                bufferPosition = buffer.position(),
+                expected = "a fully-buffered " + __fcLength + "-byte framed body",
+                actual = buffer.remaining().toString() + " bytes available",
+              )
+        }
         val __fcFrameEnd = buffer.position() + __fcLength.toInt()
         val __fcFactory = context[ForwardCompatibleFactoryKey] ?: BufferFactory.managed()
         val __fcRaw = __fcFactory.allocate(__fcLength.toInt())

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/forwardcompat/ForwardCompatibleOpScrollCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/forwardcompat/ForwardCompatibleOpScrollCodec.kt
@@ -18,6 +18,14 @@ public object ForwardCompatibleOpScrollCodec {
     val header = OpCode(buffer.readUByte())
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "Scroll.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/forwardcompat/ForwardCompatibleOpSetTitleCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/forwardcompat/ForwardCompatibleOpSetTitleCodec.kt
@@ -20,6 +20,14 @@ public object ForwardCompatibleOpSetTitleCodec {
     val header = OpCode(buffer.readUByte())
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "SetTitle.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcFrameCodec.kt
@@ -4,6 +4,7 @@ import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
 import com.ditchoom.buffer.codec.EncodeContext
 import com.ditchoom.buffer.codec.ForwardCompatibleFactoryKey
 import com.ditchoom.buffer.codec.FramedEncoder
@@ -30,6 +31,14 @@ public object Http3FcFrameCodec {
         buffer.position(discriminatorPosition)
         val __fcOpcode = Http3FcFrameTypeCodec.decode(buffer, context).raw
         val __fcLength = Http3FcLengthCodec.decode(buffer, context)
+        if (__fcLength.toInt() > buffer.remaining()) {
+          throw DecodeException(
+                fieldPath = "Unknown.@ForwardCompatible",
+                bufferPosition = buffer.position(),
+                expected = "a fully-buffered " + __fcLength + "-byte framed body",
+                actual = buffer.remaining().toString() + " bytes available",
+              )
+        }
         val __fcFrameEnd = buffer.position() + __fcLength.toInt()
         val __fcFactory = context[ForwardCompatibleFactoryKey] ?: BufferFactory.managed()
         val __fcRaw = __fcFactory.allocate(__fcLength.toInt())

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcFrameCodec.kt
@@ -1,0 +1,99 @@
+package com.ditchoom.buffer.codec.test.protocols.http3fc
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.ForwardCompatibleFactoryKey
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.managed
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object Http3FcFrameCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): Http3FcFrame {
+    val discriminatorPosition = buffer.position()
+    val __discriminator = Http3FcFrameTypeCodec.decode(buffer, context)
+    buffer.position(discriminatorPosition)
+    val __dispatchValue = __discriminator.type
+    return when (__dispatchValue) {
+      0 -> Http3FcFrameDataCodec.decode(buffer, context)
+      4 -> Http3FcFrameSettingsCodec.decode(buffer, context)
+      5 -> Http3FcFramePushPromiseCodec.decode(buffer, context)
+      7 -> Http3FcFrameGoAwayCodec.decode(buffer, context)
+      64 -> Http3FcFrameExtensionCodec.decode(buffer, context)
+      else -> {
+        buffer.position(discriminatorPosition)
+        val __fcOpcode = Http3FcFrameTypeCodec.decode(buffer, context).raw
+        val __fcLength = Http3FcLengthCodec.decode(buffer, context)
+        val __fcFrameEnd = buffer.position() + __fcLength.toInt()
+        val __fcFactory = context[ForwardCompatibleFactoryKey] ?: BufferFactory.managed()
+        val __fcRaw = __fcFactory.allocate(__fcLength.toInt())
+        val __fcSavedLimit = buffer.limit()
+        buffer.setLimit(__fcFrameEnd)
+        __fcRaw.write(buffer)
+        buffer.setLimit(__fcSavedLimit)
+        __fcRaw.resetForRead()
+        Http3FcFrame.Unknown(opcode = __fcOpcode, raw = __fcRaw)
+      }
+    }
+  }
+
+  public fun encode(
+    `value`: Http3FcFrame,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer = when (value) {
+    is Http3FcFrame.Data -> Http3FcFrameDataCodec.encode(value, context, factory)
+    is Http3FcFrame.Settings -> Http3FcFrameSettingsCodec.encode(value, context, factory)
+    is Http3FcFrame.PushPromise -> Http3FcFramePushPromiseCodec.encode(value, context, factory)
+    is Http3FcFrame.GoAway -> Http3FcFrameGoAwayCodec.encode(value, context, factory)
+    is Http3FcFrame.Extension -> Http3FcFrameExtensionCodec.encode(value, context, factory)
+    is Http3FcFrame.Unknown -> {
+      val __fcHeader = Http3FcFrameType(value.opcode)
+      val __fcHeaderSize = Http3FcFrameTypeCodec.wireSize(__fcHeader, context)
+      require(__fcHeaderSize is WireSize.Exact) {
+        "discriminator codec returned a non-Exact wire size for the preserved opcode"
+      }
+      FramedEncoder.encode(
+        factory = factory,
+        framingCodec = Http3FcLengthCodec,
+        context = context,
+        headerWireWidth = __fcHeaderSize.bytes,
+        writeHeader = { __fcBuf -> Http3FcFrameTypeCodec.encode(__fcBuf, __fcHeader, context) },
+      ) { __fcBuf ->
+        __fcBuf.write(value.raw.slice())
+      }
+    }
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    val __headerFrame = Http3FcFrameTypeCodec.peekFrameSize(stream, baseOffset)
+    if (__headerFrame !is PeekResult.Complete) {
+      return __headerFrame
+    }
+    val __headerWireWidth = __headerFrame.bytes
+    if (stream.available() - baseOffset < __headerWireWidth + 1) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + __headerWireWidth, Http3FcLengthCodec.maxWireSize) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        Http3FcLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = __headerWireWidth + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcFrameDataCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcFrameDataCodec.kt
@@ -18,6 +18,14 @@ public object Http3FcFrameDataCodec {
     val frameType = Http3FcFrameTypeCodec.decode(buffer, context)
     val __framingOuterLimit = buffer.limit()
     val __framingLength = Http3FcLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "Data.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     Http3FcLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcFrameDataCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcFrameDataCodec.kt
@@ -1,0 +1,87 @@
+package com.ditchoom.buffer.codec.test.protocols.http3fc
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object Http3FcFrameDataCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): Http3FcFrame.Data {
+    val frameType = Http3FcFrameTypeCodec.decode(buffer, context)
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = Http3FcLengthCodec.decode(buffer, context)
+    Http3FcLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val payload = RawBytesCodec.decode(buffer, context)
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "Data.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      Http3FcFrame.Data(frameType = frameType, payload = payload)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: Http3FcFrame.Data,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer {
+    val __framingHeaderSize = Http3FcFrameTypeCodec.wireSize(value.frameType, context)
+    require(__framingHeaderSize is WireSize.Exact) {
+      "framing header codec returned a non-Exact wire size for Data.frameType"
+    }
+    return FramedEncoder.encode(
+      factory = factory,
+      framingCodec = Http3FcLengthCodec,
+      context = context,
+      headerWireWidth = __framingHeaderSize.bytes,
+      writeHeader = { buffer ->
+        Http3FcFrameTypeCodec.encode(buffer, value.frameType, context)
+      },
+    ) { buffer ->
+      RawBytesCodec.encode(buffer, value.payload, context)
+    }
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    val __headerFrame = Http3FcFrameTypeCodec.peekFrameSize(stream, baseOffset)
+    if (__headerFrame !is PeekResult.Complete) {
+      return __headerFrame
+    }
+    val __headerWireWidth = __headerFrame.bytes
+    if (stream.available() - baseOffset < __headerWireWidth + 1) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + __headerWireWidth, Http3FcLengthCodec.maxWireSize) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        Http3FcLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = __headerWireWidth + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcFrameExtensionCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcFrameExtensionCodec.kt
@@ -1,0 +1,87 @@
+package com.ditchoom.buffer.codec.test.protocols.http3fc
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object Http3FcFrameExtensionCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): Http3FcFrame.Extension {
+    val frameType = Http3FcFrameTypeCodec.decode(buffer, context)
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = Http3FcLengthCodec.decode(buffer, context)
+    Http3FcLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val payload = RawBytesCodec.decode(buffer, context)
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "Extension.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      Http3FcFrame.Extension(frameType = frameType, payload = payload)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: Http3FcFrame.Extension,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer {
+    val __framingHeaderSize = Http3FcFrameTypeCodec.wireSize(value.frameType, context)
+    require(__framingHeaderSize is WireSize.Exact) {
+      "framing header codec returned a non-Exact wire size for Extension.frameType"
+    }
+    return FramedEncoder.encode(
+      factory = factory,
+      framingCodec = Http3FcLengthCodec,
+      context = context,
+      headerWireWidth = __framingHeaderSize.bytes,
+      writeHeader = { buffer ->
+        Http3FcFrameTypeCodec.encode(buffer, value.frameType, context)
+      },
+    ) { buffer ->
+      RawBytesCodec.encode(buffer, value.payload, context)
+    }
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    val __headerFrame = Http3FcFrameTypeCodec.peekFrameSize(stream, baseOffset)
+    if (__headerFrame !is PeekResult.Complete) {
+      return __headerFrame
+    }
+    val __headerWireWidth = __headerFrame.bytes
+    if (stream.available() - baseOffset < __headerWireWidth + 1) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + __headerWireWidth, Http3FcLengthCodec.maxWireSize) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        Http3FcLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = __headerWireWidth + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcFrameExtensionCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcFrameExtensionCodec.kt
@@ -18,6 +18,14 @@ public object Http3FcFrameExtensionCodec {
     val frameType = Http3FcFrameTypeCodec.decode(buffer, context)
     val __framingOuterLimit = buffer.limit()
     val __framingLength = Http3FcLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "Extension.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     Http3FcLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcFrameGoAwayCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcFrameGoAwayCodec.kt
@@ -1,0 +1,88 @@
+package com.ditchoom.buffer.codec.test.protocols.http3fc
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.codec.test.protocols.quic.QuicVarintCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object Http3FcFrameGoAwayCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): Http3FcFrame.GoAway {
+    val frameType = Http3FcFrameTypeCodec.decode(buffer, context)
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = Http3FcLengthCodec.decode(buffer, context)
+    Http3FcLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val id = QuicVarintCodec.decode(buffer, context)
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "GoAway.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      Http3FcFrame.GoAway(frameType = frameType, id = id)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: Http3FcFrame.GoAway,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer {
+    val __framingHeaderSize = Http3FcFrameTypeCodec.wireSize(value.frameType, context)
+    require(__framingHeaderSize is WireSize.Exact) {
+      "framing header codec returned a non-Exact wire size for GoAway.frameType"
+    }
+    return FramedEncoder.encode(
+      factory = factory,
+      framingCodec = Http3FcLengthCodec,
+      context = context,
+      headerWireWidth = __framingHeaderSize.bytes,
+      writeHeader = { buffer ->
+        Http3FcFrameTypeCodec.encode(buffer, value.frameType, context)
+      },
+    ) { buffer ->
+      QuicVarintCodec.encode(buffer, value.id, context)
+    }
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    val __headerFrame = Http3FcFrameTypeCodec.peekFrameSize(stream, baseOffset)
+    if (__headerFrame !is PeekResult.Complete) {
+      return __headerFrame
+    }
+    val __headerWireWidth = __headerFrame.bytes
+    if (stream.available() - baseOffset < __headerWireWidth + 1) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + __headerWireWidth, Http3FcLengthCodec.maxWireSize) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        Http3FcLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = __headerWireWidth + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcFrameGoAwayCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcFrameGoAwayCodec.kt
@@ -19,6 +19,14 @@ public object Http3FcFrameGoAwayCodec {
     val frameType = Http3FcFrameTypeCodec.decode(buffer, context)
     val __framingOuterLimit = buffer.limit()
     val __framingLength = Http3FcLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "GoAway.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     Http3FcLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcFramePushPromiseCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcFramePushPromiseCodec.kt
@@ -19,6 +19,14 @@ public object Http3FcFramePushPromiseCodec {
     val frameType = Http3FcFrameTypeCodec.decode(buffer, context)
     val __framingOuterLimit = buffer.limit()
     val __framingLength = Http3FcLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "PushPromise.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     Http3FcLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcFramePushPromiseCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcFramePushPromiseCodec.kt
@@ -1,0 +1,90 @@
+package com.ditchoom.buffer.codec.test.protocols.http3fc
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.codec.test.protocols.quic.QuicVarintCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object Http3FcFramePushPromiseCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): Http3FcFrame.PushPromise {
+    val frameType = Http3FcFrameTypeCodec.decode(buffer, context)
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = Http3FcLengthCodec.decode(buffer, context)
+    Http3FcLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val pushId = QuicVarintCodec.decode(buffer, context)
+      val encodedFieldSection = RawBytesCodec.decode(buffer, context)
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "PushPromise.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      Http3FcFrame.PushPromise(frameType = frameType, pushId = pushId, encodedFieldSection = encodedFieldSection)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: Http3FcFrame.PushPromise,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer {
+    val __framingHeaderSize = Http3FcFrameTypeCodec.wireSize(value.frameType, context)
+    require(__framingHeaderSize is WireSize.Exact) {
+      "framing header codec returned a non-Exact wire size for PushPromise.frameType"
+    }
+    return FramedEncoder.encode(
+      factory = factory,
+      framingCodec = Http3FcLengthCodec,
+      context = context,
+      headerWireWidth = __framingHeaderSize.bytes,
+      writeHeader = { buffer ->
+        Http3FcFrameTypeCodec.encode(buffer, value.frameType, context)
+      },
+    ) { buffer ->
+      QuicVarintCodec.encode(buffer, value.pushId, context)
+      RawBytesCodec.encode(buffer, value.encodedFieldSection, context)
+    }
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    val __headerFrame = Http3FcFrameTypeCodec.peekFrameSize(stream, baseOffset)
+    if (__headerFrame !is PeekResult.Complete) {
+      return __headerFrame
+    }
+    val __headerWireWidth = __headerFrame.bytes
+    if (stream.available() - baseOffset < __headerWireWidth + 1) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + __headerWireWidth, Http3FcLengthCodec.maxWireSize) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        Http3FcLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = __headerWireWidth + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcFrameSettingsCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcFrameSettingsCodec.kt
@@ -18,6 +18,14 @@ public object Http3FcFrameSettingsCodec {
     val frameType = Http3FcFrameTypeCodec.decode(buffer, context)
     val __framingOuterLimit = buffer.limit()
     val __framingLength = Http3FcLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "Settings.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     Http3FcLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcFrameSettingsCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcFrameSettingsCodec.kt
@@ -1,0 +1,92 @@
+package com.ditchoom.buffer.codec.test.protocols.http3fc
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.FramedEncoder
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.Throwable
+
+public object Http3FcFrameSettingsCodec {
+  public fun decode(buffer: ReadBuffer, context: DecodeContext): Http3FcFrame.Settings {
+    val frameType = Http3FcFrameTypeCodec.decode(buffer, context)
+    val __framingOuterLimit = buffer.limit()
+    val __framingLength = Http3FcLengthCodec.decode(buffer, context)
+    Http3FcLengthCodec.applyBound(buffer, __framingLength)
+    val __framingStart = buffer.position()
+    val __framingBound = __framingStart + __framingLength.toInt()
+    return try {
+      val entries = mutableListOf<Http3FcSetting>()
+      while (buffer.position() < buffer.limit()) {
+        entries += Http3FcSettingCodec.decode(buffer, context)
+      }
+      if (buffer.position() != __framingBound) {
+        throw DecodeException(
+              fieldPath = "Settings.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "body to consume " + __framingLength + " bytes",
+              actual = (buffer.position() - __framingStart).toString() + " bytes",
+            )
+      }
+      Http3FcFrame.Settings(frameType = frameType, entries = entries)
+    } finally {
+      buffer.setLimit(__framingOuterLimit)
+    }
+  }
+
+  public fun encode(
+    `value`: Http3FcFrame.Settings,
+    context: EncodeContext,
+    factory: BufferFactory,
+  ): ReadBuffer {
+    val __framingHeaderSize = Http3FcFrameTypeCodec.wireSize(value.frameType, context)
+    require(__framingHeaderSize is WireSize.Exact) {
+      "framing header codec returned a non-Exact wire size for Settings.frameType"
+    }
+    return FramedEncoder.encode(
+      factory = factory,
+      framingCodec = Http3FcLengthCodec,
+      context = context,
+      headerWireWidth = __framingHeaderSize.bytes,
+      writeHeader = { buffer ->
+        Http3FcFrameTypeCodec.encode(buffer, value.frameType, context)
+      },
+    ) { buffer ->
+      for (__elem in value.entries) {
+        Http3FcSettingCodec.encode(buffer, __elem, context)
+      }
+    }
+  }
+
+  public fun peekFrameSize(stream: StreamProcessor, baseOffset: Int = 0): PeekResult {
+    val __headerFrame = Http3FcFrameTypeCodec.peekFrameSize(stream, baseOffset)
+    if (__headerFrame !is PeekResult.Complete) {
+      return __headerFrame
+    }
+    val __headerWireWidth = __headerFrame.bytes
+    if (stream.available() - baseOffset < __headerWireWidth + 1) return PeekResult.NeedsMoreData
+    val __framingPeek = stream.peekBuffer(baseOffset + __headerWireWidth, Http3FcLengthCodec.maxWireSize) ?: return PeekResult.NeedsMoreData
+    try {
+      val __framingPeekStart = __framingPeek.position()
+      val __framingLength = try {
+        Http3FcLengthCodec.decode(__framingPeek, DecodeContext.Empty)
+      } catch (__e: Throwable) {
+        when (__e::class.simpleName) {
+          "BufferUnderflowException", "IndexOutOfBoundsException", "ArrayIndexOutOfBoundsException" -> return PeekResult.NeedsMoreData
+          else -> throw __e
+        }
+      }
+      val __framingPrefixWidth = __framingPeek.position() - __framingPeekStart
+      val __total = __headerWireWidth + __framingPrefixWidth + __framingLength.toInt()
+      return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+    } finally {
+      (__framingPeek as? PlatformBuffer)?.freeNativeMemory()
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcFrameTypeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcFrameTypeCodec.kt
@@ -1,4 +1,4 @@
-package com.ditchoom.buffer.codec.test.protocols.http3
+package com.ditchoom.buffer.codec.test.protocols.http3fc
 
 import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.WriteBuffer
@@ -11,21 +11,21 @@ import com.ditchoom.buffer.codec.test.protocols.quic.QuicVarintCodec
 import com.ditchoom.buffer.stream.StreamProcessor
 import kotlin.Int
 
-public object Http3FrameTypeCodec : Codec<Http3FrameType> {
-  override fun decode(buffer: ReadBuffer, context: DecodeContext): Http3FrameType {
+public object Http3FcFrameTypeCodec : Codec<Http3FcFrameType> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): Http3FcFrameType {
     val raw = QuicVarintCodec.decode(buffer, context)
-    return Http3FrameType(raw = raw)
+    return Http3FcFrameType(raw = raw)
   }
 
   override fun encode(
     buffer: WriteBuffer,
-    `value`: Http3FrameType,
+    `value`: Http3FcFrameType,
     context: EncodeContext,
   ) {
     QuicVarintCodec.encode(buffer, value.raw, context)
   }
 
-  override fun wireSize(`value`: Http3FrameType, context: EncodeContext): WireSize = QuicVarintCodec.wireSize(value.raw, context)
+  override fun wireSize(`value`: Http3FcFrameType, context: EncodeContext): WireSize = QuicVarintCodec.wireSize(value.raw, context)
 
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     val __rawFrame = QuicVarintCodec.peekFrameSize(stream, baseOffset + 0)

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcSettingCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcSettingCodec.kt
@@ -1,0 +1,33 @@
+package com.ditchoom.buffer.codec.test.protocols.http3fc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.codec.test.protocols.quic.QuicVarintCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object Http3FcSettingCodec : Codec<Http3FcSetting> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): Http3FcSetting {
+    val identifier = QuicVarintCodec.decode(buffer, context)
+    val value = QuicVarintCodec.decode(buffer, context)
+    return Http3FcSetting(identifier = identifier, value = value)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: Http3FcSetting,
+    context: EncodeContext,
+  ) {
+    QuicVarintCodec.encode(buffer, value.identifier, context)
+    QuicVarintCodec.encode(buffer, value.value, context)
+  }
+
+  override fun wireSize(`value`: Http3FcSetting, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketConnAckCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketConnAckCodec.kt
@@ -19,6 +19,14 @@ public object MqttPacketConnAckCodec {
     val header = MqttFixedHeader(buffer.readUByte())
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "ConnAck.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketConnectCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketConnectCodec.kt
@@ -23,6 +23,14 @@ public object MqttPacketConnectCodec {
     val header = MqttFixedHeader(buffer.readUByte())
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "Connect.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketDisconnectCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketDisconnectCodec.kt
@@ -17,6 +17,14 @@ public object MqttPacketDisconnectCodec {
     val header = MqttFixedHeader(buffer.readUByte())
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "Disconnect.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketPingReqCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketPingReqCodec.kt
@@ -17,6 +17,14 @@ public object MqttPacketPingReqCodec {
     val header = MqttFixedHeader(buffer.readUByte())
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "PingReq.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketPingRespCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketPingRespCodec.kt
@@ -17,6 +17,14 @@ public object MqttPacketPingRespCodec {
     val header = MqttFixedHeader(buffer.readUByte())
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "PingResp.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketPubAckCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketPubAckCodec.kt
@@ -19,6 +19,14 @@ public object MqttPacketPubAckCodec {
     val header = MqttFixedHeader(buffer.readUByte())
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "PubAck.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketPubCompCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketPubCompCodec.kt
@@ -19,6 +19,14 @@ public object MqttPacketPubCompCodec {
     val header = MqttFixedHeader(buffer.readUByte())
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "PubComp.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketPubRecCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketPubRecCodec.kt
@@ -19,6 +19,14 @@ public object MqttPacketPubRecCodec {
     val header = MqttFixedHeader(buffer.readUByte())
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "PubRec.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketPubRelCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketPubRelCodec.kt
@@ -19,6 +19,14 @@ public object MqttPacketPubRelCodec {
     val header = MqttFixedHeader(buffer.readUByte())
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "PubRel.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketPublishCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketPublishCodec.kt
@@ -26,6 +26,14 @@ public class MqttPacketPublishCodec<P : Payload>(
     val header = MqttFixedHeader(buffer.readUByte())
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "Publish.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()
@@ -130,6 +138,14 @@ public class MqttPacketPublishCodec<P : Payload>(
       val header = MqttFixedHeader(buffer.readUByte())
       val __framingOuterLimit = buffer.limit()
       val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+      if (__framingLength.toInt() > buffer.remaining()) {
+        throw DecodeException(
+              fieldPath = "Publish.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "a fully-buffered " + __framingLength + "-byte framed body",
+              actual = buffer.remaining().toString() + " bytes available",
+            )
+      }
       MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
       val topicPrefixB0 = buffer.readUByte().toUInt()
       val topicPrefixB1 = buffer.readUByte().toUInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketSubAckCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketSubAckCodec.kt
@@ -21,6 +21,14 @@ public object MqttPacketSubAckCodec {
     val header = MqttFixedHeader(buffer.readUByte())
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "SubAck.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketSubscribeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketSubscribeCodec.kt
@@ -19,6 +19,14 @@ public object MqttPacketSubscribeCodec {
     val header = MqttFixedHeader(buffer.readUByte())
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "Subscribe.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketUnsubAckCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketUnsubAckCodec.kt
@@ -19,6 +19,14 @@ public object MqttPacketUnsubAckCodec {
     val header = MqttFixedHeader(buffer.readUByte())
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "UnsubAck.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketUnsubscribeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketUnsubscribeCodec.kt
@@ -19,6 +19,14 @@ public object MqttPacketUnsubscribeCodec {
     val header = MqttFixedHeader(buffer.readUByte())
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "Unsubscribe.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketAuthCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketAuthCodec.kt
@@ -22,6 +22,14 @@ public object MqttV5PacketAuthCodec {
     val header = MqttFixedHeader(buffer.readUByte())
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "Auth.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketConnAckCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketConnAckCodec.kt
@@ -20,6 +20,14 @@ public object MqttV5PacketConnAckCodec {
     val header = MqttFixedHeader(buffer.readUByte())
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "ConnAck.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketConnectCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketConnectCodec.kt
@@ -27,6 +27,14 @@ public object MqttV5PacketConnectCodec {
     val header = MqttFixedHeader(buffer.readUByte())
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "Connect.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketDisconnectCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketDisconnectCodec.kt
@@ -22,6 +22,14 @@ public object MqttV5PacketDisconnectCodec {
     val header = MqttFixedHeader(buffer.readUByte())
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "Disconnect.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketPingReqCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketPingReqCodec.kt
@@ -19,6 +19,14 @@ public object MqttV5PacketPingReqCodec {
     val header = MqttFixedHeader(buffer.readUByte())
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "PingReq.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketPingRespCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketPingRespCodec.kt
@@ -19,6 +19,14 @@ public object MqttV5PacketPingRespCodec {
     val header = MqttFixedHeader(buffer.readUByte())
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "PingResp.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketPubAckCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketPubAckCodec.kt
@@ -24,6 +24,14 @@ public object MqttV5PacketPubAckCodec {
     val header = MqttFixedHeader(buffer.readUByte())
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "PubAck.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketPubCompCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketPubCompCodec.kt
@@ -24,6 +24,14 @@ public object MqttV5PacketPubCompCodec {
     val header = MqttFixedHeader(buffer.readUByte())
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "PubComp.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketPubRecCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketPubRecCodec.kt
@@ -24,6 +24,14 @@ public object MqttV5PacketPubRecCodec {
     val header = MqttFixedHeader(buffer.readUByte())
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "PubRec.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketPubRelCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketPubRelCodec.kt
@@ -24,6 +24,14 @@ public object MqttV5PacketPubRelCodec {
     val header = MqttFixedHeader(buffer.readUByte())
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "PubRel.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketPublishCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketPublishCodec.kt
@@ -28,6 +28,14 @@ public class MqttV5PacketPublishCodec<P : Payload>(
     val header = MqttFixedHeader(buffer.readUByte())
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "Publish.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()
@@ -135,6 +143,14 @@ public class MqttV5PacketPublishCodec<P : Payload>(
       val header = MqttFixedHeader(buffer.readUByte())
       val __framingOuterLimit = buffer.limit()
       val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+      if (__framingLength.toInt() > buffer.remaining()) {
+        throw DecodeException(
+              fieldPath = "Publish.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "a fully-buffered " + __framingLength + "-byte framed body",
+              actual = buffer.remaining().toString() + " bytes available",
+            )
+      }
       MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
       val topicPrefixB0 = buffer.readUByte().toUInt()
       val topicPrefixB1 = buffer.readUByte().toUInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketSubAckCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketSubAckCodec.kt
@@ -23,6 +23,14 @@ public object MqttV5PacketSubAckCodec {
     val header = MqttFixedHeader(buffer.readUByte())
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "SubAck.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketSubscribeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketSubscribeCodec.kt
@@ -21,6 +21,14 @@ public object MqttV5PacketSubscribeCodec {
     val header = MqttFixedHeader(buffer.readUByte())
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "Subscribe.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketUnsubAckCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketUnsubAckCodec.kt
@@ -24,6 +24,14 @@ public object MqttV5PacketUnsubAckCodec {
     val header = MqttFixedHeader(buffer.readUByte())
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "UnsubAck.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketUnsubscribeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketUnsubscribeCodec.kt
@@ -23,6 +23,14 @@ public object MqttV5PacketUnsubscribeCodec {
     val header = MqttFixedHeader(buffer.readUByte())
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "Unsubscribe.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14b/Slice14bFramedFrameFixedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14b/Slice14bFramedFrameFixedCodec.kt
@@ -17,6 +17,14 @@ public object Slice14bFramedFrameFixedCodec {
   public fun decode(buffer: ReadBuffer, context: DecodeContext): Slice14bFramedFrameFixed {
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "Slice14bFramedFrameFixed.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14b/Slice14bFramedFrameVariableCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14b/Slice14bFramedFrameVariableCodec.kt
@@ -19,6 +19,14 @@ public object Slice14bFramedFrameVariableCodec {
   public fun decode(buffer: ReadBuffer, context: DecodeContext): Slice14bFramedFrameVariable {
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "Slice14bFramedFrameVariable.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14c/Slice14cFramedDispatchACodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14c/Slice14cFramedDispatchACodec.kt
@@ -18,6 +18,14 @@ public object Slice14cFramedDispatchACodec {
     val header = Slice14cTinyHeader(buffer.readUByte())
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "A.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14c/Slice14cFramedDispatchBCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14c/Slice14cFramedDispatchBCodec.kt
@@ -20,6 +20,14 @@ public object Slice14cFramedDispatchBCodec {
     val header = Slice14cTinyHeader(buffer.readUByte())
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "B.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14cgeneric/Slice14cGenericFramedDispatchHeaderedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14cgeneric/Slice14cGenericFramedDispatchHeaderedCodec.kt
@@ -19,6 +19,14 @@ public object Slice14cGenericFramedDispatchHeaderedCodec {
     val header = Slice14cTinyHeader(buffer.readUByte())
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "Headered.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14cgeneric/Slice14cGenericFramedDispatchWithPayloadCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14cgeneric/Slice14cGenericFramedDispatchWithPayloadCodec.kt
@@ -27,6 +27,14 @@ public class Slice14cGenericFramedDispatchWithPayloadCodec<P : Payload>(
     val header = Slice14cTinyHeader(buffer.readUByte())
     val __framingOuterLimit = buffer.limit()
     val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+    if (__framingLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "WithPayload.@FramedBy",
+            bufferPosition = buffer.position(),
+            expected = "a fully-buffered " + __framingLength + "-byte framed body",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
     val __framingStart = buffer.position()
     val __framingBound = __framingStart + __framingLength.toInt()
@@ -125,6 +133,14 @@ public class Slice14cGenericFramedDispatchWithPayloadCodec<P : Payload>(
       val header = Slice14cTinyHeader(buffer.readUByte())
       val __framingOuterLimit = buffer.limit()
       val __framingLength = MqttRemainingLengthCodec.decode(buffer, context)
+      if (__framingLength.toInt() > buffer.remaining()) {
+        throw DecodeException(
+              fieldPath = "WithPayload.@FramedBy",
+              bufferPosition = buffer.position(),
+              expected = "a fully-buffered " + __framingLength + "-byte framed body",
+              actual = buffer.remaining().toString() + " bytes available",
+            )
+      }
       MqttRemainingLengthCodec.applyBound(buffer, __framingLength)
       val topicPrefixB0 = buffer.readUByte().toUInt()
       val topicPrefixB1 = buffer.readUByte().toUInt()

--- a/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcFrame.kt
+++ b/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcFrame.kt
@@ -1,0 +1,116 @@
+package com.ditchoom.buffer.codec.test.protocols.http3fc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.annotations.DispatchOn
+import com.ditchoom.buffer.codec.annotations.DispatchValue
+import com.ditchoom.buffer.codec.annotations.ForwardCompatible
+import com.ditchoom.buffer.codec.annotations.FramedBy
+import com.ditchoom.buffer.codec.annotations.PacketType
+import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+import com.ditchoom.buffer.codec.annotations.RemainingBytes
+import com.ditchoom.buffer.codec.annotations.UnknownVariant
+import com.ditchoom.buffer.codec.annotations.UseCodec
+import com.ditchoom.buffer.codec.test.protocols.quic.QuicVarintCodec
+import kotlin.jvm.JvmInline
+
+/**
+ * The full forward-compatible HTTP/3 frame shape (RFC 9114 §7.1):
+ * `Type (varint)` + `Length (varint)` + structured payload — the fixture
+ * pairing the two variable-width mechanisms the stored-length
+ * `protocols/http3` fixture does *not* exercise:
+ *
+ *  - **`@FramedBy` after a varint discriminator** — the Length is
+ *    *computed* by the framework on encode and *bounds* the body on
+ *    decode (strict consumption), so the model is **length-free**: no
+ *    `length` constructor field for call sites to keep consistent.
+ *  - **`@ForwardCompatible` on a varint union** — an unrecognized frame
+ *    type (reserved/GREASE, RFC 9114 §9) is skipped-and-preserved into
+ *    [Http3FcFrame.Unknown] carrying the full 62-bit opcode, instead of
+ *    throwing. Re-encode goes through [Http3FcFrameType]'s codec, so a
+ *    multi-byte type round-trips (minimal varint encoding).
+ *
+ * Payloads are structured per type, mirroring a real HTTP/3 client's
+ * model: opaque [ReadBuffer] views (DATA), a `List` of nested messages
+ * (SETTINGS), a bare varint (GOAWAY), and varint + opaque remainder
+ * (PUSH_PROMISE).
+ */
+@JvmInline
+@ProtocolMessage
+value class Http3FcFrameType(
+    @UseCodec(QuicVarintCodec::class) val raw: ULong,
+) {
+    /**
+     * Dispatch projection. Clamped: a varint carries up to 62 bits, and
+     * an out-of-`Int`-range type must NOT alias onto a known small type
+     * via truncation (`(2^32).toInt() == 0` would dispatch as DATA!) —
+     * `-1` never matches a `@PacketType`, so oversized types fall through
+     * to the [Http3FcFrame.Unknown] preserve arm.
+     */
+    @DispatchValue
+    val type: Int get() = if (raw <= Int.MAX_VALUE.toULong()) raw.toInt() else -1
+}
+
+@ProtocolMessage
+@DispatchOn(Http3FcFrameType::class)
+@FramedBy(Http3FcLengthCodec::class, after = "frameType")
+@ForwardCompatible(unknown = Http3FcFrame.Unknown::class)
+sealed interface Http3FcFrame {
+    /** DATA — RFC 9114 §7.2.1, type 0x00. Opaque body bytes. */
+    @PacketType(value = 0x00)
+    @ProtocolMessage
+    data class Data(
+        val frameType: Http3FcFrameType = Http3FcFrameType(0x00uL),
+        @RemainingBytes @UseCodec(RawBytesCodec::class) val payload: ReadBuffer,
+    ) : Http3FcFrame
+
+    /** SETTINGS — RFC 9114 §7.2.4, type 0x04. Id/value varint pairs to the frame end. */
+    @PacketType(value = 0x04)
+    @ProtocolMessage
+    data class Settings(
+        val frameType: Http3FcFrameType = Http3FcFrameType(0x04uL),
+        @RemainingBytes val entries: List<Http3FcSetting>,
+    ) : Http3FcFrame
+
+    /** PUSH_PROMISE — RFC 9114 §7.2.5, type 0x05. Push id varint + opaque field section. */
+    @PacketType(value = 0x05)
+    @ProtocolMessage
+    data class PushPromise(
+        val frameType: Http3FcFrameType = Http3FcFrameType(0x05uL),
+        @UseCodec(QuicVarintCodec::class) val pushId: ULong,
+        @RemainingBytes @UseCodec(RawBytesCodec::class) val encodedFieldSection: ReadBuffer,
+    ) : Http3FcFrame
+
+    /** GOAWAY — RFC 9114 §7.2.6, type 0x07. The whole payload is one varint. */
+    @PacketType(value = 0x07)
+    @ProtocolMessage
+    data class GoAway(
+        val frameType: Http3FcFrameType = Http3FcFrameType(0x07uL),
+        @UseCodec(QuicVarintCodec::class) val id: ULong,
+    ) : Http3FcFrame
+
+    /** A *known* extension frame whose type needs a 2-byte varint (0x40 = 64). */
+    @PacketType(value = 0x40)
+    @ProtocolMessage
+    data class Extension(
+        val frameType: Http3FcFrameType = Http3FcFrameType(0x40uL),
+        @RemainingBytes @UseCodec(RawBytesCodec::class) val payload: ReadBuffer,
+    ) : Http3FcFrame
+
+    /**
+     * Any frame whose type is not modeled above — reserved/GREASE types.
+     * [opcode] preserves the full 62-bit type value; [raw] the framed
+     * payload, re-emitted verbatim on encode (RFC 9114 §9 ignore-unknown).
+     */
+    @UnknownVariant
+    data class Unknown(
+        val opcode: ULong,
+        val raw: ReadBuffer,
+    ) : Http3FcFrame
+}
+
+/** One SETTINGS entry: a varint identifier and its varint value. */
+@ProtocolMessage
+data class Http3FcSetting(
+    @UseCodec(QuicVarintCodec::class) val identifier: ULong,
+    @UseCodec(QuicVarintCodec::class) val value: ULong,
+)

--- a/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcLengthCodec.kt
+++ b/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcLengthCodec.kt
@@ -1,0 +1,65 @@
+package com.ditchoom.buffer.codec.test.protocols.http3fc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.BoundingLengthCodec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.codec.test.protocols.quic.QuicVarintCodec
+
+/**
+ * The HTTP/3 frame **Length** field (RFC 9114 §7.1) as the `@FramedBy`
+ * framing codec of the forward-compatible fixture: a QUIC varint
+ * (RFC 9000 §16) carrying the byte count of the payload that follows.
+ *
+ * Unlike the stored-length fixture's `Http3LengthCodec`
+ * (`BoundingLengthCodec<ULong>`, a constructor field the consumer must
+ * keep consistent), this one is `BoundingLengthCodec<UInt>` so it can
+ * drive [com.ditchoom.buffer.codec.FramedEncoder] — the framework
+ * *computes* the prefix from the encoded body, keeping the model
+ * length-free. The UInt domain caps a frame body at 4 GiB; a peer-sent
+ * length beyond that throws rather than truncating (the wire allows
+ * 62-bit lengths, but a >4 GiB frame is not decodable into a single
+ * bounded buffer anyway).
+ */
+object Http3FcLengthCodec : BoundingLengthCodec<UInt> {
+    /** A QUIC varint is at most 8 bytes (the 62-bit length class). */
+    override val maxWireSize: Int = 8
+
+    override fun decode(
+        buffer: ReadBuffer,
+        context: DecodeContext,
+    ): UInt {
+        val position = buffer.position()
+        val value = QuicVarintCodec.decode(buffer, context)
+        if (value > UInt.MAX_VALUE.toULong()) {
+            throw DecodeException(
+                fieldPath = "Http3FcFrame.length",
+                bufferPosition = position,
+                expected = "frame length <= ${UInt.MAX_VALUE}",
+                actual = value.toString(),
+            )
+        }
+        return value.toUInt()
+    }
+
+    override fun encode(
+        buffer: WriteBuffer,
+        value: UInt,
+        context: EncodeContext,
+    ) = QuicVarintCodec.encode(buffer, value.toULong(), context)
+
+    override fun wireSize(
+        value: UInt,
+        context: EncodeContext,
+    ): WireSize = WireSize.Exact(QuicVarintCodec.encodedLength(value.toULong()))
+
+    override fun applyBound(
+        buffer: ReadBuffer,
+        decodedValue: UInt,
+    ) {
+        buffer.setLimit(buffer.position() + decodedValue.toInt())
+    }
+}

--- a/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/http3fc/RawBytesCodec.kt
+++ b/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/http3fc/RawBytesCodec.kt
@@ -1,0 +1,50 @@
+package com.ditchoom.buffer.codec.test.protocols.http3fc
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.ViewCodec
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+
+/**
+ * Opaque-payload codec for `@RemainingBytes @UseCodec(...) val: ReadBuffer`
+ * fields: decode yields a zero-copy **view** over the bounded region
+ * (`readBytes(remaining)` — lifetime tied to the source buffer, the
+ * HTTP/3-style contract where the payload is consumed before the frame
+ * buffer is recycled); encode is **non-destructive** (the payload's
+ * position is restored after copying, so a frame can be size-checked and
+ * re-encoded without its payload draining).
+ *
+ * Contrast with [com.ditchoom.buffer.codec.test.protocols.payload.BinaryDataCodec],
+ * which copies into a consumer-owned buffer on decode — the right contract
+ * when the decoded value outlives the frame buffer.
+ */
+object RawBytesCodec : ViewCodec<ReadBuffer> {
+    override fun decode(
+        buffer: ReadBuffer,
+        context: DecodeContext,
+    ): ReadBuffer = buffer.readBytes(buffer.remaining())
+
+    override fun encode(
+        buffer: WriteBuffer,
+        value: ReadBuffer,
+        context: EncodeContext,
+    ) {
+        val savedPosition = value.position()
+        buffer.write(value)
+        value.position(savedPosition)
+    }
+
+    override fun wireSize(
+        value: ReadBuffer,
+        context: EncodeContext,
+    ): WireSize = WireSize.Exact(value.remaining())
+
+    override fun peekFrameSize(
+        stream: StreamProcessor,
+        baseOffset: Int,
+    ): PeekResult = PeekResult.NoFraming
+}

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcFrameCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcFrameCodecTest.kt
@@ -1,0 +1,254 @@
+package com.ditchoom.buffer.codec.test.protocols.http3fc
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.test.protocols.quic.QuicVarintCodec
+import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+
+/**
+ * The forward-compatible, **length-free** HTTP/3 frame fixture — the two
+ * mechanisms `protocols/http3`'s stored-length fixture does not reach:
+ *
+ *  - **`@FramedBy` after a varint discriminator**: the Length varint is
+ *    computed by [com.ditchoom.buffer.codec.FramedEncoder] on encode and
+ *    bounds the body (strict consumption) on decode — no `length` field
+ *    anywhere in the model.
+ *  - **`@ForwardCompatible` over a varint union**: unknown/GREASE frame
+ *    types (RFC 9114 §9) skip-and-preserve into [Http3FcFrame.Unknown]
+ *    carrying the full 62-bit opcode, and re-encode byte-identically
+ *    (minimal varint encoding) through the discriminator's codec.
+ *
+ * What this pins:
+ *  - round-trip for every known variant across discriminator widths (1-byte
+ *    types vs the 2-byte 0x40 Extension) and length widths (≤63 vs >63);
+ *  - skip-and-preserve for unknown types at every varint width (1/2/4/8
+ *    bytes), with byte-identical re-encode;
+ *  - the oversized-type aliasing guard: a type whose low bits collide with
+ *    a known type after `toInt()` truncation must decode as Unknown;
+ *  - strict consumption: a GOAWAY body with trailing bytes throws (RFC 9114
+ *    §7.1 H3_FRAME_ERROR semantics), and applyBound stops the payload at
+ *    the frame end so back-to-back frames parse;
+ *  - drip-fed `peekFrameSize` = `NeedsMoreData` until exactly
+ *    `typeWidth + lengthWidth + length` bytes are buffered — including for
+ *    unknown types;
+ *  - encode is non-destructive for view payloads (position restored).
+ */
+class Http3FcFrameCodecTest {
+    private fun buffer(bytes: ByteArray): PlatformBuffer {
+        val buf = BufferFactory.Default.allocate(bytes.size.coerceAtLeast(1))
+        for (b in bytes) buf.writeByte(b)
+        buf.resetForRead()
+        return buf
+    }
+
+    private fun ReadBuffer.toBytes(): ByteArray {
+        val saved = position()
+        val out = ByteArray(remaining())
+        for (i in out.indices) out[i] = readByte()
+        position(saved)
+        return out
+    }
+
+    private fun encodeToBytes(frame: Http3FcFrame): ByteArray =
+        Http3FcFrameCodec.encode(frame, EncodeContext.Empty, BufferFactory.Default).toBytes()
+
+    private fun decode(bytes: ByteArray): Http3FcFrame = Http3FcFrameCodec.decode(buffer(bytes), DecodeContext.Empty)
+
+    private fun varint(value: ULong): ByteArray {
+        val buf = BufferFactory.Default.allocate(8)
+        QuicVarintCodec.encode(buf, value, EncodeContext.Empty)
+        buf.resetForRead()
+        return buf.toBytes()
+    }
+
+    private fun payloadBytes(size: Int): ByteArray = ByteArray(size) { (it and 0x7F).toByte() }
+
+    // --- known variants, length-free round trip ---------------------------------------------
+
+    @Test
+    fun dataRoundTripsAcrossLengthWidths() {
+        for (size in intArrayOf(0, 3, 200)) {
+            val body = payloadBytes(size)
+            val wire = encodeToBytes(Http3FcFrame.Data(payload = buffer(body)))
+            // Envelope: 1-byte type 0x00 + computed varint length + body.
+            assertContentEquals(byteArrayOf(0x00) + varint(size.toULong()) + body, wire, "wire bytes for DATA($size)")
+            val decoded = assertIs<Http3FcFrame.Data>(decode(wire))
+            assertContentEquals(body, decoded.payload.toBytes(), "payload for DATA($size)")
+        }
+    }
+
+    @Test
+    fun extensionUsesTwoByteTypeVarint() {
+        val body = payloadBytes(5)
+        val wire = encodeToBytes(Http3FcFrame.Extension(payload = buffer(body)))
+        assertContentEquals(varint(0x40uL) + varint(5uL) + body, wire)
+        assertEquals(2, varint(0x40uL).size, "0x40 needs the 2-byte varint class")
+        val decoded = assertIs<Http3FcFrame.Extension>(decode(wire))
+        assertContentEquals(body, decoded.payload.toBytes())
+    }
+
+    @Test
+    fun settingsRoundTripsStructuredEntries() {
+        val frame =
+            Http3FcFrame.Settings(
+                entries =
+                    listOf(
+                        Http3FcSetting(identifier = 0x01uL, value = 4096uL), // 1-byte id, 2-byte value
+                        Http3FcSetting(identifier = 0xc671706auL, value = 1uL), // 8-byte GREASE-range id
+                    ),
+            )
+        val wire = encodeToBytes(frame)
+        val expectedBody = varint(0x01uL) + varint(4096uL) + varint(0xc671706auL) + varint(1uL)
+        assertContentEquals(byteArrayOf(0x04) + varint(expectedBody.size.toULong()) + expectedBody, wire)
+        val decoded = assertIs<Http3FcFrame.Settings>(decode(wire))
+        assertEquals(frame.entries, decoded.entries)
+    }
+
+    @Test
+    fun goAwayBodyIsASingleVarint() {
+        val wire = encodeToBytes(Http3FcFrame.GoAway(id = 12345uL))
+        assertContentEquals(byteArrayOf(0x07) + varint(varint(12345uL).size.toULong()) + varint(12345uL), wire)
+        assertEquals(12345uL, assertIs<Http3FcFrame.GoAway>(decode(wire)).id)
+    }
+
+    @Test
+    fun pushPromiseCarriesPushIdThenOpaqueRemainder() {
+        val section = payloadBytes(9)
+        val wire = encodeToBytes(Http3FcFrame.PushPromise(pushId = 7uL, encodedFieldSection = buffer(section)))
+        val body = varint(7uL) + section
+        assertContentEquals(byteArrayOf(0x05) + varint(body.size.toULong()) + body, wire)
+        val decoded = assertIs<Http3FcFrame.PushPromise>(decode(wire))
+        assertEquals(7uL, decoded.pushId)
+        assertContentEquals(section, decoded.encodedFieldSection.toBytes())
+    }
+
+    // --- forward compatibility: skip-and-preserve --------------------------------------------
+
+    @Test
+    fun unknownTypesPreserveAcrossEveryVarintWidth() {
+        // GREASE/reserved types needing 1-, 2-, 4-, and 8-byte type varints.
+        for (type in ulongArrayOf(0x21uL, 0x1000uL, 0x123456uL, 0x123456789AuL)) {
+            val body = payloadBytes(6)
+            val wire = varint(type) + varint(6uL) + body
+            val decoded = assertIs<Http3FcFrame.Unknown>(decode(wire), "type $type must be unknown")
+            assertEquals(type, decoded.opcode, "preserved opcode for $type")
+            assertContentEquals(body, decoded.raw.toBytes(), "preserved payload for $type")
+            // Byte-identical re-encode (input used minimal varints).
+            assertContentEquals(wire, encodeToBytes(decoded), "re-encoded wire for $type")
+        }
+    }
+
+    @Test
+    fun oversizedTypeMustNotAliasOntoAKnownType() {
+        // 0x1_0000_0000.toInt() == 0 == DATA: without the dispatch-value
+        // clamp this would decode as DATA. It must stay Unknown.
+        val type = 0x1_0000_0000uL
+        val wire = varint(type) + varint(2uL) + byteArrayOf(1, 2)
+        val decoded = assertIs<Http3FcFrame.Unknown>(decode(wire))
+        assertEquals(type, decoded.opcode)
+        assertContentEquals(wire, encodeToBytes(decoded))
+    }
+
+    @Test
+    fun unknownWithEmptyPayloadRoundTrips() {
+        val wire = varint(0x21uL) + varint(0uL)
+        val decoded = assertIs<Http3FcFrame.Unknown>(decode(wire))
+        assertEquals(0, decoded.raw.remaining())
+        assertContentEquals(wire, encodeToBytes(decoded))
+    }
+
+    // --- strict framing -----------------------------------------------------------------------
+
+    @Test
+    fun goAwayWithTrailingBytesInsideTheFrameThrows() {
+        // Length says 3, but the id varint consumes 1 byte → 2 stray bytes
+        // inside the frame body. RFC 9114 §7.1: payload bytes past the
+        // identified fields are H3_FRAME_ERROR — strict consumption throws.
+        val wire = byteArrayOf(0x07) + varint(3uL) + varint(5uL) + byteArrayOf(0x00, 0x00)
+        assertFailsWith<DecodeException> { decode(wire) }
+    }
+
+    @Test
+    fun frameLengthBoundsThePayloadAndPositionLandsAtFrameEnd() {
+        val body = payloadBytes(4)
+        val first = byteArrayOf(0x00) + varint(4uL) + body
+        val second = byteArrayOf(0x07) + varint(1uL) + varint(9uL)
+        val buf = buffer(first + second)
+        val frame1 = assertIs<Http3FcFrame.Data>(Http3FcFrameCodec.decode(buf, DecodeContext.Empty))
+        assertContentEquals(body, frame1.payload.toBytes(), "payload capped at the frame length")
+        // Consume the view (it shares the source buffer's position space is
+        // false — it's an independent slice; the source position must already
+        // sit at the frame boundary so the next frame decodes).
+        val frame2 = assertIs<Http3FcFrame.GoAway>(Http3FcFrameCodec.decode(buf, DecodeContext.Empty))
+        assertEquals(9uL, frame2.id, "back-to-back frame after a bounded payload")
+    }
+
+    @Test
+    fun encodeIsNonDestructiveForViewPayloads() {
+        val payload = buffer(payloadBytes(8))
+        val frame = Http3FcFrame.Data(payload = payload)
+        val first = encodeToBytes(frame)
+        assertEquals(8, payload.remaining(), "payload position restored after encode")
+        assertContentEquals(first, encodeToBytes(frame), "second encode is identical")
+    }
+
+    // --- streaming peek ------------------------------------------------------------------------
+
+    @Test
+    fun peekFramesKnownAndUnknownTypesByteByByte() {
+        val cases =
+            listOf(
+                encodeToBytes(Http3FcFrame.Data(payload = buffer(payloadBytes(3)))),
+                encodeToBytes(Http3FcFrame.Data(payload = buffer(payloadBytes(200)))), // 2-byte length
+                encodeToBytes(Http3FcFrame.Extension(payload = buffer(payloadBytes(3)))), // 2-byte type
+                encodeToBytes(Http3FcFrame.GoAway(id = 5uL)),
+                varint(0x1000uL) + varint(6uL) + payloadBytes(6), // unknown 2-byte type
+            )
+        for (wire in cases) {
+            assertDripPeek(wire)
+        }
+    }
+
+    private fun assertDripPeek(wire: ByteArray) {
+        val pool = BufferPool()
+        val stream = StreamProcessor.create(pool, ByteOrder.BIG_ENDIAN)
+        try {
+            for (i in 0 until wire.size - 1) {
+                appendByte(stream, wire[i])
+                assertEquals(
+                    PeekResult.NeedsMoreData,
+                    Http3FcFrameCodec.peekFrameSize(stream),
+                    "after ${i + 1}/${wire.size} bytes",
+                )
+            }
+            appendByte(stream, wire.last())
+            assertEquals(PeekResult.Complete(wire.size), Http3FcFrameCodec.peekFrameSize(stream), "fully buffered")
+        } finally {
+            stream.release()
+            pool.clear()
+        }
+    }
+
+    private fun appendByte(
+        stream: StreamProcessor,
+        byte: Byte,
+    ) {
+        val one: PlatformBuffer = BufferFactory.Default.allocate(1)
+        one.writeByte(byte)
+        one.resetForRead()
+        stream.append(one)
+    }
+}

--- a/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/ViewCodec.kt
+++ b/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/ViewCodec.kt
@@ -1,0 +1,28 @@
+package com.ditchoom.buffer.codec
+
+/**
+ * A [Codec] whose [decode] returns a **borrowed view** into the source
+ * buffer instead of a self-contained value — the explicit opt-in that
+ * lets a `@RemainingBytes @UseCodec(C) val: T` field carry a non-[Payload]
+ * type (including `ReadBuffer` itself).
+ *
+ * The buffer-codec lockdown forbids raw buffer types in `@ProtocolMessage`
+ * fields by default because they leak ownership ambiguity (who frees,
+ * when, aliased?). Implementing `ViewCodec` *is* the ownership answer, and
+ * it is a contract the implementor must honor and document:
+ *
+ *  - **decode** returns a view whose lifetime is tied to the buffer it was
+ *    decoded from (e.g. `buffer.readBytes(buffer.remaining())`). The
+ *    consumer must read, copy, or otherwise consume the view before the
+ *    source buffer is recycled — the contract zero-copy streaming
+ *    protocols (HTTP/3 DATA/HEADERS payloads, QPACK field sections)
+ *    already place on their frame readers. Nothing is allocated and
+ *    nothing needs freeing beyond the source buffer's own lifecycle.
+ *  - **encode** must be non-consuming (restore the view's position after
+ *    copying) so a value can be size-checked and re-encoded.
+ *
+ * When the decoded value must *outlive* the source buffer, this is the
+ * wrong tool — use a [Payload]-marked type over an [OwnedBytesHandle]
+ * (consumer-owned copy) instead.
+ */
+public interface ViewCodec<T> : Codec<T>

--- a/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/annotations/Annotations.kt
+++ b/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/annotations/Annotations.kt
@@ -138,7 +138,12 @@ annotation class LengthPrefixed(
  *   - Typed binary payload via `@RemainingBytes @UseCodec(C::class) val: P`
  *     — the user codec consumes the bounded region in one call. Use this
  *     instead of a raw scalar list when the bytes are opaque (an image,
- *     a compressed blob, an encrypted payload). See [UseCodec].
+ *     a compressed blob, an encrypted payload). See [UseCodec]. `P` must
+ *     extend `Payload` (a self-contained, consumer-owned value) — unless
+ *     `C` implements `com.ditchoom.buffer.codec.ViewCodec`, the explicit
+ *     opt-in for **zero-copy borrowed views** (then `P` may be any type,
+ *     including `ReadBuffer`; the view's lifetime is tied to the source
+ *     buffer per the `ViewCodec` contract).
  *
  * For protocols that genuinely need a typed list of single bytes the
  * scalar-list shape (`List<UByte>` / `List<Byte>`) is also accepted, but
@@ -542,8 +547,13 @@ annotation class UseCodec(
  *   emitter can size the slack region for the slicing scheme.
  * @param after Names a sibling constructor field that the prefix sits
  *   immediately *after* on the wire. Empty (default) means the prefix is at
- *   offset 0. The named field must exist, have Exact wire width, and — when
- *   the class carries `@PacketType` — be the discriminator.
+ *   offset 0. The named field must exist and — when the class carries
+ *   `@PacketType` — be the discriminator. It must either have Exact wire
+ *   width (fixed-width scalars / value classes wrapping them) or be a
+ *   **varint value class** (inner scalar carrying
+ *   `@UseCodec(<VariableLengthCodec>)`, e.g. an HTTP/3 frame type): the
+ *   emit then measures the header's width per value via the codec instead
+ *   of a compile-time constant.
  *
  * ```kotlin
  * @ProtocolMessage
@@ -639,16 +649,23 @@ annotation class DispatchValue
  * 1. The annotated type must also carry [FramedBy] — you cannot skip a variant
  *    whose length you cannot measure. The framing prefix bounds the payload the
  *    decoder skips.
- * 2. The annotated type must use [DispatchOn] dispatch with a **single-byte**
- *    discriminator. (Framed sealed dispatch routes exclusively through
- *    `@DispatchOn`; a single-byte discriminator guarantees the preserved
- *    opcode re-encodes byte-identically.)
+ * 2. The annotated type must use [DispatchOn] dispatch with either a
+ *    **single-byte** discriminator (the preserved opcode is one byte,
+ *    re-encoded verbatim) or a **varint** discriminator — a value class whose
+ *    inner scalar is `@UseCodec(<VariableLengthCodec>) raw: Long | ULong`
+ *    (QUIC varint, LEB128, …). A varint opcode is preserved as its full
+ *    decoded value and re-encoded through the discriminator's own codec, so a
+ *    multi-byte GREASE-style type round-trips in its canonical minimal
+ *    encoding. Fixed multi-byte discriminators (UShort/UInt) are not
+ *    supported.
  * 3. [unknown] must name a member of the sealed type marked [UnknownVariant],
  *    whose primary constructor is shaped `(opcode: Int, raw: PlatformBuffer)`
- *    (a `ReadBuffer`-typed `raw` is also accepted). `opcode` carries the
- *    discriminator byte (the only place it can survive — `raw` is the payload
- *    only); `raw` carries the opaque framed payload, excluding the opcode and
- *    length prefix.
+ *    (a `ReadBuffer`-typed `raw` is also accepted). For a single-byte
+ *    discriminator `opcode` is `Int` and carries the discriminator byte; for
+ *    a varint discriminator it must be the discriminator's own inner type
+ *    (`Long` / `ULong`) and carries the full decoded type value. `raw`
+ *    carries the opaque framed payload, excluding the opcode and length
+ *    prefix.
  *
  * ```kotlin
  * @ProtocolMessage
@@ -684,8 +701,11 @@ annotation class ForwardCompatible(
  * Marks the single sealed-variant sink that a [ForwardCompatible] union skips
  * unknown discriminators into. The marked variant must **not** carry
  * [PacketType] — it is the `else` arm of dispatch, never matched by value — and
- * its primary constructor must be `(opcode: Int, raw: PlatformBuffer)` (or
- * `(opcode: Int, raw: ReadBuffer)`).
+ * its primary constructor must be `(opcode: Int, raw: PlatformBuffer)` (a
+ * `ReadBuffer`-typed `raw` is also accepted). For a *varint* discriminator the
+ * opcode parameter is instead the discriminator's own inner type (`Long` /
+ * `ULong`), carrying the full decoded type value — see [ForwardCompatible]
+ * requirement 3.
  *
  * @see ForwardCompatible
  */

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/stream/BufferStream.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/stream/BufferStream.kt
@@ -692,14 +692,20 @@ internal class DefaultStreamProcessor(
             }
         }
         if (chunk.remaining() > size) {
-            // Partial: slice without removing chunk (chunk stays in deque)
+            // Partial: slice without removing chunk (chunk stays in deque). The slice still
+            // holds a refCount on a pooled chunk — release it after the block, or the chunk
+            // can never return to the pool even once fully drained.
             val oldLimit = chunk.limit()
             chunk.setLimit(chunk.position() + size)
             val slice = chunk.slice()
             chunk.setLimit(oldLimit)
             chunk.position(chunk.position() + size)
             totalAvailable -= size
-            return block(slice)
+            return try {
+                block(slice)
+            } finally {
+                freeConsumedChunk(slice)
+            }
         }
 
         // Multi-chunk: copy into pooled buffer, pass to block, then free

--- a/buffer/src/commonTest/kotlin/com/ditchoom/buffer/BufferStreamTests.kt
+++ b/buffer/src/commonTest/kotlin/com/ditchoom/buffer/BufferStreamTests.kt
@@ -601,6 +601,30 @@ class BufferStreamTests {
         pool.clear()
     }
 
+    @Test
+    fun readBufferScopedPartialSliceReturnsChunkToPool() {
+        val pool = BufferPool(defaultBufferSize = 64, maxPoolSize = 10)
+        val processor = StreamProcessor.create(pool)
+
+        val chunk = pool.acquire(8)
+        chunk.writeInt(0x11223344)
+        chunk.writeInt(0x55667788)
+        chunk.resetForRead()
+        processor.append(chunk)
+
+        // Partial path: a slice of a chunk that stays in the deque. The slice holds a
+        // refCount on the pooled chunk, so the scope must release it on exit.
+        processor.readBufferScoped(4) { assertEquals(0x11223344, readInt()) }
+        // Exact path: drains the chunk; the processor releases its own reference.
+        processor.readBufferScoped(4) { assertEquals(0x55667788, readInt()) }
+
+        // Both references released -> refCount zero -> the chunk must be back in the pool.
+        assertEquals(1, pool.stats().currentPoolSize)
+
+        processor.release()
+        pool.clear()
+    }
+
     // ============================================================================
     // StreamProcessor Spanning Chunk Boundary Tests
     // ============================================================================


### PR DESCRIPTION
Implements the two features specced in `buffer-codec-processor/HTTP3_VARINT_FRAMING_GAPS.md` (track `codec/varint-h3`) that block socket's declarative `Http3FrameCodec` migration, plus one design addition that surfaced while building the fixture.

## What

### 1. `@FramedBy` after a varint discriminator (spec Gap 2, option B)
The `after` framing header may now be a varint value class (inner scalar carrying `@UseCodec(<VariableLengthCodec>)`). The framed **encode** measures the header width per value via the codec's `wireSize` and passes it to `FramedEncoder` (whose slack arithmetic was already runtime-`Int`); the framed **peek** (variant + dispatcher) measures it via the codec's own `peekFrameSize`, and the framing-prefix peek budget on the new path is `framingCodec.maxWireSize` (a QUIC varint length is 1–8 bytes). **The fixed-width emit paths are byte-identical** — pinned by the 305 pre-existing snapshot goldens, of which only `Http3FrameTypeCodec` changes (see Changed below).

### 2. `@ForwardCompatible` over varint discriminators (spec Gap 1)
F2/F5 lifted: the preserve path re-reads the unknown discriminator through its own codec, stores the **full decoded value** on the `@UnknownVariant` sink (whose opcode parameter must be the discriminator's inner `Long`/`ULong` — lossless round trip), and re-encodes through the discriminator's codec in canonical minimal form. Covers RFC 9114 §9 ignore-unknown (reserved/GREASE types); same shape fits QUIC frame types, HTTP/3 stream types, QPACK opcodes.

### 3. `ViewCodec<T>` — explicit zero-copy escape from the raw-bytes lockdown ⚠️ design addition, please sanity-check
The lockdown v1 rightly forbids raw `ReadBuffer` fields in `@ProtocolMessage` classes (ownership ambiguity). But a zero-copy streaming protocol's payload fields (HTTP/3 DATA/HEADERS, QPACK field sections) are *deliberate borrowed views* — socket's public API returns them under a documented consume-before-next-read contract, and a forced `OwnedBytesHandle` copy per DATA frame is a hot-path regression. The escape: `@RemainingBytes @UseCodec(C) val: T` accepts a non-`Payload` `T` (including `ReadBuffer`) **iff `C` implements the new `ViewCodec` marker**, whose kdoc carries the ownership contract (decode = borrowed view tied to the source buffer; encode non-consuming). Default-deny preserved; the opt-in is explicit and greppable. Precedent: the FC `Unknown.raw: ReadBuffer` already ships exactly this contract.

### Changed
- Generated varint value-class codecs forward `wireSize` to the user codec (`Exact(encodedLength)`) instead of collapsing to `BackPatch` — required so the framed encode can size the header per value. Wire format unchanged; the only pre-existing golden that changes.

### Dispatch-value clamp (fixture-pinned contract note)
A `@DispatchValue` projection narrowing a varint to `Int` must clamp out-of-range values to `-1`, not truncate — `(2^32).toInt() == 0` would alias a huge unknown type onto DATA. The fixture pins the guard; socket's model will carry the same one.

## Tests
New `protocols/http3fc` fixture — the full length-free HTTP/3 frame shape (varint dispatch incl. 2-byte known type, computed varint Length, structured payloads: opaque view / `List<Setting>` / single varint / varint+remainder, `Unknown` sink). 12 tests pin: round-trips across discriminator×length widths with hand-computed wire bytes, GREASE preserve at 1/2/4/8-byte type widths with byte-identical re-encode, the aliasing guard, strict body consumption (RFC 9114 §7.1), back-to-back frames after a bounded payload, drip-fed `peekFrameSize` incl. unknown types, non-destructive view encode.

`:buffer-codec-test:jvmTest` + `:buffer-codec:jvmTest` + `:buffer-codec-processor:test` + `:buffer-codec-test:linuxX64Test` + `ktlintCheck` all green.

## Downstream
socket's `feat/buffer-codec-migration` consumes all three features to replace its hand-written 283-line `Http3FrameCodec` with the annotated model + a byte-identical differential test (next PR over there, pending a release containing this).

## Follow-up commit: `readBufferScoped` partial-path slice leak (`e1299c88`)
Found while wiring pool recycling into socket's HTTP/3 frame reader: the partial path of `StreamProcessor.readBufferScoped` (frame smaller than the head chunk) returned `block(slice)` without releasing the slice, unlike the other three paths. On a pooled chunk that slice holds a refCount, so the chunk could never return to the pool even once fully drained. Fixed with a `try/finally` release (safe for plain slices — their `freeNativeMemory` is a no-op); regression test `readBufferScopedPartialSliceReturnsChunkToPool` verified red-on-old.

## Follow-up commit: framed-body truncation guard (`b72968fc`)
Found by downstream seeded differential fuzzing (socket, jsNodeTest): generated `@FramedBy` decode applied the bound (setLimit past capacity) and the `@ForwardCompatible` preserve arm **allocated the declared length** before any availability check. On JS, whose buffers clamp limits, a truncated unknown frame of 4 wire bytes declaring a 14389-byte body decoded to 14389 fabricated zero bytes — and a hostile frame could declare 2^30 and force a 1 GiB allocation. The emitter now guards every framed decode (variant arms + FC arm) with a `DecodeException` when the declared body exceeds `buffer.remaining()`, before applyBound/allocate — truncation behavior becomes identical on every platform. Stream readers gating on `peekFrameSize` never hit it. 45 goldens regenerate (guard insertion only); full codec suites + ktlint green.

## CI commit: AVD cache restore/save split (`cb03a1d1`)
The API-21 lane failure was *self-reinfecting*, not one-off: `actions/cache@v5` saves at job END — after `connectedAndroidTest` — so every cache-miss green run cached AVD userdata WITH the test APKs installed (possibly torn from emulator teardown). The next run then failed before any test ran: the stale install can't be uninstalled (`DELETE_FAILED_INTERNAL_ERROR` on API 21) nor reinstalled over (`INSTALL_PARSE_FAILED_INCONSISTENT_CERTIFICATES`), pinned keystore notwithstanding — the recurrence the #183 keystore pin and the uninstall sweep couldn't stop. Fixed by splitting into `actions/cache/restore` + an explicit `actions/cache/save` right after the create-AVD step, so only the pristine snapshot (no packages ever installed) is cached. Poisoned entry evicted.
