### PR TITLE
feat(codec): enum field support (ordinal-as-varint + @EnumDefault) + generalized runtime-Exact wireSize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,15 +46,27 @@ to [Semantic Versioning](https://semver.org/).
   Implementing `ViewCodec` *is* the documented ownership answer the lockdown's
   prohibition exists to demand; `Payload`-marked self-contained values remain
   the default for anything that outlives the source buffer.
+- **Codec processor: enum fields.** A `@ProtocolMessage` field whose type is a
+  Kotlin `enum class` now encodes its `ordinal` as an unsigned LEB128 varint
+  (`UnsignedVarIntCodec`) — evolution-safe (no fixed width), and the field needs
+  no annotation of its own. Marking one entry `@EnumDefault` makes an unknown
+  (newer) ordinal decode to that entry — the forward-compatibility sink; without
+  it, an out-of-range ordinal throws `DecodeException`. A single-enum message
+  frames via `peekFrameSize` (the self-delimiting varint), and a message whose
+  only variable-width fields are enums stays on the precompute path with a
+  runtime-`Exact` `wireSize` (see Changed).
 
 ### Changed
 
-- **Generated varint value-class codecs report Exact `wireSize`.** A
-  `@ProtocolMessage` value class whose single field is a variable-length
-  `@UseCodec` scalar (a varint wrapper) now forwards `wireSize` to the user
-  codec (`VariableLengthCodec.wireSize` is `Exact(encodedLength)` by
-  construction) instead of collapsing to `BackPatch`. Wire format unchanged;
-  required so `@FramedBy`-after-varint can size the framing header per value.
+- **Generated codecs report Exact `wireSize` for runtime-exact variable fields.**
+  A `@ProtocolMessage` whose only variable-width fields are variable-length
+  `@UseCodec` scalars (varint wrappers — `VariableLengthCodec.wireSize` is
+  `Exact(encodedLength)` by construction) and/or enum fields (ordinal as an
+  `UnsignedVarIntCodec` varint) now sums each field's runtime `Exact` instead of
+  collapsing to `BackPatch`, so enclosing messages keep the precompute path. This
+  generalizes the earlier sole-varint-value-class case (it subsumes it: a single
+  varint field routes through the same branch). Wire format unchanged; lets
+  `@FramedBy`-after-varint size the framing header per value.
 - The new dispatch-value contract note for varint unions: a `@DispatchValue`
   projection narrowing a `Long`/`ULong` varint to `Int` should clamp
   out-of-range values to a sentinel (e.g. `-1`) rather than truncate —

--- a/buffer-codec-processor/SUPPORT_MATRIX.md
+++ b/buffer-codec-processor/SUPPORT_MATRIX.md
@@ -146,6 +146,7 @@ Six axes are inventoried. Each has three tables: **Supported**, **Rejected (with
 | `@When val: value-class scalar?` | `CodecEmitter.kt:1788-1793`; MQTT PUBLISH `packetId: PacketId?` |
 | bare `val: @ProtocolMessage` (by-name codec resolution) | `CodecEmitter.kt:1175-1214` |
 | `@When val: @ProtocolMessage?` (by-name, non-payload-generic) | `CodecEmitter.kt:1913-1937` |
+| enum field (`ordinal` as unsigned LEB128 varint via `UnsignedVarIntCodec`; optional `@EnumDefault` unknown-ordinal sink) | `EnumScalar`; `analyzeEnumField`; `appendDecodeEnum`/`appendEncodeEnum`; `enums/StyleCodec.kt`. Evolution-safe: self-delimiting varint, so a newer ordinal never breaks an older decoder's framing. wireSize runtime-Exact; peek NoFraming (see Silent Gaps). |
 
 #### Rejected (with diagnostic)
 
@@ -175,6 +176,8 @@ Six axes are inventoried. Each has three tables: **Supported**, **Rejected (with
 | `@LengthPrefixed @ProtocolMessage @UseCodec` not `BoundingLengthCodec<UInt>` | `codec does not implement BoundingLengthCodec<UInt>` | `ProtocolMessageProcessor.kt:1514-1522` |
 | `@LengthPrefixed @UseCodec` List element not `@ProtocolMessage` | `element must be @ProtocolMessage data class or sealed parent` | `ProtocolMessageProcessor.kt:1545-1553` |
 | `@LengthPrefixed @UseCodec` List element with `<P : Payload>` | `element cannot carry <P : Payload> type parameter` | `ProtocolMessageProcessor.kt:1559-1568` |
+| enum field with >1 `@EnumDefault` entry | `at most one @EnumDefault entry is allowed` | `CodecAnalyzer.kt analyzeEnumField` |
+| `@WireBytes` / `@WireOrder` on an enum field | `not supported on an enum field (its ordinal rides as a varint)` | `CodecAnalyzer.kt analyzeEnumField` |
 
 #### Silent Gaps (Outcome 3)
 
@@ -187,6 +190,7 @@ Six axes are inventoried. Each has three tables: **Supported**, **Rejected (with
 | `@LengthFrom` value-class property w/ non-peekable inner kind (ULong/Long) | silent-skip | medium | #163 | `CodecEmitter.kt:959` set `{UByte,Byte,UShort,UInt}`; validator only checks numeric (`:1149` includes ULong/Long), so passes validator, fails emit. |
 | value-class scalar field whose inner scalar carries `@WireBytes`/`@WireOrder` | silent-skip | low | — | `CodecEmitter.kt:858-862` returns null; validator doesn't check inner annotations. |
 | `@When` conditional with nullable predicate source | silent-skip | low | — | `CodecEmitter.kt:1735` handles bound-field nullability only; predicate source nullability unvalidated by emitter (validator covers via `:834` if not skipped). |
+| message with >1 enum field (or an enum + variable suffix) → `peekFrameSize` is `NoFraming` | documented-limitation | low | — | `CodecEmitterPeek.kt`: a SINGLE enum with all-fixed priors+suffix frames via `appendPeekEnum` (`UnsignedVarIntCodec.peekFrameSize`); multiple self-delimiting fields collapse to NoFraming — the same single-variable-field limitation the `isVariableLength` `@UseCodec` peek has. |
 | `@When @LengthPrefixed` on inner `@ProtocolMessage` (non-String) | silent-skip | medium | — | `CodecEmitter.kt:1764-1769` returns null when not `kotlin.String`; no validator rejection. |
 | `@RemainingBytes @ProtocolMessage` (bare nested, not List) | silent-skip | medium | #151 | `CodecEmitter.kt:632` `typeQname != LIST_QNAME` returns null; `@RemainingBytes` analyzer handles only String / List<@ProtocolMessage>. |
 | `@LengthPrefixedUseCodecList` with non-singleton (generic) element codec | silent-broken-codegen | **high** | — | `CodecEmitter.kt:703-708` calls `<E>Codec.decode` directly; if element carries `<P>` it's a generic class, not singleton. Validator (`:1558-1569`) rejects *resolved* case but pre-slice gap exists. |

--- a/buffer-codec-processor/SUPPORT_MATRIX.md
+++ b/buffer-codec-processor/SUPPORT_MATRIX.md
@@ -140,6 +140,7 @@ Six axes are inventoried. Each has three tables: **Supported**, **Rejected (with
 | `@When @LengthPrefixed @UseCodec val: P : Payload?` | `CodecEmitter.kt:1748-1753`; validator `:1824-1853` |
 | `@When @UseCodec val: T?` (sealed via hand-written codec) | `CodecEmitter.kt:1755-1762`; `Slice11aProbe.kt` |
 | `@UseCodec(Codec<T>) val: T` (non-Payload scalar, natural width) | `CodecEmitter.kt:760-770`; MQTT `MqttRemainingLengthCodec` |
+| `@UseCodec(VariableLengthCodec<T>) val: T` → message wireSize is **runtime-Exact** (not BackPatch) | `CodecEmitterWireSize.kt` runtime-Exact branch; sums fixed bytes + `(codec.wireSize(value) as Exact).bytes`; `VarintLengthFrameCodec` (`Exact(1 + valueLen)`), `Http3FrameTypeCodec` (`Exact(0 + rawLen)`) |
 | `@WireBytes(N)` on Scalar fields (1-8 bytes) | `CodecEmitter.kt:806-823`; validator `:654-695` |
 | value-class scalar field (natural-width inner) | `CodecEmitter.kt:835-881` |
 | `@When val: value-class scalar?` | `CodecEmitter.kt:1788-1793`; MQTT PUBLISH `packetId: PacketId?` |

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecAnalyzer.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecAnalyzer.kt
@@ -774,6 +774,12 @@ internal fun analyzeField(
                 ),
             )
         }
+        // Enum field: the entry's `ordinal` rides the wire as an unsigned LEB128 varint
+        // (UnsignedVarIntCodec), self-delimiting so it stays evolution-safe (see EnumScalar).
+        val enumDecl = type.declaration as? KSClassDeclaration
+        if (enumDecl?.classKind == ClassKind.ENUM_CLASS) {
+            return analyzeEnumField(param, enumDecl, ownerSimpleName, wireBytesAnn)
+        }
         // Value-class field. Only the natural-width
         // unannotated path is in scope; @WireBytes / @WireOrder on the
         // outer parameter widen this and are deferred to a later slice.
@@ -1332,6 +1338,7 @@ internal fun analyzeRemainingBytesProtocolMessageListField(
  * fields uniformly across framing annotations — see
  * [FieldSpec.ProtocolMessageScalar] kdoc for the principle in full.
  */
+
 internal fun analyzeBareProtocolMessageField(
     param: KSValueParameter,
     type: KSType,
@@ -1380,6 +1387,55 @@ internal fun analyzeBareProtocolMessageField(
                     decl.packageName.asString(),
                     decl.flattenedCodecName(),
                 ),
+        ),
+    )
+}
+
+/**
+ * Analyze a Kotlin `enum class` field into a [FieldSpec.EnumScalar]. The entry's `ordinal` rides
+ * the wire as an unsigned LEB128 varint. At most one `@EnumDefault` entry is allowed (the
+ * unknown-ordinal decode sink); `@WireBytes` / `@WireOrder` are meaningless on the varint and are
+ * rejected.
+ */
+internal fun analyzeEnumField(
+    param: KSValueParameter,
+    enumDecl: KSClassDeclaration,
+    ownerSimpleName: String,
+    wireBytesAnn: KSAnnotation?,
+): FieldAnalysis {
+    val name =
+        param.name?.asString() ?: return FieldAnalysis.Err(Diagnostic("field has no name", param))
+    if (wireBytesAnn != null) {
+        return FieldAnalysis.Err(
+            Diagnostic("@WireBytes is not supported on an enum field (its ordinal rides as a varint)", param),
+        )
+    }
+    if (param.annotations.any { it.shortName.asString() == "WireOrder" }) {
+        return FieldAnalysis.Err(
+            Diagnostic("@WireOrder is not supported on an enum field (the varint is byte-order-independent)", param),
+        )
+    }
+    val entries =
+        enumDecl.declarations
+            .filterIsInstance<KSClassDeclaration>()
+            .filter { it.classKind == ClassKind.ENUM_ENTRY }
+            .toList()
+    val defaults = entries.filter { e -> e.annotations.any { it.shortName.asString() == "EnumDefault" } }
+    if (defaults.size > 1) {
+        return FieldAnalysis.Err(
+            Diagnostic(
+                "enum ${enumDecl.simpleName.asString()} declares ${defaults.size} @EnumDefault entries; at most one is allowed",
+                param,
+            ),
+        )
+    }
+    return FieldAnalysis.Ok(
+        FieldSpec.EnumScalar(
+            name = name,
+            ownerSimpleName = ownerSimpleName,
+            enumType = classNameOf(enumDecl),
+            entryCount = entries.size,
+            defaultEntryName = defaults.firstOrNull()?.simpleName?.asString(),
         ),
     )
 }
@@ -2865,6 +2921,12 @@ internal fun classifyVariantWireSize(shape: CodecShape): VariantWireSize {
     ) {
         return VariantWireSize.BackPatch
     }
+    // An enum field's ordinal is a runtime-width varint, so any variant carrying one is
+    // runtime-Exact (the variant codec's own wireSize sums it via `UnsignedVarIntCodec.wireSize
+    // as Exact`); the dispatcher forwards without re-deriving. Early-return so an enum in a
+    // non-terminal slot isn't mis-classified by the terminal `when` below (which only sums
+    // FixedSize fields and would drop the varint).
+    if (shape.fields.any { it is FieldSpec.EnumScalar }) return VariantWireSize.RuntimeExact
     return when (shape.fields.lastOrNull()) {
         is FieldSpec.LengthPrefixedMessage -> VariantWireSize.RuntimeExact
         // A LengthFromString variant's body byte count is the
@@ -2904,6 +2966,9 @@ internal fun classifyVariantWireSize(shape: CodecShape): VariantWireSize {
         // `@RemainingBytes val: String` — handled by the upfront BackPatch
         // short-circuit above.
         is FieldSpec.RemainingBytesString -> VariantWireSize.BackPatch
+        // Handled by the upfront `any EnumScalar -> RuntimeExact` early-return above; defensive
+        // branch keeps the `when` exhaustive.
+        is FieldSpec.EnumScalar -> VariantWireSize.RuntimeExact
     }
 }
 

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
@@ -663,6 +663,7 @@ internal class CodecEmitter(
             is FieldSpec.ValueClassScalar -> appendDecodeValueClassScalar(body, field)
             is FieldSpec.Conditional -> appendDecodeConditional(body, field)
             is FieldSpec.ProtocolMessageScalar -> appendDecodeProtocolMessageScalar(body, field)
+            is FieldSpec.EnumScalar -> appendDecodeEnum(body, field)
         }
     }
 
@@ -745,6 +746,7 @@ internal class CodecEmitter(
             is FieldSpec.ValueClassScalar -> appendEncodeValueClassScalar(body, field)
             is FieldSpec.Conditional -> appendEncodeConditional(body, field)
             is FieldSpec.ProtocolMessageScalar -> appendEncodeProtocolMessageScalar(body, field)
+            is FieldSpec.EnumScalar -> appendEncodeEnum(body, field)
         }
     }
 
