### PR TITLE
feat(buffer-crypto): new KMP crypto module (SHA-256/HMAC/HKDF/CSPRNG) + SecureBuffer

### DIFF
--- a/.github/workflows/android_integration.yaml
+++ b/.github/workflows/android_integration.yaml
@@ -138,7 +138,16 @@ jobs:
             # package first makes the install clean and idempotent regardless of
             # what signature the cached copy carried.
             adb shell pm list packages -3 | sed 's/^package://' | grep -i '\.ditchoom\.' | xargs -r -n1 adb uninstall || true
-            ./gradlew connectedAndroidTest -x connectedBenchmarkAndroidTest
+            # buffer-crypto declares minSdk 28 (its secure/deterministic key buffers
+            # allocate via Unsafe.allocateMemory, absent from the runtime before API 26).
+            # AGP installs and runs instrumented tests regardless of the device API, so
+            # exclude that module's connected tests on emulators below 28. The other
+            # modules keep their genuine minSdk-21 floor check on this emulator.
+            EXCLUDE_ARGS="-x connectedBenchmarkAndroidTest"
+            if [ "${{ matrix.api-level }}" -lt 28 ]; then
+              EXCLUDE_ARGS="$EXCLUDE_ARGS -x :buffer-crypto:connectedDebugAndroidTest"
+            fi
+            ./gradlew connectedAndroidTest $EXCLUDE_ARGS
 
       - name: Kill emulator processes
         if: always()

--- a/.github/workflows/android_integration.yaml
+++ b/.github/workflows/android_integration.yaml
@@ -138,16 +138,14 @@ jobs:
             # package first makes the install clean and idempotent regardless of
             # what signature the cached copy carried.
             adb shell pm list packages -3 | sed 's/^package://' | grep -i '\.ditchoom\.' | xargs -r -n1 adb uninstall || true
+            # NOTE: android-emulator-runner runs each script line as a separate `sh -c`,
+            # so this must stay a single line (no multi-line if/var that spans lines).
             # buffer-crypto declares minSdk 28 (its secure/deterministic key buffers
-            # allocate via Unsafe.allocateMemory, absent from the runtime before API 26).
+            # allocate via Unsafe.allocateMemory, absent from the runtime before API 26);
             # AGP installs and runs instrumented tests regardless of the device API, so
             # exclude that module's connected tests on emulators below 28. The other
             # modules keep their genuine minSdk-21 floor check on this emulator.
-            EXCLUDE_ARGS="-x connectedBenchmarkAndroidTest"
-            if [ "${{ matrix.api-level }}" -lt 28 ]; then
-              EXCLUDE_ARGS="$EXCLUDE_ARGS -x :buffer-crypto:connectedDebugAndroidTest"
-            fi
-            ./gradlew connectedAndroidTest $EXCLUDE_ARGS
+            ./gradlew connectedAndroidTest -x connectedBenchmarkAndroidTest $([ "${{ matrix.api-level }}" -lt 28 ] && echo "-x :buffer-crypto:connectedDebugAndroidTest")
 
       - name: Kill emulator processes
         if: always()

--- a/buffer-crypto/build.gradle.kts
+++ b/buffer-crypto/build.gradle.kts
@@ -144,7 +144,12 @@ kotlin {
 android {
     compileSdk = 36
     defaultConfig {
-        minSdk = 21
+        // API 28+: the secure/deterministic key-material buffers route through
+        // sun.misc.Unsafe.allocateMemory, which is absent from the Android runtime
+        // before API 26 (NoSuchMethodError on API 21). 28 is a conservative modern
+        // floor for a crypto module. AGP skips this module's instrumented tests on
+        // older emulators rather than failing to install.
+        minSdk = 28
     }
     namespace = "$group.buffer.crypto"
 

--- a/buffer-crypto/build.gradle.kts
+++ b/buffer-crypto/build.gradle.kts
@@ -73,7 +73,11 @@ kotlin {
             iosArm64()
             iosSimulatorArm64()
             iosX64()
-            watchosArm64()
+            // watchosArm64 (arm64_32) is intentionally omitted: it is the only 32-bit
+            // Apple target, and appleMain calls CommonCrypto/Security size_t functions.
+            // With no cinterop of its own this module doesn't engage size_t commonization,
+            // so the shared Apple metadata compile rejects the 32-bit vs 64-bit width
+            // mismatch. watchOS is still covered by the simulator + x64 targets below.
             watchosSimulatorArm64()
             watchosX64()
             tvosArm64()

--- a/buffer-crypto/build.gradle.kts
+++ b/buffer-crypto/build.gradle.kts
@@ -1,0 +1,250 @@
+@file:OptIn(ExperimentalWasmDsl::class)
+
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetTree
+import org.jetbrains.kotlin.konan.target.HostManager
+
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.ktlint)
+    alias(libs.plugins.maven.publish)
+    alias(libs.plugins.dokka)
+    signing
+}
+
+group = "com.ditchoom"
+val isRunningOnGithub = System.getenv("GITHUB_REPOSITORY")?.isNotBlank() == true
+
+apply(from = "../gradle/setup.gradle.kts")
+
+@Suppress("UNCHECKED_CAST")
+val getNextVersion = project.extra["getNextVersion"] as (Boolean) -> Any
+// Honor -Pversion so local publishes can pin a version without being clobbered by
+// Maven Central's getNextVersion auto-increment.
+if (!project.hasProperty("version") || project.version == "unspecified") {
+    project.version = getNextVersion(!isRunningOnGithub).toString()
+}
+
+repositories {
+    google()
+    mavenCentral()
+    maven { setUrl("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/kotlin-js-wrappers/") }
+}
+
+kotlin {
+    jvmToolchain(21)
+
+    // SHA-256 / HMAC are modeled as expect/actual classes (multiplatform impl is a Beta feature).
+    compilerOptions {
+        freeCompilerArgs.add("-Xexpect-actual-classes")
+    }
+
+    androidTarget {
+        publishLibraryVariants("release")
+        // Use JVM 1.8 for Android to maintain maximum compatibility
+        compilerOptions.jvmTarget.set(JvmTarget.JVM_1_8)
+        // Run the full common suite on a real emulator (ART), not just the host JVM.
+        instrumentedTestVariant {
+            sourceSetTree.set(KotlinSourceSetTree.test)
+        }
+    }
+    jvm {
+        compilerOptions.jvmTarget.set(JvmTarget.JVM_1_8)
+    }
+    js {
+        outputModuleName.set("buffer-crypto-kt")
+        browser()
+        nodejs()
+    }
+    wasmJs {
+        browser()
+        nodejs()
+    }
+    // Native crypto is backed by each platform's system library: JCA (JVM/Android),
+    // CommonCrypto/Security (Apple). WebCrypto's digest is async-only, so js/wasm fall
+    // back to a synchronous pure-Kotlin SHA-256/HMAC. Linux (BoringSSL) is deferred —
+    // no native target is registered for it yet.
+    if (isRunningOnGithub) {
+        if (HostManager.hostIsMac) {
+            macosX64()
+            macosArm64()
+            iosArm64()
+            iosSimulatorArm64()
+            iosX64()
+            watchosArm64()
+            watchosSimulatorArm64()
+            watchosX64()
+            tvosArm64()
+            tvosSimulatorArm64()
+            tvosX64()
+        }
+    } else if (HostManager.hostIsMac) {
+        if (System.getProperty("os.arch") == "aarch64") {
+            macosArm64()
+        } else {
+            macosX64()
+        }
+    }
+
+    applyDefaultHierarchyTemplate()
+    sourceSets {
+        commonMain.dependencies {
+            api(project(":buffer"))
+        }
+        commonTest.dependencies {
+            implementation(kotlin("test"))
+        }
+
+        val androidInstrumentedTest by getting {
+            dependencies {
+                implementation(libs.androidx.test.runner)
+                implementation(libs.androidx.test.rules)
+                implementation(libs.androidx.test.core.ktx)
+                implementation(libs.androidx.test.ext.junit)
+            }
+        }
+
+        // Shared source set for JVM and Android: both use the JCA (java.security /
+        // javax.crypto) for MessageDigest, Mac, and SecureRandom.
+        val jvmCommonMain by creating {
+            dependsOn(commonMain.get())
+        }
+        jvmMain {
+            dependsOn(jvmCommonMain)
+        }
+        androidMain {
+            dependsOn(jvmCommonMain)
+        }
+
+        // Shared source set for JS and wasmJs: pure-Kotlin SHA-256/HMAC (WebCrypto's
+        // SubtleCrypto.digest is async-only and cannot satisfy a synchronous contract).
+        val jsAndWasmJsMain by creating {
+            dependsOn(commonMain.get())
+        }
+        val jsAndWasmJsTest by creating {
+            dependsOn(commonTest.get())
+        }
+        jsMain {
+            dependsOn(jsAndWasmJsMain)
+        }
+        wasmJsMain {
+            dependsOn(jsAndWasmJsMain)
+        }
+        jsTest {
+            dependsOn(jsAndWasmJsTest)
+        }
+        wasmJsTest {
+            dependsOn(jsAndWasmJsTest)
+        }
+    }
+}
+
+android {
+    compileSdk = 36
+    defaultConfig {
+        minSdk = 21
+    }
+    namespace = "$group.buffer.crypto"
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+            withJavadocJar()
+        }
+    }
+}
+
+val javadocJar: TaskProvider<Jar> by tasks.registering(Jar::class) {
+    archiveClassifier.set("javadoc")
+}
+
+val publishedGroupId: String by project
+val libraryName: String by project
+val siteUrl: String by project
+val gitUrl: String by project
+val licenseName: String by project
+val licenseUrl: String by project
+val developerOrg: String by project
+val developerName: String by project
+val developerEmail: String by project
+val developerId: String by project
+
+project.group = publishedGroupId
+
+val signingInMemoryKey = project.findProperty("signingInMemoryKey")
+val signingInMemoryKeyPassword = project.findProperty("signingInMemoryKeyPassword")
+val isMainBranchGithub = System.getenv("GITHUB_REF") == "refs/heads/main"
+val shouldSignAndPublish = isMainBranchGithub && signingInMemoryKey is String && signingInMemoryKeyPassword is String
+
+if (shouldSignAndPublish) {
+    signing {
+        useInMemoryPgpKeys(
+            signingInMemoryKey as String,
+            signingInMemoryKeyPassword as String,
+        )
+        sign(publishing.publications)
+    }
+}
+
+mavenPublishing {
+    if (shouldSignAndPublish) {
+        publishToMavenCentral()
+        signAllPublications()
+    }
+
+    coordinates(publishedGroupId, "buffer-crypto", project.version.toString())
+
+    pom {
+        name.set("Buffer Crypto")
+        description.set("Kotlin Multiplatform cryptographic primitives (SHA-256, HMAC, HKDF) for the buffer library")
+        url.set(siteUrl)
+
+        licenses {
+            license {
+                name.set(licenseName)
+                url.set(licenseUrl)
+            }
+        }
+        developers {
+            developer {
+                id.set(developerId)
+                name.set(developerName)
+                email.set(developerEmail)
+            }
+        }
+        organization {
+            name.set(developerOrg)
+        }
+        scm {
+            connection.set(gitUrl)
+            developerConnection.set(gitUrl)
+            url.set(siteUrl)
+        }
+    }
+}
+
+ktlint {
+    verbose.set(true)
+    outputToConsole.set(true)
+    android.set(true)
+    filter {
+        exclude("**/generated/**")
+    }
+}
+
+dokka {
+    dokkaSourceSets.configureEach {
+        externalDocumentationLinks.register("kotlin-stdlib") {
+            url("https://kotlinlang.org/api/latest/jvm/stdlib/")
+            packageListUrl("https://kotlinlang.org/api/latest/jvm/stdlib/package-list")
+        }
+        reportUndocumented.set(false)
+    }
+}

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/AppleCryptoBridge.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/AppleCryptoBridge.apple.kt
@@ -1,0 +1,60 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.managedMemoryAccess
+import com.ditchoom.buffer.nativeMemoryAccess
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.CPointer
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.toCPointer
+import kotlinx.cinterop.usePinned
+
+/**
+ * Invokes [block] with a pointer to this buffer's remaining bytes and their length, without
+ * disturbing the buffer's position or allocating any array. Native buffers (NSData/direct)
+ * hand over their memory pointer directly; heap buffers pin their own backing array. No-op
+ * when there are no remaining bytes. The pointer is valid only for the duration of [block].
+ */
+internal inline fun ReadBuffer.withRemainingBytes(block: (CPointer<ByteVar>, length: Int) -> Unit) {
+    val n = remaining()
+    if (n == 0) return
+    val pos = position()
+    val managed = managedMemoryAccess
+    if (managed != null) {
+        managed.backingArray.usePinned { block(it.addressOf(managed.arrayOffset + pos), n) }
+        return
+    }
+    val native = nativeMemoryAccess
+    val ptr = native?.let { (it.nativeAddress + pos).toCPointer<ByteVar>() }
+    requireNotNull(ptr) { "buffer must expose native or managed memory" }
+    block(ptr, n)
+}
+
+/**
+ * Invokes [block] with a pointer to [count] writable bytes at this buffer's current position,
+ * then advances the position by [count]. Native buffers expose their memory pointer; heap
+ * buffers pin their own backing array. No array is allocated — the system call writes straight
+ * into the destination buffer. [count] must fit within `remaining()`.
+ */
+internal inline fun WriteBuffer.withWritablePointer(
+    count: Int,
+    block: (CPointer<ByteVar>) -> Unit,
+) {
+    require(remaining() >= count) { "dest needs $count bytes remaining, has ${remaining()}" }
+    val pos = position()
+    val managed = managedMemoryAccess
+    if (managed != null) {
+        managed.backingArray.usePinned { block(it.addressOf(managed.arrayOffset + pos)) }
+        position(pos + count)
+        return
+    }
+    val native = nativeMemoryAccess
+    val ptr = native?.let { (it.nativeAddress + pos).toCPointer<ByteVar>() }
+    requireNotNull(ptr) { "dest must expose native or managed memory" }
+    block(ptr)
+    position(pos + count)
+}

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/CryptoRandom.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/CryptoRandom.apple.kt
@@ -6,11 +6,17 @@ import com.ditchoom.buffer.WriteBuffer
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.convert
 import platform.Security.SecRandomCopyBytes
