### PR TITLE
fix(buffer): use {} releases pooled buffers, not just CloseableBuffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`PlatformBuffer.use {}` now releases pooled buffers.** The cleanup was gated
+  on `this is CloseableBuffer`, but pooled buffers (`PooledBuffer` /
+  `TrackedSlice`, returned by `BufferPool.acquire`/`slice`) are not
+  `CloseableBuffer` — their release is a refcount decrement performed by
+  `freeNativeMemory()`. As a result `use {}` silently failed to return pooled
+  buffers to their pool, contradicting its own "works on all buffers" contract
+  and leaking pool capacity. `use {}` now always invokes `freeNativeMemory()`;
+  this is a no-op on GC-managed buffers and non-owning slices, frees native
+  memory on `CloseableBuffer`s, and returns pooled buffers to the pool. No wire
+  format or allocation-path change.
+
 ## [5.5.0] — 2026-06-05
 
 ### Added

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/CloseableBuffer.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/CloseableBuffer.kt
@@ -32,7 +32,8 @@ package com.ditchoom.buffer
  *     // Platform requires explicit cleanup
  *     buffer.use { /* ... */ }
  * }
- * // Or always safe — use {} works on all buffers:
+ * // Or always safe — use {} releases any buffer (frees native memory, returns a pooled
+ * // buffer to its pool, or no-ops for GC-managed buffers):
  * BufferFactory.Default.allocate(1024).use { buf ->
  *     buf.writeInt(42)
  * }
