### PR TITLE
feat(codec): runtime-Exact wireSize for VariableLengthCodec @UseCodec dispatch variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Codec processor: runtime-`Exact` `wireSize` for `VariableLengthCodec`
+  `@UseCodec` dispatch variants** — a sealed `@ProtocolMessage` dispatch union
+  whose variants carry `VariableLengthCodec`-backed `@UseCodec` scalar fields
+  now reports `WireSize.Exact(1 + body)` for each such variant (forwarding to
+  the variant codec's own `Exact` `wireSize`) instead of collapsing the variant
+  to `WireSize.BackPatch`. `classifyVariantWireSize` previously classified
+  *every* `@UseCodec` scalar variant as `BackPatch` (the "promote later if a
+  vector benefits" note); it now mirrors `buildWireSizeFun`'s `isVariableLength`
+  split — a non-`VariableLengthCodec` `@UseCodec` (plain `Codec`, possibly
+  `BackPatch` at runtime) still collapses, while a `VariableLengthCodec` one
+  (LEB128 / QUIC-varint, always `Exact(encodedLength)`) is `RuntimeExact`.
+  This lets a dispatch union of varint-payload variants compose inside a
+  measure-first / two-pass encoder that requires `Exact` (e.g. one that embeds
+  the union to length-prefix each message). A mixed variant — a VL `@UseCodec`
+  field in a non-terminal slot followed by a fixed-size trailer — is summed
+  correctly via the runtime-Exact early-return rather than crashing the
+  fixed-size-only sum path.
 - **Codec processor: framed-body truncation guard** — generated `@FramedBy`
   decode (variant arms and the `@ForwardCompatible` preserve arm) now throws a
   `DecodeException` (`<Owner>.@FramedBy` / `<Unknown>.@ForwardCompatible`)

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecAnalyzer.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecAnalyzer.kt
@@ -2947,11 +2947,12 @@ internal fun classifyVariantWireSize(shape: CodecShape): VariantWireSize {
     // wireSize is BackPatch (see buildWireSizeFun's RemainingBytesPayload
     // early-return); the dispatcher must skip the runtime-Exact cast.
     if (shape.fields.any { it is FieldSpec.RemainingBytesPayload }) return VariantWireSize.BackPatch
-    // Same shape — buildWireSizeFun collapses any
-    // UseCodecScalar-bearing shape to BackPatch, so the dispatcher must
-    // also skip the runtime-Exact cast. Promote later if a vector
-    // benefits from runtime-Exact via codec.wireSize forwarding.
-    if (shape.fields.any { it is FieldSpec.UseCodecScalar }) return VariantWireSize.BackPatch
+    // A NON-`VariableLengthCodec` `@UseCodec` scalar may report `BackPatch` at runtime, so the
+    // dispatcher can't assume Exact — collapse (mirrors buildWireSizeFun's `!isVariableLength`
+    // BackPatch guard). A `VariableLengthCodec`-backed `@UseCodec` scalar reports
+    // `Exact(encodedLength)` and is promoted to RuntimeExact below — the "promote later if a vector
+    // benefits" note made good (a sealed grid-op union whose payloads are LEB128 `@UseCodec` fields).
+    if (shape.fields.any { it is FieldSpec.UseCodecScalar && !it.isVariableLength }) return VariantWireSize.BackPatch
     // Same — buildWireSizeFun collapses
     // LengthPrefixedUseCodecList-bearing shapes to BackPatch.
     if (shape.fields.any { it is FieldSpec.LengthPrefixedUseCodecList }) return VariantWireSize.BackPatch
@@ -2980,6 +2981,13 @@ internal fun classifyVariantWireSize(shape: CodecShape): VariantWireSize {
     ) {
         return VariantWireSize.BackPatch
     }
+    // A `VariableLengthCodec`-backed `@UseCodec` scalar reports `Exact(encodedLength)` at runtime, so
+    // any variant carrying one is runtime-Exact (the variant codec's own wireSize sums it via the
+    // `as Exact` cast — buildWireSizeFun's `isRuntimeExactVar`); the dispatcher forwards to the
+    // variant codec's wireSize without re-deriving. Early-return (like the enum case below) so a VL
+    // `@UseCodec` field in a NON-terminal slot isn't dropped by the terminal `when`'s FixedSize-only
+    // sum — e.g. a variant of `(varint, varint, enum, Boolean)` whose Boolean is last.
+    if (shape.fields.any { it is FieldSpec.UseCodecScalar && it.isVariableLength }) return VariantWireSize.RuntimeExact
     // An enum field's ordinal is a runtime-width varint, so any variant carrying one is
     // runtime-Exact (the variant codec's own wireSize sums it via `UnsignedVarIntCodec.wireSize
     // as Exact`); the dispatcher forwards without re-deriving. Early-return so an enum in a
@@ -3010,8 +3018,9 @@ internal fun classifyVariantWireSize(shape: CodecShape): VariantWireSize {
         // shape carrying a RemainingBytesPayload field before the
         // terminal-shape `when` runs.
         is FieldSpec.RemainingBytesPayload -> VariantWireSize.BackPatch
-        // Same — handled by the upfront BackPatch short-circuit
-        // above; defensive branch keeps the `when` exhaustive.
+        // Both cases handled upfront — a non-VariableLengthCodec `@UseCodec` scalar by the BackPatch
+        // short-circuit, a VariableLengthCodec one by the RuntimeExact early-return. This defensive
+        // branch is unreachable; it keeps the `when` exhaustive (BackPatch is the conservative arm).
         is FieldSpec.UseCodecScalar -> VariantWireSize.BackPatch
         // Same — handled by the upfront BackPatch
         // short-circuit above.

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/DispatchVarintUnionCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/DispatchVarintUnionCodec.kt
@@ -1,0 +1,100 @@
+package com.ditchoom.buffer.codec.test.protocols.usecodecscalar
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object DispatchVarintUnionCodec : Codec<DispatchVarintUnion> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): DispatchVarintUnion {
+    val discriminatorPosition = buffer.position()
+    val discriminator = buffer.readUByte().toInt()
+    return when (discriminator) {
+      0x01 -> DispatchVarintUnionSingleCodec.decode(buffer, context)
+      0x02 -> DispatchVarintUnionMixedCodec.decode(buffer, context)
+      0x03 -> DispatchVarintUnionMarkerCodec.decode(buffer, context)
+      0x04 -> DispatchVarintUnionPlainCodec.decode(buffer, context)
+      else -> {
+        throw DecodeException(fieldPath = "DispatchVarintUnion.discriminator", bufferPosition = discriminatorPosition, expected = "one of {0x01, 0x02, 0x03, 0x04}", actual = """0x${discriminator.toString(16).padStart(2, '0').uppercase()}""")
+      }
+    }
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: DispatchVarintUnion,
+    context: EncodeContext,
+  ) {
+    when (value) {
+      is DispatchVarintUnion.Single -> {
+        buffer.writeUByte(0x01.toUByte())
+        DispatchVarintUnionSingleCodec.encode(buffer, value, context)
+      }
+      is DispatchVarintUnion.Mixed -> {
+        buffer.writeUByte(0x02.toUByte())
+        DispatchVarintUnionMixedCodec.encode(buffer, value, context)
+      }
+      is DispatchVarintUnion.Marker -> {
+        buffer.writeUByte(0x03.toUByte())
+        DispatchVarintUnionMarkerCodec.encode(buffer, value, context)
+      }
+      is DispatchVarintUnion.Plain -> {
+        buffer.writeUByte(0x04.toUByte())
+        DispatchVarintUnionPlainCodec.encode(buffer, value, context)
+      }
+    }
+  }
+
+  override fun wireSize(`value`: DispatchVarintUnion, context: EncodeContext): WireSize = when (value) {
+    is DispatchVarintUnion.Single -> {
+      val inner = (DispatchVarintUnionSingleCodec.wireSize(value, context) as WireSize.Exact).bytes
+      WireSize.Exact(1 + inner)
+    }
+    is DispatchVarintUnion.Mixed -> {
+      val inner = (DispatchVarintUnionMixedCodec.wireSize(value, context) as WireSize.Exact).bytes
+      WireSize.Exact(1 + inner)
+    }
+    is DispatchVarintUnion.Marker -> WireSize.Exact(1)
+    is DispatchVarintUnion.Plain -> WireSize.BackPatch
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
+    val discriminator = stream.peekByte(baseOffset).toInt() and 0xFF
+    return when (discriminator) {
+      0x01 -> {
+        when (val inner = DispatchVarintUnionSingleCodec.peekFrameSize(stream, baseOffset + 1)) {
+          is PeekResult.Complete -> PeekResult.Complete(1 + inner.bytes)
+          else -> inner
+        }
+      }
+      0x02 -> {
+        when (val inner = DispatchVarintUnionMixedCodec.peekFrameSize(stream, baseOffset + 1)) {
+          is PeekResult.Complete -> PeekResult.Complete(1 + inner.bytes)
+          else -> inner
+        }
+      }
+      0x03 -> {
+        when (val inner = DispatchVarintUnionMarkerCodec.peekFrameSize(stream, baseOffset + 1)) {
+          is PeekResult.Complete -> PeekResult.Complete(1 + inner.bytes)
+          else -> inner
+        }
+      }
+      0x04 -> {
+        when (val inner = DispatchVarintUnionPlainCodec.peekFrameSize(stream, baseOffset + 1)) {
+          is PeekResult.Complete -> PeekResult.Complete(1 + inner.bytes)
+          else -> inner
+        }
+      }
+      else -> {
+        throw DecodeException(fieldPath = "DispatchVarintUnion.discriminator", bufferPosition = baseOffset, expected = "one of {0x01, 0x02, 0x03, 0x04}", actual = """0x${discriminator.toString(16).padStart(2, '0').uppercase()}""")
+      }
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/DispatchVarintUnionMarkerCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/DispatchVarintUnionMarkerCodec.kt
@@ -1,0 +1,26 @@
+package com.ditchoom.buffer.codec.test.protocols.usecodecscalar
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object DispatchVarintUnionMarkerCodec : Codec<DispatchVarintUnion.Marker> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): DispatchVarintUnion.Marker = DispatchVarintUnion.Marker
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: DispatchVarintUnion.Marker,
+    context: EncodeContext,
+  ) {
+  }
+
+  override fun wireSize(`value`: DispatchVarintUnion.Marker, context: EncodeContext): WireSize = WireSize.Exact(0)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 0) PeekResult.Complete(0) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/DispatchVarintUnionMixedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/DispatchVarintUnionMixedCodec.kt
@@ -1,0 +1,43 @@
+package com.ditchoom.buffer.codec.test.protocols.usecodecscalar
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.codec.test.protocols.quic.QuicVarintCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object DispatchVarintUnionMixedCodec : Codec<DispatchVarintUnion.Mixed> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): DispatchVarintUnion.Mixed {
+    val v = QuicVarintCodec.decode(buffer, context)
+    val flag = buffer.readByte() != 0.toByte()
+    return DispatchVarintUnion.Mixed(v = v, flag = flag)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: DispatchVarintUnion.Mixed,
+    context: EncodeContext,
+  ) {
+    QuicVarintCodec.encode(buffer, value.v, context)
+    buffer.writeByte(if (value.flag) 1.toByte() else 0.toByte())
+  }
+
+  override fun wireSize(`value`: DispatchVarintUnion.Mixed, context: EncodeContext): WireSize {
+    val __vSize = (QuicVarintCodec.wireSize(value.v, context) as WireSize.Exact).bytes
+    return WireSize.Exact(1 + __vSize)
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    val __vFrame = QuicVarintCodec.peekFrameSize(stream, baseOffset + 0)
+    if (__vFrame !is PeekResult.Complete) {
+      return __vFrame
+    }
+    val __total = 0 + __vFrame.bytes + 1
+    return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/DispatchVarintUnionPlainCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/DispatchVarintUnionPlainCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.usecodecscalar
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object DispatchVarintUnionPlainCodec : Codec<DispatchVarintUnion.Plain> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): DispatchVarintUnion.Plain {
+    val value = ZigZagUIntCodec.decode(buffer, context)
+    return DispatchVarintUnion.Plain(value = value)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: DispatchVarintUnion.Plain,
+    context: EncodeContext,
+  ) {
+    ZigZagUIntCodec.encode(buffer, value.value, context)
+  }
+
+  override fun wireSize(`value`: DispatchVarintUnion.Plain, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/DispatchVarintUnionSingleCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/DispatchVarintUnionSingleCodec.kt
@@ -1,0 +1,41 @@
+package com.ditchoom.buffer.codec.test.protocols.usecodecscalar
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.codec.test.protocols.quic.QuicVarintCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object DispatchVarintUnionSingleCodec : Codec<DispatchVarintUnion.Single> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): DispatchVarintUnion.Single {
+    val v = QuicVarintCodec.decode(buffer, context)
+    return DispatchVarintUnion.Single(v = v)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: DispatchVarintUnion.Single,
+    context: EncodeContext,
+  ) {
+    QuicVarintCodec.encode(buffer, value.v, context)
+  }
+
+  override fun wireSize(`value`: DispatchVarintUnion.Single, context: EncodeContext): WireSize {
+    val __vSize = (QuicVarintCodec.wireSize(value.v, context) as WireSize.Exact).bytes
+    return WireSize.Exact(0 + __vSize)
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    val __vFrame = QuicVarintCodec.peekFrameSize(stream, baseOffset + 0)
+    if (__vFrame !is PeekResult.Complete) {
+      return __vFrame
+    }
+    val __total = 0 + __vFrame.bytes + 0
+    return if (stream.available() - baseOffset >= __total) PeekResult.Complete(__total) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/DispatchVarintUnion.kt
+++ b/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/DispatchVarintUnion.kt
@@ -1,0 +1,49 @@
+package com.ditchoom.buffer.codec.test.protocols.usecodecscalar
+
+import com.ditchoom.buffer.codec.annotations.Endianness
+import com.ditchoom.buffer.codec.annotations.PacketType
+import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+import com.ditchoom.buffer.codec.annotations.UseCodec
+import com.ditchoom.buffer.codec.test.protocols.quic.QuicVarintCodec
+
+/**
+ * Dispatch-union vector for the **runtime-Exact promotion** of `VariableLengthCodec`-backed
+ * `@UseCodec` scalar variants. Previously `classifyVariantWireSize` collapsed *any* `@UseCodec`
+ * variant to `BackPatch`, so a sealed union of such variants reported `BackPatch` and could not be
+ * embedded inside a measure-based / two-pass encoder. Now a `VariableLengthCodec` `@UseCodec`
+ * field (here [QuicVarintCodec], which reports `Exact(encodedLength)`) classifies as `RuntimeExact`,
+ * so the generated union's `wireSize` forwards to the variant codec and reports `Exact(1 + body)`.
+ *
+ * Variants pin the three relevant shapes plus the unchanged BackPatch contract:
+ *  - [Single]  — sole field is a `VariableLengthCodec` `@UseCodec` scalar → runtime-Exact.
+ *  - [Mixed]   — the VL `@UseCodec` scalar sits in a **non-terminal** slot with a fixed scalar last;
+ *                without the early-return promotion this would fall to the terminal FixedSize-only
+ *                sum and fail `requireFixed`.
+ *  - [Marker]  — zero-field `data object` → `Exact(1)` (discriminator only).
+ *  - [Plain]   — a plain `Codec` (non-`VariableLengthCodec`) `@UseCodec` scalar → still `BackPatch`.
+ */
+@ProtocolMessage(wireOrder = Endianness.Big)
+sealed interface DispatchVarintUnion {
+    @ProtocolMessage(wireOrder = Endianness.Big)
+    @PacketType(0x01)
+    data class Single(
+        @UseCodec(QuicVarintCodec::class) val v: ULong,
+    ) : DispatchVarintUnion
+
+    @ProtocolMessage(wireOrder = Endianness.Big)
+    @PacketType(0x02)
+    data class Mixed(
+        @UseCodec(QuicVarintCodec::class) val v: ULong,
+        val flag: Boolean,
+    ) : DispatchVarintUnion
+
+    @ProtocolMessage(wireOrder = Endianness.Big)
+    @PacketType(0x03)
+    data object Marker : DispatchVarintUnion
+
+    @ProtocolMessage(wireOrder = Endianness.Big)
+    @PacketType(0x04)
+    data class Plain(
+        @UseCodec(ZigZagUIntCodec::class) val value: UInt,
+    ) : DispatchVarintUnion
+}

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/DispatchVarintUnionCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/DispatchVarintUnionCodecTest.kt
@@ -1,0 +1,66 @@
+package com.ditchoom.buffer.codec.test.protocols.usecodecscalar
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.codec.test.protocols.quic.QuicVarintCodec
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Pins the runtime-Exact promotion (see [DispatchVarintUnion]): a sealed dispatch union whose
+ * variants are `VariableLengthCodec` `@UseCodec` messages reports `Exact(1 + body)`, not `BackPatch`
+ * — so it composes inside measure-based encoders — while a plain-`Codec` `@UseCodec` variant keeps
+ * its `BackPatch` contract. Plus a round-trip over every variant.
+ */
+class DispatchVarintUnionCodecTest {
+    @Test
+    fun variableLengthUseCodecVariantsReportExactUnionWireSize() {
+        // Sole VL @UseCodec field: Exact(discriminator + runtime varint width).
+        assertEquals(
+            WireSize.Exact(1 + QuicVarintCodec.encodedLength(5uL)),
+            DispatchVarintUnionCodec.wireSize(DispatchVarintUnion.Single(5uL), EncodeContext.Empty),
+        )
+        // A 16384 value forces a wider QUIC varint, proving the size is the runtime width (not a
+        // compile-time constant), and that the VL field in a non-terminal slot + a trailing fixed
+        // Boolean is summed (1 disc + varint + 1 bool) rather than crashing the FixedSize-only path.
+        assertEquals(
+            WireSize.Exact(1 + QuicVarintCodec.encodedLength(16384uL) + 1),
+            DispatchVarintUnionCodec.wireSize(DispatchVarintUnion.Mixed(16384uL, true), EncodeContext.Empty),
+        )
+        // Zero-field data object → discriminator only.
+        assertEquals(
+            WireSize.Exact(1),
+            DispatchVarintUnionCodec.wireSize(DispatchVarintUnion.Marker, EncodeContext.Empty),
+        )
+    }
+
+    @Test
+    fun nonVariableLengthUseCodecVariantStaysBackPatch() {
+        assertEquals(
+            WireSize.BackPatch,
+            DispatchVarintUnionCodec.wireSize(DispatchVarintUnion.Plain(1u), EncodeContext.Empty),
+        )
+    }
+
+    @Test
+    fun everyVariantRoundTrips() {
+        val samples =
+            listOf(
+                DispatchVarintUnion.Single(5uL),
+                DispatchVarintUnion.Single(16384uL),
+                DispatchVarintUnion.Mixed(1uL, false),
+                DispatchVarintUnion.Mixed(16384uL, true),
+                DispatchVarintUnion.Marker,
+                DispatchVarintUnion.Plain(42u),
+            )
+        for (sample in samples) {
+            val buffer = BufferFactory.Default.allocate(64)
+            DispatchVarintUnionCodec.encode(buffer, sample, EncodeContext.Empty)
+            buffer.resetForRead()
+            assertEquals(sample, DispatchVarintUnionCodec.decode(buffer, DecodeContext.Empty), "round-trip $sample")
+        }
+    }
+}


### PR DESCRIPTION
## What

A sealed `@ProtocolMessage` dispatch union whose variants carry `VariableLengthCodec`-backed `@UseCodec` scalar fields now reports `WireSize.Exact(1 + body)` per such variant (forwarding to the variant codec's own `Exact` `wireSize`) instead of collapsing the variant to `WireSize.BackPatch`.

## Why

`classifyVariantWireSize` previously classified **every** `@UseCodec` scalar variant as `BackPatch` — the explicit *"promote later if a vector benefits from runtime-Exact via codec.wireSize forwarding"* note in the code. A dispatch union of varint-payload variants therefore reported `BackPatch` and could **not** be embedded inside a measure-first / two-pass encoder that requires `Exact` (e.g. one that embeds the union to length-prefix each message). The standalone message path was already promoted to runtime-Exact for `VariableLengthCodec` `@UseCodec` fields (#188); the dispatch classifier just lagged.

## How

`classifyVariantWireSize` now mirrors `buildWireSizeFun`'s `FieldSpec.UseCodecScalar.isVariableLength` split:

- a **non-`VariableLengthCodec`** `@UseCodec` (plain `Codec`, may be `BackPatch` at runtime) still collapses the variant to `BackPatch`;
- a **`VariableLengthCodec`** one (LEB128 / QUIC-varint, always `Exact(encodedLength)`) classifies as `RuntimeExact`, and the generated union's `wireSize` forwards to the variant codec.

The `RuntimeExact` early-return runs **before** the terminal `FixedSize`-only sum, so a *mixed* variant — a VL `@UseCodec` field in a non-terminal slot followed by a fixed-size trailer — is summed correctly rather than crashing `requireFixed`.

## Tests

- New `DispatchVarintUnion` fixture (`buffer-codec-test`) covering: sole VL `@UseCodec` field (`Single`), VL field in a non-terminal slot + fixed `Boolean` trailer (`Mixed`), zero-field `data object` (`Marker`), and a non-VL plain-`Codec` `@UseCodec` (`Plain`, stays `BackPatch`).
- `DispatchVarintUnionCodecTest` asserts the union `wireSize` is `Exact` for the VL variants (with runtime-width varints), `BackPatch` for `Plain`, plus a round-trip over every variant.
- Generated-codec snapshot baseline accepted: **0 changed, 5 new, 0 removed** — no existing generated codec is altered, so no downstream wire-format/codec-shape change.

Green: `:buffer-codec-processor:test` (139), `:buffer-codec-test` round-trips on JVM + JS + wasmJs + iOS/macOS/tvOS/watchOS, ktlint.