+import platform.Security.errSecSuccess
 import platform.Security.kSecRandomDefault
 
 /** Apple CSPRNG backed by Security.framework `SecRandomCopyBytes`, written straight into the buffer. */
 actual fun cryptoRandomInto(dest: WriteBuffer) {
     val n = dest.remaining()
     if (n == 0) return
-    dest.withWritablePointer(n) { ptr -> SecRandomCopyBytes(kSecRandomDefault, n.convert(), ptr) }
+    dest.withWritablePointer(n) { ptr ->
+        // SecRandomCopyBytes returns errSecSuccess (0) on success; on failure the destination
+        // bytes are undefined, so surface it rather than hand back non-random data.
+        val status = SecRandomCopyBytes(kSecRandomDefault, n.convert(), ptr)
+        check(status == errSecSuccess) { "SecRandomCopyBytes failed (OSStatus=$status)" }
+    }
 }

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/CryptoRandom.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/CryptoRandom.apple.kt
@@ -1,0 +1,16 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.WriteBuffer
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.convert
+import platform.Security.SecRandomCopyBytes
+import platform.Security.kSecRandomDefault
+
+/** Apple CSPRNG backed by Security.framework `SecRandomCopyBytes`, written straight into the buffer. */
+actual fun cryptoRandomInto(dest: WriteBuffer) {
+    val n = dest.remaining()
+    if (n == 0) return
+    dest.withWritablePointer(n) { ptr -> SecRandomCopyBytes(kSecRandomDefault, n.convert(), ptr) }
+}

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256Mac.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256Mac.apple.kt
@@ -1,0 +1,47 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.nativeHeap
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.reinterpret
+import platform.CoreCrypto.CCHmacContext
+import platform.CoreCrypto.CCHmacFinal
+import platform.CoreCrypto.CCHmacInit
+import platform.CoreCrypto.CCHmacUpdate
+import platform.CoreCrypto.kCCHmacAlgSHA256
+
+/** Apple HMAC-SHA256 backed by CommonCrypto (`CCHmac`). Reads and writes via buffer pointers — no arrays. */
+actual class HmacSha256Mac actual constructor(
+    key: ReadBuffer,
+) {
+    private val ctx = nativeHeap.alloc<CCHmacContext>()
+    private var finalized = false
+
+    init {
+        if (key.remaining() == 0) {
+            CCHmacInit(ctx.ptr, kCCHmacAlgSHA256, null, 0.convert())
+        } else {
+            key.withRemainingBytes { ptr, len -> CCHmacInit(ctx.ptr, kCCHmacAlgSHA256, ptr, len.convert()) }
+        }
+    }
+
+    actual fun update(input: ReadBuffer): HmacSha256Mac {
+        input.withRemainingBytes { ptr, len -> CCHmacUpdate(ctx.ptr, ptr, len.convert()) }
+        return this
+    }
+
+    actual fun doFinalInto(dest: WriteBuffer) {
+        // CommonCrypto writes the 32-byte tag straight into the destination buffer's memory.
+        dest.withWritablePointer(SHA256_DIGEST_BYTES) { ptr -> CCHmacFinal(ctx.ptr, ptr.reinterpret()) }
+        if (!finalized) {
+            finalized = true
+            nativeHeap.free(ctx)
+        }
+    }
+}

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256Mac.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256Mac.apple.kt
@@ -9,7 +9,6 @@ import kotlinx.cinterop.alloc
 import kotlinx.cinterop.convert
 import kotlinx.cinterop.nativeHeap
 import kotlinx.cinterop.ptr
-import kotlinx.cinterop.reinterpret
 import platform.CoreCrypto.CCHmacContext
 import platform.CoreCrypto.CCHmacFinal
 import platform.CoreCrypto.CCHmacInit