@@ -47,14 +48,19 @@ interface CloseableBuffer {
 }
 
 /**
- * Executes [block] with this [PlatformBuffer] and ensures cleanup when the block completes.
+ * Executes [block] with this [PlatformBuffer] and releases it when the block completes by
+ * calling [freeNativeMemory][PlatformBuffer.freeNativeMemory].
  *
- * If the buffer implements [CloseableBuffer], [freeNativeMemory][PlatformBuffer.freeNativeMemory]
- * is called after the block. Otherwise this is a no-op on completion (the buffer is
- * GC-managed).
+ * What "release" means depends on the buffer, and [freeNativeMemory] dispatches correctly for each:
+ * - [CloseableBuffer] (deterministic / native-memory buffers): frees the native memory.
+ * - A buffer acquired from a buffer pool: decrements its refcount and returns it to the pool
+ *   once all of its slices are also freed.
+ * - GC-managed buffers and non-owning slices: [freeNativeMemory] is a no-op, so this is harmless.
  *
- * This is the recommended way to use buffers when you don't know at compile time
- * whether cleanup is required.
+ * Because the release is always invoked — not gated on [CloseableBuffer] — this is safe, and the
+ * recommended way, for any buffer whose ownership ends with the block, **including pooled buffers**
+ * (an earlier version skipped non-[CloseableBuffer] buffers and silently failed to return pooled
+ * buffers to their pool).
  */
 inline fun <R> PlatformBuffer.use(block: (PlatformBuffer) -> R): R {
     var exception: Throwable? = null
@@ -64,15 +70,13 @@ inline fun <R> PlatformBuffer.use(block: (PlatformBuffer) -> R): R {
         exception = e
         throw e
     } finally {
-        if (this is CloseableBuffer) {
-            if (exception == null) {
+        if (exception == null) {
+            freeNativeMemory()
+        } else {
+            try {
                 freeNativeMemory()
-            } else {
-                try {
-                    freeNativeMemory()
-                } catch (closeException: Throwable) {
-                    exception.addSuppressed(closeException)
-                }
+            } catch (closeException: Throwable) {
+                exception.addSuppressed(closeException)
             }
         }
     }

--- a/buffer/src/commonTest/kotlin/com/ditchoom/buffer/PooledSliceLifecycleTests.kt
+++ b/buffer/src/commonTest/kotlin/com/ditchoom/buffer/PooledSliceLifecycleTests.kt
@@ -172,4 +172,54 @@ class PooledSliceLifecycleTests {
         assertNotEquals(0, stats.currentPoolSize, "Pool must hold the recycled buffer between iterations")
         pool.clear()
     }
+
+    /**
+     * [use] must return a pooled buffer to its pool. A pooled chunk is NOT a
+     * [CloseableBuffer], so the earlier `if (this is CloseableBuffer)` gate in
+     * `use` skipped its `freeNativeMemory()` and stranded the chunk forever —
+     * the exact footgun behind the "use {} works on all buffers" doc claim.
+     */
+    @Test
+    fun useReturnsPooledChunkToPool() {
+        val pool = newPool()
+        val chunk = pool.acquire(256) as PlatformBuffer
+
+        chunk.use { it.writeInt(0xCAFEBABE.toInt()) }
+
+        assertEquals(1, pool.stats().currentPoolSize, "use {} must release the pooled chunk back to the pool")
+        pool.clear()
+    }
+
+    /** [use] on a pooled slice must decrement the parent refcount, same as an explicit free. */
+    @Test
+    fun useOnPooledSliceReleasesParentReference() {
+        val pool = newPool()
+        val chunk = pool.acquire(256) as PlatformBuffer
+        val slice = chunk.slice()
+
+        chunk.freeNativeMemory()
+        assertEquals(0, pool.stats().currentPoolSize, "Slice still outstanding — chunk pinned")
+
+        slice.use { /* read/inspect */ }
+        assertEquals(1, pool.stats().currentPoolSize, "use {} on the last slice must recycle the chunk")
+        pool.clear()
+    }
+
+    /** Release must happen even when the block throws (and the original exception propagates). */
+    @Test
+    fun useReleasesPooledChunkOnException() {
+        val pool = newPool()
+        val chunk = pool.acquire(256) as PlatformBuffer
+
+        val marker = RuntimeException("boom")
+        val thrown =
+            try {
+                chunk.use { throw marker }
+            } catch (e: RuntimeException) {
+                e
+            }
+        assertEquals(marker, thrown, "Original exception must propagate")
+        assertEquals(1, pool.stats().currentPoolSize, "use {} must release the chunk even on a thrown block")
+        pool.clear()
+    }
 }


### PR DESCRIPTION
## Problem

`PlatformBuffer.use {}` gated its cleanup on `this is CloseableBuffer`:

```kotlin
finally { if (this is CloseableBuffer) freeNativeMemory() }
```

But pooled buffers — `PooledBuffer` and `TrackedSlice`, returned by `BufferPool.acquire`/`slice` — are **not** `CloseableBuffer`. Their release is a refcount decrement performed by `freeNativeMemory()` (→ `releaseToPool()` → `parent.releaseRef()`). So `use {}` hit the gate, evaluated false, and **skipped the release** — silently failing to return pooled buffers to the pool and leaking pool capacity. This directly contradicts the method's own KDoc (*"always safe — use {} works on all buffers"*).

No production caller hits this today (the pool idiom is `withBuffer`), so it's a **latent** footgun — but the doc actively invites it.

## Fix

Drop the gate; `use {}` always calls `freeNativeMemory()` in the `finally`. This is **provably safe**: every non-`CloseableBuffer` override of `freeNativeMemory()` is a no-op —

| type | freeNativeMemory | CloseableBuffer? |
|---|---|---|
| FfmAutoBuffer (JVM21 default) | `{}` no-op | no |
| FfmSliceBuffer / DeterministicSliceBuffer | `{}` no-op | no |
| default PlatformBuffer | `{}` no-op | — |
| PooledBuffer / TrackedSlice | refcount release | no ← **the fix target** |
| FfmBuffer / NativeBuffer / Deterministic{Direct,Unsafe} | frees memory | yes (already freed by use) |

So the only behavioral change is that pooled buffers now correctly return to the pool. Wire format and allocation paths are unchanged.

Also corrected the KDoc on `use` and `CloseableBuffer` to describe the actual cleanup model (native-free vs pool-return vs no-op).

## Tests

3 regression tests in `PooledSliceLifecycleTests` (red on the old gate, green now):
- `useReturnsPooledChunkToPool` — pooled chunk back in pool after `use {}`
- `useOnPooledSliceReleasesParentReference` — `use {}` on the last slice recycles the chunk
- `useReleasesPooledChunkOnException` — release still happens when the block throws, original exception propagates

`:buffer:jvmTest` + `:buffer:ktlintCheck` green locally.

## Context

Separate from #186 (codec varint-h3 features) — surfaced while reviewing why that PR's `readBufferScoped` leak fix used `freeConsumedChunk` rather than `use {}`. The answer was that `use {}` would not have released the pooled slice; this PR makes `use {}` the correct, general tool.