### PR TITLE
ci(android): cold-boot emulator to fix flaky quickboot snapshot restore

### DIFF
--- a/.github/workflows/android_integration.yaml
+++ b/.github/workflows/android_integration.yaml
@@ -67,8 +67,19 @@ jobs:
       # (DELETE_FAILED_INTERNAL_ERROR on API 21) nor reinstalled over
       # (INSTALL_PARSE_FAILED_INCONSISTENT_CERTIFICATES), even with the pinned
       # keystore. Saving explicitly right after the create-AVD step caches the
-      # PRISTINE snapshot — no package ever installed — and the post-test state
+      # PRISTINE AVD disk — no package ever installed — and the post-test state
       # is never cached.
+      #
+      # The cached AVD is deliberately SNAPSHOT-FREE: the create step runs with
+      # `-no-snapshot` so no quickboot snapshot is ever written, and `run tests`
+      # COLD-BOOTS (also `-no-snapshot`). Restoring a cached quickboot snapshot
+      # is hang-prone — a snapshot saved on one GitHub runner host and reloaded
+      # on another intermittently deadlocks the emulator ("A snapshot operation
+      # for 'test' is pending and timeout has expired"), which never recovers and
+      # trips the boot timeout. A cold boot from the cached AVD disk takes
+      # ~30-60s, far under the runner-action boot timeout, and is reproducible
+      # across hosts. We still cache ~/.android/avd/* so the AVD disk itself is
+      # reused (skips re-creation); only the fragile snapshot is dropped.
       - name: AVD cache (restore)
         uses: actions/cache/restore@v5
         id: avd-cache
@@ -80,7 +91,7 @@ jobs:
           # invalidates any cache created under the old key (see #183).
           key: avd-${{ matrix.api-level }}-${{ matrix.target }}-${{ matrix.arch }}-${{ hashFiles('.ci/debug.keystore') }}
 
-      - name: create AVD and generate snapshot for caching
+      - name: create AVD for caching (no snapshot)
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -88,11 +99,13 @@ jobs:
           target: ${{ matrix.target }}
           arch: ${{ matrix.arch }}
           force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          # -no-snapshot: create + cold-boot the AVD without writing any
+          # quickboot snapshot, so the cached AVD disk is snapshot-free.
+          emulator-options: -no-snapshot -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
-          script: echo "Generated AVD snapshot for caching."
+          script: echo "Primed pristine AVD disk for caching."
 
-      - name: AVD cache (save pristine snapshot)
+      - name: AVD cache (save pristine AVD)
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
@@ -108,7 +121,11 @@ jobs:
           target: ${{ matrix.target }}
           arch: ${{ matrix.arch }}
           force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          # -no-snapshot (== -no-snapshot-load + -no-snapshot-save): COLD-BOOT
+          # from the cached AVD disk. Never restores a quickboot snapshot, which
+          # is hang-prone when saved on one runner host and reloaded on another
+          # (see the rationale on the AVD cache steps above).
+          emulator-options: -no-snapshot -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: |
             # The cached AVD's userdata retains test APKs installed by the run


### PR DESCRIPTION
## Problem

The matrix job `test (35, google_apis, x86_64)` (and `(21, default, x86_64)`) in `.github/workflows/android_integration.yaml` intermittently failed to boot the emulator:

```
FATAL | A snapshot operation for 'test' is pending and timeout has expired. Exiting...
adb: device 'emulator-5554' not found   (repeats)
##[error]Timeout waiting for emulator to boot.
```

## Root cause

The workflow used a **two-step quickboot-snapshot cache**: a "create AVD and generate snapshot" step saved a snapshot and cached `~/.android/avd/*`; the "run tests" step (`reactivecircus/android-emulator-runner@v2`, `force-avd-creation: false`) then **warm-booted by restoring that snapshot**. Its `emulator-options` had `-no-snapshot-save` but nothing disabled snapshot **load**.

Restoring a quickboot snapshot saved on one GitHub runner host and reloaded on a *different* host is hang-prone — the emulator deadlocks on the pending snapshot operation, never recovers, and trips the boot timeout. KVM/accel is not the problem (the log shows hardware acceleration enabled).

This is **distinct** from the earlier fixes #183 (AVD cache key on keystore) and #185 (uninstall stale APKs), which are post-boot *install*-time issues. Snapshot-load-on-boot was never addressed.

## Fix

**Cold-boot, never restore the snapshot.**

- `run tests`: `-no-snapshot-save` → `-no-snapshot` (≡ `-no-snapshot-load` + `-no-snapshot-save`).
- create-AVD step: add `-no-snapshot` so the cached AVD disk is **snapshot-free** (the snapshot was the only fragile artifact).
- **Kept** the `~/.android/avd/*` cache so the AVD disk is still reused (skips re-creation); only the snapshot is dropped.

Cold boot from the cached AVD disk is well under the boot timeout. Applies to **both** matrix entries (api-level 21 and 35) — they share one set of steps. The install-time defenses from #183 (pinned debug keystore + keystore-hash cache key) and #185 (pre-install uninstall of stale `.ditchoom.` packages) are untouched and still in place.

## Validation

Re-ran the Android job **6 times (12 emulator boots across both matrix legs) — all green**, deliberately exercising both cache paths and the hit→miss→hit transition (caches were deleted mid-sequence to force a fresh miss):

| Run | `21, default` | `35, google_apis` |
|-----|---------------|-------------------|
| 1 | MISS ✅ | MISS ✅ |
| 2 | hit ✅ | hit ✅ |
| 3 | hit ✅ | hit ✅ |
| 4 | hit ✅ | hit ✅ |
| 5 (caches deleted → forced miss) | MISS ✅ | MISS ✅ |
| 6 | MISS ✅ | hit ✅ |

- **Cache MISS** (fresh AVD create → save snapshot-free → cold boot): 5 boots, all green.
- **Cache HIT** (restore snapshot-free disk → cold boot): 7 boots, all green.

The originally-flaky `35, google_apis` leg never hit the snapshot-pending timeout once. Each run is ~6–8 min (the two legs run in parallel); a cache miss adds ~2 min for AVD creation.

## Independence

Standalone infra fix off `main`, unrelated to perf PR #189 (which is green/mergeable on its own). Only the workflow file changes.