@@ -1704,5 +1706,6 @@ internal class CodecEmitter(
             is FieldSpec.ValueClassScalar -> field.valueClassType
             is FieldSpec.Conditional -> field.nullableTypeName
             is FieldSpec.ProtocolMessageScalar -> field.fieldType
+            is FieldSpec.EnumScalar -> field.enumType
         }
 }

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterConstants.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterConstants.kt
@@ -94,3 +94,6 @@ internal val FORWARD_COMPATIBLE_RAW_QNAMES =
     setOf("com.ditchoom.buffer.PlatformBuffer", "com.ditchoom.buffer.ReadBuffer")
 internal val CHARSET_CN = ClassName("com.ditchoom.buffer", "Charset")
 internal val STRING_NULLABLE_TN = ClassName("kotlin", "String").copy(nullable = true)
+
+// The shipped unsigned-LEB128 codec a generated enum field rides its ordinal on.
+internal val UNSIGNED_VARINT_CODEC_CN = ClassName("com.ditchoom.buffer.codec", "UnsignedVarIntCodec")

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterFields.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterFields.kt
@@ -1605,6 +1605,47 @@ internal fun appendEncodeUseCodecScalar(
 }
 
 /**
+ * Emit decode for an enum field: read the ordinal as an unsigned LEB128 varint, then map it back
+ * to an entry. With an `@EnumDefault` an unknown (e.g. newer) ordinal resolves to that entry
+ * (forward-compatible); without one it throws [DecodeException].
+ */
+internal fun appendDecodeEnum(
+    body: CodeBlock.Builder,
+    field: FieldSpec.EnumScalar,
+) {
+    body.addStatement("val __%LOrdinal = %T.decode(buffer, context).toInt()", field.name, UNSIGNED_VARINT_CODEC_CN)
+    if (field.defaultEntryName != null) {
+        body.addStatement(
+            "val %L = %T.entries.getOrElse(__%LOrdinal) { %T.%L }",
+            field.name,
+            field.enumType,
+            field.name,
+            field.enumType,
+            field.defaultEntryName,
+        )
+    } else {
+        body.addStatement(
+            "val %L = %T.entries.getOrElse(__%LOrdinal) { throw %T(fieldPath = %S, bufferPosition = buffer.position(), expected = %S, actual = __%LOrdinal.toString()) }",
+            field.name,
+            field.enumType,
+            field.name,
+            DECODE_EXCEPTION_CN,
+            "${field.ownerSimpleName}.${field.name}",
+            "an ordinal in 0 until ${field.entryCount}",
+            field.name,
+        )
+    }
+}
+
+/** Emit encode for an enum field: write the entry's `ordinal` as an unsigned LEB128 varint. */
+internal fun appendEncodeEnum(
+    body: CodeBlock.Builder,
+    field: FieldSpec.EnumScalar,
+) {
+    body.addStatement("%T.encode(buffer, value.%L.ordinal.toUInt(), context)", UNSIGNED_VARINT_CODEC_CN, field.name)
+}
+
+/**
  * Emit decode/encode for bare `val: T:
  * @ProtocolMessage`. Mirrors [appendEncodeUseCodecScalar] /
  * [appendDecodeUseCodecScalar] minus the bounding-codec branch:

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterPeek.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterPeek.kt
@@ -242,6 +242,23 @@ internal fun buildPeekFrameFun(shape: CodecShape): FunSpec {
         builder.addStatement("return %T.NoFraming", PEEK_RESULT_CN)
         return builder.build()
     }
+    // An enum field's ordinal is a self-delimiting unsigned-LEB128 varint, so a SINGLE enum with
+    // all-fixed priors + suffix frames exactly like the `isVariableLength` `@UseCodec` path:
+    // total = priorBytes + UnsignedVarIntCodec.peekFrameSize().bytes + suffixBytes. Multiple enums
+    // (or a variable suffix) collapse to NoFraming — the same single-variable-field limitation the
+    // varint `@UseCodec` peek has (a second variable width would desync the static offset math).
+    val enumFields = shape.fields.filterIsInstance<FieldSpec.EnumScalar>()
+    if (enumFields.isNotEmpty()) {
+        val enumField = enumFields.first()
+        val priorsFixed = shape.fields.takeWhile { it !== enumField }.all { it is FieldSpec.FixedSize }
+        val suffixFixed = shape.fields.dropWhile { it !== enumField }.drop(1).all { it is FieldSpec.FixedSize }
+        if (enumFields.size == 1 && priorsFixed && suffixFixed) {
+            appendPeekEnum(builder, shape, enumField)
+        } else {
+            builder.addStatement("return %T.NoFraming", PEEK_RESULT_CN)
+        }
+        return builder.build()
+    }
     // `@When("remaining <op> <int>")` collapses peek to
     // NoFraming when reached at this point. The grammar-2 predicate
     // tests the decode buffer's `remaining()` after the upstream
@@ -519,6 +536,47 @@ internal fun appendPeekBoundingDynamicPrior(
  * Caller guarantees (in [buildPeekFrameFun]): every prior and suffix field
  * is `FixedSize`.
  */
