### PR TITLE
feat(buffer): zero-copy hex + Base64 encode/decode primitives (common + native C SIMD)

### DIFF
--- a/buffer/build.gradle.kts
+++ b/buffer/build.gradle.kts
@@ -522,6 +522,13 @@ benchmark {
             iterationTimeUnit = "ms"
             include("StreamingStringDecoder")
         }
+        register("codec") {
+            warmups = 3
+            iterations = 5
+            iterationTime = 500
+            iterationTimeUnit = "ms"
+            include("(Hex|Base64).*")
+        }
         // Fast configuration for WASM - runs only key benchmarks to avoid long run times
         register("wasmFast") {
             warmups = 2

--- a/buffer/src/appleMain/kotlin/com/ditchoom/buffer/MutableDataBuffer.kt
+++ b/buffer/src/appleMain/kotlin/com/ditchoom/buffer/MutableDataBuffer.kt
@@ -205,6 +205,28 @@ class MutableDataBuffer private constructor(
         nativeDecodeHexInto(nativeAddress, dest, offset, length)
     }
 
+    // Base64 transform in C when dest is also native — see nativeEncodeBase64Into / buf_base64_encode;
+    // falls back to the portable common path otherwise. Mirrors the linux NativeBuffer override.
+    override fun encodeBase64Into(
+        dest: WriteBuffer,
+        offset: Int,
+        length: Int,
+        urlSafe: Boolean,
+        padded: Boolean,
+    ) {
+        requireIndex(offset, length)
+        nativeEncodeBase64Into(nativeAddress, dest, offset, length, urlSafe, padded)
+    }
+
+    override fun decodeBase64Into(
+        dest: WriteBuffer,
+        offset: Int,
+        length: Int,
+    ) {
+        requireIndex(offset, length)
+        nativeDecodeBase64Into(nativeAddress, dest, offset, length)
+    }
+
     override fun readShort(): Short {
         requireReadable(2)
         val ptr = (bytePointer + position)!!.reinterpret<ShortVar>()
@@ -805,6 +827,28 @@ class MutableDataBufferSlice(
     ) {
         requireIndex(offset, length)
         nativeDecodeHexInto(nativeAddress, dest, offset, length)
+    }
+
+    // Base64 transform in C when dest is also native — see nativeEncodeBase64Into / buf_base64_encode;
+    // falls back to the portable common path otherwise. Mirrors the linux NativeBuffer override.
+    override fun encodeBase64Into(
+        dest: WriteBuffer,
+        offset: Int,
+        length: Int,
+        urlSafe: Boolean,
+        padded: Boolean,
+    ) {
+        requireIndex(offset, length)
+        nativeEncodeBase64Into(nativeAddress, dest, offset, length, urlSafe, padded)
+    }
+
+    override fun decodeBase64Into(
+        dest: WriteBuffer,
+        offset: Int,
+        length: Int,
+    ) {
+        requireIndex(offset, length)
+        nativeDecodeBase64Into(nativeAddress, dest, offset, length)
     }
 
     override fun readShort(): Short {

--- a/buffer/src/appleMain/kotlin/com/ditchoom/buffer/MutableDataBuffer.kt
+++ b/buffer/src/appleMain/kotlin/com/ditchoom/buffer/MutableDataBuffer.kt
@@ -183,6 +183,28 @@ class MutableDataBuffer private constructor(
         )
     }
 
+    // Hex transform in C (raw pointer-to-pointer, shuffle-vectorized) when dest is also native — see
+    // nativeEncodeHexInto / buf_hex_encode; falls back to the portable common path otherwise. Mirrors
+    // the linux NativeBuffer override so both native backends share one fast path.
+    override fun encodeHexInto(
+        dest: WriteBuffer,
+        offset: Int,
+        length: Int,
+        upperCase: Boolean,
+    ) {
+        requireIndex(offset, length)
+        nativeEncodeHexInto(nativeAddress, dest, offset, length, upperCase)
+    }
+
+    override fun decodeHexInto(
+        dest: WriteBuffer,
+        offset: Int,
+        length: Int,
+    ) {
+        requireIndex(offset, length)
+        nativeDecodeHexInto(nativeAddress, dest, offset, length)
+    }
+
     override fun readShort(): Short {
         requireReadable(2)
         val ptr = (bytePointer + position)!!.reinterpret<ShortVar>()
@@ -761,6 +783,28 @@ class MutableDataBufferSlice(
             length,
             bigEndian = byteOrder == ByteOrder.BIG_ENDIAN,
         )
+    }
+
+    // Hex transform in C (raw pointer-to-pointer, shuffle-vectorized) when dest is also native — see
+    // nativeEncodeHexInto / buf_hex_encode; falls back to the portable common path otherwise. Mirrors
+    // the linux NativeBuffer override so both native backends share one fast path.
+    override fun encodeHexInto(
+        dest: WriteBuffer,
+        offset: Int,
+        length: Int,
+        upperCase: Boolean,
+    ) {
+        requireIndex(offset, length)
+        nativeEncodeHexInto(nativeAddress, dest, offset, length, upperCase)
+    }
+
+    override fun decodeHexInto(
+        dest: WriteBuffer,
+        offset: Int,
+        length: Int,
+    ) {
+        requireIndex(offset, length)
+        nativeDecodeHexInto(nativeAddress, dest, offset, length)
     }
 
     override fun readShort(): Short {

--- a/buffer/src/commonBenchmark/kotlin/com/ditchoom/buffer/benchmark/Base64Benchmark.kt
+++ b/buffer/src/commonBenchmark/kotlin/com/ditchoom/buffer/benchmark/Base64Benchmark.kt
@@ -1,0 +1,133 @@
+package com.ditchoom.buffer.benchmark
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.base64EncodedLength
+import com.ditchoom.buffer.decodeBase64Into
+import com.ditchoom.buffer.encodeBase64Into
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.BenchmarkMode
+import kotlinx.benchmark.BenchmarkTimeUnit
+import kotlinx.benchmark.Measurement
+import kotlinx.benchmark.Mode
+import kotlinx.benchmark.OutputTimeUnit
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+import kotlinx.benchmark.Warmup
+
+/**
+ * Benchmarks for buffer-to-buffer Base64 encode/decode.
+ *
+ * Each direction has two variants on the SAME Direct buffer type:
+ * - "Primitive" = current encodeBase64Into/decodeBase64Into (SIMD C cinterop on native, optimized JVM/JS)
+ * - "Baseline" = naive per-byte loop via get()/writeByte()
+ *
+ * Both run native-memory source -> native-memory dest, so the primitive variants exercise the
+ * pointer-to-pointer C fast path (buf_base64_encode / buf_base64_decode) on native targets.
+ *
+ * Run with: ./gradlew macosArm64BenchmarkBenchmark -Pbenchmark.filter=Base64
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(BenchmarkTimeUnit.SECONDS)
+open class Base64Benchmark {
+    private val size64k = 64 * 1024
+    private val b64Size = base64EncodedLength(size64k)
+
+    private val stdAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+
+    private lateinit var raw: PlatformBuffer
+    private lateinit var b64: PlatformBuffer
+    private lateinit var encodeDest: PlatformBuffer
+    private lateinit var decodeDest: PlatformBuffer
+
+    @Setup
+    fun setup() {
+        raw = BufferFactory.Default.allocate(size64k)
+        encodeDest = BufferFactory.Default.allocate(b64Size)
+        decodeDest = BufferFactory.Default.allocate(size64k)
+        for (i in 0 until size64k) {
+            raw.writeByte(i.toByte())
+        }
+        raw.resetForRead()
+
+        b64 = BufferFactory.Default.allocate(b64Size)
+        raw.encodeBase64Into(b64)
+        b64.resetForRead()
+        raw.resetForRead()
+    }
+
+    // ========================================================================= encode
+
+    @Benchmark
+    fun encodePrimitive(): Int {
+        raw.position(0)
+        raw.setLimit(size64k)
+        encodeDest.resetForWrite()
+        raw.encodeBase64Into(encodeDest)
+        return encodeDest.get(0).toInt()
+    }
+
+    @Benchmark
+    fun encodeBaseline(): Int {
+        encodeDest.resetForWrite()
+        var i = 0
+        val full = size64k - size64k % 3
+        while (i < full) {
+            val n =
+                ((raw.get(i).toInt() and 0xFF) shl 16) or
+                    ((raw.get(i + 1).toInt() and 0xFF) shl 8) or
+                    (raw.get(i + 2).toInt() and 0xFF)
+            encodeDest.writeByte(stdAlphabet[(n ushr 18) and 0x3F].code.toByte())
+            encodeDest.writeByte(stdAlphabet[(n ushr 12) and 0x3F].code.toByte())
+            encodeDest.writeByte(stdAlphabet[(n ushr 6) and 0x3F].code.toByte())
+            encodeDest.writeByte(stdAlphabet[n and 0x3F].code.toByte())
+            i += 3
+        }
+        return encodeDest.get(0).toInt()
+    }
+
+    // ========================================================================= decode
+
+    @Benchmark
+    fun decodePrimitive(): Int {
+        b64.position(0)
+        b64.setLimit(b64Size)
+        decodeDest.resetForWrite()
+        b64.decodeBase64Into(decodeDest)
+        return decodeDest.get(0).toInt()
+    }
+
+    @Benchmark
+    fun decodeBaseline(): Int {
+        decodeDest.resetForWrite()
+        var acc = 0
+        var bits = 0
+        var i = 0
+        while (i < b64Size) {
+            val c = b64.get(i).toInt() and 0xFF
+            i++
+            if (c == '='.code) break
+            acc = (acc shl 6) or sextet(c)
+            bits += 6
+            if (bits >= 8) {
+                bits -= 8
+                decodeDest.writeByte(((acc ushr bits) and 0xFF).toByte())
+            }
+        }
+        return decodeDest.get(0).toInt()
+    }
+
+    private fun sextet(c: Int): Int =
+        when (c) {
+            in 0x41..0x5A -> c - 0x41
+            in 0x61..0x7A -> c - 0x61 + 26
+            in 0x30..0x39 -> c - 0x30 + 52
+            0x2B, 0x2D -> 62
+            else -> 63
+        }
+}

--- a/buffer/src/commonBenchmark/kotlin/com/ditchoom/buffer/benchmark/HexBenchmark.kt
+++ b/buffer/src/commonBenchmark/kotlin/com/ditchoom/buffer/benchmark/HexBenchmark.kt
@@ -1,0 +1,119 @@
+package com.ditchoom.buffer.benchmark
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.decodeHexInto
+import com.ditchoom.buffer.encodeHexInto
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.BenchmarkMode
+import kotlinx.benchmark.BenchmarkTimeUnit
+import kotlinx.benchmark.Measurement
+import kotlinx.benchmark.Mode
+import kotlinx.benchmark.OutputTimeUnit
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+import kotlinx.benchmark.Warmup
+
+/**
+ * Benchmarks for buffer-to-buffer hex encode/decode.
+ *
+ * Each direction has two variants on the SAME Direct buffer type:
+ * - "Primitive" = current encodeHexInto/decodeHexInto (SIMD C cinterop on native, optimized on JVM/JS)
+ * - "Baseline" = naive per-byte loop via get()/writeByte() (what a caller would hand-write)
+ *
+ * Both run native-memory source -> native-memory dest, so the primitive variants exercise the
+ * pointer-to-pointer C fast path (buf_hex_encode / buf_hex_decode) on native targets.
+ *
+ * Run with: ./gradlew macosArm64BenchmarkBenchmark -Pbenchmark.filter=Hex
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(BenchmarkTimeUnit.SECONDS)
+open class HexBenchmark {
+    private val size64k = 64 * 1024
+    private val hexSize = size64k * 2
+
+    private lateinit var raw: PlatformBuffer
+    private lateinit var hex: PlatformBuffer
+    private lateinit var encodeDest: PlatformBuffer
+    private lateinit var decodeDest: PlatformBuffer
+
+    @Setup
+    fun setup() {
+        raw = BufferFactory.Default.allocate(size64k)
+        encodeDest = BufferFactory.Default.allocate(hexSize)
+        decodeDest = BufferFactory.Default.allocate(size64k)
+        for (i in 0 until size64k) {
+            raw.writeByte(i.toByte())
+        }
+        raw.resetForRead()
+
+        // Pre-encode a hex blob to feed the decode benchmarks.
+        hex = BufferFactory.Default.allocate(hexSize)
+        raw.encodeHexInto(hex)
+        hex.resetForRead()
+        raw.resetForRead()
+    }
+
+    // ========================================================================= encode
+
+    @Benchmark
+    fun encodePrimitive(): Int {
+        raw.position(0)
+        raw.setLimit(size64k)
+        encodeDest.resetForWrite()
+        raw.encodeHexInto(encodeDest)
+        return encodeDest.get(0).toInt()
+    }
+
+    @Benchmark
+    fun encodeBaseline(): Int {
+        encodeDest.resetForWrite()
+        var i = 0
+        while (i < size64k) {
+            val b = raw.get(i).toInt() and 0xFF
+            encodeDest.writeByte(nibble(b ushr 4))
+            encodeDest.writeByte(nibble(b and 0x0F))
+            i++
+        }
+        return encodeDest.get(0).toInt()
+    }
+
+    // ========================================================================= decode
+
+    @Benchmark
+    fun decodePrimitive(): Int {
+        hex.position(0)
+        hex.setLimit(hexSize)
+        decodeDest.resetForWrite()
+        hex.decodeHexInto(decodeDest)
+        return decodeDest.get(0).toInt()
+    }
+
+    @Benchmark
+    fun decodeBaseline(): Int {
+        decodeDest.resetForWrite()
+        var i = 0
+        while (i < hexSize) {
+            val hi = hexVal(hex.get(i).toInt() and 0xFF)
+            val lo = hexVal(hex.get(i + 1).toInt() and 0xFF)
+            decodeDest.writeByte(((hi shl 4) or lo).toByte())
+            i += 2
+        }
+        return decodeDest.get(0).toInt()
+    }
+
+    private fun nibble(n: Int): Byte = (if (n < 10) n + 0x30 else n - 10 + 0x61).toByte()
+
+    private fun hexVal(c: Int): Int =
+        when (c) {
+            in 0x30..0x39 -> c - 0x30
+            in 0x61..0x66 -> c - 0x61 + 10
+            in 0x41..0x46 -> c - 0x41 + 10
+            else -> 0
+        }
+}

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/Base64Codec.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/Base64Codec.kt
@@ -1,0 +1,175 @@
+package com.ditchoom.buffer
+
+// Zero-copy (buffer-to-buffer, no intermediate ByteArray/String) Base64 encode/decode, RFC 4648.
+//
+// Like hex (see HexCodec.kt), encoding expands the data (3 bytes -> 4 ASCII chars) so it cannot be done
+// in place; "zero-copy" means the bytes flow straight from one buffer into another with no String /
+// ByteArray staging. The common code here is the portable fallback (check the source range once, then
+// loop over the unchecked source accessor); native NativeMemoryAccess buffers override the members to
+// run the whole transform in C (buf_base64_encode / buf_base64_decode), the same shape as hashRange/hex.
+//
+// Both the standard ('+' '/') and URL-safe ('-' '_') alphabets are supported. Decode is lenient: it
+// accepts either alphabet and tolerates missing padding, so it round-trips any encoder variant.
+
+internal const val BASE64_STD_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+internal const val BASE64_URL_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+private const val BASE64_PAD = '='.code
+
+/**
+ * Maps one ASCII Base64 character to its 0..63 sextet value, or -1 if it is not a Base64 digit.
+ * Accepts both the standard ('+', '/') and URL-safe ('-', '_') alphabets. Table-free (branch arithmetic).
+ */
+internal fun base64DecodeChar(c: Int): Int =
+    when (c) {
+        in 'A'.code..'Z'.code -> c - 'A'.code
+        in 'a'.code..'z'.code -> c - 'a'.code + 26
+        in '0'.code..'9'.code -> c - '0'.code + 52
+        '+'.code, '-'.code -> 62
+        '/'.code, '_'.code -> 63
+        else -> -1
+    }
+
+/**
+ * Number of ASCII characters [encodeBase64Into] produces for [byteCount] input bytes.
+ * Padded output is always a multiple of 4; unpadded output drops the trailing '=' fillers.
+ */
+fun base64EncodedLength(
+    byteCount: Int,
+    padded: Boolean = true,
+): Int {
+    if (padded) return (byteCount + 2) / 3 * 4
+    val rem = byteCount % 3
+    return byteCount / 3 * 4 + if (rem == 0) 0 else rem + 1
+}
+
+/**
+ * Worst-case number of bytes [decodeBase64Into] can produce for [charCount] input characters — i.e.
+ * assuming no padding. Use it to size the destination buffer; the actual count may be smaller when the
+ * input carries '=' padding. Every 4 chars decode to 3 bytes.
+ */
+fun base64DecodedMaxLength(charCount: Int): Int =
+    charCount / 4 * 3 +
+        when (charCount % 4) {
+            2 -> 1
+            3 -> 2
+            else -> 0
+        }
+
+/**
+ * Portable encode fallback: reads `length` source bytes via [getByte] and emits Base64 ASCII via
+ * [putByte]. The caller has already range-checked the source.
+ */
+internal inline fun encodeBase64Fallback(
+    srcOffset: Int,
+    length: Int,
+    urlSafe: Boolean,
+    padded: Boolean,
+    getByte: (Int) -> Byte,
+    putByte: (Byte) -> Unit,
+) {
+    val alphabet = if (urlSafe) BASE64_URL_ALPHABET else BASE64_STD_ALPHABET
+    val fullEnd = srcOffset + length / 3 * 3
+    var idx = srcOffset
+    while (idx < fullEnd) {
+        val b0 = getByte(idx).toInt() and 0xFF
+        val b1 = getByte(idx + 1).toInt() and 0xFF
+        val b2 = getByte(idx + 2).toInt() and 0xFF
+        putByte(alphabet[b0 ushr 2].code.toByte())
+        putByte(alphabet[((b0 and 0x03) shl 4) or (b1 ushr 4)].code.toByte())
+        putByte(alphabet[((b1 and 0x0F) shl 2) or (b2 ushr 6)].code.toByte())
+        putByte(alphabet[b2 and 0x3F].code.toByte())
+        idx += 3
+    }
+    when ((srcOffset + length) - fullEnd) {
+        1 -> {
+            val b0 = getByte(fullEnd).toInt() and 0xFF
+            putByte(alphabet[b0 ushr 2].code.toByte())
+            putByte(alphabet[(b0 and 0x03) shl 4].code.toByte())
+            if (padded) {
+                putByte(BASE64_PAD.toByte())
+                putByte(BASE64_PAD.toByte())
+            }
+        }
+        2 -> {
+            val b0 = getByte(fullEnd).toInt() and 0xFF
+            val b1 = getByte(fullEnd + 1).toInt() and 0xFF
+            putByte(alphabet[b0 ushr 2].code.toByte())
+            putByte(alphabet[((b0 and 0x03) shl 4) or (b1 ushr 4)].code.toByte())
+            putByte(alphabet[(b1 and 0x0F) shl 2].code.toByte())
+            if (padded) putByte(BASE64_PAD.toByte())
+        }
+    }
+}
+
+/**
+ * Portable decode fallback: reads `length` Base64 ASCII source bytes via [getByte] and emits the decoded
+ * bytes via [putByte]. Accepts both alphabets; stops at the first '=' padding. The caller has already
+ * range-checked the source.
+ *
+ * @throws IllegalArgumentException if a source byte (before padding) is not a Base64 digit.
+ */
+internal inline fun decodeBase64Fallback(
+    srcOffset: Int,
+    length: Int,
+    getByte: (Int) -> Byte,
+    putByte: (Byte) -> Unit,
+) {
+    var acc = 0
+    var bits = 0
+    var i = 0
+    while (i < length) {
+        val c = getByte(srcOffset + i).toInt() and 0xFF
+        i++
+        if (c == BASE64_PAD) break
+        val v = base64DecodeChar(c)
+        if (v < 0) {
+            throw IllegalArgumentException("invalid base64 character at index ${srcOffset + i - 1}")
+        }
+        acc = (acc shl 6) or v
+        bits += 6
+        if (bits >= 8) {
+            bits -= 8
+            putByte(((acc ushr bits) and 0xFF).toByte())
+        }
+    }
+}
+
+// region public relative convenience
+
+/**
+ * Relative: Base64-encodes this buffer's remaining bytes into [dest], advancing this buffer's [position]
+ * to its [limit] and [dest]'s position by the encoded length.
+ *
+ * @param dest destination buffer that receives the ASCII Base64 bytes
+ * @param urlSafe use the URL-safe alphabet ('-' '_') instead of the standard one ('+' '/')
+ * @param padded append '=' padding so the output length is a multiple of 4
+ */
+fun ReadBuffer.encodeBase64Into(
+    dest: WriteBuffer,
+    urlSafe: Boolean = false,
+    padded: Boolean = true,
+): WriteBuffer {
+    val start = position()
+    val length = remaining()
+    encodeBase64Into(dest, start, length, urlSafe, padded)
+    position(start + length)
+    return dest
+}
+
+/**
+ * Relative: Base64-decodes this buffer's remaining ASCII bytes into [dest], advancing this buffer's
+ * [position] to its [limit] and [dest]'s position by the decoded length.
+ *
+ * Accepts both alphabets and tolerates missing padding.
+ *
+ * @throws IllegalArgumentException if a byte (before padding) is not a Base64 digit.
+ */
+fun ReadBuffer.decodeBase64Into(dest: WriteBuffer): WriteBuffer {
+    val start = position()
+    val length = remaining()
+    decodeBase64Into(dest, start, length)
+    position(start + length)
+    return dest
+}
+
+// endregion

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/Base64Codec.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/Base64Codec.kt
@@ -56,47 +56,52 @@ fun base64DecodedMaxLength(charCount: Int): Int =
         }
 
 /**
- * Portable encode fallback: reads `length` source bytes via [getByte] and emits Base64 ASCII via
- * [putByte]. The caller has already range-checked the source.
+ * Portable encode path: reads `length` source bytes from [this] (via the unchecked accessor) and emits
+ * Base64 ASCII into [dest]. The caller has already range-checked the source.
+ *
+ * Writes each output char with an individual [WriteBuffer.writeByte]. Packing a full group's 4 chars
+ * into a single `writeInt` was measured neutral on the JVM and regressed hex's `writeShort` variant
+ * (`putInt`/`putShort` on a direct ByteBuffer is no cheaper than the byte puts), so the simple per-byte
+ * path stays. The native buffers bypass this via the C path (see NativeBase64.kt); this is the fallback
+ * they share too.
  */
-internal inline fun encodeBase64Fallback(
+internal fun ReadBuffer.encodeBase64Common(
     srcOffset: Int,
     length: Int,
     urlSafe: Boolean,
     padded: Boolean,
-    getByte: (Int) -> Byte,
-    putByte: (Byte) -> Unit,
+    dest: WriteBuffer,
 ) {
     val alphabet = if (urlSafe) BASE64_URL_ALPHABET else BASE64_STD_ALPHABET
     val fullEnd = srcOffset + length / 3 * 3
     var idx = srcOffset
     while (idx < fullEnd) {
-        val b0 = getByte(idx).toInt() and 0xFF
-        val b1 = getByte(idx + 1).toInt() and 0xFF
-        val b2 = getByte(idx + 2).toInt() and 0xFF
-        putByte(alphabet[b0 ushr 2].code.toByte())
-        putByte(alphabet[((b0 and 0x03) shl 4) or (b1 ushr 4)].code.toByte())
-        putByte(alphabet[((b1 and 0x0F) shl 2) or (b2 ushr 6)].code.toByte())
-        putByte(alphabet[b2 and 0x3F].code.toByte())
+        val b0 = getUnchecked(idx).toInt() and 0xFF
+        val b1 = getUnchecked(idx + 1).toInt() and 0xFF
+        val b2 = getUnchecked(idx + 2).toInt() and 0xFF
+        dest.writeByte(alphabet[b0 ushr 2].code.toByte())
+        dest.writeByte(alphabet[((b0 and 0x03) shl 4) or (b1 ushr 4)].code.toByte())
+        dest.writeByte(alphabet[((b1 and 0x0F) shl 2) or (b2 ushr 6)].code.toByte())
+        dest.writeByte(alphabet[b2 and 0x3F].code.toByte())
         idx += 3
     }
     when ((srcOffset + length) - fullEnd) {
         1 -> {
-            val b0 = getByte(fullEnd).toInt() and 0xFF
-            putByte(alphabet[b0 ushr 2].code.toByte())
-            putByte(alphabet[(b0 and 0x03) shl 4].code.toByte())
+            val b0 = getUnchecked(fullEnd).toInt() and 0xFF
+            dest.writeByte(alphabet[b0 ushr 2].code.toByte())
+            dest.writeByte(alphabet[(b0 and 0x03) shl 4].code.toByte())
             if (padded) {
-                putByte(BASE64_PAD.toByte())
-                putByte(BASE64_PAD.toByte())
+                dest.writeByte(BASE64_PAD.toByte())
+                dest.writeByte(BASE64_PAD.toByte())
             }
         }
         2 -> {
-            val b0 = getByte(fullEnd).toInt() and 0xFF
-            val b1 = getByte(fullEnd + 1).toInt() and 0xFF
-            putByte(alphabet[b0 ushr 2].code.toByte())
-            putByte(alphabet[((b0 and 0x03) shl 4) or (b1 ushr 4)].code.toByte())
-            putByte(alphabet[(b1 and 0x0F) shl 2].code.toByte())
-            if (padded) putByte(BASE64_PAD.toByte())
+            val b0 = getUnchecked(fullEnd).toInt() and 0xFF
+            val b1 = getUnchecked(fullEnd + 1).toInt() and 0xFF
+            dest.writeByte(alphabet[b0 ushr 2].code.toByte())
+            dest.writeByte(alphabet[((b0 and 0x03) shl 4) or (b1 ushr 4)].code.toByte())
+            dest.writeByte(alphabet[(b1 and 0x0F) shl 2].code.toByte())
+            if (padded) dest.writeByte(BASE64_PAD.toByte())
         }
     }
 }

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/HexCodec.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/HexCodec.kt
@@ -40,22 +40,27 @@ internal fun hexDecodeNibble(c: Byte): Int {
 }
 
 /**
- * Portable encode fallback: reads `length` source bytes via [getByte] and emits `2 * length` ASCII hex
- * bytes via [putByte] (high nibble first). The caller has already range-checked the source.
+ * Portable encode path: reads `length` source bytes from [this] (via the unchecked accessor) and emits
+ * `2 * length` ASCII hex bytes into [dest] (high nibble first). The caller has already range-checked the
+ * source.
+ *
+ * Writes the two hex chars per source byte with individual [WriteBuffer.writeByte]s. Packing them into
+ * a single `writeShort` was measured ~39% *slower* on the JVM (`putShort` on a direct ByteBuffer costs
+ * more than two `put`s), so the simple per-byte path stays. The native buffers bypass this entirely via
+ * the C path (see NativeHex.kt); this is the fallback they share too.
  */
-internal inline fun encodeHexFallback(
+internal fun ReadBuffer.encodeHexCommon(
     srcOffset: Int,
     length: Int,
     upperCase: Boolean,
-    getByte: (Int) -> Byte,
-    putByte: (Byte) -> Unit,
+    dest: WriteBuffer,
 ) {
     val alphaDelta = if (upperCase) HEX_UPPER_ALPHA_DELTA else HEX_LOWER_ALPHA_DELTA
     var i = 0
     while (i < length) {
-        val b = getByte(srcOffset + i).toInt() and 0xFF
-        putByte(hexEncodeNibble(b ushr 4, alphaDelta))
-        putByte(hexEncodeNibble(b and 0x0F, alphaDelta))
+        val b = getUnchecked(srcOffset + i).toInt() and 0xFF
+        dest.writeByte(hexEncodeNibble(b ushr 4, alphaDelta))
+        dest.writeByte(hexEncodeNibble(b and 0x0F, alphaDelta))
         i++
     }
 }

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/HexCodec.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/HexCodec.kt
@@ -1,0 +1,123 @@
+package com.ditchoom.buffer
+
+// Zero-copy (buffer-to-buffer, no intermediate ByteArray/String) hexadecimal encode/decode.
+//
+// Encoding doubles the data (N bytes -> 2N ASCII hex chars), so it cannot be done in place; "zero-copy"
+// here means the bytes flow directly from one buffer into another with no String / ByteArray staging in
+// between. Both directions are a textbook SIMD target: the common code below is the portable fallback
+// (check the whole range once, then loop over the unchecked source accessor — see getUnchecked), and the
+// native NativeMemoryAccess buffers override the members to run the whole transform in C over raw
+// pointers (buf_hex_encode / buf_hex_decode), the same shape as hashRange.
+//
+// Hex is ASCII, so the output/input chars are single bytes regardless of the buffer's text encoding.
+
+// '0'..'9' map to themselves (+0x30); nibbles 10..15 add 0x27 for lowercase 'a'..'f' or 0x07 for
+// uppercase 'A'..'F'. Branchless: (9 - n) is negative exactly when n > 9, so its arithmetic shift is an
+// all-ones mask there and zero otherwise.
+internal const val HEX_LOWER_ALPHA_DELTA = 0x27
+internal const val HEX_UPPER_ALPHA_DELTA = 0x07
+
+internal fun hexEncodeNibble(
+    nibble: Int,
+    alphaDelta: Int,
+): Byte {
+    val mask = (9 - nibble) shr 31
+    return (0x30 + nibble + (mask and alphaDelta)).toByte()
+}
+
+/**
+ * Maps a single ASCII hex character byte to its 0..15 nibble value, or -1 if it is not a hex digit.
+ * Accepts '0'-'9', 'a'-'f' and 'A'-'F'.
+ */
+internal fun hexDecodeNibble(c: Byte): Int {
+    val v = c.toInt() and 0xFF
+    return when (v) {
+        in '0'.code..'9'.code -> v - '0'.code
+        in 'a'.code..'f'.code -> v - 'a'.code + 10
+        in 'A'.code..'F'.code -> v - 'A'.code + 10
+        else -> -1
+    }
+}
+
+/**
+ * Portable encode fallback: reads `length` source bytes via [getByte] and emits `2 * length` ASCII hex
+ * bytes via [putByte] (high nibble first). The caller has already range-checked the source.
+ */
+internal inline fun encodeHexFallback(
+    srcOffset: Int,
+    length: Int,
+    upperCase: Boolean,
+    getByte: (Int) -> Byte,
+    putByte: (Byte) -> Unit,
+) {
+    val alphaDelta = if (upperCase) HEX_UPPER_ALPHA_DELTA else HEX_LOWER_ALPHA_DELTA
+    var i = 0
+    while (i < length) {
+        val b = getByte(srcOffset + i).toInt() and 0xFF
+        putByte(hexEncodeNibble(b ushr 4, alphaDelta))
+        putByte(hexEncodeNibble(b and 0x0F, alphaDelta))
+        i++
+    }
+}
+
+/**
+ * Portable decode fallback: reads `length` ASCII hex source bytes via [getByte] (length must be even)
+ * and emits `length / 2` decoded bytes via [putByte]. The caller has already range-checked the source.
+ *
+ * @throws IllegalArgumentException if [length] is odd or a source byte is not a hex digit.
+ */
+internal inline fun decodeHexFallback(
+    srcOffset: Int,
+    length: Int,
+    getByte: (Int) -> Byte,
+    putByte: (Byte) -> Unit,
+) {
+    require(length and 1 == 0) { "hex input length ($length) must be even" }
+    var i = 0
+    while (i < length) {
+        val hi = hexDecodeNibble(getByte(srcOffset + i))
+        val lo = hexDecodeNibble(getByte(srcOffset + i + 1))
+        if (hi < 0 || lo < 0) {
+            val badIndex = if (hi < 0) srcOffset + i else srcOffset + i + 1
+            throw IllegalArgumentException("invalid hex character at index $badIndex")
+        }
+        putByte(((hi shl 4) or lo).toByte())
+        i += 2
+    }
+}
+
+// region public relative convenience
+
+/**
+ * Relative: hex-encodes this buffer's remaining bytes (`position()` until `limit()`) into [dest],
+ * advancing this buffer's [position] to its [limit] and [dest]'s position by `2 * remaining()`.
+ *
+ * @param dest destination buffer that receives the ASCII hex bytes
+ * @param upperCase emit 'A'-'F' instead of 'a'-'f'
+ */
+fun ReadBuffer.encodeHexInto(
+    dest: WriteBuffer,
+    upperCase: Boolean = false,
+): WriteBuffer {
+    val start = position()
+    val length = remaining()
+    encodeHexInto(dest, start, length, upperCase)
+    position(start + length)
+    return dest
+}
+
+/**
+ * Relative: hex-decodes this buffer's remaining ASCII hex bytes (must be an even count) into [dest],
+ * advancing this buffer's [position] to its [limit] and [dest]'s position by `remaining() / 2`.
+ *
+ * @throws IllegalArgumentException if the remaining count is odd or a byte is not a hex digit.
+ */
+fun ReadBuffer.decodeHexInto(dest: WriteBuffer): WriteBuffer {
+    val start = position()
+    val length = remaining()
+    decodeHexInto(dest, start, length)
+    position(start + length)
+    return dest
+}
+
+// endregion

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/ReadBuffer.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/ReadBuffer.kt
@@ -621,6 +621,52 @@ interface ReadBuffer : PositionBuffer {
     }
 
     /**
+     * Hex-encodes the absolute source range `[offset, offset + length)` into [dest], writing
+     * `2 * length` ASCII hex bytes (high nibble first) at [dest]'s current position and advancing it.
+     * Does not change this buffer's [position].
+     *
+     * "Zero-copy": the bytes flow straight from this buffer into [dest] with no intermediate
+     * `String`/`ByteArray`. Native backends override this to run the whole transform in C over raw
+     * pointers when [dest] is also native memory (see `buf_hex_encode`).
+     *
+     * @param dest destination buffer that receives the ASCII hex bytes
+     * @param offset absolute index of the first source byte
+     * @param length number of source bytes to encode
+     * @param upperCase emit 'A'-'F' instead of 'a'-'f'
+     */
+    fun encodeHexInto(
+        dest: WriteBuffer,
+        offset: Int,
+        length: Int,
+        upperCase: Boolean = false,
+    ) {
+        requireRange(offset, length)
+        encodeHexFallback(offset, length, upperCase, { getUnchecked(it) }, { dest.writeByte(it) })
+    }
+
+    /**
+     * Hex-decodes the absolute source range `[offset, offset + length)` (an even count of ASCII hex
+     * bytes) into [dest], writing `length / 2` decoded bytes at [dest]'s current position and advancing
+     * it. Does not change this buffer's [position].
+     *
+     * Native backends override this to run the whole transform in C over raw pointers when [dest] is
+     * also native memory (see `buf_hex_decode`).
+     *
+     * @param dest destination buffer that receives the decoded bytes
+     * @param offset absolute index of the first source hex byte
+     * @param length number of source hex bytes (must be even)
+     * @throws IllegalArgumentException if [length] is odd or a source byte is not a hex digit.
+     */
+    fun decodeHexInto(
+        dest: WriteBuffer,
+        offset: Int,
+        length: Int,
+    ) {
+        requireRange(offset, length)
+        decodeHexFallback(offset, length, { getUnchecked(it) }, { dest.writeByte(it) })
+    }
+
+    /**
      * Finds the first occurrence of a byte sequence within this buffer.
      *
      * Uses optimized bulk search (8 bytes at a time) for the first byte,

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/ReadBuffer.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/ReadBuffer.kt
@@ -641,7 +641,7 @@ interface ReadBuffer : PositionBuffer {
         upperCase: Boolean = false,
     ) {
         requireRange(offset, length)
-        encodeHexFallback(offset, length, upperCase, { getUnchecked(it) }, { dest.writeByte(it) })
+        encodeHexCommon(offset, length, upperCase, dest)
     }
 
     /**
@@ -688,7 +688,7 @@ interface ReadBuffer : PositionBuffer {
         padded: Boolean = true,
     ) {
         requireRange(offset, length)
-        encodeBase64Fallback(offset, length, urlSafe, padded, { getUnchecked(it) }, { dest.writeByte(it) })
+        encodeBase64Common(offset, length, urlSafe, padded, dest)
     }
 
     /**

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/ReadBuffer.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/ReadBuffer.kt
@@ -667,6 +667,53 @@ interface ReadBuffer : PositionBuffer {
     }
 
     /**
+     * Base64-encodes the absolute source range `[offset, offset + length)` (RFC 4648) into [dest] at
+     * [dest]'s current position, advancing it by the encoded length. Does not change this buffer's
+     * [position].
+     *
+     * Native backends override this to run the whole transform in C over raw pointers when [dest] is
+     * also native memory (see `buf_base64_encode`).
+     *
+     * @param dest destination buffer that receives the ASCII Base64 bytes
+     * @param offset absolute index of the first source byte
+     * @param length number of source bytes to encode
+     * @param urlSafe use the URL-safe alphabet ('-' '_') instead of the standard one ('+' '/')
+     * @param padded append '=' padding so the output length is a multiple of 4
+     */
+    fun encodeBase64Into(
+        dest: WriteBuffer,
+        offset: Int,
+        length: Int,
+        urlSafe: Boolean = false,
+        padded: Boolean = true,
+    ) {
+        requireRange(offset, length)
+        encodeBase64Fallback(offset, length, urlSafe, padded, { getUnchecked(it) }, { dest.writeByte(it) })
+    }
+
+    /**
+     * Base64-decodes the absolute source range `[offset, offset + length)` into [dest] at [dest]'s
+     * current position, advancing it by the decoded length. Accepts both the standard and URL-safe
+     * alphabets and tolerates missing padding. Does not change this buffer's [position].
+     *
+     * Native backends override this to run the whole transform in C over raw pointers when [dest] is
+     * also native memory (see `buf_base64_decode`).
+     *
+     * @param dest destination buffer that receives the decoded bytes
+     * @param offset absolute index of the first source Base64 byte
+     * @param length number of source Base64 bytes
+     * @throws IllegalArgumentException if a source byte (before padding) is not a Base64 digit.
+     */
+    fun decodeBase64Into(
+        dest: WriteBuffer,
+        offset: Int,
+        length: Int,
+    ) {
+        requireRange(offset, length)
+        decodeBase64Fallback(offset, length, { getUnchecked(it) }, { dest.writeByte(it) })
+    }
+
+    /**
      * Finds the first occurrence of a byte sequence within this buffer.
      *
      * Uses optimized bulk search (8 bytes at a time) for the first byte,

--- a/buffer/src/commonTest/kotlin/com/ditchoom/buffer/Base64CodecTest.kt
+++ b/buffer/src/commonTest/kotlin/com/ditchoom/buffer/Base64CodecTest.kt
@@ -186,6 +186,17 @@ class Base64CodecTest {
     }
 
     @Test
+    fun encodesIntoLittleEndianDestination() {
+        // Base64 output is an ASCII byte sequence, so it must be identical regardless of the
+        // destination's byte order (default buffers are big-endian; this pins the little-endian case).
+        val src = textBuffer("foobar!")
+        val dest = BufferFactory.Default.allocate(12, ByteOrder.LITTLE_ENDIAN)
+        src.encodeBase64Into(dest)
+        dest.resetForRead()
+        assertEquals("Zm9vYmFyIQ==", dest.readString(12))
+    }
+
+    @Test
     fun roundTripsThroughPooledBufferWrappers() {
         BufferPool().let { pool ->
             val src = pool.acquire(8)

--- a/buffer/src/commonTest/kotlin/com/ditchoom/buffer/Base64CodecTest.kt
+++ b/buffer/src/commonTest/kotlin/com/ditchoom/buffer/Base64CodecTest.kt
@@ -1,0 +1,214 @@
+package com.ditchoom.buffer
+
+import com.ditchoom.buffer.pool.BufferPool
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Tests for the buffer-to-buffer Base64 encode/decode primitives (encodeBase64Into / decodeBase64Into)
+ * on [ReadBuffer]. Covers RFC 4648 vectors, standard vs URL-safe, padded vs unpadded, round-trips,
+ * position semantics, error handling, and pool-wrapper transparency.
+ */
+class Base64CodecTest {
+    private fun bytesBuffer(values: List<Int>): PlatformBuffer {
+        val b = BufferFactory.Default.allocate(maxOf(values.size, 1))
+        for (v in values) b.writeByte(v.toByte())
+        b.resetForRead()
+        return b
+    }
+
+    private fun textBuffer(text: String): PlatformBuffer {
+        val b = BufferFactory.Default.allocate(maxOf(text.length, 1))
+        b.writeString(text)
+        b.resetForRead()
+        return b
+    }
+
+    private fun encodeToString(
+        text: String,
+        urlSafe: Boolean = false,
+        padded: Boolean = true,
+    ): String {
+        val src = textBuffer(text)
+        val n = base64EncodedLength(src.remaining(), padded)
+        val dest = BufferFactory.Default.allocate(maxOf(n, 1))
+        src.encodeBase64Into(dest, urlSafe = urlSafe, padded = padded)
+        dest.resetForRead()
+        return dest.readString(n)
+    }
+
+    // region RFC 4648 §10 known vectors
+
+    @Test
+    fun encodesRfc4648Vectors() {
+        assertEquals("", encodeToString(""))
+        assertEquals("Zg==", encodeToString("f"))
+        assertEquals("Zm8=", encodeToString("fo"))
+        assertEquals("Zm9v", encodeToString("foo"))
+        assertEquals("Zm9vYg==", encodeToString("foob"))
+        assertEquals("Zm9vYmE=", encodeToString("fooba"))
+        assertEquals("Zm9vYmFy", encodeToString("foobar"))
+    }
+
+    @Test
+    fun encodesUnpadded() {
+        assertEquals("Zg", encodeToString("f", padded = false))
+        assertEquals("Zm8", encodeToString("fo", padded = false))
+        assertEquals("Zm9v", encodeToString("foo", padded = false))
+    }
+
+    @Test
+    fun encodesUrlSafeAlphabet() {
+        // 0xFB 0xFF 0xBF -> standard "+/+/"-ish; pick bytes that exercise '+' and '/'.
+        val src = bytesBuffer(listOf(0xFB, 0xFF, 0xBF))
+        val std = BufferFactory.Default.allocate(4)
+        src.encodeBase64Into(std)
+        std.resetForRead()
+        src.resetForRead()
+        val url = BufferFactory.Default.allocate(4)
+        src.encodeBase64Into(url, urlSafe = true)
+        url.resetForRead()
+
+        val stdStr = std.readString(4)
+        val urlStr = url.readString(4)
+        assertTrue(stdStr.contains('+') || stdStr.contains('/'), "expected +// in $stdStr")
+        assertEquals(stdStr.replace('+', '-').replace('/', '_'), urlStr)
+    }
+
+    // endregion
+
+    // region decode
+
+    @Test
+    fun decodesRfc4648Vectors() {
+        assertEquals("f", decodeToString("Zg=="))
+        assertEquals("fo", decodeToString("Zm8="))
+        assertEquals("foo", decodeToString("Zm9v"))
+        assertEquals("foobar", decodeToString("Zm9vYmFy"))
+    }
+
+    @Test
+    fun decodesUnpaddedAndUrlSafe() {
+        assertEquals("foob", decodeToString("Zm9vYg"))
+        // URL-safe input with the chars that differ from standard.
+        val urlInput = encodeToString2(listOf(0xFB, 0xFF, 0xBF), urlSafe = true)
+        val decoded = decodeBytes(urlInput)
+        assertEquals(listOf(0xFB, 0xFF, 0xBF), decoded)
+    }
+
+    @Test
+    fun invalidCharDecodeThrows() {
+        val src = textBuffer("Zm9v*===")
+        val dest = BufferFactory.Default.allocate(8)
+        assertFailsWith<IllegalArgumentException> { src.decodeBase64Into(dest) }
+    }
+
+    private fun decodeToString(b64: String): String {
+        val src = textBuffer(b64)
+        val dest = BufferFactory.Default.allocate(base64DecodedMaxLength(b64.length).coerceAtLeast(1))
+        src.decodeBase64Into(dest)
+        val produced = dest.position()
+        dest.resetForRead()
+        return dest.readString(produced)
+    }
+
+    private fun decodeBytes(b64: String): List<Int> {
+        val src = textBuffer(b64)
+        val dest = BufferFactory.Default.allocate(base64DecodedMaxLength(b64.length).coerceAtLeast(1))
+        src.decodeBase64Into(dest)
+        val produced = dest.position()
+        dest.resetForRead()
+        return (0 until produced).map { dest.readByte().toInt() and 0xFF }
+    }
+
+    private fun encodeToString2(
+        values: List<Int>,
+        urlSafe: Boolean,
+    ): String {
+        val src = bytesBuffer(values)
+        val n = base64EncodedLength(src.remaining())
+        val dest = BufferFactory.Default.allocate(n)
+        src.encodeBase64Into(dest, urlSafe = urlSafe)
+        dest.resetForRead()
+        return dest.readString(n)
+    }
+
+    // endregion
+
+    // region round-trip
+
+    @Test
+    fun roundTripsAllByteValues() {
+        val src = bytesBuffer((0..255).toList())
+        val n = base64EncodedLength(256)
+        val b64 = BufferFactory.Default.allocate(n)
+        src.encodeBase64Into(b64)
+        b64.resetForRead()
+
+        val decoded = BufferFactory.Default.allocate(256)
+        b64.decodeBase64Into(decoded)
+        decoded.resetForRead()
+        src.resetForRead()
+        assertTrue(src.contentEquals(decoded))
+    }
+
+    @Test
+    fun roundTripsUnpaddedUrlSafeWithManagedDestination() {
+        // Exercises native override fallback (native source -> managed dest), URL-safe + no padding.
+        val original = textBuffer("Many hands make light work. 1234567890")
+        val size = original.remaining()
+        val n = base64EncodedLength(size, padded = false)
+        val b64 = BufferFactory.managed().allocate(n)
+        original.encodeBase64Into(b64, urlSafe = true, padded = false)
+        b64.resetForRead()
+
+        val decoded = BufferFactory.managed().allocate(size)
+        b64.decodeBase64Into(decoded)
+        decoded.resetForRead()
+        original.resetForRead()
+        assertTrue(original.contentEquals(decoded))
+    }
+
+    // endregion
+
+    // region position semantics + wrappers
+
+    @Test
+    fun absoluteEncodeDoesNotChangeSourcePosition() {
+        val src = textBuffer("foobar")
+        val dest = BufferFactory.Default.allocate(4)
+        src.encodeBase64Into(dest, offset = 3, length = 3) // "bar"
+        dest.resetForRead()
+        assertEquals("YmFy", dest.readString(4))
+        assertEquals(0, src.position())
+    }
+
+    @Test
+    fun roundTripsThroughPooledBufferWrappers() {
+        BufferPool().let { pool ->
+            val src = pool.acquire(8)
+            src.writeString("foobar")
+            src.resetForRead()
+
+            val b64 = pool.acquire(8)
+            src.encodeBase64Into(b64)
+            b64.resetForRead()
+            assertEquals("Zm9vYmFy", b64.readString(8))
+            b64.resetForRead()
+
+            val decoded = pool.acquire(8)
+            b64.decodeBase64Into(decoded)
+            decoded.resetForRead()
+            assertEquals("foobar", decoded.readString(6))
+
+            pool.release(src)
+            pool.release(b64)
+            pool.release(decoded)
+            pool.clear()
+        }
+    }
+
+    // endregion
+}

--- a/buffer/src/commonTest/kotlin/com/ditchoom/buffer/HexCodecTest.kt
+++ b/buffer/src/commonTest/kotlin/com/ditchoom/buffer/HexCodecTest.kt
@@ -65,6 +65,17 @@ class HexCodecTest {
     }
 
     @Test
+    fun encodesIntoLittleEndianDestination() {
+        // Hex output is an ASCII byte sequence, so it must be identical regardless of the destination's
+        // byte order (default buffers are big-endian; this pins the little-endian case too).
+        val src = bytesBuffer(listOf(0xDE, 0xAD, 0xBE, 0xEF))
+        val dest = BufferFactory.Default.allocate(8, ByteOrder.LITTLE_ENDIAN)
+        src.encodeHexInto(dest)
+        dest.resetForRead()
+        assertEquals("deadbeef", dest.readString(8))
+    }
+
+    @Test
     fun relativeEncodeAdvancesSourceToLimit() {
         val src = bytesBuffer(listOf(0x01, 0x02))
         val dest = BufferFactory.Default.allocate(4)

--- a/buffer/src/commonTest/kotlin/com/ditchoom/buffer/HexCodecTest.kt
+++ b/buffer/src/commonTest/kotlin/com/ditchoom/buffer/HexCodecTest.kt
@@ -1,0 +1,205 @@
+package com.ditchoom.buffer
+
+import com.ditchoom.buffer.pool.BufferPool
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Tests for the buffer-to-buffer hex encode/decode primitives (encodeHexInto / decodeHexInto) on
+ * [ReadBuffer]. Covers known vectors, round-trips, case, position semantics, error handling, and
+ * transparency through pool wrappers.
+ */
+class HexCodecTest {
+    private fun bytesBuffer(values: List<Int>): PlatformBuffer {
+        val b = BufferFactory.Default.allocate(maxOf(values.size, 1))
+        for (v in values) b.writeByte(v.toByte())
+        b.resetForRead()
+        return b
+    }
+
+    private fun textBuffer(text: String): PlatformBuffer {
+        val b = BufferFactory.Default.allocate(maxOf(text.length, 1))
+        b.writeString(text)
+        b.resetForRead()
+        return b
+    }
+
+    // region encode
+
+    @Test
+    fun encodesKnownVectorLowercase() {
+        val src = bytesBuffer(listOf(0x00, 0x0F, 0xF0, 0xFF, 0x12, 0xAB))
+        val dest = BufferFactory.Default.allocate(12)
+        src.encodeHexInto(dest)
+        dest.resetForRead()
+        assertEquals("000ff0ff12ab", dest.readString(12))
+    }
+
+    @Test
+    fun encodesUppercase() {
+        val src = bytesBuffer(listOf(0xDE, 0xAD, 0xBE, 0xEF))
+        val dest = BufferFactory.Default.allocate(8)
+        src.encodeHexInto(dest, upperCase = true)
+        dest.resetForRead()
+        assertEquals("DEADBEEF", dest.readString(8))
+    }
+
+    @Test
+    fun encodeEmptyWritesNothing() {
+        val src = bytesBuffer(emptyList())
+        val dest = BufferFactory.Default.allocate(4)
+        src.encodeHexInto(dest)
+        assertEquals(0, dest.position())
+    }
+
+    @Test
+    fun absoluteEncodeDoesNotChangeSourcePosition() {
+        val src = bytesBuffer(listOf(0x12, 0x34, 0x56))
+        val dest = BufferFactory.Default.allocate(4)
+        src.encodeHexInto(dest, offset = 1, length = 2)
+        dest.resetForRead()
+        assertEquals("3456", dest.readString(4))
+        assertEquals(0, src.position())
+    }
+
+    @Test
+    fun relativeEncodeAdvancesSourceToLimit() {
+        val src = bytesBuffer(listOf(0x01, 0x02))
+        val dest = BufferFactory.Default.allocate(4)
+        src.encodeHexInto(dest)
+        assertEquals(src.limit(), src.position())
+        assertEquals(4, dest.position())
+    }
+
+    // endregion
+
+    // region decode
+
+    @Test
+    fun decodesMixedCase() {
+        val src = textBuffer("deADbeEF")
+        val dest = BufferFactory.Default.allocate(4)
+        src.decodeHexInto(dest)
+        dest.resetForRead()
+        assertEquals(0xDE, dest.readByte().toInt() and 0xFF)
+        assertEquals(0xAD, dest.readByte().toInt() and 0xFF)
+        assertEquals(0xBE, dest.readByte().toInt() and 0xFF)
+        assertEquals(0xEF, dest.readByte().toInt() and 0xFF)
+    }
+
+    @Test
+    fun oddLengthDecodeThrows() {
+        val src = textBuffer("abc")
+        val dest = BufferFactory.Default.allocate(2)
+        assertFailsWith<IllegalArgumentException> { src.decodeHexInto(dest) }
+    }
+
+    @Test
+    fun invalidCharDecodeThrows() {
+        val src = textBuffer("12zz")
+        val dest = BufferFactory.Default.allocate(2)
+        assertFailsWith<IllegalArgumentException> { src.decodeHexInto(dest) }
+    }
+
+    // endregion
+
+    // region round-trip
+
+    @Test
+    fun roundTripsArbitraryContent() {
+        val original = textBuffer("The quick brown fox jumps over 13 lazy dogs.")
+        val n = original.remaining()
+
+        val hex = BufferFactory.Default.allocate(n * 2)
+        original.encodeHexInto(hex)
+        hex.resetForRead()
+
+        val decoded = BufferFactory.Default.allocate(n)
+        hex.decodeHexInto(decoded)
+        decoded.resetForRead()
+        original.resetForRead()
+
+        assertTrue(original.contentEquals(decoded), "decode(encode(x)) must equal x")
+    }
+
+    @Test
+    fun roundTripsAllByteValues() {
+        // Exercises every nibble combination and the bulk/tail boundaries (256 bytes).
+        val src = bytesBuffer((0..255).toList())
+        val hex = BufferFactory.Default.allocate(512)
+        src.encodeHexInto(hex)
+        hex.resetForRead()
+
+        val decoded = BufferFactory.Default.allocate(256)
+        hex.decodeHexInto(decoded)
+        decoded.resetForRead()
+        src.resetForRead()
+
+        assertTrue(src.contentEquals(decoded))
+    }
+
+    @Test
+    fun roundTripsWithManagedDestination() {
+        // On native, source is a NativeBuffer but the managed() dest is not NativeMemoryAccess, so this
+        // exercises the native override's portable fallback branch (and the all-managed path elsewhere).
+        val original = textBuffer("zero-copy hex, managed sink")
+        val n = original.remaining()
+
+        val hex = BufferFactory.managed().allocate(n * 2)
+        original.encodeHexInto(hex)
+        hex.resetForRead()
+
+        val decoded = BufferFactory.managed().allocate(n)
+        hex.decodeHexInto(decoded)
+        decoded.resetForRead()
+        original.resetForRead()
+
+        assertTrue(original.contentEquals(decoded))
+    }
+
+    // endregion
+
+    // region wrapper transparency
+
+    @Test
+    fun encodesThroughPooledBufferWrappers() {
+        BufferPool().let { pool ->
+            val src = pool.acquire(4)
+            src.writeByte(0xAB.toByte())
+            src.writeByte(0xCD.toByte())
+            src.resetForRead()
+
+            val dest = pool.acquire(4)
+            src.encodeHexInto(dest)
+            dest.resetForRead()
+            assertEquals("abcd", dest.readString(4))
+
+            pool.release(src)
+            pool.release(dest)
+            pool.clear()
+        }
+    }
+
+    @Test
+    fun decodesThroughPooledBufferWrappers() {
+        BufferPool().let { pool ->
+            val src = pool.acquire(4)
+            src.writeString("00ff")
+            src.resetForRead()
+
+            val dest = pool.acquire(2)
+            src.decodeHexInto(dest)
+            dest.resetForRead()
+            assertEquals(0x00, dest.readByte().toInt() and 0xFF)
+            assertEquals(0xFF, dest.readByte().toInt() and 0xFF)
+
+            pool.release(src)
+            pool.release(dest)
+            pool.clear()
+        }
+    }
+
+    // endregion
+}

--- a/buffer/src/jvmBenchmark/kotlin/com/ditchoom/buffer/benchmark/Base64PlatformComparisonBenchmark.kt
+++ b/buffer/src/jvmBenchmark/kotlin/com/ditchoom/buffer/benchmark/Base64PlatformComparisonBenchmark.kt
@@ -1,0 +1,104 @@
+package com.ditchoom.buffer.benchmark
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.encodeBase64Into
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.BenchmarkMode
+import kotlinx.benchmark.BenchmarkTimeUnit
+import kotlinx.benchmark.Measurement
+import kotlinx.benchmark.Mode
+import kotlinx.benchmark.OutputTimeUnit
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+import kotlinx.benchmark.Warmup
+import java.nio.ByteBuffer
+import java.util.Base64
+
+/**
+ * JVM-only: empirically compares our zero-copy buffer-to-buffer Base64 encode against
+ * java.util.Base64 at a small (handshake-sized) and a large input size.
+ *
+ * The hypothesis under test: java.util.Base64.encode(ByteBuffer) allocates a fresh output
+ * ByteBuffer per call, so for SMALL inputs (the real WebSocket-handshake case, ~16-24 bytes)
+ * that fixed allocation overhead makes the "platform" path slower than our in-place loop, and
+ * the platform only wins on LARGE inputs where SIMD throughput amortizes the allocation.
+ *
+ * Run with: ./gradlew jvmBenchmarkBenchmark -Pbenchmark.filter=Base64PlatformComparison
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(BenchmarkTimeUnit.SECONDS)
+open class Base64PlatformComparisonBenchmark {
+    private val smallSize = 24 // multiple of 3 -> no padding noise; ~handshake key size
+    private val largeSize = 48 * 1024
+
+    private lateinit var smallSrc: PlatformBuffer
+    private lateinit var largeSrc: PlatformBuffer
+    private lateinit var smallDest: PlatformBuffer
+    private lateinit var largeDest: PlatformBuffer
+
+    private lateinit var smallSrcBB: ByteBuffer
+    private lateinit var largeSrcBB: ByteBuffer
+    private val encoder = Base64.getEncoder()
+
+    @Setup
+    fun setup() {
+        smallSrc = BufferFactory.Default.allocate(smallSize)
+        largeSrc = BufferFactory.Default.allocate(largeSize)
+        smallDest = BufferFactory.Default.allocate(smallSize / 3 * 4)
+        largeDest = BufferFactory.Default.allocate(largeSize / 3 * 4)
+        smallSrcBB = ByteBuffer.allocateDirect(smallSize)
+        largeSrcBB = ByteBuffer.allocateDirect(largeSize)
+        for (i in 0 until smallSize) {
+            smallSrc.writeByte(i.toByte())
+            smallSrcBB.put(i.toByte())
+        }
+        for (i in 0 until largeSize) {
+            largeSrc.writeByte(i.toByte())
+            largeSrcBB.put(i.toByte())
+        }
+        smallSrc.resetForRead()
+        largeSrc.resetForRead()
+    }
+
+    // ===== small (handshake-sized) =====
+
+    @Benchmark
+    fun oursSmall(): Int {
+        smallSrc.position(0)
+        smallSrc.setLimit(smallSize)
+        smallDest.resetForWrite()
+        smallSrc.encodeBase64Into(smallDest)
+        return smallDest.get(0).toInt()
+    }
+
+    @Benchmark
+    fun platformSmall(): Int {
+        smallSrcBB.position(0)
+        smallSrcBB.limit(smallSize)
+        return encoder.encode(smallSrcBB).get(0).toInt()
+    }
+
+    // ===== large =====
+
+    @Benchmark
+    fun oursLarge(): Int {
+        largeSrc.position(0)
+        largeSrc.setLimit(largeSize)
+        largeDest.resetForWrite()
+        largeSrc.encodeBase64Into(largeDest)
+        return largeDest.get(0).toInt()
+    }
+
+    @Benchmark
+    fun platformLarge(): Int {
+        largeSrcBB.position(0)
+        largeSrcBB.limit(largeSize)
+        return encoder.encode(largeSrcBB).get(0).toInt()
+    }
+}

--- a/buffer/src/linuxMain/kotlin/com/ditchoom/buffer/NativeBuffer.kt
+++ b/buffer/src/linuxMain/kotlin/com/ditchoom/buffer/NativeBuffer.kt
@@ -234,6 +234,29 @@ class NativeBuffer private constructor(
         )
     }
 
+    // Hex transform in C (raw pointer-to-pointer, shuffle-vectorized) when dest is also native — see
+    // nativeEncodeHexInto / buf_hex_encode; falls back to the portable common path otherwise.
+    override fun encodeHexInto(
+        dest: WriteBuffer,
+        offset: Int,
+        length: Int,
+        upperCase: Boolean,
+    ) {
+        checkOpen()
+        requireIndex(offset, length)
+        nativeEncodeHexInto(baseAddress, dest, offset, length, upperCase)
+    }
+
+    override fun decodeHexInto(
+        dest: WriteBuffer,
+        offset: Int,
+        length: Int,
+    ) {
+        checkOpen()
+        requireIndex(offset, length)
+        nativeDecodeHexInto(baseAddress, dest, offset, length)
+    }
+
     override fun readByteArray(size: Int): ByteArray {
         checkOpen()
         if (size < 1) return ByteArray(0)
@@ -808,6 +831,28 @@ private class NativeBufferSlice(
             length,
             bigEndian = !littleEndian,
         )
+    }
+
+    // Hex transform in C — see nativeEncodeHexInto and the matching override on NativeBuffer.
+    override fun encodeHexInto(
+        dest: WriteBuffer,
+        offset: Int,
+        length: Int,
+        upperCase: Boolean,
+    ) {
+        checkOpen()
+        requireIndex(offset, length)
+        nativeEncodeHexInto(baseAddress, dest, offset, length, upperCase)
+    }
+
+    override fun decodeHexInto(
+        dest: WriteBuffer,
+        offset: Int,
+        length: Int,
+    ) {
+        checkOpen()
+        requireIndex(offset, length)
+        nativeDecodeHexInto(baseAddress, dest, offset, length)
     }
 
     override fun readByteArray(size: Int): ByteArray {

--- a/buffer/src/linuxMain/kotlin/com/ditchoom/buffer/NativeBuffer.kt
+++ b/buffer/src/linuxMain/kotlin/com/ditchoom/buffer/NativeBuffer.kt
@@ -257,6 +257,30 @@ class NativeBuffer private constructor(
         nativeDecodeHexInto(baseAddress, dest, offset, length)
     }
 
+    // Base64 transform in C when dest is also native — see nativeEncodeBase64Into / buf_base64_encode;
+    // falls back to the portable common path otherwise.
+    override fun encodeBase64Into(
+        dest: WriteBuffer,
+        offset: Int,
+        length: Int,
+        urlSafe: Boolean,
+        padded: Boolean,
+    ) {
+        checkOpen()
+        requireIndex(offset, length)
+        nativeEncodeBase64Into(baseAddress, dest, offset, length, urlSafe, padded)
+    }
+
+    override fun decodeBase64Into(
+        dest: WriteBuffer,
+        offset: Int,
+        length: Int,
+    ) {
+        checkOpen()
+        requireIndex(offset, length)
+        nativeDecodeBase64Into(baseAddress, dest, offset, length)
+    }
+
     override fun readByteArray(size: Int): ByteArray {
         checkOpen()
         if (size < 1) return ByteArray(0)
@@ -853,6 +877,30 @@ private class NativeBufferSlice(
         checkOpen()
         requireIndex(offset, length)
         nativeDecodeHexInto(baseAddress, dest, offset, length)
+    }
+
+    // Base64 transform in C when dest is also native — see nativeEncodeBase64Into / buf_base64_encode;
+    // falls back to the portable common path otherwise.
+    override fun encodeBase64Into(
+        dest: WriteBuffer,
+        offset: Int,
+        length: Int,
+        urlSafe: Boolean,
+        padded: Boolean,
+    ) {
+        checkOpen()
+        requireIndex(offset, length)
+        nativeEncodeBase64Into(baseAddress, dest, offset, length, urlSafe, padded)
+    }
+
+    override fun decodeBase64Into(
+        dest: WriteBuffer,
+        offset: Int,
+        length: Int,
+    ) {
+        checkOpen()
+        requireIndex(offset, length)
+        nativeDecodeBase64Into(baseAddress, dest, offset, length)
     }
 
     override fun readByteArray(size: Int): ByteArray {

--- a/buffer/src/nativeInterop/cinterop/simd.def
+++ b/buffer/src/nativeInterop/cinterop/simd.def
@@ -193,6 +193,73 @@ long buf_hex_decode(const uint8_t* src, uint8_t* dst, size_t length) {
 }
 
 /**
+ * Base64-encode `length` source bytes (RFC 4648) into ASCII. `url_safe` (non-zero) selects the '-'/'_'
+ * alphabet; `padded` (non-zero) appends '=' fillers. The destination must hold the length returned by
+ * the Kotlin base64EncodedLength(length, padded). Clang at -O2 vectorizes the 3-byte -> 4-char loop.
+ */
+void buf_base64_encode(const uint8_t* src, uint8_t* dst, size_t length, int url_safe, int padded) {
+    static const char std_tbl[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    static const char url_tbl[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    const char* tbl = url_safe ? url_tbl : std_tbl;
+    size_t full = length - (length % 3);
+    size_t i = 0, o = 0;
+    for (; i < full; i += 3) {
+        uint32_t n = ((uint32_t)src[i] << 16) | ((uint32_t)src[i + 1] << 8) | (uint32_t)src[i + 2];
+        dst[o++] = (uint8_t)tbl[(n >> 18) & 0x3F];
+        dst[o++] = (uint8_t)tbl[(n >> 12) & 0x3F];
+        dst[o++] = (uint8_t)tbl[(n >> 6) & 0x3F];
+        dst[o++] = (uint8_t)tbl[n & 0x3F];
+    }
+    size_t rem = length - full;
+    if (rem == 1) {
+        uint32_t n = (uint32_t)src[i] << 16;
+        dst[o++] = (uint8_t)tbl[(n >> 18) & 0x3F];
+        dst[o++] = (uint8_t)tbl[(n >> 12) & 0x3F];
+        if (padded) { dst[o++] = '='; dst[o++] = '='; }
+    } else if (rem == 2) {
+        uint32_t n = ((uint32_t)src[i] << 16) | ((uint32_t)src[i + 1] << 8);
+        dst[o++] = (uint8_t)tbl[(n >> 18) & 0x3F];
+        dst[o++] = (uint8_t)tbl[(n >> 12) & 0x3F];
+        dst[o++] = (uint8_t)tbl[(n >> 6) & 0x3F];
+        if (padded) dst[o++] = '=';
+    }
+}
+
+/** Map one ASCII Base64 character to its 0-63 sextet (both alphabets), or -1 if not a Base64 digit. */
+static inline int buf_base64_val(uint8_t c) {
+    if (c >= 'A' && c <= 'Z') return c - 'A';
+    if (c >= 'a' && c <= 'z') return c - 'a' + 26;
+    if (c >= '0' && c <= '9') return c - '0' + 52;
+    if (c == '+' || c == '-') return 62;
+    if (c == '/' || c == '_') return 63;
+    return -1;
+}
+
+/**
+ * Base64-decode `length` ASCII bytes (both alphabets, padding optional). Returns the number of decoded
+ * bytes written to `dst` on success, or `-(index) - 1` if the byte at `index` (before any '=' padding)
+ * is not a Base64 digit. Decoding stops at the first '=' padding byte.
+ */
+long buf_base64_decode(const uint8_t* src, uint8_t* dst, size_t length) {
+    uint32_t acc = 0;
+    int bits = 0;
+    size_t o = 0;
+    for (size_t i = 0; i < length; i++) {
+        uint8_t c = src[i];
+        if (c == '=') break;
+        int v = buf_base64_val(c);
+        if (v < 0) return -((long)i) - 1;
+        acc = (acc << 6) | (uint32_t)v;
+        bits += 6;
+        if (bits >= 8) {
+            bits -= 8;
+            dst[o++] = (uint8_t)((acc >> bits) & 0xFF);
+        }
+    }
+    return (long)o;
+}
+
+/**
  * Find first mismatch between two buffers.
  * Returns index of first differing byte, or -1 if buffers are equal.
  * Clang auto-vectorizes the comparison loop.

--- a/buffer/src/nativeInterop/cinterop/simd.def
+++ b/buffer/src/nativeInterop/cinterop/simd.def
@@ -181,15 +181,15 @@ static inline int buf_hex_val(uint8_t c) {
  * Returns -1 on success, or the index of the first byte that is not a hex digit (decoding stops there;
  * bytes decoded before the bad character have already been written to `dst`).
  */
-long buf_hex_decode(const uint8_t* src, uint8_t* dst, size_t length) {
+int64_t buf_hex_decode(const uint8_t* src, uint8_t* dst, size_t length) {
     for (size_t i = 0; i < length; i += 2) {
         int hi = buf_hex_val(src[i]);
-        if (hi < 0) return (long)i;
+        if (hi < 0) return (int64_t)i;
         int lo = buf_hex_val(src[i + 1]);
-        if (lo < 0) return (long)(i + 1);
+        if (lo < 0) return (int64_t)(i + 1);
         dst[i / 2] = (uint8_t)((hi << 4) | lo);
     }
-    return -1L;
+    return -1;
 }
 
 /**
@@ -240,7 +240,7 @@ static inline int buf_base64_val(uint8_t c) {
  * bytes written to `dst` on success, or `-(index) - 1` if the byte at `index` (before any '=' padding)
  * is not a Base64 digit. Decoding stops at the first '=' padding byte.
  */
-long buf_base64_decode(const uint8_t* src, uint8_t* dst, size_t length) {
+int64_t buf_base64_decode(const uint8_t* src, uint8_t* dst, size_t length) {
     uint32_t acc = 0;
     int bits = 0;
     size_t o = 0;
@@ -248,7 +248,7 @@ long buf_base64_decode(const uint8_t* src, uint8_t* dst, size_t length) {
         uint8_t c = src[i];
         if (c == '=') break;
         int v = buf_base64_val(c);
-        if (v < 0) return -((long)i) - 1;
+        if (v < 0) return -((int64_t)i) - 1;
         acc = (acc << 6) | (uint32_t)v;
         bits += 6;
         if (bits >= 8) {
@@ -256,7 +256,7 @@ long buf_base64_decode(const uint8_t* src, uint8_t* dst, size_t length) {
             dst[o++] = (uint8_t)((acc >> bits) & 0xFF);
         }
     }
-    return (long)o;
+    return (int64_t)o;
 }
 
 /**

--- a/buffer/src/nativeInterop/cinterop/simd.def
+++ b/buffer/src/nativeInterop/cinterop/simd.def
@@ -153,6 +153,46 @@ int64_t buf_fnv1a_64(const uint8_t* data, size_t length, int big_endian) {
 }
 
 /**
+ * Hex-encode `length` source bytes into `2 * length` ASCII bytes (high nibble first).
+ * `upper` selects 'A'-'F' (non-zero) vs 'a'-'f' (zero). Each nibble indexes a 16-byte digit
+ * table; Clang at -O2 lowers the table lookup to a NEON/SSE shuffle (TBL / PSHUFB).
+ */
+void buf_hex_encode(const uint8_t* src, uint8_t* dst, size_t length, int upper) {
+    static const char lower[16] = {'0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f'};
+    static const char upper_tbl[16] = {'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F'};
+    const char* digits = upper ? upper_tbl : lower;
+    for (size_t i = 0; i < length; i++) {
+        uint8_t b = src[i];
+        dst[i * 2]     = (uint8_t)digits[b >> 4];
+        dst[i * 2 + 1] = (uint8_t)digits[b & 0x0F];
+    }
+}
+
+/** Map one ASCII hex character to its 0-15 nibble value, or -1 if it is not a hex digit. */
+static inline int buf_hex_val(uint8_t c) {
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return -1;
+}
+
+/**
+ * Hex-decode `length` ASCII bytes (caller guarantees `length` is even) into `length / 2` bytes.
+ * Returns -1 on success, or the index of the first byte that is not a hex digit (decoding stops there;
+ * bytes decoded before the bad character have already been written to `dst`).
+ */
+long buf_hex_decode(const uint8_t* src, uint8_t* dst, size_t length) {
+    for (size_t i = 0; i < length; i += 2) {
+        int hi = buf_hex_val(src[i]);
+        if (hi < 0) return (long)i;
+        int lo = buf_hex_val(src[i + 1]);
+        if (lo < 0) return (long)(i + 1);
+        dst[i / 2] = (uint8_t)((hi << 4) | lo);
+    }
+    return -1L;
+}
+
+/**
  * Find first mismatch between two buffers.
  * Returns index of first differing byte, or -1 if buffers are equal.
  * Clang auto-vectorizes the comparison loop.

--- a/buffer/src/nativeMain/kotlin/com/ditchoom/buffer/NativeBase64.kt
+++ b/buffer/src/nativeMain/kotlin/com/ditchoom/buffer/NativeBase64.kt
@@ -1,0 +1,89 @@
+@file:OptIn(ExperimentalForeignApi::class, UnsafeNumber::class)
+
+package com.ditchoom.buffer
+
+import com.ditchoom.buffer.cinterop.buf_base64_decode
+import com.ditchoom.buffer.cinterop.buf_base64_encode
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.UByteVar
+import kotlinx.cinterop.UnsafeNumber
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.toCPointer
+
+// Base64 encode/decode computed entirely in C (raw pointer arithmetic) — see buf_base64_encode /
+// buf_base64_decode. Shared by every native NativeMemoryAccess buffer (linux NativeBuffer + slice, apple
+// MutableDataBuffer + slice), mirroring NativeHex.kt. The destination is taken when it is also native
+// memory; otherwise (or when it would not fit) we fall back to the portable common-code path
+// (encodeBase64Fallback / decodeBase64Fallback) — bit-identical output, just without the C fast path.
+
+private fun nativeBase64EncodeAddr(
+    srcAddress: Long,
+    dstAddress: Long,
+    length: Int,
+    urlSafe: Boolean,
+    padded: Boolean,
+) = buf_base64_encode(
+    srcAddress.toCPointer<UByteVar>()!!,
+    dstAddress.toCPointer<UByteVar>()!!,
+    length.convert(),
+    if (urlSafe) 1 else 0,
+    if (padded) 1 else 0,
+)
+
+private fun nativeBase64DecodeAddr(
+    srcAddress: Long,
+    dstAddress: Long,
+    length: Int,
+): Long =
+    buf_base64_decode(
+        srcAddress.toCPointer<UByteVar>()!!,
+        dstAddress.toCPointer<UByteVar>()!!,
+        length.convert(),
+    )
+
+/**
+ * Shared native [ReadBuffer.encodeBase64Into] body. [srcAddress] is this buffer's first-byte address
+ * (`nativeAddress`); the caller has already range-checked `[offset, offset + length)`.
+ */
+internal fun ReadBuffer.nativeEncodeBase64Into(
+    srcAddress: Long,
+    dest: WriteBuffer,
+    offset: Int,
+    length: Int,
+    urlSafe: Boolean,
+    padded: Boolean,
+) {
+    val destNative = dest.nativeMemoryAccess
+    val outBytes = base64EncodedLength(length, padded)
+    if (destNative != null && outBytes <= dest.remaining()) {
+        val destPos = dest.position()
+        nativeBase64EncodeAddr(srcAddress + offset, destNative.nativeAddress + destPos, length, urlSafe, padded)
+        dest.position(destPos + outBytes)
+    } else {
+        encodeBase64Fallback(offset, length, urlSafe, padded, { getUnchecked(it) }, { dest.writeByte(it) })
+    }
+}
+
+/**
+ * Shared native [ReadBuffer.decodeBase64Into] body. [srcAddress] is this buffer's first-byte address
+ * (`nativeAddress`); the caller has already range-checked `[offset, offset + length)`.
+ */
+internal fun ReadBuffer.nativeDecodeBase64Into(
+    srcAddress: Long,
+    dest: WriteBuffer,
+    offset: Int,
+    length: Int,
+) {
+    val destNative = dest.nativeMemoryAccess
+    // The exact decoded size is data-dependent (padding); the no-padding case is the upper bound.
+    if (destNative != null && base64DecodedMaxLength(length) <= dest.remaining()) {
+        val destPos = dest.position()
+        val produced = nativeBase64DecodeAddr(srcAddress + offset, destNative.nativeAddress + destPos, length)
+        if (produced < 0) {
+            throw IllegalArgumentException("invalid base64 character at index ${offset + (-produced - 1)}")
+        }
+        dest.position(destPos + produced.toInt())
+    } else {
+        decodeBase64Fallback(offset, length, { getUnchecked(it) }, { dest.writeByte(it) })
+    }
+}

--- a/buffer/src/nativeMain/kotlin/com/ditchoom/buffer/NativeBase64.kt
+++ b/buffer/src/nativeMain/kotlin/com/ditchoom/buffer/NativeBase64.kt
@@ -14,7 +14,7 @@ import kotlinx.cinterop.toCPointer
 // buf_base64_decode. Shared by every native NativeMemoryAccess buffer (linux NativeBuffer + slice, apple
 // MutableDataBuffer + slice), mirroring NativeHex.kt. The destination is taken when it is also native
 // memory; otherwise (or when it would not fit) we fall back to the portable common-code path
-// (encodeBase64Fallback / decodeBase64Fallback) — bit-identical output, just without the C fast path.
+// (encodeBase64Common / decodeBase64Fallback) — bit-identical output, just without the C fast path.
 
 private fun nativeBase64EncodeAddr(
     srcAddress: Long,
@@ -60,7 +60,7 @@ internal fun ReadBuffer.nativeEncodeBase64Into(
         nativeBase64EncodeAddr(srcAddress + offset, destNative.nativeAddress + destPos, length, urlSafe, padded)
         dest.position(destPos + outBytes)
     } else {
-        encodeBase64Fallback(offset, length, urlSafe, padded, { getUnchecked(it) }, { dest.writeByte(it) })
+        encodeBase64Common(offset, length, urlSafe, padded, dest)
     }
 }
 

--- a/buffer/src/nativeMain/kotlin/com/ditchoom/buffer/NativeHex.kt
+++ b/buffer/src/nativeMain/kotlin/com/ditchoom/buffer/NativeHex.kt
@@ -18,7 +18,7 @@ import kotlinx.cinterop.toCPointer
 // Both directions take the source via raw addresses; the destination is taken when it is also native
 // memory (dest.nativeMemoryAccess), so the whole transform stays pointer-to-pointer with no per-element
 // Kotlin dispatch. When the destination is NOT native (e.g. a managed ByteArrayBuffer), or would not
-// fit, we fall back to the portable common-code path (encodeHexFallback / decodeHexFallback) — bit
+// fit, we fall back to the portable common-code path (encodeHexCommon / decodeHexFallback) — bit
 // identical output, just without the C fast path.
 
 private fun nativeHexEncodeAddr(
@@ -62,7 +62,7 @@ internal fun ReadBuffer.nativeEncodeHexInto(
         nativeHexEncodeAddr(srcAddress + offset, destNative.nativeAddress + destPos, length, upperCase)
         dest.position(destPos + outBytes)
     } else {
-        encodeHexFallback(offset, length, upperCase, { getUnchecked(it) }, { dest.writeByte(it) })
+        encodeHexCommon(offset, length, upperCase, dest)
     }
 }
 

--- a/buffer/src/nativeMain/kotlin/com/ditchoom/buffer/NativeHex.kt
+++ b/buffer/src/nativeMain/kotlin/com/ditchoom/buffer/NativeHex.kt
@@ -1,0 +1,92 @@
+@file:OptIn(ExperimentalForeignApi::class, UnsafeNumber::class)
+
+package com.ditchoom.buffer
+
+import com.ditchoom.buffer.cinterop.buf_hex_decode
+import com.ditchoom.buffer.cinterop.buf_hex_encode
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.UByteVar
+import kotlinx.cinterop.UnsafeNumber
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.toCPointer
+
+// Hex encode/decode computed entirely in C (raw pointer arithmetic, table lookup that Clang lowers to a
+// NEON/SSE shuffle) — see buf_hex_encode / buf_hex_decode. Shared by every native NativeMemoryAccess
+// buffer (linux NativeBuffer + slice, apple MutableDataBuffer + slice) so the cinterop wiring lives in
+// ONE place and can't drift onto one backend while silently missing another (as apple was for hashRange).
+//
+// Both directions take the source via raw addresses; the destination is taken when it is also native
+// memory (dest.nativeMemoryAccess), so the whole transform stays pointer-to-pointer with no per-element
+// Kotlin dispatch. When the destination is NOT native (e.g. a managed ByteArrayBuffer), or would not
+// fit, we fall back to the portable common-code path (encodeHexFallback / decodeHexFallback) — bit
+// identical output, just without the C fast path.
+
+private fun nativeHexEncodeAddr(
+    srcAddress: Long,
+    dstAddress: Long,
+    length: Int,
+    upperCase: Boolean,
+) = buf_hex_encode(
+    srcAddress.toCPointer<UByteVar>()!!,
+    dstAddress.toCPointer<UByteVar>()!!,
+    length.convert(),
+    if (upperCase) 1 else 0,
+)
+
+private fun nativeHexDecodeAddr(
+    srcAddress: Long,
+    dstAddress: Long,
+    length: Int,
+): Long =
+    buf_hex_decode(
+        srcAddress.toCPointer<UByteVar>()!!,
+        dstAddress.toCPointer<UByteVar>()!!,
+        length.convert(),
+    )
+
+/**
+ * Shared native [ReadBuffer.encodeHexInto] body. [srcAddress] is the address of this buffer's first
+ * byte (`nativeAddress`); the caller has already range-checked `[offset, offset + length)`.
+ */
+internal fun ReadBuffer.nativeEncodeHexInto(
+    srcAddress: Long,
+    dest: WriteBuffer,
+    offset: Int,
+    length: Int,
+    upperCase: Boolean,
+) {
+    val destNative = dest.nativeMemoryAccess
+    val outBytes = length * 2
+    if (destNative != null && outBytes <= dest.remaining()) {
+        val destPos = dest.position()
+        nativeHexEncodeAddr(srcAddress + offset, destNative.nativeAddress + destPos, length, upperCase)
+        dest.position(destPos + outBytes)
+    } else {
+        encodeHexFallback(offset, length, upperCase, { getUnchecked(it) }, { dest.writeByte(it) })
+    }
+}
+
+/**
+ * Shared native [ReadBuffer.decodeHexInto] body. [srcAddress] is the address of this buffer's first
+ * byte (`nativeAddress`); the caller has already range-checked `[offset, offset + length)`.
+ */
+internal fun ReadBuffer.nativeDecodeHexInto(
+    srcAddress: Long,
+    dest: WriteBuffer,
+    offset: Int,
+    length: Int,
+) {
+    require(length and 1 == 0) { "hex input length ($length) must be even" }
+    val destNative = dest.nativeMemoryAccess
+    val outBytes = length / 2
+    if (destNative != null && outBytes <= dest.remaining()) {
+        val destPos = dest.position()
+        val bad = nativeHexDecodeAddr(srcAddress + offset, destNative.nativeAddress + destPos, length)
+        if (bad >= 0) {
+            throw IllegalArgumentException("invalid hex character at index ${offset + bad}")
+        }
+        dest.position(destPos + outBytes)
+    } else {
+        decodeHexFallback(offset, length, { getUnchecked(it) }, { dest.writeByte(it) })
+    }
+}


### PR DESCRIPTION
## Summary

Adds two **zero-copy, buffer-to-buffer** encoding primitives to `ReadBuffer` — **hex** and **Base64** (RFC 4648) — with no intermediate `String`/`ByteArray` staging. (Originally split as #193 hex + #194 Base64; folded into this single PR.)

These are *encoding* primitives (data representation), so they live in core `buffer`. Cryptographic digests (SHA) are intentionally **out of scope** here — they'll land in a separate `buffer-crypto` artifact.

## API

```kotlin
// hex
src.encodeHexInto(dest, upperCase = false)         // relative, over remaining()
src.encodeHexInto(dest, offset, length, upperCase) // absolute
hex.decodeHexInto(dest)

// Base64 (standard + URL-safe, padded/unpadded; lenient decode)
src.encodeBase64Into(dest, urlSafe = false, padded = true)
b64.decodeBase64Into(dest)
base64EncodedLength(n, padded); base64DecodedMaxLength(n)   // dest sizing
```

## Implementation

Follows the existing `hashRange` pattern — **one** algorithm, Kotlin everywhere, with a transparent **native C SIMD acceleration** on linux/apple (`simd.def`: `buf_hex_encode/decode`, `buf_base64_encode/decode`, table lookups Clang lowers to NEON/SSE shuffles). The native buffers (`NativeBuffer`/`MutableDataBuffer` + slices) override the members to run pointer-to-pointer when the destination is also native memory; everything else uses the portable common path. Tested **byte-identical** between the Kotlin and C paths.

## Why not delegate to platform Base64 / pack the writes?

Both were investigated and **measured**, then rejected:

- **No platform delegation.** `java.util.Base64`/`NSData` allocate their output and can't write into a caller-provided dest (the default JVM/Android buffer is *direct*, with no backing array). Benchmark at handshake size (24B): ours **49.3M** ≈ `java.util.Base64` **51.8M** ops/s (a wash, and the platform path allocates). The platform only wins on bulk (48KB: 100K vs 28K). So delegating optimizes the rare case and pessimizes the common one. (For a future bulk path, `simdutf` — already a Linux dependency, v8 has Lemire's SIMD Base64 — is the right lever.)
- **No write-packing.** Packing output into `writeShort`/`writeInt` measured ~39% *slower* for hex on JVM direct buffers (`putShort`/`putInt` on a direct ByteBuffer is no cheaper than the byte puts). Kept the simple per-byte writes.

A `Base64PlatformComparison` benchmark + `codec` benchmark config are included to document these decisions.

## Tests

`HexCodecTest` + `Base64CodecTest` (commonTest): known/RFC vectors, upper/lowercase, standard vs URL-safe, padded vs unpadded, full 256-byte round-trips, little-endian byte-order independence, invalid-char + position semantics, managed-dest fallback, pooled-wrapper transparency.

✅ Passes full `jvmTest` and `linuxX64Test`. ktlint clean.