@@ -38,10 +37,10 @@ actual class HmacSha256Mac actual constructor(
 
     actual fun doFinalInto(dest: WriteBuffer) {
         // CommonCrypto writes the 32-byte tag straight into the destination buffer's memory.
-        dest.withWritablePointer(SHA256_DIGEST_BYTES) { ptr -> CCHmacFinal(ctx.ptr, ptr.reinterpret()) }
+        dest.withWritablePointer(SHA256_DIGEST_BYTES) { ptr -> CCHmacFinal(ctx.ptr, ptr) }
         if (!finalized) {
             finalized = true
-            nativeHeap.free(ctx)
+            nativeHeap.free(ctx.rawPtr)
         }
     }
 }

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/Sha256Digest.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/Sha256Digest.apple.kt
@@ -34,7 +34,7 @@ actual class Sha256Digest actual constructor() {
         dest.withWritablePointer(SHA256_DIGEST_BYTES) { ptr -> CC_SHA256_Final(ptr.reinterpret(), ctx.ptr) }
         if (!finalized) {
             finalized = true
-            nativeHeap.free(ctx)
+            nativeHeap.free(ctx.rawPtr)
         }
     }
 }

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/Sha256Digest.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/Sha256Digest.apple.kt
@@ -1,0 +1,40 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.nativeHeap
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.reinterpret
+import platform.CoreCrypto.CC_SHA256_CTX
+import platform.CoreCrypto.CC_SHA256_Final
+import platform.CoreCrypto.CC_SHA256_Init
+import platform.CoreCrypto.CC_SHA256_Update
+
+/** Apple SHA-256 backed by CommonCrypto (`CC_SHA256`). Reads and writes via buffer pointers — no arrays. */
+actual class Sha256Digest actual constructor() {
+    private val ctx = nativeHeap.alloc<CC_SHA256_CTX>()
+    private var finalized = false
+
+    init {
+        CC_SHA256_Init(ctx.ptr)
+    }
+
+    actual fun update(input: ReadBuffer): Sha256Digest {
+        input.withRemainingBytes { ptr, len -> CC_SHA256_Update(ctx.ptr, ptr, len.convert()) }
+        return this
+    }
+
+    actual fun digestInto(dest: WriteBuffer) {
+        // CommonCrypto writes the 32-byte digest straight into the destination buffer's memory.
+        dest.withWritablePointer(SHA256_DIGEST_BYTES) { ptr -> CC_SHA256_Final(ptr.reinterpret(), ctx.ptr) }
+        if (!finalized) {
+            finalized = true
+            nativeHeap.free(ctx)
+        }
+    }
+}

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/CryptoRandom.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/CryptoRandom.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.WriteBuffer
+
+/**
+ * Fills the remaining bytes of [dest] (position to limit) with cryptographically secure
+ * random bytes, advancing its position to the limit.
+ *
+ * Backed by each platform's CSPRNG: `java.security.SecureRandom` (JVM/Android),
+ * `SecRandomCopyBytes` (Apple), and `crypto.getRandomValues` (js/wasmJs — this WebCrypto
+ * call is synchronous, unlike `SubtleCrypto`).
+ */
+expect fun cryptoRandomInto(dest: WriteBuffer)
+
+/**
+ * Returns a freshly allocated, read-ready buffer of [size] cryptographically secure
+ * random bytes, allocated via [factory].
+ */
+fun cryptoRandom(
+    size: Int,
+    factory: BufferFactory = BufferFactory.Default,
+): PlatformBuffer {
+    val out = factory.allocate(size)
+    cryptoRandomInto(out)
+    out.resetForRead()
+    return out
+}

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/Hkdf.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/Hkdf.kt
@@ -1,0 +1,136 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.deterministic
+import com.ditchoom.buffer.use
+
+/**
+ * Pure-common HKDF-SHA256 (RFC 5869), built on the platform-native [HmacSha256Mac].
+ *
+ * Because the only primitive it needs is HMAC — which is already platform-native and
+ * synchronous on every target — HKDF itself stays in `commonMain` and runs identically
+ * everywhere. Used for deterministic nonce derivation and key-schedule expansion.
+ *
+ * All key-derived intermediates (the PRK and each `T` block) are allocated from a
+ * secure, deterministic scratch factory and wiped on the way out — even on the failure
+ * path. The output [WriteBuffer] is owned by the caller; pass a secure/deterministic
+ * destination (see [secure]) if it too must be wiped.
+ */
+object Hkdf {
+    private const val HASH_LEN = HMAC_SHA256_BYTES // 32
+    private const val MAX_BLOCKS = 255
+
+    /** Scratch factory for key-derived intermediates: deterministic so it can be `use {}`-freed, secure so it is wiped. */
+    private val scratch: BufferFactory get() = BufferFactory.deterministic().secure()
+
+    /**
+     * HKDF-Extract: writes `PRK = HMAC(salt, ikm)` (32 bytes) into [dest].
+     * A null/empty [salt] is treated as [HASH_LEN] zero bytes (per RFC 5869).
+     */
+    fun extractInto(
+        salt: ReadBuffer?,
+        ikm: ReadBuffer,
+        dest: WriteBuffer,
+    ) {
+        if (salt != null && salt.remaining() > 0) {
+            HmacSha256Mac(salt).update(ikm).doFinalInto(dest)
+        } else {
+            // Empty salt → a block of zero bytes. The scratch buffer is zero-initialized.
+            scratch.allocate(HASH_LEN).use { zeroSalt ->
+                HmacSha256Mac(zeroSalt).update(ikm).doFinalInto(dest)
+            }
+        }
+    }
+
+    /**
+     * HKDF-Expand: writes [length] bytes of output keying material into [dest], derived
+     * from the pseudo-random key [prk] (32 bytes) and optional [info].
+     *
+     * [dest] must have at least [length] bytes remaining.
+     */
+    fun expandInto(
+        prk: ReadBuffer,
+        info: ReadBuffer?,
+        length: Int,
+        dest: WriteBuffer,
+    ) {
+        require(length >= 0) { "length must be non-negative, was $length" }
+        val blocks = (length + HASH_LEN - 1) / HASH_LEN
+        require(blocks <= MAX_BLOCKS) { "HKDF cannot expand to $length bytes (max ${MAX_BLOCKS * HASH_LEN})" }
+        require(dest.remaining() >= length) { "dest needs $length bytes remaining, has ${dest.remaining()}" }
+
+        // Two ping-pong T blocks plus a one-byte counter, all wiped on close.
+        scratch.allocate(HASH_LEN).use { tA ->
+            scratch.allocate(HASH_LEN).use { tB ->
+                scratch.allocate(1).use { counter ->
+                    var prev: PlatformBuffer? = null // T(0) is empty
+                    var cur = tA
+                    var spare = tB
+                    var written = 0
+                    for (i in 1..blocks) {
+                        // T(i) = HMAC(prk, T(i-1) ‖ info ‖ i) — streamed, never concatenated.
+                        val mac = HmacSha256Mac(prk)
+                        prev?.let { mac.update(it) }
+                        info?.let { mac.update(it) }
+                        counter.resetForWrite()
+                        counter.writeByte(i.toByte())
+                        counter.resetForRead()
+                        mac.update(counter)
+                        cur.resetForWrite()
+                        mac.doFinalInto(cur)
+                        cur.resetForRead()
+
+                        val take = minOf(HASH_LEN, length - written)
+                        for (j in 0 until take) dest.writeByte(cur.get(j))
+                        written += take
+
+                        // Swap: this block becomes T(i-1) for the next round.
+                        prev = cur
+                        val next = spare
+                        spare = cur
+                        cur = next
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * One-shot HKDF-SHA256: extract then expand to [length] bytes, written into [dest]
+     * (which must have at least [length] bytes remaining).
+     */
+    fun deriveInto(
+        salt: ReadBuffer?,
+        ikm: ReadBuffer,
+        info: ReadBuffer?,
+        length: Int,
+        dest: WriteBuffer,
+    ) {
+        scratch.allocate(HASH_LEN).use { prk ->
+            extractInto(salt, ikm, prk)
+            prk.resetForRead()
+            expandInto(prk, info, length, dest)
+        }
+    }
+
+    /**
+     * One-shot HKDF-SHA256 returning a freshly allocated, read-ready buffer of [length]
+     * bytes allocated via [factory]. Use `factory = BufferFactory.deterministic().secure()`
+     * if the derived key material must be wiped after use.
+     */
+    fun derive(
+        salt: ReadBuffer?,
+        ikm: ReadBuffer,
+        info: ReadBuffer?,
+        length: Int,
+        factory: BufferFactory,
+    ): ReadBuffer {
+        val out = factory.allocate(length)
+        deriveInto(salt, ikm, info, length, out)
+        out.resetForRead()
+        return out
+    }
+}

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256.kt
@@ -1,0 +1,67 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+
+/** HMAC-SHA256 output length in bytes (equals the SHA-256 digest length). */
+const val HMAC_SHA256_BYTES = SHA256_DIGEST_BYTES
+
+/**
+ * Incremental HMAC-SHA256 (RFC 2104).
+ *
+ * Backed by the platform's native MAC (JCA `Mac("HmacSHA256")` on JVM/Android,
+ * CommonCrypto `CCHmac` on Apple) and by a pure-Kotlin implementation on js/wasmJs.
+ *
+ * The key is the remaining bytes of the [key] buffer passed to the constructor.
+ * Feed the message with [update] (call repeatedly to MAC `a ‖ b` without concatenating),
+ * then [doFinalInto] to write the 32-byte tag into a caller-owned destination.
+ * Reads are non-destructive (operate on `slice()`s).
+ *
+ * Not thread-safe — use one instance per MAC. Key-bearing intermediates are wiped after use.
+ */
+expect class HmacSha256Mac(
+    key: ReadBuffer,
+) {
+    /** Absorbs the remaining bytes of [input] (non-destructive). Returns `this` for chaining. */
+    fun update(input: ReadBuffer): HmacSha256Mac
+
+    /**
+     * Finalizes and writes [HMAC_SHA256_BYTES] bytes into [dest] at its current
+     * position, advancing it. [dest] must have at least [HMAC_SHA256_BYTES] remaining.
+     */
+    fun doFinalInto(dest: WriteBuffer)
+}
+
+/**
+ * One-shot HMAC-SHA256 of [message] under [key], written into [dest] (zero allocation).
+ *
+ * [dest] must have at least [HMAC_SHA256_BYTES] remaining.
+ */
+fun hmacSha256(
+    key: ReadBuffer,
+    message: ReadBuffer,
+    dest: WriteBuffer,
+) {
+    require(dest.remaining() >= HMAC_SHA256_BYTES) {
+        "dest needs $HMAC_SHA256_BYTES bytes remaining, has ${dest.remaining()}"
+    }
+    HmacSha256Mac(key).update(message).doFinalInto(dest)
+}
+
+/**
+ * One-shot HMAC-SHA256 of [message] under [key], returning a freshly allocated,
+ * read-ready buffer allocated via [factory].
+ */
+fun hmacSha256(
+    key: ReadBuffer,
+    message: ReadBuffer,
+    factory: BufferFactory = BufferFactory.Default,
+): ReadBuffer {
+    val out: PlatformBuffer = factory.allocate(HMAC_SHA256_BYTES)
+    HmacSha256Mac(key).update(message).doFinalInto(out)
+    out.resetForRead()
+    return out
+}

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/SecureBuffer.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/SecureBuffer.kt
@@ -1,0 +1,87 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.PlatformBuffer
+
+/**
+ * A [PlatformBuffer] decorator that zeroes its full backing storage when it is freed,
+ * so cryptographic key material does not linger on the heap after use.
+ *
+ * The constructor is `internal`: a [SecureBuffer] can only originate from
+ * [SecureBufferFactory] (via [BufferFactory.secure]). This guarantees that anything typed
+ * "secure" really does wipe — there is no way to hand-roll an unwiped one — and that the
+ * full-capacity wipe (not just `remaining()`) is performed in exactly one audited place.
+ *
+ * The wipe runs on every standard teardown path, because they all funnel through
+ * [freeNativeMemory]: `use {}`, `freeIfNeeded()`, `freeAll()`, and an explicit
+ * `freeNativeMemory()` call. There is **no GC finalizer hook** — a buffer that is never
+ * explicitly freed is never wiped — so secret-bearing buffers should come from a
+ * deterministic factory and be released with `use {}`:
+ *
+ * ```kotlin
+ * BufferFactory.deterministic().secure().allocate(32).use { key ->
+ *     // ... key is zeroed here, at end of block ...
+ * }
+ * ```
+ *
+ * **Best-effort.** On GC-managed backings (heap [ByteArray], JS `Int8Array`) the runtime
+ * may already have copied the bytes elsewhere before the wipe; the guarantee is strongest
+ * on native/direct backings (direct `ByteBuffer`, FFM, malloc, WASM linear memory). This
+ * is defense-in-depth, not a defense against a live-memory adversary.
+ */
+class SecureBuffer internal constructor(
+    private val inner: PlatformBuffer,
+) : PlatformBuffer by inner {
+    private var wiped = false
+
+    override fun freeNativeMemory() {
+        if (!wiped) {
+            wiped = true
+            try {
+                // Address the WHOLE buffer, not just remaining() — fill() writes
+                // position..limit, so widen the window to cover every byte first.
+                inner.position(0)
+                inner.setLimit(inner.capacity)
+                inner.fill(0)
+            } catch (_: Throwable) {
+                // A best-effort wipe must never mask the real free below; swallow and free.
+            }
+        }
+        inner.freeNativeMemory()
+    }
+
+    override fun slice(byteOrder: ByteOrder): PlatformBuffer = inner.slice(byteOrder)
+}
+
+/**
+ * A [BufferFactory] decorator whose buffers wipe their backing storage on free. Composes
+ * over any delegate factory — `BufferFactory.deterministic().secure()`,
+ * `someFactory.withPooling(pool).secure()`, etc. — so the secure-erase behavior layers
+ * on top of whatever allocation strategy the delegate provides.
+ */
+internal class SecureBufferFactory(
+    private val delegate: BufferFactory,
+) : BufferFactory {
+    override fun allocate(
+        size: Int,
+        byteOrder: ByteOrder,
+    ): PlatformBuffer = SecureBuffer(delegate.allocate(size, byteOrder))
+
+    override fun wrap(
+        array: ByteArray,
+        byteOrder: ByteOrder,
+    ): PlatformBuffer = SecureBuffer(delegate.wrap(array, byteOrder))
+}
+
+/**
+ * Returns a factory whose buffers zero their backing storage when freed (see [SecureBuffer]).
+ *
+ * Layer it over the allocation strategy you want; for key material prefer a deterministic
+ * delegate so the wipe is guaranteed to run:
+ * ```kotlin
+ * val secure = BufferFactory.deterministic().secure()
+ * secure.allocate(32).use { key -> /* ... */ } // zeroed at end of block
+ * ```
+ */
+fun BufferFactory.secure(): BufferFactory = SecureBufferFactory(this)

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/Sha256.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/Sha256.kt
@@ -1,0 +1,71 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+
+/** SHA-256 digest length in bytes (FIPS 180-4). */
+const val SHA256_DIGEST_BYTES = 32
+
+/** SHA-256 internal block length in bytes. */
+const val SHA256_BLOCK_BYTES = 64
+
+/**
+ * Incremental SHA-256 (FIPS 180-4).
+ *
+ * Backed by each platform's native crypto subsystem where a synchronous API exists
+ * (JCA `MessageDigest` on JVM/Android, CommonCrypto `CC_SHA256` on Apple) and by a
+ * synchronous pure-Kotlin implementation on js/wasmJs (WebCrypto's `SubtleCrypto.digest`
+ * is async-only and cannot satisfy this synchronous contract).
+ *
+ * Feed bytes with [update] (call repeatedly to hash `keyMaterial ‖ message` without
+ * first concatenating it), then [digestInto] to write the 32-byte result into a
+ * caller-owned destination. Reading is non-destructive: [update] consumes a `slice()`
+ * of the input, leaving the source buffer's position untouched.
+ *
+ * Not thread-safe — use one instance per digest. [digestInto] wipes the instance's
+ * scratch before returning and finalizes the digest; the instance must not be reused.
+ */
+expect class Sha256Digest() {
+    /** Absorbs the remaining bytes of [input] (non-destructive). Returns `this` for chaining. */
+    fun update(input: ReadBuffer): Sha256Digest
+
+    /**
+     * Finalizes and writes [SHA256_DIGEST_BYTES] bytes into [dest] at its current
+     * position, advancing it. [dest] must have at least [SHA256_DIGEST_BYTES] remaining.
+     */
+    fun digestInto(dest: WriteBuffer)
+}
+
+/**
+ * One-shot SHA-256 of [input]'s remaining bytes, written into [dest] (zero allocation).
+ *
+ * [dest] must have at least [SHA256_DIGEST_BYTES] remaining. Use a secure/deterministic
+ * destination (see [secure][com.ditchoom.buffer.crypto.secure]) if the digest must be
+ * wiped after use.
+ */
+fun sha256(
+    input: ReadBuffer,
+    dest: WriteBuffer,
+) {
+    require(dest.remaining() >= SHA256_DIGEST_BYTES) {
+        "dest needs $SHA256_DIGEST_BYTES bytes remaining, has ${dest.remaining()}"
+    }
+    Sha256Digest().update(input).digestInto(dest)
+}
+
+/**
+ * One-shot SHA-256 of [input]'s remaining bytes, returning a freshly allocated,
+ * read-ready buffer. The result is allocated via [factory].
+ */
+fun sha256(
+    input: ReadBuffer,
+    factory: BufferFactory = BufferFactory.Default,
+): ReadBuffer {
+    val out: PlatformBuffer = factory.allocate(SHA256_DIGEST_BYTES)
+    Sha256Digest().update(input).digestInto(out)
+    out.resetForRead()
+    return out
+}

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/BufferBackingTests.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/BufferBackingTests.kt
@@ -1,0 +1,94 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.ReadWriteBuffer
+import com.ditchoom.buffer.crypto.CryptoTestVectors.toHex
+import com.ditchoom.buffer.managed
+import com.ditchoom.buffer.pool.BufferPool
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The crypto primitives must produce identical output regardless of how the input and
+ * destination buffers are backed. Each backing exercises a different branch of the platform
+ * bridges:
+ *  - heap (managed ByteArray) -> `managedMemoryAccess` array path / `SecretKeySpec(array, …)`
+ *  - direct (native)          -> native-pointer / `ByteBuffer` path / `SecretKeySpec(copy)`
+ *  - PooledBuffer / slice     -> wrapper delegation (the CLAUDE.md wrapper-transparency contract)
+ *
+ * A regression in any one branch (e.g. a broken direct-dest fast path) would otherwise pass
+ * CI silently, because the existing KAT tests only hit one backing per platform incidentally.
+ */
+class BufferBackingTests {
+    private enum class Backing { HEAP, DIRECT, POOLED, SLICE }
+
+    // SHA-256("abc") and RFC 4231 Case 2 HMAC-SHA256(key="Jefe", msg="what do ya want for nothing?").
+    private val sha256Abc = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    private val hmacJefe = "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843"
+
+    private fun load(
+        buf: ReadWriteBuffer,
+        text: String,
+    ): ReadWriteBuffer {
+        for (c in text) buf.writeByte(c.code.toByte())
+        buf.resetForRead()
+        return buf
+    }
+
+    /** A read-ready [text] buffer with the requested [kind] backing. */
+    private fun input(
+        kind: Backing,
+        text: String,
+        pool: BufferPool,
+    ): ReadBuffer =
+        when (kind) {
+            Backing.HEAP -> load(BufferFactory.managed().allocate(text.length), text)
+            Backing.DIRECT -> load(BufferFactory.Default.allocate(text.length), text)
+            Backing.POOLED -> load(pool.acquire(text.length), text)
+            Backing.SLICE -> load(BufferFactory.managed().allocate(text.length), text).slice()
+        }
+
+    /** An empty writable destination of [size] bytes with the requested [kind] backing. */
+    private fun dest(
+        kind: Backing,
+        size: Int,
+        pool: BufferPool,
+    ): ReadWriteBuffer =
+        when (kind) {
+            Backing.HEAP -> BufferFactory.managed().allocate(size)
+            Backing.DIRECT -> BufferFactory.Default.allocate(size)
+            Backing.POOLED -> pool.acquire(size)
+            Backing.SLICE -> error("slice is read-only; not a valid destination")
+        }
+
+    @Test
+    fun sha256AcrossInputAndDestBackings() {
+        val pool = BufferPool()
+        val inputs = listOf(Backing.HEAP, Backing.DIRECT, Backing.POOLED, Backing.SLICE)
+        val dests = listOf(Backing.HEAP, Backing.DIRECT, Backing.POOLED)
+        for (ik in inputs) {
+            for (dk in dests) {
+                val out = dest(dk, SHA256_DIGEST_BYTES, pool)
+                sha256(input(ik, "abc", pool), out)
+                out.resetForRead()
+                assertEquals(sha256Abc, out.toHex(), "sha256 input=$ik dest=$dk")
+            }
+        }
+        pool.clear()
+    }
+
+    @Test
+    fun hmacAcrossKeyBackings() {
+        // Varying the key backing toggles the SecretKeySpec(array, …) vs SecretKeySpec(copy)
+        // branch on JVM and the managed/native pointer branch on Apple.
+        val pool = BufferPool()
+        for (keyKind in listOf(Backing.HEAP, Backing.DIRECT, Backing.POOLED, Backing.SLICE)) {
+            val key = input(keyKind, "Jefe", pool)
+            val message = input(Backing.DIRECT, "what do ya want for nothing?", pool)
+            assertEquals(hmacJefe, hmacSha256(key, message).toHex(), "hmac key=$keyKind")
+        }
+        pool.clear()
+    }
+}

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/CryptoEdgeCaseTests.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/CryptoEdgeCaseTests.kt
@@ -1,0 +1,99 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.crypto.CryptoTestVectors.ascii
+import com.ditchoom.buffer.crypto.CryptoTestVectors.repeatedByte
+import com.ditchoom.buffer.crypto.CryptoTestVectors.toHex
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/** Boundary and precondition coverage for the crypto primitives. */
+class CryptoEdgeCaseTests {
+    @Test
+    fun hmacEmptyMessage() {
+        // HMAC-SHA256(key="Jefe", message="").
+        assertEquals(
+            "923598ca6d64af2a5dba79dcd021a8a0fe5c5f557519adaaf0ad532d4506dd30",
+            hmacSha256(ascii("Jefe"), ascii("")).toHex(),
+        )
+    }
+
+    @Test
+    fun hmacKeyLengthBoundaries() {
+        // Keys at the 64-byte block boundary: <= block is zero-padded, > block is hashed first.
+        // Vectors are HMAC-SHA256(key=0x6b ('k') repeated N, message="abc").
+        val expected =
+            mapOf(
+                63 to "23670528b6b8c55d2f8ef2f36c1f000cec7c23ec76881c485f2e89b5fe705cca",
+                64 to "ae0c0e4a2340cf50185eb46aaa8723f4769153661612e212fb0d1fa3170c6202",
+                65 to "ed378e5dfa30dc98814ba09b2e610d9b6af66054922ceef9480da094a3f11b2d",
+            )
+        for ((keyLen, hex) in expected) {
+            assertEquals(hex, hmacSha256(repeatedByte(0x6b, keyLen), ascii("abc")).toHex(), "key len $keyLen")
+        }
+    }
+
+    @Test
+    fun hkdfZeroLengthProducesEmptyOutput() {
+        val out = Hkdf.derive(salt = null, ikm = repeatedByte(0x0b, 22), info = null, length = 0, factory = BufferFactory.Default)
+        assertEquals(0, out.remaining())
+    }
+
+    @Test
+    fun hkdfMaxLengthSucceeds() {
+        // RFC 5869 caps Expand output at 255 * HashLen = 8160 bytes.
+        val out =
+            Hkdf.derive(
+                salt = null,
+                ikm = repeatedByte(0x0b, 22),
+                info = null,
+                length = 255 * SHA256_DIGEST_BYTES,
+                factory = BufferFactory.Default,
+            )
+        assertEquals(255 * SHA256_DIGEST_BYTES, out.remaining())
+    }
+
+    @Test
+    fun hkdfOverMaxLengthThrows() {
+        assertFailsWith<IllegalArgumentException> {
+            Hkdf.derive(
+                salt = null,
+                ikm = repeatedByte(0x0b, 22),
+                info = null,
+                length = 255 * SHA256_DIGEST_BYTES + 1,
+                factory = BufferFactory.Default,
+            )
+        }
+    }
+
+    @Test
+    fun sha256DestTooSmallThrows() {
+        assertFailsWith<IllegalArgumentException> {
+            sha256(ascii("abc"), BufferFactory.Default.allocate(SHA256_DIGEST_BYTES - 1))
+        }
+    }
+
+    @Test
+    fun hmacDestTooSmallThrows() {
+        assertFailsWith<IllegalArgumentException> {
+            hmacSha256(ascii("Jefe"), ascii("abc"), BufferFactory.Default.allocate(HMAC_SHA256_BYTES - 1))
+        }
+    }
+
+    @Test
+    fun cryptoRandomFillsOnlyRemainingLeavingPrefixIntact() {
+        // Write a known prefix, advance past it, then fill the rest with random bytes.
+        // The prefix must be untouched and the random tail must not be all-zero.
+        val buf = BufferFactory.Default.allocate(8 + SHA256_DIGEST_BYTES)
+        repeat(8) { buf.writeByte(0x7f) }
+        cryptoRandomInto(buf) // fills the remaining 32 bytes at the current position
+        buf.resetForRead()
+        repeat(8) { assertEquals(0x7f.toByte(), buf.readByte(), "prefix byte $it must be preserved") }
+        var anyNonZero = false
+        repeat(SHA256_DIGEST_BYTES) { if (buf.readByte() != 0.toByte()) anyNonZero = true }
+        assertTrue(anyNonZero, "random tail must not be all zero")
+    }
+}

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/CryptoRandomTest.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/CryptoRandomTest.kt
@@ -1,0 +1,26 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.crypto.CryptoTestVectors.toHex
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class CryptoRandomTest {
+    @Test
+    fun producesRequestedLength() {
+        assertEquals(32, cryptoRandom(32).remaining())
+    }
+
+    @Test
+    fun twoDrawsDiffer() {
+        // Astronomically unlikely to collide; a constant generator would fail here.
+        assertNotEquals(cryptoRandom(32).toHex(), cryptoRandom(32).toHex())
+    }
+
+    @Test
+    fun notAllZero() {
+        val hex = cryptoRandom(32).toHex()
+        assertTrue(hex.any { it != '0' }, "CSPRNG returned all zero bytes")
+    }
+}

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/CryptoTestVectors.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/CryptoTestVectors.kt
@@ -1,0 +1,46 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.toReadBuffer
+
+/** Test helpers that build inputs and render outputs through the buffer API only (no ByteArray). */
+object CryptoTestVectors {
+    /** Materializes a hex string into a read-ready buffer via byte writes. */
+    fun hexBuffer(hex: String): ReadBuffer {
+        val n = hex.length / 2
+        val b = BufferFactory.Default.allocate(n)
+        for (i in 0 until n) b.writeByte(hex.substring(i * 2, i * 2 + 2).toInt(16).toByte())
+        b.resetForRead()
+        return b
+    }
+
+    /** A read-ready buffer of [count] bytes each equal to [value]. */
+    fun repeatedByte(
+        value: Int,
+        count: Int,
+    ): ReadBuffer {
+        val b = BufferFactory.Default.allocate(count)
+        repeat(count) { b.writeByte(value.toByte()) }
+        b.resetForRead()
+        return b
+    }
+
+    /** A read-ready buffer of [text]'s UTF-8 bytes. */
+    fun ascii(text: String): ReadBuffer = text.toReadBuffer()
+
+    /** Lowercase hex of this buffer's remaining bytes (non-destructive). */
+    fun ReadBuffer.toHex(): String {
+        val hex = "0123456789abcdef"
+        val start = position()
+        val n = remaining()
+        val sb = StringBuilder(n * 2)
+        for (i in 0 until n) {
+            val v = get(start + i).toInt() and 0xFF
+            sb.append(hex[v ushr 4])
+            sb.append(hex[v and 0xF])
+        }
+        return sb.toString()
+    }
+}

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/HkdfTest.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/HkdfTest.kt
@@ -1,0 +1,56 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.crypto.CryptoTestVectors.hexBuffer
+import com.ditchoom.buffer.crypto.CryptoTestVectors.repeatedByte
+import com.ditchoom.buffer.crypto.CryptoTestVectors.toHex
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/** RFC 5869 known-answer vectors for HKDF-SHA256. */
+class HkdfTest {
+    private fun derive(
+        salt: ReadBuffer?,
+        ikm: ReadBuffer,
+        info: ReadBuffer?,
+        length: Int,
+    ): String = Hkdf.derive(salt, ikm, info, length, BufferFactory.Default).toHex()
+
+    @Test
+    fun rfc5869Case1Extract() {
+        val prk = BufferFactory.Default.allocate(HMAC_SHA256_BYTES)
+        Hkdf.extractInto(salt = hexBuffer("000102030405060708090a0b0c"), ikm = repeatedByte(0x0b, 22), dest = prk)
+        prk.resetForRead()
+        assertEquals("077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5", prk.toHex())
+    }
+
+    @Test
+    fun rfc5869Case1Expand() {
+        assertEquals(
+            "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865",
+            derive(
+                salt = hexBuffer("000102030405060708090a0b0c"),
+                ikm = repeatedByte(0x0b, 22),
+                info = hexBuffer("f0f1f2f3f4f5f6f7f8f9"),
+                length = 42,
+            ),
+        )
+    }
+
+    @Test
+    fun rfc5869Case3EmptySaltAndInfo() {
+        assertEquals(
+            "8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d9d201395faa4b61a96c8",
+            derive(salt = null, ikm = repeatedByte(0x0b, 22), info = null, length = 42),
+        )
+    }
+
+    @Test
+    fun expandProducesRequestedLength() {
+        assertEquals(1, Hkdf.derive(null, repeatedByte(1, 32), null, 1, BufferFactory.Default).remaining())
+        assertEquals(12, Hkdf.derive(null, repeatedByte(1, 32), null, 12, BufferFactory.Default).remaining())
+        assertEquals(80, Hkdf.derive(null, repeatedByte(1, 32), null, 80, BufferFactory.Default).remaining())
+    }
+}

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/HmacSha256Test.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/HmacSha256Test.kt
@@ -1,0 +1,50 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.crypto.CryptoTestVectors.ascii
+import com.ditchoom.buffer.crypto.CryptoTestVectors.repeatedByte
+import com.ditchoom.buffer.crypto.CryptoTestVectors.toHex
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/** RFC 4231 known-answer vectors for HMAC-SHA256. */
+class HmacSha256Test {
+    @Test
+    fun case1() {
+        // key = 0x0b x20, data = "Hi There"
+        assertEquals(
+            "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7",
+            hmacSha256(repeatedByte(0x0b, 20), ascii("Hi There")).toHex(),
+        )
+    }
+
+    @Test
+    fun case2() {
+        // key = "Jefe", data = "what do ya want for nothing?"
+        assertEquals(
+            "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843",
+            hmacSha256(ascii("Jefe"), ascii("what do ya want for nothing?")).toHex(),
+        )
+    }
+
+    @Test
+    fun case6LongKeyIsHashed() {
+        // key = 0xaa x131 (longer than the 64-byte block → key gets pre-hashed)
+        assertEquals(
+            "60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f0ee37f54",
+            hmacSha256(
+                repeatedByte(0xaa, 131),
+                ascii("Test Using Larger Than Block-Size Key - Hash Key First"),
+            ).toHex(),
+        )
+    }
+
+    @Test
+    fun streamedMessageMatchesOneShot() {
+        val out = BufferFactory.Default.allocate(HMAC_SHA256_BYTES)
+        HmacSha256Mac(repeatedByte(0x0b, 20)).update(ascii("Hi ")).update(ascii("There")).doFinalInto(out)
+        out.resetForRead()
+        assertEquals("b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7", out.toHex())
+    }
+}

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/SecureBufferTest.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/SecureBufferTest.kt
@@ -1,0 +1,46 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.managed
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SecureBufferTest {
+    // A managed (heap) delegate is used so the buffer stays readable AFTER freeNativeMemory()
+    // (managed free is a GC no-op), letting the test observe the wipe in isolation.
+    private val secureManaged = BufferFactory.managed().secure()
+
+    @Test
+    fun factoryProducesSecureBuffer() {
+        assertTrue(secureManaged.allocate(16) is SecureBuffer)
+    }
+
+    @Test
+    fun freeWipesEveryByte() {
+        val buf = secureManaged.allocate(16)
+        repeat(16) { buf.writeByte(0xFF.toByte()) }
+        buf.freeNativeMemory()
+        for (i in 0 until 16) assertEquals(0, buf.get(i).toInt(), "byte $i not wiped")
+    }
+
+    @Test
+    fun freeWipesFullCapacityNotJustRemaining() {
+        // Leave position mid-buffer: fill() only covers position..limit, so the wipe must
+        // first widen the window to 0..capacity. If it didn't, bytes 0..7 would survive.
+        val buf = secureManaged.allocate(16)
+        repeat(16) { buf.writeByte(0xFF.toByte()) }
+        buf.position(8)
+        buf.freeNativeMemory()
+        for (i in 0 until 16) assertEquals(0, buf.get(i).toInt(), "byte $i not wiped")
+    }
+
+    @Test
+    fun doubleFreeIsIdempotent() {
+        val buf = secureManaged.allocate(8)
+        repeat(8) { buf.writeByte(0x7F) }
+        buf.freeNativeMemory()
+        buf.freeNativeMemory()
+        for (i in 0 until 8) assertEquals(0, buf.get(i).toInt())
+    }
+}

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/Sha256Test.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/Sha256Test.kt
@@ -3,6 +3,7 @@ package com.ditchoom.buffer.crypto
 import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.Default
 import com.ditchoom.buffer.crypto.CryptoTestVectors.ascii
+import com.ditchoom.buffer.crypto.CryptoTestVectors.repeatedByte
 import com.ditchoom.buffer.crypto.CryptoTestVectors.toHex
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -49,5 +50,27 @@ class Sha256Test {
         sha256(input)
         // update() consumed a slice; the caller's position must be untouched.
         assertEquals(3, input.remaining())
+    }
+
+    @Test
+    fun paddingBoundaries() {
+        // Message lengths straddling the 64-byte block boundary and the 56-byte point where
+        // the 8-byte length field forces an extra block — the classic SHA-256 padding edges.
+        // Vectors are SHA-256 of byte 0x61 ('a') repeated N times. These exercise the
+        // hand-rolled js/wasmJs core; JVM/Apple confirm the vectors against their system libs.
+        val expected =
+            mapOf(
+                55 to "9f4390f8d30c2dd92ec9f095b65e2b9ae9b0a925a5258e241c9f1e910f734318",
+                56 to "b35439a4ac6f0948b6d6f9e3c6af0f5f590ce20f1bde7090ef7970686ec6738a",
+                57 to "f13b2d724659eb3bf47f2dd6af1accc87b81f09f59f2b75e5c0bed6589dfe8c6",
+                63 to "7d3e74a05d7db15bce4ad9ec0658ea98e3f06eeecf16b4c6fff2da457ddc2f34",
+                64 to "ffe054fe7ae0cb6dc65c3af9b61d5209f439851db43d0ba5997337df154668eb",
+                65 to "635361c48bb9eab14198e76ea8ab7f1a41685d6ad62aa9146d301d4f17eb0ae0",
+                119 to "31eba51c313a5c08226adf18d4a359cfdfd8d2e816b13f4af952f7ea6584dcfb",
+                120 to "2f3d335432c70b580af0e8e1b3674a7c020d683aa5f73aaaedfdc55af904c21c",
+            )
+        for ((n, hex) in expected) {
+            assertEquals(hex, sha256(repeatedByte(0x61, n)).toHex(), "SHA-256 of 'a'*$n")
+        }
     }
 }

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/Sha256Test.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/Sha256Test.kt
@@ -1,0 +1,53 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.crypto.CryptoTestVectors.ascii
+import com.ditchoom.buffer.crypto.CryptoTestVectors.toHex
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/** NIST FIPS 180-4 known-answer vectors for SHA-256. */
+class Sha256Test {
+    @Test
+    fun emptyString() {
+        assertEquals(
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            sha256(ascii("")).toHex(),
+        )
+    }
+
+    @Test
+    fun abc() {
+        assertEquals(
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+            sha256(ascii("abc")).toHex(),
+        )
+    }
+
+    @Test
+    fun twoBlockMessage() {
+        // 56-byte message that forces a second padding block.
+        assertEquals(
+            "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1",
+            sha256(ascii("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")).toHex(),
+        )
+    }
+
+    @Test
+    fun incrementalUpdateMatchesOneShot() {
+        // Hashing "abc" in two updates must equal the one-shot digest.
+        val out = BufferFactory.Default.allocate(SHA256_DIGEST_BYTES)
+        Sha256Digest().update(ascii("a")).update(ascii("bc")).digestInto(out)
+        out.resetForRead()
+        assertEquals("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad", out.toHex())
+    }
+
+    @Test
+    fun updateIsNonDestructive() {
+        val input = ascii("abc")
+        sha256(input)
+        // update() consumed a slice; the caller's position must be untouched.
+        assertEquals(3, input.remaining())
+    }
+}

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/CryptoRandom.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/CryptoRandom.jsAndWasmJs.kt
@@ -1,0 +1,22 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.WriteBuffer
+
+/**
+ * js/wasmJs CSPRNG backed by WebCrypto's `crypto.getRandomValues`. Unlike `SubtleCrypto`
+ * (hashing/signing), `getRandomValues` is synchronous, so it satisfies the synchronous
+ * [cryptoRandomInto] contract directly. Node 18+ exposes the same `globalThis.crypto`.
+ */
+actual fun cryptoRandomInto(dest: WriteBuffer) {
+    val n = dest.remaining()
+    var i = 0
+    // Pulled one byte at a time so the same source compiles for both the JS and the Wasm
+    // backend without typed-array marshalling. Crypto material is small (nonces/keys);
+    // bulk random is not the intended use.
+    while (i < n) {
+        dest.writeByte(secureRandomByte().toByte())
+        i++
+    }
+}
+
+private fun secureRandomByte(): Int = js("(globalThis.crypto).getRandomValues(new Uint8Array(1))[0]")

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256Mac.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256Mac.jsAndWasmJs.kt
@@ -1,0 +1,53 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.managed
+
+/** js/wasmJs HMAC-SHA256 (RFC 2104) over the pure-Kotlin [Sha256Core]. Holds no primitive arrays. */
+actual class HmacSha256Mac actual constructor(
+    key: ReadBuffer,
+) {
+    // inner accumulates H(ipad ‖ message); opad (a managed buffer) is held for the outer hash.
+    private val inner = Sha256Core()
+    private val opad: PlatformBuffer = BufferFactory.managed().allocate(SHA256_BLOCK_BYTES)
+
+    init {
+        // Normalize the key to a single block (managed buffer, zero-initialized): hash it if
+        // longer than a block, else zero-pad.
+        val kBlock: PlatformBuffer = BufferFactory.managed().allocate(SHA256_BLOCK_BYTES)
+        val n = key.remaining()
+        val start = key.position()
+        if (n > SHA256_BLOCK_BYTES) {
+            val kh = Sha256Core()
+            kh.update(key)
+            kh.finish()
+            for (i in 0 until SHA256_DIGEST_BYTES) kBlock.set(i, kh.digestByte(i))
+        } else {
+            for (i in 0 until n) kBlock.set(i, key.get(start + i))
+        }
+        for (i in 0 until SHA256_BLOCK_BYTES) {
+            val kb = kBlock.get(i).toInt()
+            inner.absorbByte((kb xor 0x36).toByte()) // ipad
+            opad.set(i, (kb xor 0x5c).toByte())
+        }
+        kBlock.fill(0) // wipe the key-derived block
+    }
+
+    actual fun update(input: ReadBuffer): HmacSha256Mac {
+        inner.update(input)
+        return this
+    }
+
+    actual fun doFinalInto(dest: WriteBuffer) {
+        inner.finish() // inner = H(ipad ‖ message)
+        val outer = Sha256Core()
+        for (i in 0 until SHA256_BLOCK_BYTES) outer.absorbByte(opad.get(i))
+        for (i in 0 until SHA256_DIGEST_BYTES) outer.absorbByte(inner.digestByte(i))
+        outer.finish()
+        for (i in 0 until SHA256_DIGEST_BYTES) dest.writeByte(outer.digestByte(i))
+        opad.fill(0)
+    }
+}

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Sha256Core.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Sha256Core.kt
@@ -1,0 +1,163 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.managed
+
+/**
+ * Pure-Kotlin streaming SHA-256 (FIPS 180-4), used as the js/wasmJs fallback because
+ * WebCrypto's `SubtleCrypto.digest` is async-only and cannot satisfy the synchronous
+ * [Sha256Digest] / [HmacSha256Mac] contracts.
+ *
+ * Holds **no primitive arrays**: the working state lives in a single big-endian managed
+ * [work] buffer (message block in words 0..15, expanded schedule in words 16..63, read and
+ * written word-at-a-time via absolute `getInt`/`set`) and eight `UInt` hash-state fields.
+ * Round constants live in a shared read-only buffer ([K]). Correctness is pinned by the
+ * common NIST/RFC known-answer vectors.
+ *
+ * Not thread-safe — one instance per digest.
+ */
+internal class Sha256Core {
+    private var h0 = 0x6a09e667u
+    private var h1 = 0xbb67ae85u
+    private var h2 = 0x3c6ef372u
+    private var h3 = 0xa54ff53au
+    private var h4 = 0x510e527fu
+    private var h5 = 0x9b05688cu
+    private var h6 = 0x1f83d9abu
+    private var h7 = 0x5be0cd19u
+
+    // 64-byte message block (bytes 0..63 = schedule words 0..15) plus room for the
+    // expanded schedule words 16..63 (bytes 64..255). One allocation, no arrays.
+    private val work: PlatformBuffer = BufferFactory.managed().allocate(256, ByteOrder.BIG_ENDIAN)
+    private var blockLen = 0
+    private var totalBytes = 0L
+
+    /** Absorbs the remaining bytes of [input] without disturbing its position. */
+    fun update(input: ReadBuffer) {
+        val start = input.position()
+        val end = input.limit()
+        var i = start
+        while (i < end) {
+            absorbByte(input.get(i))
+            i++
+        }
+    }
+
+    /** Absorbs a single byte. */
+    fun absorbByte(b: Byte) {
+        work.set(blockLen, b)
+        blockLen++
+        if (blockLen == SHA256_BLOCK_BYTES) {
+            processBlock()
+            blockLen = 0
+        }
+        totalBytes++
+    }
+
+    /** Pads and finalizes; afterwards [digestByte] returns the digest bytes. */
+    fun finish() {
+        val bitLen = totalBytes * 8
+        work.set(blockLen, 0x80.toByte())
+        blockLen++
+        if (blockLen > SHA256_BLOCK_BYTES - 8) {
+            while (blockLen < SHA256_BLOCK_BYTES) {
+                work.set(blockLen, 0.toByte())
+                blockLen++
+            }
+            processBlock()
+            blockLen = 0
+        }
+        while (blockLen < SHA256_BLOCK_BYTES - 8) {
+            work.set(blockLen, 0.toByte())
+            blockLen++
+        }
+        work.set(SHA256_BLOCK_BYTES - 8, bitLen) // 64-bit big-endian length at bytes 56..63
+        processBlock()
+    }
+
+    /** Digest byte [i] (0..31), valid only after [finish]. */
+    fun digestByte(i: Int): Byte {
+        val word =
+            when (i ushr 2) {
+                0 -> h0
+                1 -> h1
+                2 -> h2
+                3 -> h3
+                4 -> h4
+                5 -> h5
+                6 -> h6
+                else -> h7
+            }
+        return (word shr (24 - 8 * (i and 3))).toByte()
+    }
+
+    private fun processBlock() {
+        // Expand schedule words 16..63 in place (words 0..15 are the message block).
+        for (t in 16 until 64) {
+            val w15 = work.getInt((t - 15) * 4).toUInt()
+            val w2 = work.getInt((t - 2) * 4).toUInt()
+            val s0 = w15.rotateRight(7) xor w15.rotateRight(18) xor (w15 shr 3)
+            val s1 = w2.rotateRight(17) xor w2.rotateRight(19) xor (w2 shr 10)
+            val v = work.getInt((t - 16) * 4).toUInt() + s0 + work.getInt((t - 7) * 4).toUInt() + s1
+            work.set(t * 4, v.toInt())
+        }
+
+        var a = h0
+        var b = h1
+        var c = h2
+        var d = h3
+        var e = h4
+        var f = h5
+        var g = h6
+        var hh = h7
+
+        for (t in 0 until 64) {
+            val w = work.getInt(t * 4).toUInt()
+            val bigS1 = e.rotateRight(6) xor e.rotateRight(11) xor e.rotateRight(25)
+            val ch = (e and f) xor (e.inv() and g)
+            val t1 = hh + bigS1 + ch + K.getInt(t * 4).toUInt() + w
+            val bigS0 = a.rotateRight(2) xor a.rotateRight(13) xor a.rotateRight(22)
+            val maj = (a and b) xor (a and c) xor (b and c)
+            val t2 = bigS0 + maj
+            hh = g
+            g = f
+            f = e
+            e = d + t1
+            d = c
+            c = b
+            b = a
+            a = t1 + t2
+        }
+
+        h0 += a
+        h1 += b
+        h2 += c
+        h3 += d
+        h4 += e
+        h5 += f
+        h6 += g
+        h7 += hh
+    }
+
+    companion object {
+        // First 32 bits of the fractional parts of the cube roots of the first 64 primes,
+        // stored in a shared read-only big-endian buffer (no primitive array).
+        private const val K_HEX =
+            "428a2f9871374491b5c0fbcfe9b5dba53956c25b59f111f1923f82a4ab1c5ed5" +
+                "d807aa9812835b01243185be550c7dc372be5d7480deb1fe9bdc06a7c19bf174" +
+                "e49b69c1efbe47860fc19dc6240ca1cc2de92c6f4a7484aa5cb0a9dc76f988da" +
+                "983e5152a831c66db00327c8bf597fc7c6e00bf3d5a7914706ca635114292967" +
+                "27b70a852e1b21384d2c6dfc53380d13650a7354766a0abb81c2c92e92722c85" +
+                "a2bfe8a1a81a664bc24b8b70c76c51a3d192e819d6990624f40e3585106aa070" +
+                "19a4c1161e376c082748774c34b0bcb5391c0cb34ed8aa4a5b9cca4f682e6ff3" +
+                "748f82ee78a5636f84c878148cc7020890befffaa4506cebbef9a3f7c67178f2"
+
+        private val K: ReadBuffer =
+            BufferFactory.managed().allocate(256, ByteOrder.BIG_ENDIAN).apply {
+                for (i in 0 until 256) set(i, K_HEX.substring(i * 2, i * 2 + 2).toInt(16).toByte())
+            }
+    }
+}

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Sha256Digest.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Sha256Digest.jsAndWasmJs.kt
@@ -1,0 +1,19 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+
+/** js/wasmJs SHA-256 backed by the synchronous pure-Kotlin [Sha256Core]. */
+actual class Sha256Digest actual constructor() {
+    private val core = Sha256Core()
+
+    actual fun update(input: ReadBuffer): Sha256Digest {
+        core.update(input)
+        return this
+    }
+
+    actual fun digestInto(dest: WriteBuffer) {
+        core.finish()
+        for (i in 0 until SHA256_DIGEST_BYTES) dest.writeByte(core.digestByte(i))
+    }
+}

--- a/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/CryptoRandom.jvmCommon.kt
+++ b/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/CryptoRandom.jvmCommon.kt
@@ -1,0 +1,26 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.WriteBuffer
+import java.security.SecureRandom
+
+private val secureRandom = SecureRandom()
+
+/**
+ * JVM/Android CSPRNG backed by [java.security.SecureRandom]. Fills the buffer eight bytes at
+ * a time via [SecureRandom.nextLong] so no intermediate `ByteArray` is allocated — the random
+ * bytes are written straight into the destination buffer.
+ */
+actual fun cryptoRandomInto(dest: WriteBuffer) {
+    var remaining = dest.remaining()
+    while (remaining >= 8) {
+        dest.writeLong(secureRandom.nextLong())
+        remaining -= 8
+    }
+    if (remaining > 0) {
+        var bits = secureRandom.nextLong()
+        repeat(remaining) {
+            dest.writeByte(bits.toByte())
+            bits = bits ushr 8
+        }
+    }
+}

--- a/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256Mac.jvmCommon.kt
+++ b/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256Mac.jvmCommon.kt
@@ -1,0 +1,35 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.managedMemoryAccess
+import com.ditchoom.buffer.toByteArray
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+/** JVM/Android HMAC-SHA256 backed by the JCA [Mac]. */
+actual class HmacSha256Mac actual constructor(
+    key: ReadBuffer,
+) {
+    private val mac =
+        Mac.getInstance("HmacSHA256").apply {
+            val managed = key.managedMemoryAccess
+            val spec =
+                if (managed != null) {
+                    // SecretKeySpec copies the requested range, so no aliasing of the source buffer.
+                    SecretKeySpec(managed.backingArray, managed.arrayOffset + key.position(), key.remaining(), "HmacSHA256")
+                } else {
+                    SecretKeySpec(key.toByteArray(), "HmacSHA256")
+                }
+            init(spec)
+        }
+
+    actual fun update(input: ReadBuffer): HmacSha256Mac {
+        mac.updateRemaining(input)
+        return this
+    }
+
+    actual fun doFinalInto(dest: WriteBuffer) {
+        mac.doFinalInto(dest)
+    }
+}

--- a/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/JvmCryptoBridge.jvmCommon.kt
+++ b/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/JvmCryptoBridge.jvmCommon.kt
@@ -1,0 +1,64 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.managedMemoryAccess
+import com.ditchoom.buffer.toNativeData
+import java.security.MessageDigest
+import javax.crypto.Mac
+
+/**
+ * Feeds the remaining bytes of [buffer] into this digest without disturbing the buffer's
+ * position. Zero-copy on both backings: heap buffers go through their own backing array,
+ * direct buffers through a read-only `ByteBuffer` view ([toNativeData] is non-destructive
+ * and scoped to position..limit). No intermediate array is allocated by this module.
+ */
+internal fun MessageDigest.updateRemaining(buffer: ReadBuffer) {
+    if (buffer.remaining() == 0) return
+    val managed = buffer.managedMemoryAccess
+    if (managed != null) {
+        update(managed.backingArray, managed.arrayOffset + buffer.position(), buffer.remaining())
+    } else {
+        update(buffer.toNativeData().byteBuffer)
+    }
+}
+
+/** As [MessageDigest.updateRemaining], for an HMAC. */
+internal fun Mac.updateRemaining(buffer: ReadBuffer) {
+    if (buffer.remaining() == 0) return
+    val managed = buffer.managedMemoryAccess
+    if (managed != null) {
+        update(managed.backingArray, managed.arrayOffset + buffer.position(), buffer.remaining())
+    } else {
+        update(buffer.toNativeData().byteBuffer)
+    }
+}
+
+/**
+ * Writes the final digest into [dest] at its current position, advancing it. When [dest] is
+ * heap-backed the digest is written straight into the buffer's own backing array (zero-copy,
+ * no allocation by this module). Otherwise JCA returns its own array, which we hand to the
+ * buffer via `writeBytes` — the only `ByteArray` here is the one the system API produces.
+ */
+internal fun MessageDigest.digestInto(dest: WriteBuffer) {
+    val managed = dest.managedMemoryAccess
+    if (managed != null) {
+        val pos = dest.position()
+        digest(managed.backingArray, managed.arrayOffset + pos, SHA256_DIGEST_BYTES)
+        dest.position(pos + SHA256_DIGEST_BYTES)
+    } else {
+        dest.writeBytes(digest())
+    }
+}
+
+/** As [MessageDigest.digestInto], for an HMAC tag. */
+internal fun Mac.doFinalInto(dest: WriteBuffer) {
+    val managed = dest.managedMemoryAccess
+    if (managed != null) {
+        val pos = dest.position()
+        doFinal(managed.backingArray, managed.arrayOffset + pos)
+        dest.position(pos + HMAC_SHA256_BYTES)
+    } else {
+        dest.writeBytes(doFinal())
+    }
+}

--- a/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/Sha256Digest.jvmCommon.kt
+++ b/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/Sha256Digest.jvmCommon.kt
@@ -1,0 +1,19 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import java.security.MessageDigest
+
+/** JVM/Android SHA-256 backed by the JCA [MessageDigest]. */
+actual class Sha256Digest actual constructor() {
+    private val md = MessageDigest.getInstance("SHA-256")
+
+    actual fun update(input: ReadBuffer): Sha256Digest {
+        md.updateRemaining(input)
+        return this
+    }
+
+    actual fun digestInto(dest: WriteBuffer) {
+        md.digestInto(dest)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,6 +23,7 @@ develocity {
 // Monorepo modules
 include(":buffer")
 include(":buffer-compression")
+include(":buffer-crypto")
 include(":buffer-flow")
 include(":buffer-codec")
 include(":buffer-codec-schema")


### PR DESCRIPTION
## What

New published `:buffer-crypto` module providing **synchronous, buffer-native** cryptographic primitives backed by each platform's **system crypto subsystem**.

Motivated by theE2E-encryption work : extract the reusable SHA-256 → HMAC → HKDF stack into the public buffer library so it can be depended on instead of re-implemented per consumer.

## Primitives (package `com.ditchoom.buffer.crypto`)

- `Sha256Digest` / `sha256(input, dest|factory)`
- `HmacSha256Mac` / `hmacSha256(key, message, dest|factory)`
- `Hkdf` (pure-common, built on the native HMAC): `extractInto` / `expandInto` / `deriveInto` / `derive`
- `cryptoRandomInto(dest)` / `cryptoRandom(size, factory)`
- `SecureBuffer` + `BufferFactory.secure()` — `PooledBuffer`-style decorator that zeroes its **full** backing storage on `freeNativeMemory()` (fires on `use {}` / `freeIfNeeded()`). `internal` ctor → only obtainable via `SecureBufferFactory`; composes over any delegate, e.g. `BufferFactory.deterministic().secure()`.

## Platform backends (system functions, zero-copy, no fabricated arrays)

| Target | Hash / HMAC | CSPRNG |
|---|---|---|
| JVM / Android | JCA `MessageDigest` / `Mac` | `SecureRandom` |
| Apple | CommonCrypto `CC_SHA256` / `CCHmac` | Security `SecRandomCopyBytes` |
| js / wasmJs | synchronous pure-Kotlin (WebCrypto `digest` is async-only) | `crypto.getRandomValues` (sync) |
| Linux | deferred — no target registered (BoringSSL is a future addition) |

**Zero-copy, both directions.** The dest-buffer form is the primitive: input is fed from the buffer's own backing array (heap) / native pointer / direct `ByteBuffer` view; output (digest/MAC/random) is written **straight into the caller's buffer** — JVM via `digest(arr,off,len)`/`doFinal(arr,off)` into a managed dest, Apple via `CC_SHA256_Final`/`CCHmacFinal`/`SecRandomCopyBytes` into the dest's memory pointer.

**No fabricated `ByteArray`/primitive arrays anywhere.** Random is filled via `nextLong`/`SecRandomCopyBytes`; the pure-Kotlin SHA core keeps its state in a managed buffer + `UInt` fields + a shared constant buffer. The only array touches are the buffer's own `toByteArray()` and the system API's own returns, used only where JCA absolutely requires a `byte[]` (e.g. `SecretKeySpec`).

## Testing

Known-answer vectors expressed through the buffer API (no `ByteArray` in tests): NIST FIPS 180-4 SHA-256, RFC 4231 HMAC-SHA256, RFC 5869 HKDF-SHA256, plus CSPRNG and `SecureBuffer` full-capacity-wipe tests.

- **Verified locally (Linux): JVM, JS, WASM green; Android compiles** (shares the JCA actuals).
- ⚠️ **Apple actuals could not be compiled locally** (Apple targets only register on a Mac). **This draft exists to let macOS CI validate the CommonCrypto / Security path** (`appleMain`).

## Scope / deferred

PR #403's stack only. AES-GCM / ECDSA / HPKE and Linux/BoringSSL are deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)