### PR TITLE
ci(android): skip modules above the emulator API level instead of failing the API-21 leg

### DIFF
--- a/.github/workflows/android_integration.yaml
+++ b/.github/workflows/android_integration.yaml
@@ -138,7 +138,14 @@ jobs:
             # package first makes the install clean and idempotent regardless of
             # what signature the cached copy carried.
             adb shell pm list packages -3 | sed 's/^package://' | grep -i '\.ditchoom\.' | xargs -r -n1 adb uninstall || true
-            ./gradlew connectedAndroidTest -x connectedBenchmarkAndroidTest
+            # connectedAndroidTestCompatible (root build.gradle.kts) schedules only the
+            # connected tests for modules whose minSdk <= this emulator's API level.
+            # AGP fails connectedAndroidTest for a module whose minSdk exceeds the device
+            # API ("No compatible devices connected.[TestRunner] FAILED") instead of
+            # skipping it, which red-failed the API-21 leg the moment a higher-minSdk
+            # module (e.g. buffer-crypto, minSdk 28) was present. Passing the matrix
+            # api-level lets the build drop those modules cleanly on the low-API leg.
+            ./gradlew connectedAndroidTestCompatible -PdeviceApiLevel=${{ matrix.api-level }}
 
       - name: Kill emulator processes
         if: always()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,6 +76,59 @@ tasks.register("buildAll") {
     dependsOn(":buffer:build", ":buffer-compression:build", ":buffer-flow:build", ":buffer-codec:build", ":buffer-codec-schema:build", ":buffer-codec-processor:build", ":buffer-codec-gradle-plugin:build", ":buffer-codec-test:build")
 }
 
