### PR TITLE
feat(buffer): zero-copy hex encode/decode primitives (common + native C SIMD)

### DIFF
--- a/buffer/src/appleMain/kotlin/com/ditchoom/buffer/MutableDataBuffer.kt
+++ b/buffer/src/appleMain/kotlin/com/ditchoom/buffer/MutableDataBuffer.kt
@@ -183,6 +183,28 @@ class MutableDataBuffer private constructor(
         )
     }
 
+    // Hex transform in C (raw pointer-to-pointer, shuffle-vectorized) when dest is also native — see
+    // nativeEncodeHexInto / buf_hex_encode; falls back to the portable common path otherwise. Mirrors
+    // the linux NativeBuffer override so both native backends share one fast path.
+    override fun encodeHexInto(
+        dest: WriteBuffer,
+        offset: Int,
+        length: Int,
+        upperCase: Boolean,
+    ) {
+        requireIndex(offset, length)
+        nativeEncodeHexInto(nativeAddress, dest, offset, length, upperCase)
+    }
+
+    override fun decodeHexInto(
+        dest: WriteBuffer,
+        offset: Int,
+        length: Int,
+    ) {
+        requireIndex(offset, length)
+        nativeDecodeHexInto(nativeAddress, dest, offset, length)
+    }
+
     override fun readShort(): Short {
         requireReadable(2)
         val ptr = (bytePointer + position)!!.reinterpret<ShortVar>()
@@ -761,6 +783,28 @@ class MutableDataBufferSlice(
             length,
             bigEndian = byteOrder == ByteOrder.BIG_ENDIAN,
         )
+    }
+
+    // Hex transform in C (raw pointer-to-pointer, shuffle-vectorized) when dest is also native — see
+    // nativeEncodeHexInto / buf_hex_encode; falls back to the portable common path otherwise. Mirrors
+    // the linux NativeBuffer override so both native backends share one fast path.
+    override fun encodeHexInto(
+        dest: WriteBuffer,
+        offset: Int,
+        length: Int,
+        upperCase: Boolean,
+    ) {
+        requireIndex(offset, length)
+        nativeEncodeHexInto(nativeAddress, dest, offset, length, upperCase)
+    }
+
+    override fun decodeHexInto(
+        dest: WriteBuffer,
+        offset: Int,
+        length: Int,
+    ) {
+        requireIndex(offset, length)
+        nativeDecodeHexInto(nativeAddress, dest, offset, length)
     }
 
     override fun readShort(): Short {

--- a/buffer/src/commonBenchmark/kotlin/com/ditchoom/buffer/benchmark/HexBenchmark.kt
+++ b/buffer/src/commonBenchmark/kotlin/com/ditchoom/buffer/benchmark/HexBenchmark.kt
@@ -1,0 +1,119 @@
+package com.ditchoom.buffer.benchmark
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.decodeHexInto
+import com.ditchoom.buffer.encodeHexInto
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.BenchmarkMode
+import kotlinx.benchmark.BenchmarkTimeUnit
+import kotlinx.benchmark.Measurement
+import kotlinx.benchmark.Mode
+import kotlinx.benchmark.OutputTimeUnit
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+import kotlinx.benchmark.Warmup
+
+/**
+ * Benchmarks for buffer-to-buffer hex encode/decode.
+ *
+ * Each direction has two variants on the SAME Direct buffer type:
+ * - "Primitive" = current encodeHexInto/decodeHexInto (SIMD C cinterop on native, optimized on JVM/JS)
+ * - "Baseline" = naive per-byte loop via get()/writeByte() (what a caller would hand-write)
+ *
+ * Both run native-memory source -> native-memory dest, so the primitive variants exercise the
+ * pointer-to-pointer C fast path (buf_hex_encode / buf_hex_decode) on native targets.
+ *
+ * Run with: ./gradlew macosArm64BenchmarkBenchmark -Pbenchmark.filter=Hex
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(BenchmarkTimeUnit.SECONDS)
+open class HexBenchmark {
+    private val size64k = 64 * 1024
+    private val hexSize = size64k * 2
+
+    private lateinit var raw: PlatformBuffer
+    private lateinit var hex: PlatformBuffer
+    private lateinit var encodeDest: PlatformBuffer
+    private lateinit var decodeDest: PlatformBuffer
+
+    @Setup
+    fun setup() {
+        raw = BufferFactory.Default.allocate(size64k)
+        encodeDest = BufferFactory.Default.allocate(hexSize)
+        decodeDest = BufferFactory.Default.allocate(size64k)
+        for (i in 0 until size64k) {
+            raw.writeByte(i.toByte())
+        }
+        raw.resetForRead()
+
+        // Pre-encode a hex blob to feed the decode benchmarks.
+        hex = BufferFactory.Default.allocate(hexSize)
+        raw.encodeHexInto(hex)
+        hex.resetForRead()
+        raw.resetForRead()
+    }
+
+    // ========================================================================= encode
+
+    @Benchmark
+    fun encodePrimitive(): Int {
+        raw.position(0)
+        raw.setLimit(size64k)
+        encodeDest.resetForWrite()
+        raw.encodeHexInto(encodeDest)
+        return encodeDest.get(0).toInt()
+    }
+
+    @Benchmark
+    fun encodeBaseline(): Int {
+        encodeDest.resetForWrite()
+        var i = 0
+        while (i < size64k) {
+            val b = raw.get(i).toInt() and 0xFF
+            encodeDest.writeByte(nibble(b ushr 4))
+            encodeDest.writeByte(nibble(b and 0x0F))
+            i++
+        }
+        return encodeDest.get(0).toInt()
+    }
+
+    // ========================================================================= decode
+
+    @Benchmark
+    fun decodePrimitive(): Int {
+        hex.position(0)
+        hex.setLimit(hexSize)
+        decodeDest.resetForWrite()
+        hex.decodeHexInto(decodeDest)
+        return decodeDest.get(0).toInt()
+    }
+
+    @Benchmark
+    fun decodeBaseline(): Int {
+        decodeDest.resetForWrite()
+        var i = 0
+        while (i < hexSize) {
+            val hi = hexVal(hex.get(i).toInt() and 0xFF)
+            val lo = hexVal(hex.get(i + 1).toInt() and 0xFF)
+            decodeDest.writeByte(((hi shl 4) or lo).toByte())
+            i += 2
+        }
+        return decodeDest.get(0).toInt()
+    }
+
+    private fun nibble(n: Int): Byte = (if (n < 10) n + 0x30 else n - 10 + 0x61).toByte()
+
+    private fun hexVal(c: Int): Int =
+        when (c) {
+            in 0x30..0x39 -> c - 0x30
+            in 0x61..0x66 -> c - 0x61 + 10
+            in 0x41..0x46 -> c - 0x41 + 10
+            else -> 0
+        }
+}

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/HexCodec.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/HexCodec.kt
@@ -1,0 +1,123 @@
+package com.ditchoom.buffer
+
+// Zero-copy (buffer-to-buffer, no intermediate ByteArray/String) hexadecimal encode/decode.
+//
+// Encoding doubles the data (N bytes -> 2N ASCII hex chars), so it cannot be done in place; "zero-copy"
+// here means the bytes flow directly from one buffer into another with no String / ByteArray staging in
+// between. Both directions are a textbook SIMD target: the common code below is the portable fallback
+// (check the whole range once, then loop over the unchecked source accessor — see getUnchecked), and the
+// native NativeMemoryAccess buffers override the members to run the whole transform in C over raw
+// pointers (buf_hex_encode / buf_hex_decode), the same shape as hashRange.
+//
+// Hex is ASCII, so the output/input chars are single bytes regardless of the buffer's text encoding.
+
+// '0'..'9' map to themselves (+0x30); nibbles 10..15 add 0x27 for lowercase 'a'..'f' or 0x07 for
+// uppercase 'A'..'F'. Branchless: (9 - n) is negative exactly when n > 9, so its arithmetic shift is an
+// all-ones mask there and zero otherwise.
+internal const val HEX_LOWER_ALPHA_DELTA = 0x27
+internal const val HEX_UPPER_ALPHA_DELTA = 0x07
+
+internal fun hexEncodeNibble(
+    nibble: Int,
+    alphaDelta: Int,
+): Byte {
+    val mask = (9 - nibble) shr 31
+    return (0x30 + nibble + (mask and alphaDelta)).toByte()
+}
+
+/**
+ * Maps a single ASCII hex character byte to its 0..15 nibble value, or -1 if it is not a hex digit.
+ * Accepts '0'-'9', 'a'-'f' and 'A'-'F'.
+ */
+internal fun hexDecodeNibble(c: Byte): Int {
+    val v = c.toInt() and 0xFF
+    return when (v) {
+        in '0'.code..'9'.code -> v - '0'.code
+        in 'a'.code..'f'.code -> v - 'a'.code + 10
+        in 'A'.code..'F'.code -> v - 'A'.code + 10
+        else -> -1
+    }
+}
+
+/**
+ * Portable encode fallback: reads `length` source bytes via [getByte] and emits `2 * length` ASCII hex
+ * bytes via [putByte] (high nibble first). The caller has already range-checked the source.
+ */
+internal inline fun encodeHexFallback(
+    srcOffset: Int,
+    length: Int,
+    upperCase: Boolean,
+    getByte: (Int) -> Byte,
+    putByte: (Byte) -> Unit,
+) {
+    val alphaDelta = if (upperCase) HEX_UPPER_ALPHA_DELTA else HEX_LOWER_ALPHA_DELTA
+    var i = 0
+    while (i < length) {
+        val b = getByte(srcOffset + i).toInt() and 0xFF
+        putByte(hexEncodeNibble(b ushr 4, alphaDelta))
+        putByte(hexEncodeNibble(b and 0x0F, alphaDelta))
+        i++
+    }
+}
+
+/**
+ * Portable decode fallback: reads `length` ASCII hex source bytes via [getByte] (length must be even)
+ * and emits `length / 2` decoded bytes via [putByte]. The caller has already range-checked the source.
+ *
+ * @throws IllegalArgumentException if [length] is odd or a source byte is not a hex digit.
+ */
+internal inline fun decodeHexFallback(
+    srcOffset: Int,
+    length: Int,
+    getByte: (Int) -> Byte,
+    putByte: (Byte) -> Unit,
+) {
+    require(length and 1 == 0) { "hex input length ($length) must be even" }
+    var i = 0
+    while (i < length) {
+        val hi = hexDecodeNibble(getByte(srcOffset + i))
+        val lo = hexDecodeNibble(getByte(srcOffset + i + 1))
+        if (hi < 0 || lo < 0) {
+            val badIndex = if (hi < 0) srcOffset + i else srcOffset + i + 1
+            throw IllegalArgumentException("invalid hex character at index $badIndex")
+        }
+        putByte(((hi shl 4) or lo).toByte())
+        i += 2
+    }
+}
+
+// region public relative convenience
+
+/**
+ * Relative: hex-encodes this buffer's remaining bytes (`position()` until `limit()`) into [dest],
+ * advancing this buffer's [position] to its [limit] and [dest]'s position by `2 * remaining()`.
+ *
+ * @param dest destination buffer that receives the ASCII hex bytes
+ * @param upperCase emit 'A'-'F' instead of 'a'-'f'
+ */
+fun ReadBuffer.encodeHexInto(
+    dest: WriteBuffer,
+    upperCase: Boolean = false,
+): WriteBuffer {
+    val start = position()
+    val length = remaining()
+    encodeHexInto(dest, start, length, upperCase)
+    position(start + length)
+    return dest
+}
+
+/**
+ * Relative: hex-decodes this buffer's remaining ASCII hex bytes (must be an even count) into [dest],
+ * advancing this buffer's [position] to its [limit] and [dest]'s position by `remaining() / 2`.
+ *
+ * @throws IllegalArgumentException if the remaining count is odd or a byte is not a hex digit.
+ */
+fun ReadBuffer.decodeHexInto(dest: WriteBuffer): WriteBuffer {
+    val start = position()
+    val length = remaining()
+    decodeHexInto(dest, start, length)
+    position(start + length)
+    return dest
+}
+
+// endregion

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/ReadBuffer.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/ReadBuffer.kt
@@ -621,6 +621,52 @@ interface ReadBuffer : PositionBuffer {
     }
 
     /**
+     * Hex-encodes the absolute source range `[offset, offset + length)` into [dest], writing
+     * `2 * length` ASCII hex bytes (high nibble first) at [dest]'s current position and advancing it.
+     * Does not change this buffer's [position].
+     *
+     * "Zero-copy": the bytes flow straight from this buffer into [dest] with no intermediate
+     * `String`/`ByteArray`. Native backends override this to run the whole transform in C over raw
+     * pointers when [dest] is also native memory (see `buf_hex_encode`).
+     *
+     * @param dest destination buffer that receives the ASCII hex bytes
+     * @param offset absolute index of the first source byte
+     * @param length number of source bytes to encode
+     * @param upperCase emit 'A'-'F' instead of 'a'-'f'
+     */
+    fun encodeHexInto(
+        dest: WriteBuffer,
+        offset: Int,
+        length: Int,
+        upperCase: Boolean = false,
+    ) {
+        requireRange(offset, length)
+        encodeHexFallback(offset, length, upperCase, { getUnchecked(it) }, { dest.writeByte(it) })
+    }
+
+    /**
+     * Hex-decodes the absolute source range `[offset, offset + length)` (an even count of ASCII hex
+     * bytes) into [dest], writing `length / 2` decoded bytes at [dest]'s current position and advancing
+     * it. Does not change this buffer's [position].
+     *
+     * Native backends override this to run the whole transform in C over raw pointers when [dest] is
+     * also native memory (see `buf_hex_decode`).
+     *
+     * @param dest destination buffer that receives the decoded bytes
+     * @param offset absolute index of the first source hex byte
+     * @param length number of source hex bytes (must be even)
+     * @throws IllegalArgumentException if [length] is odd or a source byte is not a hex digit.
+     */
+    fun decodeHexInto(
+        dest: WriteBuffer,
+        offset: Int,
+        length: Int,
+    ) {
+        requireRange(offset, length)
+        decodeHexFallback(offset, length, { getUnchecked(it) }, { dest.writeByte(it) })
+    }
+
+    /**
      * Finds the first occurrence of a byte sequence within this buffer.
      *
      * Uses optimized bulk search (8 bytes at a time) for the first byte,

--- a/buffer/src/commonTest/kotlin/com/ditchoom/buffer/HexCodecTest.kt
+++ b/buffer/src/commonTest/kotlin/com/ditchoom/buffer/HexCodecTest.kt
@@ -1,0 +1,205 @@
+package com.ditchoom.buffer
+
+import com.ditchoom.buffer.pool.BufferPool
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Tests for the buffer-to-buffer hex encode/decode primitives (encodeHexInto / decodeHexInto) on
+ * [ReadBuffer]. Covers known vectors, round-trips, case, position semantics, error handling, and
+ * transparency through pool wrappers.
+ */
+class HexCodecTest {
+    private fun bytesBuffer(values: List<Int>): PlatformBuffer {
+        val b = BufferFactory.Default.allocate(maxOf(values.size, 1))
+        for (v in values) b.writeByte(v.toByte())
+        b.resetForRead()
+        return b
+    }
+
+    private fun textBuffer(text: String): PlatformBuffer {
+        val b = BufferFactory.Default.allocate(maxOf(text.length, 1))
+        b.writeString(text)
+        b.resetForRead()
+        return b
+    }
+
+    // region encode
+
+    @Test
+    fun encodesKnownVectorLowercase() {
+        val src = bytesBuffer(listOf(0x00, 0x0F, 0xF0, 0xFF, 0x12, 0xAB))
+        val dest = BufferFactory.Default.allocate(12)
+        src.encodeHexInto(dest)
+        dest.resetForRead()
+        assertEquals("000ff0ff12ab", dest.readString(12))
+    }
+
+    @Test
+    fun encodesUppercase() {
+        val src = bytesBuffer(listOf(0xDE, 0xAD, 0xBE, 0xEF))
+        val dest = BufferFactory.Default.allocate(8)
+        src.encodeHexInto(dest, upperCase = true)
+        dest.resetForRead()
+        assertEquals("DEADBEEF", dest.readString(8))
+    }
+
+    @Test
+    fun encodeEmptyWritesNothing() {
+        val src = bytesBuffer(emptyList())
+        val dest = BufferFactory.Default.allocate(4)
+        src.encodeHexInto(dest)
+        assertEquals(0, dest.position())
+    }
+
+    @Test
+    fun absoluteEncodeDoesNotChangeSourcePosition() {
+        val src = bytesBuffer(listOf(0x12, 0x34, 0x56))
+        val dest = BufferFactory.Default.allocate(4)
+        src.encodeHexInto(dest, offset = 1, length = 2)
+        dest.resetForRead()
+        assertEquals("3456", dest.readString(4))
+        assertEquals(0, src.position())
+    }
+
+    @Test
+    fun relativeEncodeAdvancesSourceToLimit() {
+        val src = bytesBuffer(listOf(0x01, 0x02))
+        val dest = BufferFactory.Default.allocate(4)
+        src.encodeHexInto(dest)
+        assertEquals(src.limit(), src.position())
+        assertEquals(4, dest.position())
+    }
+
+    // endregion
+
+    // region decode
+
+    @Test
+    fun decodesMixedCase() {
+        val src = textBuffer("deADbeEF")
+        val dest = BufferFactory.Default.allocate(4)
+        src.decodeHexInto(dest)
+        dest.resetForRead()
+        assertEquals(0xDE, dest.readByte().toInt() and 0xFF)
+        assertEquals(0xAD, dest.readByte().toInt() and 0xFF)
+        assertEquals(0xBE, dest.readByte().toInt() and 0xFF)
+        assertEquals(0xEF, dest.readByte().toInt() and 0xFF)
+    }
+
+    @Test
+    fun oddLengthDecodeThrows() {
+        val src = textBuffer("abc")
+        val dest = BufferFactory.Default.allocate(2)
+        assertFailsWith<IllegalArgumentException> { src.decodeHexInto(dest) }
+    }
+
+    @Test
+    fun invalidCharDecodeThrows() {
+        val src = textBuffer("12zz")
+        val dest = BufferFactory.Default.allocate(2)
+        assertFailsWith<IllegalArgumentException> { src.decodeHexInto(dest) }
+    }
+
+    // endregion
+
+    // region round-trip
+
+    @Test
+    fun roundTripsArbitraryContent() {
+        val original = textBuffer("The quick brown fox jumps over 13 lazy dogs.")
+        val n = original.remaining()
+
+        val hex = BufferFactory.Default.allocate(n * 2)
+        original.encodeHexInto(hex)
+        hex.resetForRead()
+
+        val decoded = BufferFactory.Default.allocate(n)
+        hex.decodeHexInto(decoded)
+        decoded.resetForRead()
+        original.resetForRead()
+
+        assertTrue(original.contentEquals(decoded), "decode(encode(x)) must equal x")
+    }
+
+    @Test
+    fun roundTripsAllByteValues() {
+        // Exercises every nibble combination and the bulk/tail boundaries (256 bytes).
+        val src = bytesBuffer((0..255).toList())
+        val hex = BufferFactory.Default.allocate(512)
+        src.encodeHexInto(hex)
+        hex.resetForRead()
+
+        val decoded = BufferFactory.Default.allocate(256)
+        hex.decodeHexInto(decoded)
+        decoded.resetForRead()
+        src.resetForRead()
+
+        assertTrue(src.contentEquals(decoded))
+    }
+
+    @Test
+    fun roundTripsWithManagedDestination() {
+        // On native, source is a NativeBuffer but the managed() dest is not NativeMemoryAccess, so this
+        // exercises the native override's portable fallback branch (and the all-managed path elsewhere).
+        val original = textBuffer("zero-copy hex, managed sink")
+        val n = original.remaining()
+
+        val hex = BufferFactory.managed().allocate(n * 2)
+        original.encodeHexInto(hex)
+        hex.resetForRead()
+
+        val decoded = BufferFactory.managed().allocate(n)
+        hex.decodeHexInto(decoded)
+        decoded.resetForRead()
+        original.resetForRead()
+
+        assertTrue(original.contentEquals(decoded))
+    }
+
+    // endregion
+
+    // region wrapper transparency
+
+    @Test
+    fun encodesThroughPooledBufferWrappers() {
+        BufferPool().let { pool ->
+            val src = pool.acquire(4)
+            src.writeByte(0xAB.toByte())
+            src.writeByte(0xCD.toByte())
+            src.resetForRead()
+
+            val dest = pool.acquire(4)
+            src.encodeHexInto(dest)
+            dest.resetForRead()
+            assertEquals("abcd", dest.readString(4))
+
+            pool.release(src)
+            pool.release(dest)
+            pool.clear()
+        }
+    }
+
+    @Test
+    fun decodesThroughPooledBufferWrappers() {
+        BufferPool().let { pool ->
+            val src = pool.acquire(4)
+            src.writeString("00ff")
+            src.resetForRead()
+
+            val dest = pool.acquire(2)
+            src.decodeHexInto(dest)
+            dest.resetForRead()
+            assertEquals(0x00, dest.readByte().toInt() and 0xFF)
+            assertEquals(0xFF, dest.readByte().toInt() and 0xFF)
+
+            pool.release(src)
+            pool.release(dest)
+            pool.clear()
+        }
+    }
+
+    // endregion
+}

--- a/buffer/src/linuxMain/kotlin/com/ditchoom/buffer/NativeBuffer.kt
+++ b/buffer/src/linuxMain/kotlin/com/ditchoom/buffer/NativeBuffer.kt
@@ -234,6 +234,29 @@ class NativeBuffer private constructor(
         )
     }
 
