### PR TITLE
perf(buffer): skip FFM session-liveness check in DirectJvmBuffer unchecked reads

### DIFF
--- a/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/DirectUncheckedAccess.kt
+++ b/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/DirectUncheckedAccess.kt
@@ -1,0 +1,19 @@
+@file:Suppress("unused") // Loaded at runtime via multi-release JAR, not referenced directly
+
+package com.ditchoom.buffer
+
+import java.lang.foreign.MemorySegment
+import java.lang.foreign.ValueLayout
+
+// FFM implementation for Java 21+ (shadows the Unsafe version in jvmMain via the multi-release JAR).
+//
+// A single global-scope segment spanning all addressable memory. Because its scope is the GLOBAL
+// session — which can never be closed — segment.get() carries no per-access liveness check: the JIT
+// proves it always valid and folds it away, so reads compile to the same bare load as Unsafe, but
+// through the supported FFM API (no sun.misc.Unsafe, no --add-opens). This is the JDK-blessed
+// replacement for the Unsafe memory accessors. Layouts are native byte order; callers adjust.
+private val EVERYTHING: MemorySegment = MemorySegment.NULL.reinterpret(Long.MAX_VALUE)
+
+internal fun directGetByte(address: Long): Byte = EVERYTHING.get(ValueLayout.JAVA_BYTE, address)
+
+internal fun directGetLong(address: Long): Long = EVERYTHING.get(ValueLayout.JAVA_LONG_UNALIGNED, address)

--- a/buffer/src/jvmMain/kotlin/com/ditchoom/buffer/DirectJvmBuffer.kt
+++ b/buffer/src/jvmMain/kotlin/com/ditchoom/buffer/DirectJvmBuffer.kt
@@ -30,5 +30,52 @@ class DirectJvmBuffer(
      */
     override val nativeSize: Long get() = capacity.toLong()
 
+    // Address of THIS buffer's index 0, position-independent (getUnchecked/getLongUnchecked take ABSOLUTE
+    // indices, like get(index)/getLong(index)). Resolved lazily on first unchecked access and cached in a
+    // plain field: the value is an idempotent address, so a benign data race only recomputes the same
+    // number — no `lazy` volatile in the hot loop. 0 means "unavailable" (a real mapping base is never 0,
+    // e.g. JVM<21 without `--add-opens java.base/java.nio`) → the unchecked accessors fall back to the
+    // checked path. UNRESOLVED is the not-yet-computed sentinel.
+    private var directBaseCache: Long = UNRESOLVED
+
+    private fun directBase(): Long {
+        var base = directBaseCache
+        if (base == UNRESOLVED) {
+            base =
+                runCatching {
+                    getDirectBufferAddress(
+                        byteBuffer.duplicate().apply {
+                            position(0)
+                            limit(capacity())
+                        },
+                    )
+                }.getOrDefault(0L)
+            directBaseCache = base
+        }
+        return base
+    }
+
+    // Unchecked fast paths (see ReadBuffer.getUnchecked): read straight from the native address,
+    // bypassing DirectByteBuffer.get() -> ScopedMemoryAccess.checkValidStateRaw (the FFM session-liveness
+    // check, ~20% of a direct/mmap scan on JDK 21+). The read goes through directGet*: a global-scope FFM
+    // MemorySegment on JDK 21+ (no Unsafe, no --add-opens), sun.misc.Unsafe on 8-20. Safe under the
+    // unchecked contract — the caller range-checked the window once and the memory outlives the scan.
+    override fun getUnchecked(index: Int): Byte {
+        val base = directBase()
+        return if (base != 0L) directGetByte(base + index) else get(index)
+    }
+
+    override fun getLongUnchecked(index: Int): Long {
+        val base = directBase()
+        if (base == 0L) return getLong(index)
+        val raw = directGetLong(base + index)
+        return if (byteOrder == ByteOrder.BIG_ENDIAN) java.lang.Long.reverseBytes(raw) else raw
+    }
+
     override fun slice(byteOrder: ByteOrder): DirectJvmBuffer = DirectJvmBuffer(byteBuffer.slice().order(byteOrder.toJava()))
+
+    private companion object {
+        // Sentinel for "address not yet resolved". Distinct from 0L ("resolved but unavailable").
+        private const val UNRESOLVED: Long = Long.MIN_VALUE
+    }
 }

--- a/buffer/src/jvmMain/kotlin/com/ditchoom/buffer/DirectUncheckedAccess.kt
+++ b/buffer/src/jvmMain/kotlin/com/ditchoom/buffer/DirectUncheckedAccess.kt
@@ -1,0 +1,13 @@
+package com.ditchoom.buffer
+
+// Unchecked native reads for direct buffers, addressed absolutely (the caller has already range-checked
+// the window — see ReadBuffer.getUnchecked). These bypass DirectByteBuffer.get(), whose
+// ScopedMemoryAccess path runs a per-access session-liveness check (MemorySessionImpl.checkValidStateRaw)
+// that the JIT cannot hoist out of a hot scan loop — ~20% of a direct/mmap scan on JDK 21+.
+//
+// MRJAR: this sun.misc.Unsafe implementation is used on JVM 8-20 (FFM does not exist there). On JDK 21+
+// it is shadowed by the FFM version in jvm21Main, which needs neither Unsafe nor any --add-opens. Both
+// read in native byte order; callers adjust for the buffer's byteOrder.
+internal fun directGetByte(address: Long): Byte = UnsafeMemory.getByte(address)
+
+internal fun directGetLong(address: Long): Long = UnsafeMemory.getLong(address)