+// minSdk-aware aggregate for Android instrumented tests on a SPECIFIC emulator API level.
+//
+// Why this exists: AGP's `connectedAndroidTest` does NOT skip a module whose
+// `minSdk` exceeds the connected device's API level — it logs
+//   "Skipping device '<emu>' for ':module:': minSdkVersion [N] > deviceApiLevel [M]"
+//   "> : No compatible devices connected.[TestRunner] FAILED"
+// and FAILS the task (there is no AGP flag to turn that into a skip). On the CI
+// emulator matrix that means any module with a minSdk above the matrix's lowest
+// API level (e.g. an API-21 leg) red-fails the whole leg even though the emulator
+// booted fine and every compatible module passed. See PR discussion / the
+// `android_integration.yaml` API-21 leg failures.
+//
+// Fix: schedule only the connected-test tasks for modules whose `minSdk` is <= the
+// emulator API level. The level is passed by CI as `-PdeviceApiLevel=<api-level>`
+// (the same value as the emulator matrix entry). When the property is absent every
+// Android module is included (local `connectedCheck`-style runs against whatever
+// device is attached keep their existing all-modules behaviour).
+tasks.register("connectedAndroidTestCompatible") {
+    description = "Run connectedDebugAndroidTest only for Android modules whose minSdk <= -PdeviceApiLevel (defaults to all modules when unset)."
+    group = "verification"
+
+    val deviceApiLevel = (findProperty("deviceApiLevel") as String?)?.toIntOrNull()
+
+    // Android library modules instrumented in CI, paired with the module's declared
+    // minSdk (see each module's build.gradle.kts `android { defaultConfig { minSdk } }`).
+    // This mirrors exactly the set the previous CI command
+    // (`connectedAndroidTest -x connectedBenchmarkAndroidTest`) scheduled: the
+    // debug-variant connected tests. `:buffer` is intentionally absent — it pins
+    // testBuildType = "benchmark", so its only connected variant is
+    // connectedBenchmarkAndroidTest, which the previous command excluded with `-x`
+    // (emulator timings are not representative) and which therefore stays excluded here.
+    // When a new module is added (e.g. buffer-crypto, minSdk 28), add it here with its
+    // minSdk so the API-21 leg cleanly skips it instead of failing.
+    val androidConnectedTests =
+        listOf(
+            Triple(":buffer-compression", ":buffer-compression:connectedDebugAndroidTest", 21),
+            Triple(":buffer-flow", ":buffer-flow:connectedDebugAndroidTest", 21),
+            Triple(":buffer-codec", ":buffer-codec:connectedDebugAndroidTest", 21),
+        )
+
+    androidConnectedTests.forEach { (_, testTaskPath, minSdk) ->
+        val compatible = deviceApiLevel == null || minSdk <= deviceApiLevel
+        if (compatible) {
+            dependsOn(testTaskPath)
+        } else {
+            logger.lifecycle(
+                "connectedAndroidTestCompatible: skipping $testTaskPath " +
+                    "(minSdk=$minSdk > deviceApiLevel=$deviceApiLevel)",
+            )
+        }
+    }
+}
+
 // Copy Dokka output to Docusaurus static directory
 tasks.register<Copy>("copyDokkaToDocusaurus") {
     description = "Generate and copy API documentation to Docusaurus"


### PR DESCRIPTION
## Symptom

The \`Android Emulator Integration Test\` workflow's **API 21** matrix leg (\`test (21, default, x86_64)\`) fails consistently, while the API 35 leg passes. At first glance the logs look like an emulator boot failure:

\`\`\`
Emulator boot timeout: 600
adb: device offline
[EmulatorConsole]: Failed to start Emulator console for 5554
> : No compatible devices connected.[TestRunner] FAILED
\`\`\`

## Root cause — it is NOT a boot failure

The emulator boots fine on **both** legs. The lines above are red herrings: \`Emulator boot timeout: 600\`, \`adb: device offline\`, and \`Failed to start Emulator console for 5554\` appear **identically on the green API 35 leg**, and the API 21 log clearly shows \`Emulator booted.\` followed by compatible modules' tests actually running and passing.

The real failure is one line earlier:

\`\`\`
Skipping device 'emulator-5554 - 5.0.2' for ':buffer-crypto:': minSdkVersion [28] > deviceApiLevel [21]
> : No compatible devices connected.[TestRunner] FAILED
\`\`\`

AGP does **not** skip a module whose \`minSdk\` exceeds the connected device's API level — it **fails** the \`connectedAndroidTest\` task, and there is no AGP flag to turn that into a skip ([AGP has no skip-on-incompatible option](https://github.com/facebook/react-native/issues/29805)). So any module with \`minSdk > 21\` (e.g. \`buffer-crypto\`, minSdk 28) red-fails the entire API-21 leg even though the emulator booted and every compatible module passed.

On \`main\` today all four Android modules are minSdk 21, so the leg is green — but this is a latent trap that fires the moment a higher-minSdk module lands.

## Fix

Add a root \`connectedAndroidTestCompatible\` aggregate task (in \`build.gradle.kts\`) that schedules a module's \`connectedDebugAndroidTest\` only when its \`minSdk <= -PdeviceApiLevel\`. CI passes the matrix api-level:

\`\`\`
./gradlew connectedAndroidTestCompatible -PdeviceApiLevel=\${{ matrix.api-level }}
\`\`\`

- **No property set** (local runs) → every module is included, unchanged behaviour.
- **On main** (all modules minSdk 21) → behaviourally identical to the old \`connectedAndroidTest -x connectedBenchmarkAndroidTest\`.
- **On the low-API leg** → higher-minSdk modules are dropped cleanly (logged) instead of failing the build.

When a new module is added, register it in the task's list with its minSdk.

## Why this over other options

Boot-reliability flags (\`-no-snapshot\`, software GPU, cold boot, pinned keystore, split cache) are **already** in place from prior PRs (#173/#183/#185/#192) and the emulator boots reliably — adding more would not address this failure. Raising the minimum tested API level would drop the intentional minSdk-21 coverage floor for the core modules. Filtering by minSdk preserves full coverage on every leg while eliminating the spurious failure.

## Validation

Locally (cannot run GitHub's x86_64 emulator, but task selection is host-independent):
- \`./gradlew connectedAndroidTestCompatible -PdeviceApiLevel=21 --dry-run\` schedules exactly \`:buffer-codec\`, \`:buffer-compression\`, \`:buffer-flow\` \`connectedDebugAndroidTest\` — matching the previous CI command.
- \`-PdeviceApiLevel=19 --dry-run\` logs the three skips and the aggregate **succeeds** (the previously-failing path now passes).
- \`./gradlew ktlintKotlinScriptCheck\` passes for the edited build script.

CI on this PR will exercise both legs.

Scope: CI workflow + root build aggregate only. No library source changed.