### PR TITLE
feat(buffer-crypto): enable Apple CryptoKit primitives via Swift @_cdecl shim (#201)

### DIFF
--- a/buffer-crypto/build.gradle.kts
+++ b/buffer-crypto/build.gradle.kts
@@ -35,6 +35,89 @@ repositories {
     maven { setUrl("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/kotlin-js-wrappers/") }
 }
 
+/**
+ * Per-target wiring for the CryptoKit Swift shim. Returns null for non-Apple konan targets (they
+ * have no CryptoKit). For an Apple target it registers a task that compiles
+ * src/nativeInterop/swift/CryptoKitShim.swift into a per-target static archive
+ * `lib<konan>cryptokitshim.a`, and exposes the archive name, output dir, and the toolchain's
+ * per-SDK Swift runtime lib dir for the cinterop + final-binary linker.
+ */
+class AppleSwiftShim(
+    val task: TaskProvider<Exec>,
+    val archiveName: String,
+    val outDir: File,
+    val swiftLibDir: String,
+)
+
+fun appleSwiftShim(
+    project: org.gradle.api.Project,
+    konanTarget: org.jetbrains.kotlin.konan.target.KonanTarget,
+): AppleSwiftShim? {
+    // (swift -target triple, xcrun --sdk name, swift runtime lib subdir under .../lib/swift/)
+    val spec: Triple<String, String, String> =
+        when (konanTarget.name) {
+            "macos_arm64" -> Triple("arm64-apple-macos11", "macosx", "macosx")
+            "macos_x64" -> Triple("x86_64-apple-macos11", "macosx", "macosx")
+            "ios_arm64" -> Triple("arm64-apple-ios14", "iphoneos", "iphoneos")
+            "ios_simulator_arm64" -> Triple("arm64-apple-ios14-simulator", "iphonesimulator", "iphonesimulator")
+            "ios_x64" -> Triple("x86_64-apple-ios14-simulator", "iphonesimulator", "iphonesimulator")
+            "tvos_arm64" -> Triple("arm64-apple-tvos14", "appletvos", "appletvos")
+            "tvos_simulator_arm64" -> Triple("arm64-apple-tvos14-simulator", "appletvsimulator", "appletvsimulator")
+            "tvos_x64" -> Triple("x86_64-apple-tvos14-simulator", "appletvsimulator", "appletvsimulator")
+            "watchos_simulator_arm64" -> Triple("arm64-apple-watchos7-simulator", "watchsimulator", "watchsimulator")
+            "watchos_x64" -> Triple("x86_64-apple-watchos7-simulator", "watchsimulator", "watchsimulator")
+            else -> return null
+        }
+    val (triple, sdkName, swiftSubdir) = spec
+    val swiftLibDir =
+        File(
+            project.providers
+                .exec { commandLine("xcrun", "--find", "swiftc") }
+                .standardOutput.asText
+                .get()
+                .trim(),
+        ).parentFile.parentFile // .../usr/bin/swiftc -> .../usr
+            .resolve("lib/swift/$swiftSubdir")
+            .absolutePath
+    val sdkPath =
+        project.providers
+            .exec { commandLine("xcrun", "--sdk", sdkName, "--show-sdk-path") }
+            .standardOutput.asText
+            .get()
+            .trim()
+    val outDir =
+        project.layout.buildDirectory
+            .dir("cryptokitshim/${konanTarget.name}")
+            .get()
+            .asFile
+    val archiveName = "${konanTarget.name}cryptokitshim"
+    val src = project.file("src/nativeInterop/swift/CryptoKitShim.swift")
+    val archive = File(outDir, "lib$archiveName.a")
+    val task =
+        project.tasks.register("compileCryptoKitShim${konanTarget.name.replaceFirstChar { it.uppercase() }}", Exec::class.java) {
+            inputs.file(src)
+            inputs.property("triple", triple)
+            inputs.property("sdkPath", sdkPath)
+            outputs.file(archive)
+            doFirst { outDir.mkdirs() }
+            commandLine(
+                "xcrun",
+                "swiftc",
+                "-emit-library",
+                "-static",
+                "-target",
+                triple,
+                "-sdk",
+                sdkPath,
+                "-O",
+                "-o",
+                archive.absolutePath,
+                src.absolutePath,
+            )
+        }
+    return AppleSwiftShim(task, archiveName, outDir, swiftLibDir)
+}
+
 kotlin {
     jvmToolchain(21)
 
@@ -101,6 +184,44 @@ kotlin {
     targets.withType<org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget>().configureEach {
         compilations.getByName("main").cinterops.create("commoncryptogcm") {
             defFile(project.file("src/nativeInterop/cinterop/commoncryptogcm.def"))
+        }
+
+        // CryptoKit shim: ChaCha20-Poly1305, Ed25519, X25519, and ECDSA-sign-from-scalar live in
+        // CryptoKit, which is Swift-only with no Objective-C/C interface — Kotlin/Native cinterop
+        // cannot bind it directly the way it binds CommonCrypto/Security. We compile a tiny Swift
+        // shim (src/nativeInterop/swift/CryptoKitShim.swift) that re-exposes those primitives through
+        // an `@_cdecl` plain-C surface into a per-target static archive, then cinterop against the
+        // hand-written header and link the archive + the Swift runtime. Registered on every Apple
+        // target so the commonizer exposes it to appleMain.
+        val konan = konanTarget
+        appleSwiftShim(project, konan)?.let { shim ->
+            compilations.getByName("main").cinterops.create("cryptokitshim") {
+                defFile(project.file("src/nativeInterop/cinterop/cryptokitshim.def"))
+                includeDirs(project.file("src/nativeInterop/swift"))
+                extraOpts(
+                    "-staticLibrary",
+                    "lib${shim.archiveName}.a",
+                    "-libraryPath",
+                    shim.outDir.absolutePath,
+                )
+            }
+            // The cinterop task is registered by the KMP plugin under a derived name; wire the
+            // Swift-archive build ahead of it.
+            val capName = konan.name.split("_").joinToString("") { it.replaceFirstChar { c -> c.uppercase() } }
+            project.tasks.named("cinteropCryptokitshim$capName").configure { dependsOn(shim.task) }
+            // The Swift static archive references the Swift runtime; point the final-binary linker
+            // at the toolchain's per-SDK Swift libs and the CryptoKit/Foundation frameworks.
+            binaries.all {
+                linkerOpts(
+                    "-L${shim.swiftLibDir}",
+                    "-lswiftCore",
+                    "-lswiftFoundation",
+                    "-framework",
+                    "CryptoKit",
+                    "-framework",
+                    "Foundation",
+                )
+            }
         }
     }
 

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/AeadBridge.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/AeadBridge.apple.kt
@@ -6,12 +6,23 @@ import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.Default
 import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.BCKS_OK
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.bcks_chachapoly_open
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.bcks_chachapoly_seal
 import kotlinx.cinterop.ByteVar
 import kotlinx.cinterop.CPointer
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.convert
 import kotlinx.cinterop.get
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.reinterpret
 import kotlinx.cinterop.usePinned
+import kotlinx.cinterop.value
+import platform.posix.size_tVar
 
 /*
  * Apple AEAD glue shared by Aead.apple.kt (aesGcmSeal) and the ChaCha20-Poly1305 bridge.
@@ -82,18 +93,13 @@ internal fun nativeTagBuffer(tag: CPointer<ByteVar>): ReadBuffer {
  * ChaCha20-Poly1305 on Apple via CryptoKit (`ChaChaPoly.seal` / `.open`).
  *
  * CommonCrypto exposes no Kotlin/Native-bindable ChaCha20-Poly1305 one-shot, so the algorithm
- * routes through a CryptoKit Swift shim wired up in the **macOS CI** toolchain (a Swift source
- * file + cinterop bridging header registered only when building on a Mac). On a host without
- * that shim (e.g. this Linux-hosted build) the symbol is absent: [appleChaChaPolyAvailable] is
- * `false`, so the AEAD entry points throw [UnsupportedOperationException] — never a polyfill —
- * exactly as the web target does for ChaCha.
- *
- * Mac CI replaces [appleChaChaPolyAvailable] with `true` and supplies the [appleChaChaPolySeal]
- * / [appleChaChaPolyOpen] bodies that call into the CryptoKit shim, at which point the shared
- * KAT/Wycheproof/tamper suite gates the algorithm on Apple. This default keeps the Linux build
- * honest: it compiles, reports the capability as unsupported, and never fabricates a tag.
+ * routes through the CryptoKit Swift shim ([bcks_chachapoly_seal] / [bcks_chachapoly_open], from
+ * `CryptoKitShim.swift` via the `cryptokitshim` cinterop). CryptoKit is available on every Apple
+ * target this module builds for (macOS 10.15+, iOS 13+, tvOS 13+, watchOS 6+), all of which exceed
+ * the module's deployment floors, so [appleChaChaPolyAvailable] is `true` unconditionally — no
+ * runtime feature-detection is needed.
  */
-internal val appleChaChaPolyAvailable: Boolean = false
+internal val appleChaChaPolyAvailable: Boolean = true
 
 internal fun appleChaChaPolySeal(
     key: ChaChaPolyKey,
@@ -101,7 +107,44 @@ internal fun appleChaChaPolySeal(
     aad: ReadBuffer?,
     plaintext: ReadBuffer,
     dest: WriteBuffer,
-): Unit = throw UnsupportedOperationException("ChaCha20-Poly1305 requires the CryptoKit shim (macOS CI)")
+) {
+    val ptLen = plaintext.remaining()
+    require(dest.remaining() >= ptLen + AEAD_TAG_BYTES) {
+        "dest needs ${ptLen + AEAD_TAG_BYTES} bytes remaining, has ${dest.remaining()}"
+    }
+    memScoped {
+        val tag = allocArray<ByteVar>(AEAD_TAG_BYTES)
+        var status = -1
+        key.material.withRemainingBytes { keyPtr, keyLen ->
+            nonce.withRemainingBytes { ivPtr, ivLen ->
+                withOptionalBytes(aad) { aadPtr, aadLen ->
+                    plaintext.withRemainingBytes2(ptLen) { ptPtr ->
+                        // Ciphertext (== plaintext length) goes straight into dest; tag to scratch.
+                        dest.withWritablePointer(ptLen) { ctPtr ->
+                            status =
+                                bcks_chachapoly_seal(
+                                    keyPtr.reinterpret(),
+                                    keyLen.convert(),
+                                    ivPtr.reinterpret(),
+                                    ivLen.convert(),
+                                    aadPtr.reinterpret(),
+                                    aadLen.convert(),
+                                    ptPtr.reinterpret(),
+                                    ptLen.convert(),
+                                    ctPtr.reinterpret(),
+                                    ptLen.convert(),
+                                    tag.reinterpret(),
+                                    AEAD_TAG_BYTES.convert(),
+                                )
+                        }
+                    }
+                }
+            }
+        }
+        check(status == BCKS_OK) { "ChaCha20-Poly1305 seal failed (status=$status)" }
+        for (i in 0 until AEAD_TAG_BYTES) dest.writeByte(tag[i])
+    }
+}
 
 internal fun appleChaChaPolyOpen(
     key: ChaChaPolyKey,
@@ -109,4 +152,60 @@ internal fun appleChaChaPolyOpen(
     aad: ReadBuffer?,
     ciphertextAndTag: ReadBuffer,
     dest: WriteBuffer,
-): Unit = throw UnsupportedOperationException("ChaCha20-Poly1305 requires the CryptoKit shim (macOS CI)")
+) {
+    require(ciphertextAndTag.remaining() >= AEAD_TAG_BYTES) {
+        "ciphertext+tag must be at least $AEAD_TAG_BYTES bytes"
+    }
+    val ctLen = ciphertextAndTag.remaining() - AEAD_TAG_BYTES
+    require(dest.remaining() >= ctLen) { "dest needs $ctLen bytes remaining, has ${dest.remaining()}" }
+
+    val ctView = absoluteView(ciphertextAndTag, ciphertextAndTag.position(), ctLen)
+    val tagView = absoluteView(ciphertextAndTag, ciphertextAndTag.position() + ctLen, AEAD_TAG_BYTES)
+
+    memScoped {
+        val destStart = dest.position()
+        var status = -1
+        var written = 0
+        val writtenVar = alloc<size_tVar>()
+        key.material.withRemainingBytes { keyPtr, keyLen ->
+            nonce.withRemainingBytes { ivPtr, ivLen ->
+                withOptionalBytes(aad) { aadPtr, aadLen ->
+                    ctView.withRemainingBytes2(ctLen) { ctPtr ->
+                        tagView.withRemainingBytes2(AEAD_TAG_BYTES) { tagPtr ->
+                            // CryptoKit authenticates first; on tag mismatch it returns BCKS_ERR_AUTH
+                            // and never writes plaintext into dest.
+                            dest.withWritablePointer(ctLen) { ptPtr ->
+                                status =
+                                    bcks_chachapoly_open(
+                                        keyPtr.reinterpret(),
+                                        keyLen.convert(),
+                                        ivPtr.reinterpret(),
+                                        ivLen.convert(),
+                                        aadPtr.reinterpret(),
+                                        aadLen.convert(),
+                                        ctPtr.reinterpret(),
+                                        ctLen.convert(),
+                                        tagPtr.reinterpret(),
+                                        AEAD_TAG_BYTES.convert(),
+                                        ptPtr.reinterpret(),
+                                        ctLen.convert(),
+                                        writtenVar.ptr,
+                                    )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        written = writtenVar.value.toInt()
+        if (status != BCKS_OK || written != ctLen) {
+            // Scrub any bytes that may have been written and reject. CryptoKit does not release
+            // unverified plaintext, but we zero dest defensively to honor the no-leak contract.
+            val end = dest.position()
+            dest.position(destStart)
+            while (dest.position() < end) dest.writeByte(0)
+            dest.position(destStart)
+            throw VerificationFailed()
+        }
+    }
+}

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/KeyAgreement.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/KeyAgreement.apple.kt
@@ -6,13 +6,20 @@ import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.Default
 import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.BCKS_OK
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.bcks_x25519_agree
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.bcks_x25519_generate
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.bcks_x25519_public_key
+import kotlinx.cinterop.ByteVar
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.IntVar
 import kotlinx.cinterop.alloc
+import kotlinx.cinterop.allocArray
 import kotlinx.cinterop.convert
 import kotlinx.cinterop.get
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.ptr
+import kotlinx.cinterop.reinterpret
 import kotlinx.cinterop.value
 import platform.CoreFoundation.CFDataGetBytePtr
 import platform.CoreFoundation.CFDataGetLength
@@ -42,6 +49,7 @@ import platform.Security.kSecAttrKeySizeInBits
 import platform.Security.kSecAttrKeyType
 import platform.Security.kSecAttrKeyTypeECSECPrimeRandom
 import platform.Security.kSecKeyAlgorithmECDHKeyExchangeStandard
+import platform.posix.size_tVar
 
 /**
  * Apple key agreement.
@@ -52,16 +60,18 @@ import platform.Security.kSecKeyAlgorithmECDHKeyExchangeStandard
  * small-subgroup peer points are rejected by `SecKeyCreateWithData` / the exchange, surfaced as
  * [InvalidPublicKey]. This file is verified on Mac CI — the Linux dev box does not compile Apple.
  *
- * **X25519** has no Security-framework key type — Curve25519 key agreement lives only in CryptoKit,
- * which is Swift-only and unreachable through Kotlin/Native cinterop without a Swift shim. It is
- * therefore reported unsupported here ([supportsSyncX25519] = `false`) and throws; adding it needs a
- * CryptoKit bridge (tracked as a follow-up — see the PR notes).
+ * **X25519** has no Security-framework key type — Curve25519 key agreement lives only in CryptoKit.
+ * It is wired through the `cryptokitshim` cinterop ([bcks_x25519_generate] / [bcks_x25519_public_key]
+ * / [bcks_x25519_agree]), which calls CryptoKit `Curve25519.KeyAgreement`. Keys use the RFC 7748 raw
+ * encoding (32-byte little-endian scalar / u-coordinate) directly, matching the cross-platform
+ * contract. [supportsSyncX25519] is therefore `true`. The RFC 7748 §6.1 all-zero rejection is applied
+ * by the shared [validateRawSecret] post-check (the `deriveSharedSecret` path runs it via the KDF).
  *
- * Private keys are stored as the Security framework external representation (`0x04‖X‖Y‖scalar`) in a
- * wiped [SecureBuffer]; that encoding round-trips through `SecKeyCreateWithData` for the agreement.
+ * EC private keys are stored as the Security framework external representation (`0x04‖X‖Y‖scalar`) in
+ * a wiped [SecureBuffer]; that encoding round-trips through `SecKeyCreateWithData` for the agreement.
  */
 
-actual val supportsSyncX25519: Boolean = false
+actual val supportsSyncX25519: Boolean = true
 actual val supportsSyncEcdhP256: Boolean = true
 actual val supportsSyncEcdhP384: Boolean = true
 actual val supportsSyncEcdhP521: Boolean = true
@@ -74,9 +84,15 @@ private fun keySizeBits(curve: KeyAgreementCurve): Int =
         KeyAgreementCurve.X25519 -> error("X25519 unsupported on Apple")
     }
 
+private fun requireSupported(curve: KeyAgreementCurve) {
+    if (!supportsSync(curve)) {
+        throw UnsupportedOperationException("${curve.curveName} key agreement is not available on this platform")
+    }
+}
+
 private fun requireEc(curve: KeyAgreementCurve) {
     if (curve == KeyAgreementCurve.X25519 || !supportsSync(curve)) {
-        throw UnsupportedOperationException("${curve.curveName} key agreement is not available on this platform")
+        throw UnsupportedOperationException("${curve.curveName} EC key agreement is not available on this platform")
     }
 }
 
@@ -125,7 +141,8 @@ private fun attributes(
 }
 
 actual fun generateKeyPair(curve: KeyAgreementCurve): KeyAgreementKeyPair {
-    requireEc(curve)
+    requireSupported(curve)
+    if (curve == KeyAgreementCurve.X25519) return generateX25519KeyPair()
     val attrs = attributes(curve, kSecAttrKeyClassPrivate)
     val privKey =
         SecKeyCreateRandomKey(attrs, null) ?: run {
@@ -184,6 +201,7 @@ private fun rawAgreeApple(
 ): PlatformBuffer {
     val curve = privateKey.curve
     require(curve == peerPublicKey.curve) { "private/public key curve mismatch" }
+    if (curve == KeyAgreementCurve.X25519) return rawAgreeX25519(privateKey, peerPublicKey)
     requireEc(curve)
 
     val privData = privateKey.encoded.toNsData()
@@ -233,6 +251,82 @@ private fun rawAgreeApple(
         CFRelease(privAttrs)
         CFRelease(pubAttrs)
     }
+}
+
+// =============================================================================
+// X25519 via the CryptoKit shim (Curve25519.KeyAgreement)
+// =============================================================================
+
+private const val X25519_BYTES = 32
+
+/** Generates an X25519 key pair through CryptoKit; private scalar lands in a wiped SecureBuffer. */
+private fun generateX25519KeyPair(): KeyAgreementKeyPair {
+    memScoped {
+        val privOut = allocArray<ByteVar>(X25519_BYTES)
+        val pubOut = allocArray<ByteVar>(X25519_BYTES)
+        val privLen = alloc<size_tVar>()
+        val pubLen = alloc<size_tVar>()
+        val status =
+            bcks_x25519_generate(
+                privOut.reinterpret(),
+                X25519_BYTES.convert(),
+                privLen.ptr,
+                pubOut.reinterpret(),
+                X25519_BYTES.convert(),
+                pubLen.ptr,
+            )
+        check(status == BCKS_OK) { "X25519 key generation failed (status=$status)" }
+        val privBuf = secureScratch.allocate(X25519_BYTES)
+        for (i in 0 until X25519_BYTES) privBuf.writeByte(privOut[i])
+        privBuf.resetForRead()
+        val pubBuf = BufferFactory.Default.allocate(X25519_BYTES)
+        for (i in 0 until X25519_BYTES) pubBuf.writeByte(pubOut[i])
+        pubBuf.resetForRead()
+        return KeyAgreementKeyPair(
+            KeyAgreementCurve.X25519,
+            KeyAgreementPrivateKey(KeyAgreementCurve.X25519, privBuf),
+            KeyAgreementPublicKey(KeyAgreementCurve.X25519, pubBuf),
+        )
+    }
+}
+
+/**
+ * Raw X25519 agreement through CryptoKit into a wiped SecureBuffer. CryptoKit validates the peer
+ * point and rejects malformed keys (surfaced as [InvalidPublicKey]); the shared
+ * [validateRawSecret] / [deriveFromRawSecret] post-check enforces the RFC 7748 §6.1 all-zero
+ * rejection for low-order points.
+ */
+private fun rawAgreeX25519(
+    privateKey: KeyAgreementPrivateKey,
+    peerPublicKey: KeyAgreementPublicKey,
+): PlatformBuffer {
+    val out = secureScratch.allocate(X25519_BYTES)
+    memScoped {
+        val secretOut = allocArray<ByteVar>(X25519_BYTES)
+        val secretLen = alloc<size_tVar>()
+        var status = -1
+        privateKey.encoded.withRemainingBytes { privPtr, privLen ->
+            peerPublicKey.encoded.withRemainingBytes { peerPtr, peerLen ->
+                status =
+                    bcks_x25519_agree(
+                        privPtr.reinterpret(),
+                        privLen.convert(),
+                        peerPtr.reinterpret(),
+                        peerLen.convert(),
+                        secretOut.reinterpret(),
+                        X25519_BYTES.convert(),
+                        secretLen.ptr,
+                    )
+            }
+        }
+        if (status != BCKS_OK) {
+            out.freeNativeMemory()
+            throw InvalidPublicKey(KeyAgreementCurve.X25519.curveName)
+        }
+        for (i in 0 until X25519_BYTES) out.writeByte(secretOut[i])
+    }
+    out.resetForRead()
+    return out
 }
 
 actual suspend fun generateKeyPairAsync(curve: KeyAgreementCurve): KeyAgreementKeyPair = generateKeyPair(curve)

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/Signatures.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/Signatures.apple.kt
@@ -3,17 +3,23 @@
 package com.ditchoom.buffer.crypto
 
 import com.ditchoom.buffer.BufferFactory
-import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.BCKS_OK
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.bcks_ecdsa_sign_from_scalar
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.bcks_ed25519_sign
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.bcks_ed25519_verify
 import com.ditchoom.buffer.toNSData
+import kotlinx.cinterop.ByteVar
 import kotlinx.cinterop.ExperimentalForeignApi
-import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.alloc
+import kotlinx.cinterop.allocArray
 import kotlinx.cinterop.convert
+import kotlinx.cinterop.get
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.ptr
-import kotlinx.cinterop.usePinned
+import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.value
 import platform.CoreFoundation.CFDataRef
 import platform.CoreFoundation.CFDictionaryCreateMutable
 import platform.CoreFoundation.CFDictionarySetValue
@@ -23,11 +29,9 @@ import platform.CoreFoundation.CFRelease
 import platform.CoreFoundation.kCFAllocatorDefault
 import platform.CoreFoundation.kCFTypeDictionaryKeyCallBacks
 import platform.CoreFoundation.kCFTypeDictionaryValueCallBacks
-import platform.Foundation.CFBridgingRelease
 import platform.Foundation.CFBridgingRetain
 import platform.Foundation.NSData
 import platform.Security.SecKeyAlgorithm
-import platform.Security.SecKeyCreateSignature
 import platform.Security.SecKeyCreateWithData
 import platform.Security.SecKeyRef
 import platform.Security.SecKeyVerifySignature
@@ -39,7 +43,7 @@ import platform.Security.kSecAttrKeyTypeECSECPrimeRandom
 import platform.Security.kSecKeyAlgorithmECDSASignatureMessageX962SHA256
 import platform.Security.kSecKeyAlgorithmECDSASignatureMessageX962SHA384
 import platform.Security.kSecKeyAlgorithmECDSASignatureMessageX962SHA512
-import platform.posix.memcpy
+import platform.posix.size_tVar
 
 /**
  * Apple signature bridge over **Security.framework** (`SecKey*`).
@@ -48,36 +52,40 @@ import platform.posix.memcpy
  * `kSecKeyAlgorithmECDSASignatureMessageX962SHA{256,384,512}` algorithms, which hash-then-sign and
  * produce/consume **DER/X9.62** signatures — so [ecdsaSignatureEncoding] is `Der`, matching JVM.
  *
- * **Ed25519** is **not** exposed by the Security.framework C API (it lives in CryptoKit, which is
- * Swift-only and not reachable from this module's Kotlin/Native cinterop). Rather than ship a
- * Swift bridge that can't be built/verified here, Ed25519 is reported **unsupported** on Apple:
- * [supportsSyncEd25519] is `false` and every Ed25519 entry point throws
- * [UnsupportedOperationException] — the honest "native-or-throw" contract. (Documented deviation
- * from the original plan, which assumed a CryptoKit bridge.)
+ * **Ed25519** is not exposed by the Security.framework C API — it lives in CryptoKit. It is wired
+ * through the `cryptokitshim` cinterop ([bcks_ed25519_sign] / [bcks_ed25519_verify]), which calls
+ * CryptoKit `Curve25519.Signing`. [supportsSyncEd25519] is therefore `true` on Apple.
  *
- * **Key import note (Apple-specific):** `SecKeyCreateWithData` for an EC *private* key requires the
- * full ANSI X9.63 representation `04 ‖ X ‖ Y ‖ K` (public point concatenated with the private
- * scalar), not the bare scalar. So on Apple a [SigningKey] for ECDSA must be built from that full
- * representation. *Verify* keys are the ordinary uncompressed point `04 ‖ X ‖ Y`.
+ * **ECDSA signing-from-scalar (Apple-specific):** `SecKeyCreateWithData` for an EC *private* key
+ * requires the full ANSI X9.63 representation `04 ‖ X ‖ Y ‖ K`, not the bare scalar — it cannot
+ * derive the public point. CryptoKit's `P###.Signing.PrivateKey(rawRepresentation:)` *can* build a
+ * signing key from the bare scalar, so ECDSA signing routes through the CryptoKit shim
+ * ([bcks_ecdsa_sign_from_scalar]) and [supportsEcdsaSigningFromScalar] is `true`. ECDSA *verify*
+ * stays on Security.framework (`SecKeyVerifySignature`), which consumes the uncompressed point
+ * `04 ‖ X ‖ Y` and DER signatures directly.
  */
 
-actual val supportsSyncEd25519: Boolean get() = false
+actual val supportsSyncEd25519: Boolean get() = true
 
 actual val supportsSyncEcdsa: Boolean get() = true
 
 actual val ecdsaSignatureEncoding: EcdsaSignatureEncoding get() = EcdsaSignatureEncoding.Der
 
-private fun unsupportedEd25519(): Nothing =
-    throw UnsupportedOperationException(
-        "Ed25519 is unavailable on Apple via Security.framework (CryptoKit bridge not wired)",
-    )
+/** Curve order in bits for the CryptoKit ECDSA-from-scalar shim (256 / 384 / 521). */
+private fun ecdsaCurveCode(scheme: SignatureScheme): Int =
+    when (scheme) {
+        SignatureScheme.EcdsaP256 -> 256
+        SignatureScheme.EcdsaP384 -> 384
+        SignatureScheme.EcdsaP521 -> 521
+        SignatureScheme.Ed25519 -> error("not an ECDSA scheme")
+    }
 
 private fun ecdsaAlgorithm(scheme: SignatureScheme): SecKeyAlgorithm? =
     when (scheme) {
         SignatureScheme.EcdsaP256 -> kSecKeyAlgorithmECDSASignatureMessageX962SHA256
         SignatureScheme.EcdsaP384 -> kSecKeyAlgorithmECDSASignatureMessageX962SHA384
         SignatureScheme.EcdsaP521 -> kSecKeyAlgorithmECDSASignatureMessageX962SHA512
-        SignatureScheme.Ed25519 -> unsupportedEd25519()
+        SignatureScheme.Ed25519 -> error("Ed25519 does not use a Security.framework ECDSA algorithm")
     }
 
 /** Snapshot the remaining bytes of [buffer] into an NSData (independent copy). */
@@ -131,29 +139,85 @@ private fun createKey(
     }
 }
 
-private fun appleEcdsaSign(
+/**
+ * Signs [message] under [key] through the CryptoKit shim and returns the signature bytes.
+ *
+ * Both schemes go through CryptoKit: Ed25519 via `Curve25519.Signing`, and ECDSA via
+ * `P###.Signing.PrivateKey(rawRepresentation:)`, which (unlike Security.framework) accepts the bare
+ * private scalar the [SigningKey] holds. ECDSA emits DER; Ed25519 the canonical 64-byte form.
+ */
+private fun cryptoKitSign(
     key: SigningKey,
     message: ReadBuffer,
-): NSData {
-    if (key.scheme == SignatureScheme.Ed25519) unsupportedEd25519()
-    val priv =
-        createKey(key.requireOpen().toNsData(), isPrivate = true)
-            ?: throw IllegalArgumentException("invalid ${key.scheme.schemeName} private key")
-
-    @Suppress("UNCHECKED_CAST")
-    val msgData = CFBridgingRetain(message.toNsData()) as CFDataRef
-    return try {
-        memScoped {
-            val err = alloc<CFErrorRefVar>()
-            val sig =
-                SecKeyCreateSignature(priv, ecdsaAlgorithm(key.scheme), msgData, err.ptr)
-                    ?: throw IllegalArgumentException("ECDSA signing failed")
-            CFBridgingRelease(sig) as NSData
+): ByteArray {
+    val cap = maxSignatureBytes(key.scheme)
+    val scalar = key.requireOpen()
+    return memScoped {
+        val sigOut = allocArray<ByteVar>(cap)
+        val sigLen = alloc<size_tVar>()
+        var status = -1
+        val msgLen = message.remaining()
+        scalar.withRemainingBytes { keyPtr, keyLen ->
+            // withRemainingBytes2 tolerates an empty message (Ed25519 KAT signs ""); it pins a
+            // 1-byte placeholder and we still pass length 0 to the shim.
+            message.withRemainingBytes2(msgLen) { msgPtr ->
+                status =
+                    if (key.scheme == SignatureScheme.Ed25519) {
+                        bcks_ed25519_sign(
+                            keyPtr.reinterpret(),
+                            keyLen.convert(),
+                            msgPtr.reinterpret(),
+                            msgLen.convert(),
+                            sigOut.reinterpret(),
+                            cap.convert(),
+                            sigLen.ptr,
+                        )
+                    } else {
+                        bcks_ecdsa_sign_from_scalar(
+                            ecdsaCurveCode(key.scheme),
+                            keyPtr.reinterpret(),
+                            keyLen.convert(),
+                            msgPtr.reinterpret(),
+                            msgLen.convert(),
+                            sigOut.reinterpret(),
+                            cap.convert(),
+                            sigLen.ptr,
+                        )
+                    }
+            }
         }
-    } finally {
-        CFRelease(msgData)
-        CFRelease(priv)
+        require(status == BCKS_OK) { "invalid ${key.scheme.schemeName} private key" }
+        val n = sigLen.value.toInt()
+        ByteArray(n) { sigOut[it] }
     }
+}
+
+/** Verifies an Ed25519 signature through the CryptoKit shim. */
+private fun appleEd25519Verify(
+    key: VerifyKey,
+    message: ReadBuffer,
+    signature: ReadBuffer,
+): Boolean {
+    // Ed25519 signatures are a fixed 64 bytes; reject anything else without calling into CryptoKit.
+    if (signature.remaining() != 64) return false
+    var status = -1
+    val msgLen = message.remaining()
+    key.material.withRemainingBytes { pubPtr, pubLen ->
+        message.withRemainingBytes2(msgLen) { msgPtr ->
+            signature.withRemainingBytes { sigPtr, sigLen ->
+                status =
+                    bcks_ed25519_verify(
+                        pubPtr.reinterpret(),
+                        pubLen.convert(),
+                        msgPtr.reinterpret(),
+                        msgLen.convert(),
+                        sigPtr.reinterpret(),
+                        sigLen.convert(),
+                    )
+            }
+        }
+    }
+    return status == BCKS_OK
 }
 
 /**
@@ -224,7 +288,6 @@ private fun appleEcdsaVerify(
     message: ReadBuffer,
     signature: ReadBuffer,
 ): Boolean {
-    if (key.scheme == SignatureScheme.Ed25519) unsupportedEd25519()
     // SecKeyVerifySignature accepts non-canonical BER; reject anything that is not strict DER first.
     if (!isCanonicalEcdsaDer(signature)) return false
     val pub = createKey(key.material.toNsData(), isPrivate = false) ?: return false
@@ -246,38 +309,15 @@ private fun appleEcdsaVerify(
     }
 }
 
-/** Copies [n] bytes from [data] into [dest] at its current position, advancing it. */
-private fun copyNsDataInto(
-    data: NSData,
-    dest: WriteBuffer,
-    n: Int,
-) {
-    if (n == 0) return
-    val bytes = ByteArray(n)
-    bytes.usePinned { pinned ->
-        memcpy(pinned.addressOf(0), data.bytes, n.convert())
-    }
-    dest.writeBytes(bytes)
-}
-
-private fun NSData.toReadBuffer(factory: BufferFactory): PlatformBuffer {
-    val n = length.toInt()
-    val out = factory.allocate(n)
-    copyNsDataInto(this, out, n)
-    out.resetForRead()
-    return out
-}
-
 actual fun signInto(
     key: SigningKey,
     message: ReadBuffer,
     dest: WriteBuffer,
 ): Int {
-    if (key.scheme == SignatureScheme.Ed25519) unsupportedEd25519()
-    val sig = appleEcdsaSign(key, message)
-    val n = sig.length.toInt()
+    val sig = cryptoKitSign(key, message)
+    val n = sig.size
     require(dest.remaining() >= n) { "dest needs $n bytes remaining, has ${dest.remaining()}" }
-    copyNsDataInto(sig, dest, n)
+    dest.writeBytes(sig)
     return n
 }
 
@@ -285,23 +325,31 @@ actual fun verify(
     key: VerifyKey,
     message: ReadBuffer,
     signature: ReadBuffer,
-): Boolean = appleEcdsaVerify(key, message, signature)
+): Boolean =
+    if (key.scheme == SignatureScheme.Ed25519) {
+        appleEd25519Verify(key, message, signature)
+    } else {
+        appleEcdsaVerify(key, message, signature)
+    }
 
 actual suspend fun signAsync(
     key: SigningKey,
     message: ReadBuffer,
     factory: BufferFactory,
 ): ReadBuffer {
-    if (key.scheme == SignatureScheme.Ed25519) unsupportedEd25519()
-    return appleEcdsaSign(key, message).toReadBuffer(factory)
+    val sig = cryptoKitSign(key, message)
+    val out = factory.allocate(sig.size)
+    out.writeBytes(sig)
+    out.resetForRead()
+    return out
 }
 
 actual suspend fun verifyAsync(
     key: VerifyKey,
     message: ReadBuffer,
     signature: ReadBuffer,
-): Boolean = appleEcdsaVerify(key, message, signature)
+): Boolean = verify(key, message, signature)
 
-actual suspend fun ed25519AsyncAvailable(): Boolean = false
+actual suspend fun ed25519AsyncAvailable(): Boolean = true
 
-actual val supportsEcdsaSigningFromScalar: Boolean get() = false
+actual val supportsEcdsaSigningFromScalar: Boolean get() = true

--- a/buffer-crypto/src/appleTest/kotlin/com/ditchoom/buffer/crypto/KeyAgreementTestSupport.apple.kt
+++ b/buffer-crypto/src/appleTest/kotlin/com/ditchoom/buffer/crypto/KeyAgreementTestSupport.apple.kt
@@ -1,10 +1,13 @@
 package com.ditchoom.buffer.crypto
 
-// Apple has synchronous ECDH (Security framework); X25519 is unsupported (no Security key type).
-// The async path delegates to sync, so support matches the sync flag.
+// Apple has synchronous ECDH (Security framework) and X25519 (CryptoKit). The async path delegates
+// to sync, so support matches the sync flag.
 actual fun asyncAgreementSupported(curve: KeyAgreementCurve): Boolean = supportsSync(curve)
 
 actual val isWebPlatform: Boolean = false
 
-// Apple's private encoding is the Security external representation, not a raw scalar.
-actual fun supportsRawScalarKat(curve: KeyAgreementCurve): Boolean = false
+// Apple's *EC* private encoding is the Security external representation (04‖X‖Y‖scalar), not a raw
+// scalar, so the raw-scalar KAT/Wycheproof vectors cannot be imported for P-256/384/521. X25519,
+// however, goes through CryptoKit's Curve25519.KeyAgreement, which imports the bare 32-byte scalar
+// directly — so the RFC 7748 raw-scalar KAT and the X25519 Wycheproof vectors DO apply there.
+actual fun supportsRawScalarKat(curve: KeyAgreementCurve): Boolean = curve == KeyAgreementCurve.X25519

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/SignatureKatTest.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/SignatureKatTest.kt
@@ -12,11 +12,15 @@ import kotlin.test.assertTrue
 /**
  * Known-answer vectors (RFC 8032 Ed25519 + NIST/FIPS-186 ECDSA) and sign→verify round-trips.
  *
- * Ed25519 is deterministic (RFC 8032), so its KAT asserts the exact signature bytes **and** that
- * verify accepts them. ECDSA signing is randomized (the per-signature nonce `k`), so its KAT is a
- * verify-of-known-good check, and correctness of our signing is proven by a sign→verify round-trip
- * (sign here, verify the produced signature). All ops use the async API so the suite runs on every
- * platform (WebCrypto async on JS/WASM, native otherwise).
+ * Ed25519 per RFC 8032 is deterministic, so where the platform produces deterministic signatures
+ * (JCA on the JVM, WebCrypto) the KAT asserts the exact signature bytes. Apple's CryptoKit instead
+ * produces *hedged* (randomized) Ed25519 signatures — still valid and RFC-conformant on the verify
+ * side, but not bit-identical to the RFC test vector — so on such platforms the KAT proves
+ * correctness by verifying the known-good signature and round-tripping our own. Which mode applies
+ * is probed at runtime (sign the same message twice; identical ⇒ deterministic). ECDSA signing is
+ * always randomized (the per-signature nonce `k`), so its KAT is a verify-of-known-good check plus a
+ * sign→verify round-trip. All ops use the async API so the suite runs on every platform (WebCrypto
+ * async on JS/WASM, native otherwise).
  */
 class SignatureKatTest {
     // RFC 8032 §7.1 — Ed25519 (seed, publicKey, message, signature).
@@ -43,14 +47,37 @@ class SignatureKatTest {
         val sig: String,
     )
 
+    /**
+     * Probes whether this platform's Ed25519 signing is deterministic by signing the same message
+     * twice and comparing. RFC 8032 mandates deterministic signatures, but CryptoKit (Apple) hedges
+     * them with randomness, so the exact-bytes assertion only applies where signing is deterministic.
+     */
+    private suspend fun ed25519IsDeterministic(): Boolean {
+        val seed = ed25519Vectors.first().seed
+        val msg = hexBuffer("ab")
+        signingKey(SignatureScheme.Ed25519, seed).use { sk ->
+            val a = signAsync(sk, msg).toHex()
+            val b = signingKey(SignatureScheme.Ed25519, seed).use { sk2 -> signAsync(sk2, hexBuffer("ab")).toHex() }
+            return a == b
+        }
+    }
+
     @Test
     fun ed25519DeterministicSignAndVerify() =
         runTest {
             if (!ed25519AsyncAvailable()) return@runTest
+            val deterministic = ed25519IsDeterministic()
             for (v in ed25519Vectors) {
                 signingKey(SignatureScheme.Ed25519, v.seed).use { sk ->
                     val produced = signAsync(sk, hexBuffer(v.msg))
-                    assertEquals(v.sig, produced.toHex(), "Ed25519 sign(seed=${v.seed.take(8)}…)")
+                    if (deterministic) {
+                        // RFC 8032 deterministic signing must reproduce the published vector exactly.
+                        assertEquals(v.sig, produced.toHex(), "Ed25519 sign(seed=${v.seed.take(8)}…)")
+                    } else {
+                        // Hedged signing (CryptoKit): the produced signature must still verify.
+                        val selfOk = verifyAsync(verifyKey(SignatureScheme.Ed25519, v.pub), hexBuffer(v.msg), produced)
+                        assertTrue(selfOk, "Ed25519 hedged sign→verify(seed=${v.seed.take(8)}…)")
+                    }
                 }
                 val ok =
                     verifyAsync(

--- a/buffer-crypto/src/nativeInterop/cinterop/cryptokitshim.def
+++ b/buffer-crypto/src/nativeInterop/cinterop/cryptokitshim.def
@@ -1,0 +1,4 @@
+package = com.ditchoom.buffer.crypto.cinterop.cryptokit
+language = C
+headers = CryptoKitShim.h
+---

--- a/buffer-crypto/src/nativeInterop/swift/CryptoKitShim.h
+++ b/buffer-crypto/src/nativeInterop/swift/CryptoKitShim.h
@@ -1,0 +1,83 @@
+// C surface for the CryptoKit Swift shim (CryptoKitShim.swift).
+//
+// CryptoKit has no Objective-C / C interface, so the Swift shim re-exposes the primitives we need
+// through `@_cdecl` plain-C functions. This header declares exactly those functions so Kotlin/Native
+// cinterop can bind them (see cryptokitshim.def). The symbols resolve from the static archive built
+// from CryptoKitShim.swift and linked into the Apple test/binary by the cinterop linkerOpts.
+//
+// All byte buffers are (pointer, length); outputs are (pointer, capacity) plus a written-length
+// out-parameter. Every function returns one of the status codes below; no secret or error text is
+// ever returned through the status.
+
+#ifndef BUFFER_CRYPTO_CRYPTOKIT_SHIM_H
+#define BUFFER_CRYPTO_CRYPTOKIT_SHIM_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#define BCKS_OK 0
+#define BCKS_ERR_INPUT (-1)
+#define BCKS_ERR_AUTH (-2)
+#define BCKS_ERR_BUFFER (-3)
+#define BCKS_ERR_INTERNAL (-4)
+
+// ChaCha20-Poly1305.
+int32_t bcks_chachapoly_seal(
+    const uint8_t *keyPtr, size_t keyLen,
+    const uint8_t *noncePtr, size_t nonceLen,
+    const uint8_t *aadPtr, size_t aadLen,
+    const uint8_t *ptPtr, size_t ptLen,
+    uint8_t *ctOut, size_t ctCap,
+    uint8_t *tagOut, size_t tagCap);
+
+int32_t bcks_chachapoly_open(
+    const uint8_t *keyPtr, size_t keyLen,
+    const uint8_t *noncePtr, size_t nonceLen,
+    const uint8_t *aadPtr, size_t aadLen,
+    const uint8_t *ctPtr, size_t ctLen,
+    const uint8_t *tagPtr, size_t tagLen,
+    uint8_t *ptOut, size_t ptCap,
+    size_t *ptLenOut);
+
+// Ed25519.
+int32_t bcks_ed25519_public_key(
+    const uint8_t *seedPtr, size_t seedLen,
+    uint8_t *pubOut, size_t pubCap,
+    size_t *pubLenOut);
+
+int32_t bcks_ed25519_sign(
+    const uint8_t *seedPtr, size_t seedLen,
+    const uint8_t *msgPtr, size_t msgLen,
+    uint8_t *sigOut, size_t sigCap,
+    size_t *sigLenOut);
+
+int32_t bcks_ed25519_verify(
+    const uint8_t *pubPtr, size_t pubLen,
+    const uint8_t *msgPtr, size_t msgLen,
+    const uint8_t *sigPtr, size_t sigLen);
+
+// X25519.
+int32_t bcks_x25519_generate(
+    uint8_t *privOut, size_t privCap, size_t *privLenOut,
+    uint8_t *pubOut, size_t pubCap, size_t *pubLenOut);
+
+int32_t bcks_x25519_public_key(
+    const uint8_t *privPtr, size_t privLen,
+    uint8_t *pubOut, size_t pubCap,
+    size_t *pubLenOut);
+
+int32_t bcks_x25519_agree(
+    const uint8_t *privPtr, size_t privLen,
+    const uint8_t *peerPtr, size_t peerLen,
+    uint8_t *secretOut, size_t secretCap,
+    size_t *secretLenOut);
+
+// ECDSA signing from a bare scalar (curve: 256, 384, or 521).
+int32_t bcks_ecdsa_sign_from_scalar(
+    int32_t curve,
+    const uint8_t *scalarPtr, size_t scalarLen,
+    const uint8_t *msgPtr, size_t msgLen,
+    uint8_t *sigOut, size_t sigCap,
+    size_t *sigLenOut);
+
+#endif // BUFFER_CRYPTO_CRYPTOKIT_SHIM_H

--- a/buffer-crypto/src/nativeInterop/swift/CryptoKitShim.swift
+++ b/buffer-crypto/src/nativeInterop/swift/CryptoKitShim.swift
@@ -1,0 +1,236 @@
+// CryptoKit shim for buffer-crypto Apple actuals.
+//
+// CryptoKit is Swift-only and exposes no Objective-C / C interface, so Kotlin/Native cinterop
+// cannot bind it directly the way it binds CommonCrypto / Security. This file re-exposes the four
+// CryptoKit primitives the module needs (ChaCha20-Poly1305 AEAD, Ed25519 signatures, X25519 key
+// agreement, ECDSA signing from a bare scalar) through a flat `@_cdecl` plain-C surface that
+// cinterop CAN bind (see CryptoKitShim.h / cryptokitshim.def).
+//
+// ABI conventions:
+//  - Byte buffers are passed as (pointer, length) pairs; output buffers as (pointer, capacity) plus
+//    an out-parameter that receives the number of bytes actually written.
+//  - Every function returns an Int32 status: BCKS_OK (0) on success, a negative code on failure.
+//    No error string or secret material is ever returned through the status.
+//  - Secrets are handled inside the Swift heap and released by ARC at function exit; nothing is
+//    logged. The Kotlin side keeps key material in its own wiped SecureBuffer and only passes
+//    pointers in for the duration of the call.
+
+import CryptoKit
+import Foundation
+
+// Status codes — kept in sync with CryptoKitShim.h.
+private let BCKS_OK: Int32 = 0
+private let BCKS_ERR_INPUT: Int32 = -1 // malformed key / nonce / point / signature
+private let BCKS_ERR_AUTH: Int32 = -2 // AEAD tag mismatch / signature did not verify
+private let BCKS_ERR_BUFFER: Int32 = -3 // output buffer too small
+private let BCKS_ERR_INTERNAL: Int32 = -4 // unexpected CryptoKit failure
+
+// Copy a CryptoKit Data result into a caller-provided output buffer, writing the length out.
+private func emit(_ data: Data, _ out: UnsafeMutablePointer<UInt8>?, _ outCap: Int, _ outLen: UnsafeMutablePointer<Int>?) -> Int32 {
+    if data.count > outCap { return BCKS_ERR_BUFFER }
+    if let out = out, data.count > 0 {
+        data.copyBytes(to: out, count: data.count)
+    }
+    outLen?.pointee = data.count
+    return BCKS_OK
+}
+
+// Build a Data view over a (pointer, length) pair without copying (valid only for the call).
+private func bytes(_ ptr: UnsafePointer<UInt8>?, _ len: Int) -> Data {
+    guard let ptr = ptr, len > 0 else { return Data() }
+    return Data(bytes: ptr, count: len)
+}
+
+// =============================================================================
+// ChaCha20-Poly1305 (AEAD) — CryptoKit ChaChaPoly
+// =============================================================================
+
+// Seal: writes ciphertext (== plaintext length) into ctOut and the 16-byte tag into tagOut.
+@_cdecl("bcks_chachapoly_seal")
+public func bcks_chachapoly_seal(
+    _ keyPtr: UnsafePointer<UInt8>?, _ keyLen: Int,
+    _ noncePtr: UnsafePointer<UInt8>?, _ nonceLen: Int,
+    _ aadPtr: UnsafePointer<UInt8>?, _ aadLen: Int,
+    _ ptPtr: UnsafePointer<UInt8>?, _ ptLen: Int,
+    _ ctOut: UnsafeMutablePointer<UInt8>?, _ ctCap: Int,
+    _ tagOut: UnsafeMutablePointer<UInt8>?, _ tagCap: Int
+) -> Int32 {
+    let key = SymmetricKey(data: bytes(keyPtr, keyLen))
+    guard let nonce = try? ChaChaPoly.Nonce(data: bytes(noncePtr, nonceLen)) else { return BCKS_ERR_INPUT }
+    let aad = bytes(aadPtr, aadLen)
+    let pt = bytes(ptPtr, ptLen)
+    guard let box = try? ChaChaPoly.seal(pt, using: key, nonce: nonce, authenticating: aad) else {
+        return BCKS_ERR_INTERNAL
+    }
+    if box.ciphertext.count > ctCap || box.tag.count > tagCap { return BCKS_ERR_BUFFER }
+    if let ctOut = ctOut, box.ciphertext.count > 0 { box.ciphertext.copyBytes(to: ctOut, count: box.ciphertext.count) }
+    if let tagOut = tagOut { box.tag.copyBytes(to: tagOut, count: box.tag.count) }
+    return BCKS_OK
+}
+
+// Open: authenticates and decrypts; writes plaintext (== ciphertext length) into ptOut.
+// Returns BCKS_ERR_AUTH on tag mismatch without touching ptOut.
+@_cdecl("bcks_chachapoly_open")
+public func bcks_chachapoly_open(
+    _ keyPtr: UnsafePointer<UInt8>?, _ keyLen: Int,
+    _ noncePtr: UnsafePointer<UInt8>?, _ nonceLen: Int,
+    _ aadPtr: UnsafePointer<UInt8>?, _ aadLen: Int,
+    _ ctPtr: UnsafePointer<UInt8>?, _ ctLen: Int,
+    _ tagPtr: UnsafePointer<UInt8>?, _ tagLen: Int,
+    _ ptOut: UnsafeMutablePointer<UInt8>?, _ ptCap: Int,
+    _ ptLenOut: UnsafeMutablePointer<Int>?
+) -> Int32 {
+    let key = SymmetricKey(data: bytes(keyPtr, keyLen))
+    guard let nonce = try? ChaChaPoly.Nonce(data: bytes(noncePtr, nonceLen)) else { return BCKS_ERR_INPUT }
+    let aad = bytes(aadPtr, aadLen)
+    guard let box = try? ChaChaPoly.SealedBox(
+        nonce: nonce,
+        ciphertext: bytes(ctPtr, ctLen),
+        tag: bytes(tagPtr, tagLen)
+    ) else { return BCKS_ERR_INPUT }
+    guard let pt = try? ChaChaPoly.open(box, using: key, authenticating: aad) else {
+        return BCKS_ERR_AUTH
+    }
+    return emit(pt, ptOut, ptCap, ptLenOut)
+}
+
+// =============================================================================
+// Ed25519 (signatures) — CryptoKit Curve25519.Signing
+// =============================================================================
+
+// Derive the 32-byte public key from a 32-byte private seed.
+@_cdecl("bcks_ed25519_public_key")
+public func bcks_ed25519_public_key(
+    _ seedPtr: UnsafePointer<UInt8>?, _ seedLen: Int,
+    _ pubOut: UnsafeMutablePointer<UInt8>?, _ pubCap: Int,
+    _ pubLenOut: UnsafeMutablePointer<Int>?
+) -> Int32 {
+    guard let priv = try? Curve25519.Signing.PrivateKey(rawRepresentation: bytes(seedPtr, seedLen)) else {
+        return BCKS_ERR_INPUT
+    }
+    return emit(priv.publicKey.rawRepresentation, pubOut, pubCap, pubLenOut)
+}
+
+// Sign message under a 32-byte private seed; writes the 64-byte signature into sigOut.
+@_cdecl("bcks_ed25519_sign")
+public func bcks_ed25519_sign(
+    _ seedPtr: UnsafePointer<UInt8>?, _ seedLen: Int,
+    _ msgPtr: UnsafePointer<UInt8>?, _ msgLen: Int,
+    _ sigOut: UnsafeMutablePointer<UInt8>?, _ sigCap: Int,
+    _ sigLenOut: UnsafeMutablePointer<Int>?
+) -> Int32 {
+    guard let priv = try? Curve25519.Signing.PrivateKey(rawRepresentation: bytes(seedPtr, seedLen)) else {
+        return BCKS_ERR_INPUT
+    }
+    guard let sig = try? priv.signature(for: bytes(msgPtr, msgLen)) else { return BCKS_ERR_INTERNAL }
+    return emit(sig, sigOut, sigCap, sigLenOut)
+}
+
+// Verify a 64-byte signature over message under a 32-byte public key.
+// Returns BCKS_OK if valid, BCKS_ERR_AUTH if not, BCKS_ERR_INPUT if the key is malformed.
+@_cdecl("bcks_ed25519_verify")
+public func bcks_ed25519_verify(
+    _ pubPtr: UnsafePointer<UInt8>?, _ pubLen: Int,
+    _ msgPtr: UnsafePointer<UInt8>?, _ msgLen: Int,
+    _ sigPtr: UnsafePointer<UInt8>?, _ sigLen: Int
+) -> Int32 {
+    guard let pub = try? Curve25519.Signing.PublicKey(rawRepresentation: bytes(pubPtr, pubLen)) else {
+        return BCKS_ERR_INPUT
+    }
+    let ok = pub.isValidSignature(bytes(sigPtr, sigLen), for: bytes(msgPtr, msgLen))
+    return ok ? BCKS_OK : BCKS_ERR_AUTH
+}
+
+// =============================================================================
+// X25519 (key agreement) — CryptoKit Curve25519.KeyAgreement
+// =============================================================================
+
+// Generate an X25519 key pair: 32-byte private scalar into privOut, 32-byte public key into pubOut.
+@_cdecl("bcks_x25519_generate")
+public func bcks_x25519_generate(
+    _ privOut: UnsafeMutablePointer<UInt8>?, _ privCap: Int,
+    _ privLenOut: UnsafeMutablePointer<Int>?,
+    _ pubOut: UnsafeMutablePointer<UInt8>?, _ pubCap: Int,
+    _ pubLenOut: UnsafeMutablePointer<Int>?
+) -> Int32 {
+    let priv = Curve25519.KeyAgreement.PrivateKey()
+    let s = emit(priv.rawRepresentation, privOut, privCap, privLenOut)
+    if s != BCKS_OK { return s }
+    return emit(priv.publicKey.rawRepresentation, pubOut, pubCap, pubLenOut)
+}
+
+// Derive the 32-byte public key from a 32-byte private scalar.
+@_cdecl("bcks_x25519_public_key")
+public func bcks_x25519_public_key(
+    _ privPtr: UnsafePointer<UInt8>?, _ privLen: Int,
+    _ pubOut: UnsafeMutablePointer<UInt8>?, _ pubCap: Int,
+    _ pubLenOut: UnsafeMutablePointer<Int>?
+) -> Int32 {
+    guard let priv = try? Curve25519.KeyAgreement.PrivateKey(rawRepresentation: bytes(privPtr, privLen)) else {
+        return BCKS_ERR_INPUT
+    }
+    return emit(priv.publicKey.rawRepresentation, pubOut, pubCap, pubLenOut)
+}
+
+// Compute the raw 32-byte X25519 shared secret. Caller enforces the RFC 7748 all-zero rejection.
+@_cdecl("bcks_x25519_agree")
+public func bcks_x25519_agree(
+    _ privPtr: UnsafePointer<UInt8>?, _ privLen: Int,
+    _ peerPtr: UnsafePointer<UInt8>?, _ peerLen: Int,
+    _ secretOut: UnsafeMutablePointer<UInt8>?, _ secretCap: Int,
+    _ secretLenOut: UnsafeMutablePointer<Int>?
+) -> Int32 {
+    guard let priv = try? Curve25519.KeyAgreement.PrivateKey(rawRepresentation: bytes(privPtr, privLen)) else {
+        return BCKS_ERR_INPUT
+    }
+    guard let peer = try? Curve25519.KeyAgreement.PublicKey(rawRepresentation: bytes(peerPtr, peerLen)) else {
+        return BCKS_ERR_INPUT
+    }
+    guard let shared = try? priv.sharedSecretFromKeyAgreement(with: peer) else {
+        return BCKS_ERR_INPUT
+    }
+    let raw = shared.withUnsafeBytes { Data($0) }
+    return emit(raw, secretOut, secretCap, secretLenOut)
+}
+
+// =============================================================================
+// ECDSA signing from a bare scalar — CryptoKit P256/P384/P521.Signing
+// =============================================================================
+//
+// Security.framework's SecKeyCreateWithData needs the full X9.63 private representation
+// (04 ‖ X ‖ Y ‖ K); it cannot derive the public point from the scalar. CryptoKit's
+// P###.Signing.PrivateKey(rawRepresentation:) accepts the bare big-endian scalar and derives the
+// point internally, then signs (hash-then-sign with the curve's paired SHA-2) and emits DER.
+
+private func ecdsaSign(_ curve: Int32, _ scalar: Data, _ msg: Data) -> Data? {
+    switch curve {
+    case 256:
+        guard let k = try? P256.Signing.PrivateKey(rawRepresentation: scalar) else { return nil }
+        return (try? k.signature(for: msg))?.derRepresentation
+    case 384:
+        guard let k = try? P384.Signing.PrivateKey(rawRepresentation: scalar) else { return nil }
+        return (try? k.signature(for: msg))?.derRepresentation
+    case 521:
+        guard let k = try? P521.Signing.PrivateKey(rawRepresentation: scalar) else { return nil }
+        return (try? k.signature(for: msg))?.derRepresentation
+    default:
+        return nil
+    }
+}
+
+// Sign message with an ECDSA private scalar for the given curve (256/384/521), emitting a DER
+// signature. The hash is the curve's paired SHA-2 (P-256↔SHA-256, P-384↔SHA-384, P-521↔SHA-512),
+// matching the Security.framework ECDSA path and the cross-platform DER contract.
+@_cdecl("bcks_ecdsa_sign_from_scalar")
+public func bcks_ecdsa_sign_from_scalar(
+    _ curve: Int32,
+    _ scalarPtr: UnsafePointer<UInt8>?, _ scalarLen: Int,
+    _ msgPtr: UnsafePointer<UInt8>?, _ msgLen: Int,
+    _ sigOut: UnsafeMutablePointer<UInt8>?, _ sigCap: Int,
+    _ sigLenOut: UnsafeMutablePointer<Int>?
+) -> Int32 {
+    guard let sig = ecdsaSign(curve, bytes(scalarPtr, scalarLen), bytes(msgPtr, msgLen)) else {
+        return BCKS_ERR_INPUT
+    }
+    return emit(sig, sigOut, sigCap, sigLenOut)
+}


### PR DESCRIPTION
Closes #201.

## Summary
Four crypto primitives live in **CryptoKit**, which is Swift-only with **no Objective-C / C interface**, so Kotlin/Native cinterop cannot bind it the way it binds CommonCrypto / Security. They were therefore capability-gated **off** on Apple (throwing `UnsupportedOperationException`). This PR un-gates all four by adding a CryptoKit interop shim.

## Shim approach
- **`src/nativeInterop/swift/CryptoKitShim.swift`** — re-exposes the CryptoKit ops through a flat `@_cdecl` **plain-C** surface (the least painful thing to cinterop against). Byte buffers pass as `(pointer, length)`; outputs as `(pointer, capacity, *outLen)`; every function returns an `Int32` status — no secret or error text in the status. Secrets stay on the Swift heap (ARC-freed at call exit); nothing is logged.
- **`src/nativeInterop/swift/CryptoKitShim.h`** — hand-written C header cinterop parses.
- **`src/nativeInterop/cinterop/cryptokitshim.def`** — cinterop def (mirrors `commoncryptogcm.def`).
- **`build.gradle.kts`** — per-Apple-target `Exec` task compiles the Swift source to a static archive `lib<konan>cryptokitshim.a` (correct triple + SDK per target), the `cryptokitshim` cinterop links it via `-staticLibrary`/`-libraryPath`, and final binaries link the toolchain's per-SDK Swift runtime (`-lswiftCore -lswiftFoundation`) plus `-framework CryptoKit -framework Foundation`. Registered for every Apple target the module declares (macos/ios/tvos/watchos arm64 + simulators/x64).

## Capability flags flipped to `true`
| Flag | File |
|------|------|
| `appleChaChaPolyAvailable` (drives `supportsChaChaPoly` / `supportsSyncChaChaPoly`) | `AeadBridge.apple.kt` |
| `supportsSyncEd25519`, `ed25519AsyncAvailable()` | `Signatures.apple.kt` |
| `supportsEcdsaSigningFromScalar` | `Signatures.apple.kt` |
| `supportsSyncX25519` | `KeyAgreement.apple.kt` |

Notes:
- **ChaCha20-Poly1305** → CryptoKit `ChaChaPoly`. CryptoKit authenticates before releasing plaintext; the open path also defensively scrubs `dest` and throws `VerificationFailed` on mismatch.
- **Ed25519** → `Curve25519.Signing`. Verify stays exact; sign is hedged (see Tests).
- **ECDSA sign-from-scalar** → `P256/P384/P521.Signing.PrivateKey(rawRepresentation:)`, which accepts the bare scalar that `SecKeyCreateWithData` cannot. **ECDSA verify stays on Security.framework** (strict canonical-DER pre-check preserved).
- **X25519** → `Curve25519.KeyAgreement`; raw secret reuses the shared `validateRawSecret` / `deriveFromRawSecret` RFC 7748 §6.1 all-zero rejection.

## Test adjustments
- CryptoKit produces **hedged (randomized) Ed25519** signatures (verified: differs run-to-run, but every signature still verifies and the public key matches the RFC vector). The deterministic-bytes KAT now **probes signing determinism at runtime** (sign the same message twice) — asserts exact RFC 8032 bytes where deterministic (JCA/WebCrypto), falls back to a sign→verify check where hedged (CryptoKit). No new expect/actual; change is confined to `SignatureKatTest.kt`.
- Apple test support now enables the raw-scalar KAT/Wycheproof **for X25519 only** (CryptoKit imports the bare 32-byte scalar; EC still needs the X9.63 external rep), so the RFC 7748 KAT, the X25519 Wycheproof vectors, and DHKEM-X25519 HPKE vectors now actually run on Apple.

## Verification (macosArm64, real Xcode/Swift 6.3 toolchain)
```
./gradlew :buffer-crypto:macosArm64Test
FINAL macosArm64Test: tests=129 failures=0 errors=0 skipped=0
BUILD SUCCESSFUL

./gradlew :buffer-crypto:ktlintCheck
BUILD SUCCESSFUL
```
The KAT + Wycheproof + negative/tamper + capability suites all run green with the four primitives now enabled (ChaChaPoly AEAD/tamper/Wycheproof, Ed25519 KAT/Wycheproof/capability, ECDSA sign→verify round-trip from scalar, X25519 KAT/Wycheproof/round-trip, DHKEM-X25519 HPKE).

## Follow-ups
- All-Apple-target compile (ios/tvos/watchos simulators) is exercised by the `build-apple` CI check; only macosArm64 runs locally on this host.