--- a/buffer/src/jvmTest/kotlin/com/ditchoom/buffer/DirectUncheckedAccessTest.kt
+++ b/buffer/src/jvmTest/kotlin/com/ditchoom/buffer/DirectUncheckedAccessTest.kt
@@ -1,0 +1,59 @@
+package com.ditchoom.buffer
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Verifies [DirectJvmBuffer]'s unchecked fast-path accessors ([ReadBuffer.getUnchecked] /
+ * [ReadBuffer.getLongUnchecked]) — which read straight from the native address via the FFM/Unsafe
+ * direct path — return bit-identical results to the checked accessors. Covers both byte orders and a
+ * sliced buffer (whose index 0 is a non-zero offset into the parent, exercising the position-independent
+ * base-address derivation that an earlier prototype got wrong).
+ */
+class DirectUncheckedAccessTest {
+    private fun directBufferOf(
+        size: Int,
+        order: ByteOrder,
+    ): PlatformBuffer {
+        val buf = BufferFactory.Default.allocate(size, order)
+        for (i in 0 until size) buf.writeByte((i * 7 + 1).toByte())
+        buf.resetForRead()
+        return buf
+    }
+
+    private fun assertUncheckedMatchesChecked(
+        buf: ReadBuffer,
+        size: Int,
+    ) {
+        for (i in 0 until size) {
+            assertEquals(buf.get(i), buf.getUnchecked(i), "byte at $i")
+        }
+        for (i in 0..size - 8) {
+            assertEquals(buf.getLong(i), buf.getLongUnchecked(i), "long at $i")
+        }
+    }
+
+    @Test
+    fun matchesCheckedBigEndian() {
+        val size = 40
+        val buf = directBufferOf(size, ByteOrder.BIG_ENDIAN)
+        // Ensure we are actually exercising the direct native path, not a heap fallback.
+        assertTrue(buf.unwrapFully() is DirectJvmBuffer, "expected DirectJvmBuffer from Default.allocate")
+        assertUncheckedMatchesChecked(buf, size)
+    }
+
+    @Test
+    fun matchesCheckedLittleEndian() {
+        val size = 40
+        assertUncheckedMatchesChecked(directBufferOf(size, ByteOrder.LITTLE_ENDIAN), size)
+    }
+
+    @Test
+    fun matchesCheckedOnSlice() {
+        val parent = directBufferOf(40, ByteOrder.BIG_ENDIAN)
+        parent.position(8)
+        val slice = parent.slice(ByteOrder.BIG_ENDIAN)
+        assertUncheckedMatchesChecked(slice, 32)
+    }
+}


### PR DESCRIPTION
## Summary
On JDK 19+/21, every `DirectByteBuffer.get()` routes through `ScopedMemoryAccess` and pays a per-access **session-liveness check** (`MemorySessionImpl.checkValidStateRaw`) that the JIT cannot hoist out of a hot scan loop. Profiling the 1BRC solver put it at **~20% of the mmap scan**.

The check-once/unchecked-loop from #189 didn't help on JVM: `ReadBuffer.getUnchecked`'s default delegates to `DirectByteBuffer.get()`, so the scoped check stayed. Native (linux/apple) already override the unchecked accessors; **JVM-direct didn't** — this closes that gap.

`DirectJvmBuffer.getUnchecked`/`getLongUnchecked` now read straight from the native address:
- **JDK 21+** — via a single **global-scope FFM `MemorySegment`** (`jvm21Main`). Global scope is never closeable, so `get()` carries no liveness check (the JIT folds it away) — same codegen as Unsafe, but **no `sun.misc.Unsafe`, no `--add-opens`**.
- **JDK 8–20** — `sun.misc.Unsafe` via `UnsafeMemory` (the only option pre-FFM), selected by the multi-release JAR.

The index-0 base address is **position-independent** (the accessors take absolute indices), resolved lazily and cached in a plain field (idempotent address → benign race, no `lazy` volatile in the hot loop), and **falls back to the checked accessor** when the address can't be resolved (e.g. JDK<21 without `--add-opens java.base/java.nio`) — behavior is never broken, only sped up.

This is a **library-wide** win for any JVM consumer scanning a direct/mapped buffer, not 1BRC-specific.

## Measurements (100M-row 1BRC, JDK 21, 18 workers, warm, idle box)
| | Best | Throughput |
|---|---|---|
| Baseline | 0.276s | ~4,800 MB/s |
| **This PR (FFM)** | **0.208s** | **~6,360 MB/s** (~+32%) |

JFR confirms the mechanism: `checkValidStateRaw` drops from **~20% → ~2%** of the solve. (A raw-Unsafe prototype hit 0.186s; the production FFM path trades a sliver for no Unsafe / no flags.)

> ⚠️ **All performance numbers above are JDK 21 only.** Performance on JDK <21 was **not measured** — `:buffer-1brc` targets JVM 21 bytecode, so the solver cannot run on a 17 (or earlier) runtime. The scoped-memory liveness check is itself a JDK 19+/21 phenomenon, so on <21 the baseline is expected to already be fast and this change should be correctness-neutral (no regression) rather than a speedup — but that is **reasoned, not benchmarked**.

## Correctness
`DirectUncheckedAccessTest` (both byte orders + sliced buffers, unchecked vs checked) + existing `BufferHashTest`, validated on:
- **JDK 21** — FFM path, no flags.
- **JDK 17** — Unsafe + reflection path (the pre-21 branch of the MRJAR), with the `--add-opens` the buffer test task already sets. **Correctness only** — see the perf caveat above.

## Notes
- Stacked on #189 (depends on its `ReadBuffer.getUnchecked` infrastructure + the `:buffer-1brc` module used for the A/B). Retarget to `main` once #189 merges.
- The `<21` Unsafe path needs `--add-opens java.base/java.nio=ALL-UNNAMED`; on 21+ there is no such requirement.