+    // Hex transform in C (raw pointer-to-pointer, shuffle-vectorized) when dest is also native — see
+    // nativeEncodeHexInto / buf_hex_encode; falls back to the portable common path otherwise.
+    override fun encodeHexInto(
+        dest: WriteBuffer,
+        offset: Int,
+        length: Int,
+        upperCase: Boolean,
+    ) {
+        checkOpen()
+        requireIndex(offset, length)
+        nativeEncodeHexInto(baseAddress, dest, offset, length, upperCase)
+    }
+
+    override fun decodeHexInto(
+        dest: WriteBuffer,
+        offset: Int,
+        length: Int,
+    ) {
+        checkOpen()
+        requireIndex(offset, length)
+        nativeDecodeHexInto(baseAddress, dest, offset, length)
+    }
+
     override fun readByteArray(size: Int): ByteArray {
         checkOpen()
         if (size < 1) return ByteArray(0)
@@ -808,6 +831,28 @@ private class NativeBufferSlice(
             length,
             bigEndian = !littleEndian,
         )
+    }
+
+    // Hex transform in C — see nativeEncodeHexInto and the matching override on NativeBuffer.
+    override fun encodeHexInto(
+        dest: WriteBuffer,
+        offset: Int,
+        length: Int,
+        upperCase: Boolean,
+    ) {
+        checkOpen()
+        requireIndex(offset, length)
+        nativeEncodeHexInto(baseAddress, dest, offset, length, upperCase)
+    }
+
+    override fun decodeHexInto(
+        dest: WriteBuffer,
+        offset: Int,
+        length: Int,
+    ) {
+        checkOpen()
+        requireIndex(offset, length)
+        nativeDecodeHexInto(baseAddress, dest, offset, length)
     }
 
     override fun readByteArray(size: Int): ByteArray {

--- a/buffer/src/nativeInterop/cinterop/simd.def
+++ b/buffer/src/nativeInterop/cinterop/simd.def
@@ -153,6 +153,46 @@ int64_t buf_fnv1a_64(const uint8_t* data, size_t length, int big_endian) {
 }
 
 /**
+ * Hex-encode `length` source bytes into `2 * length` ASCII bytes (high nibble first).
+ * `upper` selects 'A'-'F' (non-zero) vs 'a'-'f' (zero). Each nibble indexes a 16-byte digit
+ * table; Clang at -O2 lowers the table lookup to a NEON/SSE shuffle (TBL / PSHUFB).
+ */
+void buf_hex_encode(const uint8_t* src, uint8_t* dst, size_t length, int upper) {
+    static const char lower[16] = {'0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f'};
+    static const char upper_tbl[16] = {'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F'};
+    const char* digits = upper ? upper_tbl : lower;
+    for (size_t i = 0; i < length; i++) {
+        uint8_t b = src[i];
+        dst[i * 2]     = (uint8_t)digits[b >> 4];
+        dst[i * 2 + 1] = (uint8_t)digits[b & 0x0F];
+    }
+}
+
+/** Map one ASCII hex character to its 0-15 nibble value, or -1 if it is not a hex digit. */
+static inline int buf_hex_val(uint8_t c) {
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return -1;
+}
+
+/**
+ * Hex-decode `length` ASCII bytes (caller guarantees `length` is even) into `length / 2` bytes.
+ * Returns -1 on success, or the index of the first byte that is not a hex digit (decoding stops there;
+ * bytes decoded before the bad character have already been written to `dst`).
+ */
+long buf_hex_decode(const uint8_t* src, uint8_t* dst, size_t length) {
+    for (size_t i = 0; i < length; i += 2) {
+        int hi = buf_hex_val(src[i]);
+        if (hi < 0) return (long)i;
+        int lo = buf_hex_val(src[i + 1]);
+        if (lo < 0) return (long)(i + 1);
+        dst[i / 2] = (uint8_t)((hi << 4) | lo);
+    }
+    return -1L;
+}
+
+/**
  * Find first mismatch between two buffers.
  * Returns index of first differing byte, or -1 if buffers are equal.
  * Clang auto-vectorizes the comparison loop.

--- a/buffer/src/nativeMain/kotlin/com/ditchoom/buffer/NativeHex.kt
+++ b/buffer/src/nativeMain/kotlin/com/ditchoom/buffer/NativeHex.kt
@@ -1,0 +1,92 @@
+@file:OptIn(ExperimentalForeignApi::class, UnsafeNumber::class)
+
+package com.ditchoom.buffer
+
+import com.ditchoom.buffer.cinterop.buf_hex_decode
+import com.ditchoom.buffer.cinterop.buf_hex_encode
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.UByteVar
+import kotlinx.cinterop.UnsafeNumber
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.toCPointer
+
+// Hex encode/decode computed entirely in C (raw pointer arithmetic, table lookup that Clang lowers to a
+// NEON/SSE shuffle) — see buf_hex_encode / buf_hex_decode. Shared by every native NativeMemoryAccess
+// buffer (linux NativeBuffer + slice, apple MutableDataBuffer + slice) so the cinterop wiring lives in
+// ONE place and can't drift onto one backend while silently missing another (as apple was for hashRange).
+//
+// Both directions take the source via raw addresses; the destination is taken when it is also native
+// memory (dest.nativeMemoryAccess), so the whole transform stays pointer-to-pointer with no per-element
+// Kotlin dispatch. When the destination is NOT native (e.g. a managed ByteArrayBuffer), or would not
+// fit, we fall back to the portable common-code path (encodeHexFallback / decodeHexFallback) — bit
+// identical output, just without the C fast path.
+
+private fun nativeHexEncodeAddr(
+    srcAddress: Long,
+    dstAddress: Long,
+    length: Int,
+    upperCase: Boolean,
+) = buf_hex_encode(
+    srcAddress.toCPointer<UByteVar>()!!,
+    dstAddress.toCPointer<UByteVar>()!!,
+    length.convert(),
+    if (upperCase) 1 else 0,
+)
+
+private fun nativeHexDecodeAddr(
+    srcAddress: Long,
+    dstAddress: Long,
+    length: Int,
+): Long =
+    buf_hex_decode(
+        srcAddress.toCPointer<UByteVar>()!!,
+        dstAddress.toCPointer<UByteVar>()!!,
+        length.convert(),
+    )
+
+/**
+ * Shared native [ReadBuffer.encodeHexInto] body. [srcAddress] is the address of this buffer's first
+ * byte (`nativeAddress`); the caller has already range-checked `[offset, offset + length)`.
+ */
+internal fun ReadBuffer.nativeEncodeHexInto(
+    srcAddress: Long,
+    dest: WriteBuffer,
+    offset: Int,
+    length: Int,
+    upperCase: Boolean,
+) {
+    val destNative = dest.nativeMemoryAccess
+    val outBytes = length * 2
+    if (destNative != null && outBytes <= dest.remaining()) {
+        val destPos = dest.position()
+        nativeHexEncodeAddr(srcAddress + offset, destNative.nativeAddress + destPos, length, upperCase)
+        dest.position(destPos + outBytes)
+    } else {
+        encodeHexFallback(offset, length, upperCase, { getUnchecked(it) }, { dest.writeByte(it) })
+    }
+}
+
+/**
+ * Shared native [ReadBuffer.decodeHexInto] body. [srcAddress] is the address of this buffer's first
+ * byte (`nativeAddress`); the caller has already range-checked `[offset, offset + length)`.
+ */
+internal fun ReadBuffer.nativeDecodeHexInto(
+    srcAddress: Long,
+    dest: WriteBuffer,
+    offset: Int,
+    length: Int,
+) {
+    require(length and 1 == 0) { "hex input length ($length) must be even" }
+    val destNative = dest.nativeMemoryAccess
+    val outBytes = length / 2
+    if (destNative != null && outBytes <= dest.remaining()) {
+        val destPos = dest.position()
+        val bad = nativeHexDecodeAddr(srcAddress + offset, destNative.nativeAddress + destPos, length)
+        if (bad >= 0) {
+            throw IllegalArgumentException("invalid hex character at index ${offset + bad}")
+        }
+        dest.position(destPos + outBytes)
+    } else {
+        decodeHexFallback(offset, length, { getUnchecked(it) }, { dest.writeByte(it) })
+    }
+}


### PR DESCRIPTION
## Summary

Adds high-performance, **buffer-to-buffer** hexadecimal encode/decode to `ReadBuffer` — no intermediate `String`/`ByteArray` staging (per the library's no-ByteArray convention). Encoding necessarily doubles size (N bytes → 2N ASCII hex chars), so "zero-copy" here means the bytes flow straight from one buffer into another with no heap staging in between.

This is the first of a two-part track; **SHA-256** is the planned follow-up.

## API

```kotlin
// relative (over remaining()), advances both positions
src.encodeHexInto(dest)                       // lowercase
src.encodeHexInto(dest, upperCase = true)     // uppercase
hex.decodeHexInto(dest)

// absolute (source position unchanged)
src.encodeHexInto(dest, offset, length, upperCase = false)
hex.decodeHexInto(dest, offset, length)
```

Decode validates input: odd length and non-hex characters throw `IllegalArgumentException` with the offending index.

## Implementation

Follows the established `hashRange` pattern (common default + native C override):

- **Common** (`HexCodec.kt` + `ReadBuffer` members): check-the-range-once then loop over the unchecked source accessor; branchless nibble↔ASCII.
- **Native C SIMD** (`simd.def`): `buf_hex_encode` / `buf_hex_decode` use a digit-table lookup that Clang at `-O2` lowers to a NEON/SSE shuffle (TBL / PSHUFB). Bridged via `nativeMain/NativeHex.kt` and overridden on `NativeBuffer`(+slice, linux) and `MutableDataBuffer`(+slice, apple). The C fast path runs **pointer-to-pointer only when the destination is also native memory**; otherwise it falls back to the portable common path (bit-identical output). One shared bridge keeps both native backends in sync.

## Tests

`commonTest/HexCodecTest.kt` — known vectors, upper/lowercase, full 256-byte round-trip, absolute vs relative position semantics, odd-length + invalid-char errors, pooled-wrapper transparency, and the native fallback branch.

✅ Passes full `jvmTest` and `linuxX64Test`. ktlint clean.

## Benchmark

`commonBenchmark/HexBenchmark.kt` — primitive vs hand-written baseline, native source → native dest. Note: no `linuxX64` benchmark target is registered, so the C-path numbers come from the macOS-arm64 / CI run.