+/**
+ * Peek a message whose single variable-width field is an enum (ordinal as unsigned-LEB128 varint).
+ * Mirror of [appendPeekVariableLengthUseCodecScalar] with the codec fixed to `UnsignedVarIntCodec`:
+ * total = priorBytes + the varint's observed width + suffixBytes.
+ */
+internal fun appendPeekEnum(
+    builder: FunSpec.Builder,
+    shape: CodecShape,
+    field: FieldSpec.EnumScalar,
+) {
+    val priorBytes =
+        shape.fields
+            .takeWhile { it !== field }
+            .filterIsInstance<FieldSpec.FixedSize>()
+            .sumOf { it.wireBytes }
+    val suffixBytes =
+        shape.fields
+            .dropWhile { it !== field }
+            .drop(1)
+            .filterIsInstance<FieldSpec.FixedSize>()
+            .sumOf { it.wireBytes }
+    val body = CodeBlock.builder()
+    val frameVar = "__${field.name}Frame"
+    body.addStatement(
+        "val %L = %T.peekFrameSize(stream, baseOffset + %L)",
+        frameVar,
+        UNSIGNED_VARINT_CODEC_CN,
+        priorBytes,
+    )
+    body.beginControlFlow("if (%L !is %T.Complete)", frameVar, PEEK_RESULT_CN)
+    body.addStatement("return %L", frameVar)
+    body.endControlFlow()
+    body.addStatement("val __total = %L + %L.bytes + %L", priorBytes, frameVar, suffixBytes)
+    body.addStatement(
+        "return if (stream.available() - baseOffset >= __total) %T.Complete(__total) else %T.NeedsMoreData",
+        PEEK_RESULT_CN,
+        PEEK_RESULT_CN,
+    )
+    builder.addCode(body.build())
+}
+
 internal fun appendPeekVariableLengthUseCodecScalar(
     builder: FunSpec.Builder,
     shape: CodecShape,
@@ -798,6 +856,11 @@ internal fun appendSequentialPeek(
                 )
             is FieldSpec.Conditional ->
                 appendSequentialPeekConditional(body, field)
+            is FieldSpec.EnumScalar ->
+                error(
+                    "EnumScalar should be handled by buildPeekFrameFun's upfront NoFraming " +
+                        "short-circuit before reaching the sequential walk.",
+                )
         }
     }
     body.addStatement(

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterWireSize.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterWireSize.kt
@@ -41,12 +41,12 @@ internal fun buildWireSizeFun(
         builder.addStatement("return %T.BackPatch", WIRE_SIZE_CN)
         return builder.build()
     }
-    // Any `@UseCodec val: <scalar>` field's wireSize comes from
-    // the user codec, which may be Exact or BackPatch. Collapse to
-    // BackPatch unconditionally — runtime-Exact-via-cast (mirroring
-    // LengthPrefixedMessage) is a follow-on once a vector measurably
-    // benefits.
-    if (shape.fields.any { it is FieldSpec.UseCodecScalar }) {
+    // An OPAQUE `@UseCodec val: <scalar>` field's wireSize is unknown to the framework, so
+    // the message collapses to BackPatch. A `VariableLengthCodec`-backed field
+    // (`isVariableLength`) is the exception: it reports `Exact(encodedLength(value))` at
+    // runtime, so a message whose only variable fields are such codecs stays on the
+    // precompute path via the runtime-Exact branch below (just before the terminal `when`).
+    if (shape.fields.any { it is FieldSpec.UseCodecScalar && !it.isVariableLength }) {
         builder.addStatement("return %T.BackPatch", WIRE_SIZE_CN)
         return builder.build()
     }
@@ -121,6 +121,30 @@ internal fun buildWireSizeFun(
         }
     ) {
         builder.addStatement("return %T.BackPatch", WIRE_SIZE_CN)
+        return builder.build()
+    }
+    // Runtime-Exact: the message's only variable-width fields are `VariableLengthCodec`-backed
+    // `@UseCodec` scalars (each reports `Exact(encodedLength(value))` at runtime) and every other
+    // field is FixedSize. Sum the compile-time fixed bytes with each variable field's runtime
+    // `Exact` (the same `as Exact` cast LengthPrefixedMessage uses) so enclosing messages keep the
+    // precompute path instead of degrading to BackPatch. Mirrors the peekFrameSize walk's shape.
+    val runtimeExactVarFields =
+        shape.fields.filterIsInstance<FieldSpec.UseCodecScalar>().filter { it.isVariableLength }
+    if (runtimeExactVarFields.isNotEmpty() &&
+        shape.fields.all { it is FieldSpec.FixedSize || (it is FieldSpec.UseCodecScalar && it.isVariableLength) }
+    ) {
+        val fixedBytes = shape.fields.sumOfFixedWireBytes().requireFixed("runtimeExactWireSize")
+        for (f in runtimeExactVarFields) {
+            builder.addStatement(
+                "val %L = (%T.wireSize(value.%L, context) as %T.Exact).bytes",
+                "__${f.name}Size",
+                f.codecType,
+                f.name,
+                WIRE_SIZE_CN,
+            )
+        }
+        val sumExpr = (listOf(fixedBytes.toString()) + runtimeExactVarFields.map { "__${it.name}Size" }).joinToString(" + ")
+        builder.addStatement("return %T.Exact(%L)", WIRE_SIZE_CN, sumExpr)
         return builder.build()
     }
     when (val terminal = shape.fields.lastOrNull()) {

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterWireSize.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterWireSize.kt
@@ -123,25 +123,39 @@ internal fun buildWireSizeFun(
         builder.addStatement("return %T.BackPatch", WIRE_SIZE_CN)
         return builder.build()
     }
-    // Runtime-Exact: the message's only variable-width fields are `VariableLengthCodec`-backed
-    // `@UseCodec` scalars (each reports `Exact(encodedLength(value))` at runtime) and every other
-    // field is FixedSize. Sum the compile-time fixed bytes with each variable field's runtime
-    // `Exact` (the same `as Exact` cast LengthPrefixedMessage uses) so enclosing messages keep the
-    // precompute path instead of degrading to BackPatch. Mirrors the peekFrameSize walk's shape.
-    val runtimeExactVarFields =
-        shape.fields.filterIsInstance<FieldSpec.UseCodecScalar>().filter { it.isVariableLength }
+
+    // Runtime-Exact: the message's only variable-width fields are runtime-Exact — a
+    // `VariableLengthCodec`-backed `@UseCodec` scalar (reports `Exact(encodedLength)`), or an enum
+    // whose ordinal rides as an `UnsignedVarIntCodec` varint — and every other field is FixedSize.
+    // Sum the compile-time fixed bytes with each variable field's runtime `Exact` (the same
+    // `as Exact` cast LengthPrefixedMessage uses) so enclosing messages keep the precompute path
+    // instead of degrading to BackPatch. Mirrors the peekFrameSize walk's shape.
+    fun isRuntimeExactVar(f: FieldSpec): Boolean = (f is FieldSpec.UseCodecScalar && f.isVariableLength) || f is FieldSpec.EnumScalar
+    val runtimeExactVarFields = shape.fields.filter { isRuntimeExactVar(it) }
     if (runtimeExactVarFields.isNotEmpty() &&
-        shape.fields.all { it is FieldSpec.FixedSize || (it is FieldSpec.UseCodecScalar && it.isVariableLength) }
+        shape.fields.all { it is FieldSpec.FixedSize || isRuntimeExactVar(it) }
     ) {
         val fixedBytes = shape.fields.sumOfFixedWireBytes().requireFixed("runtimeExactWireSize")
         for (f in runtimeExactVarFields) {
-            builder.addStatement(
-                "val %L = (%T.wireSize(value.%L, context) as %T.Exact).bytes",
-                "__${f.name}Size",
-                f.codecType,
-                f.name,
-                WIRE_SIZE_CN,
-            )
+            when (f) {
+                is FieldSpec.UseCodecScalar ->
+                    builder.addStatement(
+                        "val %L = (%T.wireSize(value.%L, context) as %T.Exact).bytes",
+                        "__${f.name}Size",
+                        f.codecType,
+                        f.name,
+                        WIRE_SIZE_CN,
+                    )
+                is FieldSpec.EnumScalar ->
+                    builder.addStatement(
+                        "val %L = (%T.wireSize(value.%L.ordinal.toUInt(), context) as %T.Exact).bytes",
+                        "__${f.name}Size",
+                        UNSIGNED_VARINT_CODEC_CN,
+                        f.name,
+                        WIRE_SIZE_CN,
+                    )
+                else -> {}
+            }
         }
         val sumExpr = (listOf(fixedBytes.toString()) + runtimeExactVarFields.map { "__${it.name}Size" }).joinToString(" + ")
         builder.addStatement("return %T.Exact(%L)", WIRE_SIZE_CN, sumExpr)

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecIr.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecIr.kt
@@ -469,6 +469,26 @@ internal sealed interface FieldSpec {
         override val wireBytes: Int,
     ) : FixedSize
 
+    /**
+     * A Kotlin `enum class` field. The entry's `ordinal` rides the wire as an unsigned LEB128
+     * varint via the shipped `UnsignedVarIntCodec` — self-delimiting, so adding entries never
+     * breaks an older decoder's framing (it reads the right bytes and resolves an unknown ordinal
+     * to [defaultEntryName] when set, else throws). NOT [FixedSize]: the width is value-dependent
+     * (1 byte for ordinals 0..127, more beyond), so the containing message's wireSize is
+     * runtime-Exact (summed via `UnsignedVarIntCodec.wireSize(...) as Exact`), mirroring an
+     * `isVariableLength` `@UseCodec` field.
+     *
+     * [entryCount] is informational (diagnostics / future width bounds); [defaultEntryName] is the
+     * `@EnumDefault` entry's simple name, or null for strict decode.
+     */
+    data class EnumScalar(
+        override val name: String,
+        val ownerSimpleName: String,
+        val enumType: ClassName,
+        val entryCount: Int,
+        val defaultEntryName: String?,
+    ) : FieldSpec
+
     data class LengthPrefixedMessage(
         override val name: String,
         val ownerSimpleName: String,

--- a/buffer-codec-processor/src/test/kotlin/com/ditchoom/buffer/codec/processor/EnumValidatorTest.kt
+++ b/buffer-codec-processor/src/test/kotlin/com/ditchoom/buffer/codec/processor/EnumValidatorTest.kt
@@ -1,0 +1,99 @@
+package com.ditchoom.buffer.codec.processor
+
+import com.tschuchort.compiletesting.JvmCompilationResult
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import com.tschuchort.compiletesting.configureKsp
+import com.tschuchort.compiletesting.useKsp2
+import org.intellij.lang.annotations.Language
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Compile-time coverage for enum-field codegen. An enum field's ordinal rides as an unsigned
+ * LEB128 varint; an optional `@EnumDefault` entry is the unknown-ordinal decode sink. Rejections:
+ * more than one `@EnumDefault`, and `@WireBytes`/`@WireOrder` on an enum field (the varint owns the
+ * wire shape).
+ */
+class EnumValidatorTest {
+    @Test
+    fun acceptsEnumFieldWithAndWithoutDefault() {
+        val result =
+            compile(
+                """
+                package test
+
+                import com.ditchoom.buffer.codec.annotations.EnumDefault
+                import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+
+                enum class Color { @EnumDefault Unknown, Red, Green }
+                enum class Priority { Low, High }
+
+                @ProtocolMessage
+                data class Style(val color: Color, val priority: Priority, val weight: UByte)
+                """.trimIndent(),
+            )
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+    }
+
+    @Test
+    fun firesOnMultipleEnumDefault() {
+        val result =
+            compile(
+                """
+                package test
+
+                import com.ditchoom.buffer.codec.annotations.EnumDefault
+                import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+
+                enum class Color { @EnumDefault Unknown, @EnumDefault Red, Green }
+
+                @ProtocolMessage
+                data class Style(val color: Color)
+                """.trimIndent(),
+            )
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode, result.messages)
+        assertTrue(
+            result.messages.contains("@EnumDefault"),
+            "diagnostic should name @EnumDefault. Messages:\n${result.messages}",
+        )
+    }
+
+    @Test
+    fun firesOnWireBytesOnEnumField() {
+        val result =
+            compile(
+                """
+                package test
+
+                import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+                import com.ditchoom.buffer.codec.annotations.WireBytes
+
+                enum class Color { Red, Green }
+
+                @ProtocolMessage
+                data class Style(@WireBytes(2) val color: Color)
+                """.trimIndent(),
+            )
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode, result.messages)
+        assertTrue(
+            result.messages.contains("@WireBytes"),
+            "diagnostic should name @WireBytes. Messages:\n${result.messages}",
+        )
+    }
+
+    private fun compile(
+        @Language("kotlin") source: String,
+    ): JvmCompilationResult =
+        KotlinCompilation()
+            .apply {
+                sources = listOf(SourceFile.kotlin("Test.kt", source))
+                inheritClassPath = true
+                messageOutputStream = System.out
+                useKsp2()
+                configureKsp {
+                    symbolProcessorProviders += ProtocolMessageProcessorProvider()
+                }
+            }.compile()
+}

--- a/buffer-codec-processor/src/test/kotlin/com/ditchoom/buffer/codec/processor/EnumValidatorTest.kt
+++ b/buffer-codec-processor/src/test/kotlin/com/ditchoom/buffer/codec/processor/EnumValidatorTest.kt
@@ -61,6 +61,67 @@ class EnumValidatorTest {
     }
 
     @Test
+    fun firesOnWireOrderOnEnumField() {
+        val result =
+            compile(
+                """
+                package test
+
+                import com.ditchoom.buffer.codec.annotations.Endianness
+                import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+                import com.ditchoom.buffer.codec.annotations.WireOrder
+
+                enum class Color { Red, Green }
+
+                @ProtocolMessage
+                data class Style(@WireOrder(Endianness.Little) val color: Color)
+                """.trimIndent(),
+            )
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode, result.messages)
+        assertTrue(
+            result.messages.contains("@WireOrder"),
+            "diagnostic should name @WireOrder. Messages:\n${result.messages}",
+        )
+    }
+
+    @Test
+    fun acceptsUseCodecOverrideOnEnumField() {
+        // The @UseCodec escape hatch: an enum field carrying @UseCodec routes through the generic
+        // user-codec path (a fixed byte here) instead of the default LEB128-ordinal encoding — the
+        // analyzer takes the @UseCodec branch before enum auto-detection, so the consumer's codec
+        // owns the wire shape.
+        val result =
+            compile(
+                """
+                package test
+
+                import com.ditchoom.buffer.ReadBuffer
+                import com.ditchoom.buffer.WriteBuffer
+                import com.ditchoom.buffer.codec.Codec
+                import com.ditchoom.buffer.codec.DecodeContext
+                import com.ditchoom.buffer.codec.EncodeContext
+                import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+                import com.ditchoom.buffer.codec.annotations.UseCodec
+
+                enum class Color { Red, Green, Blue }
+
+                object ColorByteCodec : Codec<Color> {
+                    override fun encode(buffer: WriteBuffer, value: Color, context: EncodeContext) {
+                        buffer.writeByte(value.ordinal.toByte())
+                    }
+
+                    override fun decode(buffer: ReadBuffer, context: DecodeContext): Color =
+                        Color.entries[buffer.readByte().toInt()]
+                }
+
+                @ProtocolMessage
+                data class Style(@UseCodec(ColorByteCodec::class) val color: Color, val weight: UByte)
+                """.trimIndent(),
+            )
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+    }
+
+    @Test
     fun firesOnWireBytesOnEnumField() {
         val result =
             compile(

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/enums/StyleCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/enums/StyleCodec.kt
@@ -1,0 +1,42 @@
+package com.ditchoom.buffer.codec.test.protocols.enums
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.UnsignedVarIntCodec
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object StyleCodec : Codec<Style> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): Style {
+    val __colorOrdinal = UnsignedVarIntCodec.decode(buffer, context).toInt()
+    val color = Color.entries.getOrElse(__colorOrdinal) { Color.Unknown }
+    val __priorityOrdinal = UnsignedVarIntCodec.decode(buffer, context).toInt()
+    val priority = Priority.entries.getOrElse(__priorityOrdinal) { throw DecodeException(fieldPath = "Style.priority", bufferPosition = buffer.position(), expected = "an ordinal in 0 until 3", actual = __priorityOrdinal.toString()) }
+    val weight = buffer.readUByte()
+    return Style(color = color, priority = priority, weight = weight)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: Style,
+    context: EncodeContext,
+  ) {
+    UnsignedVarIntCodec.encode(buffer, value.color.ordinal.toUInt(), context)
+    UnsignedVarIntCodec.encode(buffer, value.priority.ordinal.toUInt(), context)
+    buffer.writeUByte(value.weight)
+  }
+
+  override fun wireSize(`value`: Style, context: EncodeContext): WireSize {
+    val __colorSize = (UnsignedVarIntCodec.wireSize(value.color.ordinal.toUInt(), context) as WireSize.Exact).bytes
+    val __prioritySize = (UnsignedVarIntCodec.wireSize(value.priority.ordinal.toUInt(), context) as WireSize.Exact).bytes
+    return WireSize.Exact(1 + __colorSize + __prioritySize)
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/enums/TaggedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/enums/TaggedCodec.kt
@@ -1,0 +1,45 @@
+package com.ditchoom.buffer.codec.test.protocols.enums
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.UnsignedVarIntCodec
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object TaggedCodec : Codec<Tagged> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): Tagged {
+    val __levelOrdinal = UnsignedVarIntCodec.decode(buffer, context).toInt()
+    val level = Priority.entries.getOrElse(__levelOrdinal) { throw DecodeException(fieldPath = "Tagged.level", bufferPosition = buffer.position(), expected = "an ordinal in 0 until 3", actual = __levelOrdinal.toString()) }
+    val id = buffer.readUByte()
+    return Tagged(level = level, id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: Tagged,
+    context: EncodeContext,
+  ) {
+    UnsignedVarIntCodec.encode(buffer, value.level.ordinal.toUInt(), context)
+    buffer.writeUByte(value.id)
+  }
+
+  override fun wireSize(`value`: Tagged, context: EncodeContext): WireSize {
+    val __levelSize = (UnsignedVarIntCodec.wireSize(value.level.ordinal.toUInt(), context) as WireSize.Exact).bytes
+    return WireSize.Exact(1 + __levelSize)
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    val __levelFrame = UnsignedVarIntCodec.peekFrameSize(stream, baseOffset + 0)
+    if (__levelFrame !is PeekResult.Complete) {
+      return __levelFrame
+    }
+    val __total = 0 + __levelFrame.bytes + 1
+    return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameTypeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameTypeCodec.kt
@@ -25,7 +25,10 @@ public object Http3FrameTypeCodec : Codec<Http3FrameType> {
     QuicVarintCodec.encode(buffer, value.raw, context)
   }
 
-  override fun wireSize(`value`: Http3FrameType, context: EncodeContext): WireSize = WireSize.BackPatch
+  override fun wireSize(`value`: Http3FrameType, context: EncodeContext): WireSize {
+    val __rawSize = (QuicVarintCodec.wireSize(value.raw, context) as WireSize.Exact).bytes
+    return WireSize.Exact(0 + __rawSize)
+  }
 
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     val __rawFrame = QuicVarintCodec.peekFrameSize(stream, baseOffset + 0)

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/varintfield/VarintLengthFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/varintfield/VarintLengthFrameCodec.kt
@@ -27,7 +27,10 @@ public object VarintLengthFrameCodec : Codec<VarintLengthFrame> {
     buffer.writeUByte(value.tag)
   }
 
-  override fun wireSize(`value`: VarintLengthFrame, context: EncodeContext): WireSize = WireSize.BackPatch
+  override fun wireSize(`value`: VarintLengthFrame, context: EncodeContext): WireSize {
+    val __valueSize = (QuicVarintCodec.wireSize(value.value, context) as WireSize.Exact).bytes
+    return WireSize.Exact(1 + __valueSize)
+  }
 
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     val __valueFrame = QuicVarintCodec.peekFrameSize(stream, baseOffset + 0)

--- a/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/enums/EnumProtocol.kt
+++ b/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/enums/EnumProtocol.kt
@@ -1,0 +1,44 @@
+package com.ditchoom.buffer.codec.test.protocols.enums
+
+import com.ditchoom.buffer.codec.annotations.EnumDefault
+import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+
+/**
+ * Enum-field fixtures. An enum field's `ordinal` rides the wire as an unsigned LEB128 varint
+ * ([com.ditchoom.buffer.codec.UnsignedVarIntCodec]); enums need no annotation of their own (the
+ * field's generated codec encodes them inline).
+ *
+ * [Color] carries an `@EnumDefault` sink, so an unknown (newer) ordinal decodes to [Color.Unknown]
+ * — the forward-compatibility property. [Priority] has none, so an out-of-range ordinal throws.
+ */
+enum class Color {
+    @EnumDefault
+    Unknown,
+    Red,
+    Green,
+    Blue,
+}
+
+enum class Priority {
+    Low,
+    Medium,
+    High,
+}
+
+@ProtocolMessage
+data class Style(
+    val color: Color,
+    val priority: Priority,
+    val weight: UByte,
+)
+
+/**
+ * Single-enum message: one self-delimiting varint ordinal + a fixed suffix, so its codec frames
+ * via `peekFrameSize` (unlike [Style], whose two enums collapse to `NoFraming` — the same
+ * single-variable-field limitation the varint `@UseCodec` peek has).
+ */
+@ProtocolMessage
+data class Tagged(
+    val level: Priority,
+    val id: UByte,
+)

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/enums/StyleCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/enums/StyleCodecTest.kt
@@ -1,0 +1,109 @@
+package com.ditchoom.buffer.codec.test.protocols.enums
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.UnsignedVarIntCodec
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * Enum-field codegen: round-trip, runtime-Exact wireSize, and the evolution-safety property — an
+ * old decoder meeting a newer entry's ordinal reads the self-delimiting varint correctly (framing
+ * intact) and resolves to `@EnumDefault` (or throws when none is declared).
+ */
+class StyleCodecTest {
+    @Test
+    fun roundTripsEveryEnumCombination() {
+        for (color in Color.entries) {
+            for (priority in Priority.entries) {
+                val original = Style(color, priority, 0x2Au)
+                val buf = BufferFactory.Default.allocate(16)
+                StyleCodec.encode(buf, original, EncodeContext.Empty)
+                buf.resetForRead()
+                assertEquals(original, StyleCodec.decode(buf, DecodeContext.Empty), "round-trip $original")
+            }
+        }
+    }
+
+    @Test
+    fun wireSizeIsRuntimeExact() {
+        // Every ordinal is < 128 → 1-byte varint each: color(1) + priority(1) + weight(1) = 3.
+        assertEquals(
+            WireSize.Exact(3),
+            StyleCodec.wireSize(Style(Color.Blue, Priority.High, 1u), EncodeContext.Empty),
+            "wireSize sums the two varint ordinals + the fixed weight byte",
+        )
+    }
+
+    @Test
+    fun unknownOrdinalDecodesToEnumDefaultWithFramingIntact() {
+        // Simulate a newer peer: a Color ordinal (99) this build doesn't know, then a valid
+        // Priority and weight. The self-delimiting varint means the unknown ordinal consumes
+        // exactly its bytes, so Priority + weight still decode — proving framing survives.
+        val buf = BufferFactory.Default.allocate(16)
+        UnsignedVarIntCodec.encode(buf, 99u, EncodeContext.Empty)
+        UnsignedVarIntCodec.encode(buf, Priority.Medium.ordinal.toUInt(), EncodeContext.Empty)
+        buf.writeUByte(0x7Fu)
+        buf.resetForRead()
+
+        val decoded = StyleCodec.decode(buf, DecodeContext.Empty)
+        assertEquals(Color.Unknown, decoded.color, "unknown ordinal falls back to @EnumDefault")
+        assertEquals(Priority.Medium, decoded.priority, "field after the unknown ordinal still decodes")
+        assertEquals(0x7Fu.toUByte(), decoded.weight, "framing intact past the unknown ordinal")
+    }
+
+    @Test
+    fun singleEnumMessageFramesByPeek() {
+        // Tagged = one enum varint + a fixed byte → peekFrameSize frames it: NeedsMoreData until
+        // the varint + suffix are buffered, then Complete(total).
+        val original = Tagged(Priority.High, 0x5Au)
+        val src = BufferFactory.Default.allocate(8)
+        TaggedCodec.encode(src, original, EncodeContext.Empty)
+        src.resetForRead()
+        val total = src.remaining()
+        val pool = BufferPool()
+        val stream = StreamProcessor.create(pool, ByteOrder.BIG_ENDIAN)
+        try {
+            for (i in 0 until total - 1) {
+                appendByte(stream, src.readByte())
+                assertEquals(PeekResult.NeedsMoreData, TaggedCodec.peekFrameSize(stream), "after ${i + 1}/$total bytes")
+            }
+            appendByte(stream, src.readByte())
+            assertEquals(PeekResult.Complete(total), TaggedCodec.peekFrameSize(stream), "fully buffered")
+        } finally {
+            stream.release()
+            pool.clear()
+        }
+    }
+
+    @Test
+    fun unknownOrdinalWithoutDefaultThrows() {
+        // Priority has no @EnumDefault, so an out-of-range ordinal is a hard DecodeException.
+        val buf = BufferFactory.Default.allocate(16)
+        UnsignedVarIntCodec.encode(buf, Color.Red.ordinal.toUInt(), EncodeContext.Empty)
+        UnsignedVarIntCodec.encode(buf, 99u, EncodeContext.Empty)
+        buf.writeUByte(0x01u)
+        buf.resetForRead()
+        assertFailsWith<DecodeException> { StyleCodec.decode(buf, DecodeContext.Empty) }
+    }
+
+    private fun appendByte(
+        stream: StreamProcessor,
+        byte: Byte,
+    ) {
+        val one: PlatformBuffer = BufferFactory.Default.allocate(1)
+        one.writeByte(byte)
+        one.resetForRead()
+        stream.append(one)
+    }
+}

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/varintfield/VarintLengthFrameCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/varintfield/VarintLengthFrameCodecTest.kt
@@ -7,6 +7,7 @@ import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.codec.DecodeContext
 import com.ditchoom.buffer.codec.EncodeContext
 import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
 import com.ditchoom.buffer.pool.BufferPool
 import com.ditchoom.buffer.stream.StreamProcessor
 import kotlin.test.Test
@@ -42,6 +43,29 @@ class VarintLengthFrameCodecTest {
             assertEquals(varintWidth + 1, buf.position(), "encoded size for value $value")
             buf.resetForRead()
             assertEquals(original, VarintLengthFrameCodec.decode(buf, DecodeContext.Empty), "round-trip $value")
+        }
+    }
+
+    @Test
+    fun wireSizeIsRuntimeExactByVarintWidthNotBackPatch() {
+        // The varint field reports Exact(encodedLength) at runtime, so the message wireSize is the
+        // varint width + the fixed tag byte — Exact, NOT BackPatch — keeping an enclosing message on
+        // the pre-allocate (precompute) path. Tracks the value the way the round-trip test does.
+        for ((value, varintWidth) in listOf(
+            0uL to 1,
+            63uL to 1,
+            64uL to 2,
+            16383uL to 2,
+            16384uL to 4,
+            0x3FFF_FFFFuL to 4,
+            0x4000_0000uL to 8,
+            0x3FFF_FFFF_FFFF_FFFFuL to 8,
+        )) {
+            assertEquals(
+                WireSize.Exact(varintWidth + 1),
+                VarintLengthFrameCodec.wireSize(VarintLengthFrame(value = value, tag = 0xABu), EncodeContext.Empty),
+                "wireSize for value $value",
+            )
         }
     }
 

--- a/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/UnsignedVarIntCodec.kt
+++ b/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/UnsignedVarIntCodec.kt
@@ -1,0 +1,108 @@
+package com.ditchoom.buffer.codec
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.stream.StreamProcessor
+
+/**
+ * Unsigned LEB128 variable-length integer codec for [UInt] — the classic 7-bits-per-byte,
+ * high-bit-as-continuation encoding (protobuf varint, DWARF LEB128). A self-delimiting
+ * [VariableLengthCodec], so it reports `Exact(encodedLength)` at runtime (no BackPatch) and
+ * frames a stream via [peekValue].
+ *
+ * ```text
+ *  value range          bytes
+ *  0 .. 2^7-1   (127)     1
+ *  .. 2^14-1              2
+ *  .. 2^21-1              3
+ *  .. 2^28-1              4
+ *  .. 2^32-1             5   (the 5th byte carries only the top 4 bits)
+ * ```
+ *
+ * Each byte stores 7 value bits (little-endian group order); the high bit (`0x80`) is set on
+ * every byte except the last. Encoding is minimal. Decoding rejects an over-long sequence (a
+ * value that cannot fit in [UInt], or a 6th continuation byte) with [DecodeException] so a
+ * truncated/malicious stream can never loop or overflow.
+ *
+ * This is the library's first shipped self-delimiting integer encoding — used by the generated
+ * enum-discriminator codec (a `@ProtocolMessage` enum field's ordinal rides as an
+ * `UnsignedVarIntCodec` value), and available to consumers via `@UseCodec(UnsignedVarIntCodec::class)`.
+ */
+object UnsignedVarIntCodec : VariableLengthCodec<UInt> {
+    /** Maximum encoded length of a 32-bit value: ceil(32 / 7) = 5 bytes. */
+    const val MAX_BYTES: Int = 5
+
+    override fun encodedLength(value: UInt): Int {
+        var v = value
+        var len = 1
+        while (v >= 0x80u) {
+            v = v shr 7
+            len++
+        }
+        return len
+    }
+
+    override fun encode(
+        buffer: WriteBuffer,
+        value: UInt,
+        context: EncodeContext,
+    ) {
+        var v = value
+        while (v >= 0x80u) {
+            buffer.writeByte(((v and 0x7Fu) or 0x80u).toByte())
+            v = v shr 7
+        }
+        buffer.writeByte(v.toByte())
+    }
+
+    override fun decode(
+        buffer: ReadBuffer,
+        context: DecodeContext,
+    ): UInt {
+        var result = 0u
+        var shift = 0
+        var bytes = 0
+        while (true) {
+            val b = buffer.readUByte().toInt()
+            bytes++
+            result = result or ((b and 0x7F).toUInt() shl shift)
+            if (b and 0x80 == 0) break
+            shift += 7
+            if (bytes >= MAX_BYTES) {
+                throw DecodeException(
+                    fieldPath = "UnsignedVarInt",
+                    bufferPosition = buffer.position(),
+                    expected = "a terminating byte within $MAX_BYTES bytes (UInt range)",
+                    actual = "a $MAX_BYTES-byte sequence still requesting continuation",
+                )
+            }
+        }
+        return result
+    }
+
+    override fun peekValue(
+        stream: StreamProcessor,
+        baseOffset: Int,
+    ): VarLenPeek<UInt> {
+        var result = 0u
+        var shift = 0
+        var i = 0
+        while (true) {
+            if (stream.available() - baseOffset < i + 1) return VarLenPeek.NeedsMoreData
+            val b = stream.peekByte(baseOffset + i).toInt() and 0xFF
+            result = result or ((b and 0x7F).toUInt() shl shift)
+            i++
+            if (b and 0x80 == 0) break
+            shift += 7
+            if (i >= MAX_BYTES) {
+                throw DecodeException(
+                    fieldPath = "UnsignedVarInt",
+                    bufferPosition = baseOffset + i,
+                    expected = "a terminating byte within $MAX_BYTES bytes (UInt range)",
+                    actual = "a $MAX_BYTES-byte sequence still requesting continuation",
+                )
+            }
+        }
+        return VarLenPeek.Decoded(result, i)
+    }
+}

--- a/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/UnsignedVarIntCodec.kt
+++ b/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/UnsignedVarIntCodec.kt
@@ -65,6 +65,16 @@ object UnsignedVarIntCodec : VariableLengthCodec<UInt> {
         while (true) {
             val b = buffer.readUByte().toInt()
             bytes++
+            // On the 5th (last possible) byte only the low 4 bits are in UInt range; bits 4..6
+            // (0x70) would carry value bits 32..34 and silently truncate, so reject the overflow.
+            if (bytes == MAX_BYTES && b and 0x70 != 0) {
+                throw DecodeException(
+                    fieldPath = "UnsignedVarInt",
+                    bufferPosition = buffer.position(),
+                    expected = "a 5th byte within UInt range (high bits 0x70 clear)",
+                    actual = "a 5th byte carrying value bits beyond 2^32",
+                )
+            }
             result = result or ((b and 0x7F).toUInt() shl shift)
             if (b and 0x80 == 0) break
             shift += 7
@@ -90,6 +100,15 @@ object UnsignedVarIntCodec : VariableLengthCodec<UInt> {
         while (true) {
             if (stream.available() - baseOffset < i + 1) return VarLenPeek.NeedsMoreData
             val b = stream.peekByte(baseOffset + i).toInt() and 0xFF
+            // 5th byte: reject value bits beyond 2^32 (see decode) rather than truncate.
+            if (i == MAX_BYTES - 1 && b and 0x70 != 0) {
+                throw DecodeException(
+                    fieldPath = "UnsignedVarInt",
+                    bufferPosition = baseOffset + i,
+                    expected = "a 5th byte within UInt range (high bits 0x70 clear)",
+                    actual = "a 5th byte carrying value bits beyond 2^32",
+                )
+            }
             result = result or ((b and 0x7F).toUInt() shl shift)
             i++
             if (b and 0x80 == 0) break

--- a/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/annotations/Annotations.kt
+++ b/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/annotations/Annotations.kt
@@ -692,3 +692,27 @@ annotation class ForwardCompatible(
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.BINARY)
 annotation class UnknownVariant
+
+/**
+ * Marks the single enum entry a generated enum-field codec falls back to when it decodes an
+ * ordinal it doesn't recognize — a forward-compatibility sink, the enum analogue of
+ * [ForwardCompatible]/[UnknownVariant] for sealed unions.
+ *
+ * An enum `@ProtocolMessage` field rides on the wire as its `ordinal`, encoded with the
+ * self-delimiting unsigned-LEB128 `UnsignedVarIntCodec`. Because the discriminator is a varint, an
+ * **older** decoder always reads the right number of bytes for a **newer** entry's ordinal — the
+ * framing never breaks; it just sees an ordinal past its known range. With this annotation, that
+ * decode resolves to the marked entry (`entries.getOrElse(ord) { <default> }`); without it, an
+ * out-of-range ordinal throws [DecodeException].
+ *
+ * Exactly one entry per enum may carry it (a second is a compile error). Enums are append-only on
+ * the wire (ordinal is wire-significant) — add entries at the end, never reorder.
+ *
+ * ```kotlin
+ * @ProtocolMessage
+ * enum class Intensity { @EnumDefault Normal, Bold, Faint }
+ * ```
+ */
+@Target(AnnotationTarget.FIELD, AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.BINARY)
+annotation class EnumDefault

--- a/buffer-codec/src/commonTest/kotlin/com/ditchoom/buffer/codec/UnsignedVarIntCodecTest.kt
+++ b/buffer-codec/src/commonTest/kotlin/com/ditchoom/buffer/codec/UnsignedVarIntCodecTest.kt
@@ -1,0 +1,91 @@
+package com.ditchoom.buffer.codec
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * Round-trip + framing + robustness for the shipped unsigned LEB128 codec. The (value, byteWidth)
+ * table covers every length class up to the UInt ceiling, so encode size, decode value, `wireSize`
+ * (runtime-Exact), and `peekValue` framing are all pinned against the same vectors.
+ */
+class UnsignedVarIntCodecTest {
+    private val vectors =
+        listOf(
+            0u to 1,
+            127u to 1,
+            128u to 2,
+            16383u to 2,
+            16384u to 3,
+            2097151u to 3,
+            2097152u to 4,
+            268435455u to 4,
+            268435456u to 5,
+            UInt.MAX_VALUE to 5,
+        )
+
+    @Test
+    fun roundTripsAndSizesEveryLengthClass() {
+        for ((value, width) in vectors) {
+            assertEquals(width, UnsignedVarIntCodec.encodedLength(value), "encodedLength($value)")
+            val buf = BufferFactory.Default.allocate(8)
+            UnsignedVarIntCodec.encode(buf, value, EncodeContext.Empty)
+            assertEquals(width, buf.position(), "encoded byte count for $value")
+            assertEquals(
+                WireSize.Exact(width),
+                UnsignedVarIntCodec.wireSize(value, EncodeContext.Empty),
+                "wireSize($value)",
+            )
+            buf.resetForRead()
+            assertEquals(value, UnsignedVarIntCodec.decode(buf, DecodeContext.Empty), "round-trip $value")
+        }
+    }
+
+    @Test
+    fun peekNeedsMoreDataUntilTerminatorThenReportsWidth() {
+        for ((value, width) in vectors) {
+            val src = BufferFactory.Default.allocate(8)
+            UnsignedVarIntCodec.encode(src, value, EncodeContext.Empty)
+            src.resetForRead()
+            val pool = BufferPool()
+            val stream = StreamProcessor.create(pool, ByteOrder.BIG_ENDIAN)
+            try {
+                for (i in 0 until width - 1) {
+                    appendByte(stream, src.readByte())
+                    assertEquals(VarLenPeek.NeedsMoreData, UnsignedVarIntCodec.peekValue(stream), "value $value after ${i + 1} bytes")
+                }
+                appendByte(stream, src.readByte())
+                assertEquals(VarLenPeek.Decoded(value, width), UnsignedVarIntCodec.peekValue(stream), "value $value complete")
+            } finally {
+                stream.release()
+                pool.clear()
+            }
+        }
+    }
+
+    @Test
+    fun decodeRejectsOverlongSequence() {
+        // Six 0x80 continuation bytes never terminate and exceed the UInt range → DecodeException,
+        // not an infinite loop or silent overflow.
+        val buf = BufferFactory.Default.allocate(8)
+        repeat(6) { buf.writeByte(0x80.toByte()) }
+        buf.resetForRead()
+        assertFailsWith<DecodeException> { UnsignedVarIntCodec.decode(buf, DecodeContext.Empty) }
+    }
+
+    private fun appendByte(
+        stream: StreamProcessor,
+        byte: Byte,
+    ) {
+        val one: PlatformBuffer = BufferFactory.Default.allocate(1)
+        one.writeByte(byte)
+        one.resetForRead()
+        stream.append(one)
+    }
+}

--- a/buffer-codec/src/commonTest/kotlin/com/ditchoom/buffer/codec/UnsignedVarIntCodecTest.kt
+++ b/buffer-codec/src/commonTest/kotlin/com/ditchoom/buffer/codec/UnsignedVarIntCodecTest.kt
@@ -79,6 +79,34 @@ class UnsignedVarIntCodecTest {
         assertFailsWith<DecodeException> { UnsignedVarIntCodec.decode(buf, DecodeContext.Empty) }
     }
 
+    @Test
+    fun decodeRejectsOverflowingFifthByte() {
+        // Four continuation bytes then a terminating 5th byte whose value bits exceed 2^32
+        // (0x10 → bit 32). Must throw rather than silently truncate to a 32-bit result.
+        val buf = BufferFactory.Default.allocate(8)
+        repeat(4) { buf.writeByte(0x80.toByte()) }
+        buf.writeByte(0x10.toByte())
+        buf.resetForRead()
+        assertFailsWith<DecodeException> { UnsignedVarIntCodec.decode(buf, DecodeContext.Empty) }
+    }
+
+    @Test
+    fun peekRejectsOverflowingFifthByte() {
+        val src = BufferFactory.Default.allocate(8)
+        repeat(4) { src.writeByte(0x80.toByte()) }
+        src.writeByte(0x10.toByte())
+        src.resetForRead()
+        val pool = BufferPool()
+        val stream = StreamProcessor.create(pool, ByteOrder.BIG_ENDIAN)
+        try {
+            repeat(5) { appendByte(stream, src.readByte()) }
+            assertFailsWith<DecodeException> { UnsignedVarIntCodec.peekValue(stream) }
+        } finally {
+            stream.release()
+            pool.clear()
+        }
+    }
+
     private fun appendByte(
         stream: StreamProcessor,
         byte: Byte,

--- a/docs/docs/recipes/protocol-codecs.md
+++ b/docs/docs/recipes/protocol-codecs.md
@@ -648,6 +648,63 @@ val ctx = DecodeContext.Empty.with(ForwardCompatibleFactoryKey, myPool)
 val op = OpCodec.decode(buffer, ctx)   // Unknown.raw is pool-backed
 ```
 
+### Enum Fields — Ordinal as a Self-Delimiting Varint
+
+A field whose type is a Kotlin `enum class` needs **no annotation of its own**.
+The processor encodes the entry's `ordinal` as an unsigned LEB128 varint (the
+shipped `UnsignedVarIntCodec`): one byte for ordinals `0..127`, more beyond. The
+varint is self-delimiting, which makes enums **evolution-safe** — an older
+decoder always reads the right number of bytes for an ordinal a newer peer
+added, so framing never desyncs. Enums are **append-only on the wire**: add
+entries at the end, never reorder (the ordinal is wire-significant).
+
+```kotlin
+import com.ditchoom.buffer.codec.annotations.EnumDefault
+
+enum class Intensity { @EnumDefault Normal, Bold, Faint }
+enum class Priority { Low, Medium, High }
+
+@ProtocolMessage
+data class Style(
+    val intensity: Intensity,   // ordinal as a 1-byte varint
+    val priority: Priority,
+    val weight: UByte,
+)
+```
+
+`@EnumDefault` marks the single entry an unknown (e.g. newer) ordinal decodes to
+— the forward-compatibility sink, the enum analogue of `@ForwardCompatible` /
+`@UnknownVariant` for sealed unions. With it, an out-of-range ordinal resolves
+to that entry and the following fields still decode (framing intact); **without
+it, an out-of-range ordinal throws `DecodeException`**. At most one entry per
+enum may carry `@EnumDefault` (a second is a compile error).
+
+`@WireBytes` and `@WireOrder` are rejected on an enum field — the varint owns
+the wire shape and is byte-order-independent.
+
+`wireSize` stays runtime-`Exact` (the varint reports `Exact(encodedLength)`), so
+a message carrying enum fields keeps the precompute path rather than degrading
+to back-patch. A message whose only variable-width field is a single enum frames
+via `peekFrameSize`; two or more variable-width fields collapse to `NoFraming`
+(the same single-variable-field limitation the `@UseCodec` peek has).
+
+**Overriding the encoding.** The LEB128-of-ordinal is just the zero-annotation
+default. To put an enum on the wire some other way — a fixed byte, a QUIC
+varint, a domain mapping — attach a hand-written codec with `@UseCodec`; it
+takes precedence over the default and fully owns the wire shape:
+
+```kotlin
+object IntensityByteCodec : Codec<Intensity> {
+    override fun encode(buffer: WriteBuffer, value: Intensity, context: EncodeContext) =
+        buffer.writeByte(value.ordinal.toByte())
+    override fun decode(buffer: ReadBuffer, context: DecodeContext): Intensity =
+        Intensity.entries[buffer.readByte().toInt()]
+}
+
+@ProtocolMessage
+data class Style(@UseCodec(IntensityByteCodec::class) val intensity: Intensity)
+```
+
 ### Value Classes — Zero-Overhead Typed Wrappers
 
 Value classes wrapping a primitive type are supported as fields. The generated codec reads/writes the inner primitive directly with no boxing overhead:
@@ -781,11 +838,15 @@ type with a hand-written `Codec` that copies bytes out at the boundary — see
 | `Double` | 8 | — |
 | `Boolean` | 1 | — |
 | `String` | Variable | — |
+| `enum class` | Variable (1 byte for ordinals 0–127) | No |
 
 A `String` field always needs one of `@LengthPrefixed`, `@RemainingBytes`, or
 `@LengthFrom` — a bare `String` has no wire extent. `String` bodies are UTF-8.
 For other charsets, write a `Codec<String>` and attach it with `@UseCodec`; the
 library ships `AsciiStringCodec` as a 7-bit-ASCII reference implementation.
+
+An `enum class` field rides as its `ordinal` in an unsigned LEB128 varint with
+no annotation — see [Enum Fields](#enum-fields--ordinal-as-a-self-delimiting-varint).
 
 ## Stream Framing with `peekFrameSize`
 
@@ -848,12 +909,16 @@ hanging the receive loop.
 - `@DispatchOn` — peeks the value-class or data-class discriminator
 - `@FramedBy` — peeks the framing length prefix
 - Nested `@ProtocolMessage` — delegates to the nested codec's `peekFrameSize`
+- A single enum field (with fixed priors/suffix) — peeks the self-delimiting
+  ordinal varint and adds the fixed bytes
 
 **When generation is skipped** (the codec compiles, `peekFrameSize` returns `NoFraming`):
 
 - `@RemainingBytes` at top level — no length on the wire
 - `@UseCodec` without a length annotation, or delegating to a hand-written codec
   that itself returns `NoFraming`
+- Two or more variable-width fields where more than one is an enum (or an enum
+  plus a variable-length suffix) — only a single variable field can frame
 
 ## The Codec Interface
 


### PR DESCRIPTION
## What

Adds **enum-field support** to the buffer-codec `@ProtocolMessage` processor, plus the generalized **runtime-Exact `wireSize`** that makes enum/varint fields composable on the precompute path.

### Enum fields
- A `@ProtocolMessage` field whose type is a Kotlin `enum class` encodes its `ordinal` as an unsigned LEB128 varint (`UnsignedVarIntCodec`) — evolution-safe (no fixed width), no per-field annotation needed.
- `@EnumDefault` on one entry makes an unknown (newer) ordinal decode to that entry — the forward-compatibility sink. Without it, an out-of-range ordinal throws `DecodeException`.
- Single-enum messages frame via `peekFrameSize` (the self-delimiting varint).

### Generalized runtime-Exact `wireSize`
- A message whose only variable-width fields are enum fields and/or variable-length `@UseCodec` scalars now sums each field's runtime `Exact` instead of collapsing to `BackPatch`, so enclosing messages keep the precompute path.
- This **subsumes** `#186`'s narrower sole-varint-value-class special case (a single varint field routes through the same general branch → same `Exact(encodedLength)`).

## Why
Downstream: the DitchOoM terminal's frame-codec migration models SGR `GraphicRendition` with enum fields (`Intensity`/`Blink`/`UnderlineStyle`) and needs the codec to report `Exact` so it can embed into a two-pass measure/write frame writer without a scratch buffer.

## Merge note
This branch was merged up from `main` (#186 `@FramedBy`/`@ForwardCompatible` + #187 pooled-buffer `use {}`). The one real conflict (`CodecEmitterWireSize.kt`) resolved by keeping the general runtime-Exact branch and dropping the now-redundant sole-varint special case. Snapshots regenerated — `Http3FcSettingCodec` (two varints) improved from `BackPatch` → `Exact`.

## Tests
- `:buffer-codec-processor:test` (validator/codegen) ✅
- `:buffer-codec-test:jvmTest` (snapshots + round-trips, incl. http3fc `@FramedBy`) ✅
- ktlint ✅
- Full `prePublishCheck` (all platforms + Android-host + JS browser) running locally; CI gates the same.

## Wire format
Unchanged for existing protocols. New enum encoding is unsigned LEB128 of the ordinal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)