### PR TITLE
feat(buffer-crypto): Linux native crypto backend (BoringSSL) — closes #202

### DIFF
--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -58,7 +58,8 @@ jobs:
       - name: Install ARM64 dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y qemu-user-static gcc-aarch64-linux-gnu
+          # g++-aarch64-linux-gnu is needed to cross-compile buffer-crypto's BoringSSL (C++) for arm64.
+          sudo apt-get install -y qemu-user-static gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
           # ARM64 runtime libraries for QEMU
           mkdir -p /tmp/arm64-libs
           cd /tmp/arm64-libs
@@ -102,15 +103,21 @@ jobs:
           --no-build-cache ${{ inputs.gradle-args }}
 
       - name: Run Linux x64 tests
+        # :buffer-crypto:linuxX64Test runs the full common crypto suite (KAT + Wycheproof +
+        # tamper/negative + capability) over the BoringSSL backend. Its first run provisions
+        # BoringSSL via the self-contained buildBoringsslX64 task (clone + cmake + make crypto),
+        # which needs the go/cmake toolchains present on the runner.
         run: >-
           ./gradlew :buffer:linuxX64Test :buffer-compression:linuxX64Test :buffer-flow:linuxX64Test
-          :buffer-codec:linuxX64Test :buffer-codec-test:linuxX64Test
+          :buffer-codec:linuxX64Test :buffer-codec-test:linuxX64Test :buffer-crypto:linuxX64Test
           --no-build-cache ${{ inputs.gradle-args }}
 
       - name: Build ARM64 test binaries
+        # buffer-crypto cross-builds its arm64 BoringSSL via buildBoringsslArm64 (uses the
+        # aarch64-linux-gnu cross toolchain installed above).
         run: >-
           ./gradlew :buffer:linkDebugTestLinuxArm64 :buffer-compression:linkDebugTestLinuxArm64 :buffer-flow:linkDebugTestLinuxArm64
-          :buffer-codec-test:linkDebugTestLinuxArm64
+          :buffer-codec-test:linkDebugTestLinuxArm64 :buffer-crypto:linkDebugTestLinuxArm64
           --no-build-cache ${{ inputs.gradle-args }}
 
       - name: Run buffer ARM64 tests via QEMU

--- a/buffer-crypto/.gitignore
+++ b/buffer-crypto/.gitignore
@@ -1,0 +1,3 @@
+# BoringSSL static libs + headers, provisioned by the buildBoringssl<Arch> Gradle task (or
+# symlinked from a prebuilt tree on a dev box). Never commit the .a binaries or vendored headers.
+/libs/boringssl/

--- a/buffer-crypto/build.gradle.kts
+++ b/buffer-crypto/build.gradle.kts
@@ -130,9 +130,10 @@ fun appleSwiftShim(
 // multi-minute BoringSSL build entirely.
 // ---------------------------------------------------------------------------
 
-// Pinned BoringSSL commit. Bump deliberately; it gates the rebuild marker file. This commit
-// predates BoringSSL's CMake "no top-level make target" reshuffle, so `make crypto` still works.
-val boringSslCommit = "dd5219451c3ce26c5ffa73caebdf09f44b753f60"
+// Pinned BoringSSL commit, fetched from the GitHub mirror (which — unlike googlesource — reliably
+// serves `git fetch --depth 1 <sha>`). Bump deliberately; the SHA gates the rebuild marker file.
+val boringSslCommit = "63893acb3684fc756ddfa1ca4c6bab9e7b924e53"
+val boringSslRepo = "https://github.com/google/boringssl.git"
 val boringSslBuildScratch = layout.buildDirectory.dir("boringssl")
 
 fun createBuildBoringSslTask(arch: String): TaskProvider<Task> {
@@ -169,7 +170,7 @@ fun createBuildBoringSslTask(arch: String): TaskProvider<Task> {
                     if (rc != 0) throw GradleException("command failed (${cmd.joinToString(" ")}): exit $rc")
                 }
                 run("git", "init", "boringssl", dir = scratch)
-                run("git", "remote", "add", "origin", "https://boringssl.googlesource.com/boringssl", dir = srcDir)
+                run("git", "remote", "add", "origin", boringSslRepo, dir = srcDir)
                 run("git", "fetch", "--depth", "1", "origin", boringSslCommit, dir = srcDir)
                 run("git", "checkout", "FETCH_HEAD", dir = srcDir)
             }
@@ -178,14 +179,22 @@ fun createBuildBoringSslTask(arch: String): TaskProvider<Task> {
             if (cmakeBuildDir.exists()) cmakeBuildDir.deleteRecursively()
             cmakeBuildDir.mkdirs()
 
+            // Compatibility flags so the produced libcrypto.a only references symbols present in
+            // Kotlin/Native's bundled (older) glibc. Modern Ubuntu gcc + glibc 2.38+ otherwise emit:
+            //   * __*_chk (fortify) — from the distro's default _FORTIFY_SOURCE; disabled here.
+            //   * __stack_chk_fail — from -fstack-protector; disabled here.
+            //   * __isoc23_strtoull — glibc redirects strtoull under gcc 13+/C23; a tiny compat
+            //     translation unit (below, appended to the archive) provides it.
+            // K/N's ld.lld links against its own glibc, where these newer symbols are absent.
+            val compatCFlags = "-fPIC -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0 -fno-stack-protector"
             val cmakeArgs =
                 mutableListOf(
                     "cmake",
                     "-DCMAKE_BUILD_TYPE=Release",
                     "-DBUILD_SHARED_LIBS=OFF",
                     "-DCMAKE_POSITION_INDEPENDENT_CODE=ON",
-                    "-DCMAKE_C_FLAGS=-fPIC",
-                    "-DCMAKE_CXX_FLAGS=-fPIC",
+                    "-DCMAKE_C_FLAGS=$compatCFlags",
+                    "-DCMAKE_CXX_FLAGS=$compatCFlags",
                     "-G",
                     "Unix Makefiles",
                 )
@@ -196,8 +205,8 @@ fun createBuildBoringSslTask(arch: String): TaskProvider<Task> {
                         "-DCMAKE_SYSTEM_PROCESSOR=aarch64",
                         "-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc",
                         "-DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++",
-                        "-DCMAKE_C_FLAGS=-fPIC -mno-outline-atomics",
-                        "-DCMAKE_CXX_FLAGS=-fPIC -mno-outline-atomics",
+                        "-DCMAKE_C_FLAGS=$compatCFlags -mno-outline-atomics",
+                        "-DCMAKE_CXX_FLAGS=$compatCFlags -mno-outline-atomics",
                     ),
                 )
             }
@@ -223,11 +232,29 @@ fun createBuildBoringSslTask(arch: String): TaskProvider<Task> {
             val cpu = Runtime.getRuntime().availableProcessors()
             runIn(cmakeBuildDir, "make", "-j$cpu", "crypto")
 
-            outputDir.resolve("lib").mkdirs()
-            val cryptoLib =
+            val builtCrypto =
                 cmakeBuildDir.walk().firstOrNull { it.name == "libcrypto.a" }
                     ?: throw GradleException("libcrypto.a not found under ${cmakeBuildDir.absolutePath}")
-            cryptoLib.copyTo(outputDir.resolve("lib/libcrypto.a"), overwrite = true)
+
+            // Append a tiny compat translation unit providing __isoc23_strtoull (glibc 2.38+/gcc-13
+            // redirects strtoull to it; K/N's bundled glibc lacks the symbol). It just forwards to
+            // the classic strtoull, which is present everywhere.
+            val compatC = File(cmakeBuildDir, "kn_glibc_compat.c")
+            compatC.writeText(
+                """
+                #include <stdlib.h>
+                unsigned long long __isoc23_strtoull(const char *nptr, char **endptr, int base) {
+                    return strtoull(nptr, endptr, base);
+                }
+                """.trimIndent(),
+            )
+            val compatO = File(cmakeBuildDir, "kn_glibc_compat.o")
+            val cc = if (arch == "arm64" && System.getProperty("os.arch") != "aarch64") "aarch64-linux-gnu-gcc" else "cc"
+            runIn(cmakeBuildDir, cc, "-fPIC", "-c", compatC.absolutePath, "-o", compatO.absolutePath)
+            runIn(cmakeBuildDir, "ar", "r", builtCrypto.absolutePath, compatO.absolutePath)
+
+            outputDir.resolve("lib").mkdirs()
+            builtCrypto.copyTo(outputDir.resolve("lib/libcrypto.a"), overwrite = true)
 
             val includeOutput = outputDir.resolve("include")
             val srcInclude = srcDir.resolve("src/include")

--- a/buffer-crypto/build.gradle.kts
+++ b/buffer-crypto/build.gradle.kts
@@ -3,6 +3,7 @@
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetTree
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.konan.target.HostManager
 
 plugins {
@@ -118,6 +119,148 @@ fun appleSwiftShim(
     return AppleSwiftShim(task, archiveName, outDir, swiftLibDir)
 }
 
+// ---------------------------------------------------------------------------
+// Linux: BoringSSL provisioning + cinterop wiring for the native crypto backend.
+//
+// The backend statically links BoringSSL's libcrypto.a (EVP/EC/AEAD/HKDF/curve25519).
+// Provisioning is self-contained for CI: `buildBoringssl<Arch>` shallow-clones BoringSSL at a
+// pinned commit and builds the static lib + headers into libs/boringssl/linux-$arch (gitignored,
+// never committed). The build is skipped when the libs already exist, so a dev box can drop in a
+// prebuilt tree (e.g. symlink the sibling :socket: module's libs/boringssl/linux-x64) and avoid the
+// multi-minute BoringSSL build entirely.
+// ---------------------------------------------------------------------------
+
+// Pinned BoringSSL commit. Bump deliberately; it gates the rebuild marker file. This commit
+// predates BoringSSL's CMake "no top-level make target" reshuffle, so `make crypto` still works.
+val boringSslCommit = "dd5219451c3ce26c5ffa73caebdf09f44b753f60"
+val boringSslBuildScratch = layout.buildDirectory.dir("boringssl")
+
+fun createBuildBoringSslTask(arch: String): TaskProvider<Task> {
+    val taskName = "buildBoringssl${arch.replaceFirstChar { it.uppercase() }}"
+    val outputDir = project.projectDir.resolve("libs/boringssl/linux-$arch")
+    val markerFile = outputDir.resolve("lib/.built-$boringSslCommit")
+
+    return tasks.register(taskName) {
+        group = "build"
+        description = "Build BoringSSL static libcrypto for Linux $arch"
+        inputs.property("boringSslCommit", boringSslCommit)
+        outputs.file(markerFile)
+        onlyIf { !markerFile.exists() }
+
+        doLast {
+            val scratch = boringSslBuildScratch.get().asFile
+            val srcDir = File(scratch, "boringssl")
+            if (!File(srcDir, "include").exists()) {
+                scratch.mkdirs()
+                srcDir.deleteRecursively()
+                logger.lifecycle("Cloning BoringSSL @ $boringSslCommit ...")
+
+                fun run(
+                    vararg cmd: String,
+                    dir: File,
+                ) {
+                    val rc =
+                        ProcessBuilder(*cmd)
+                            .directory(dir)
+                            .redirectErrorStream(true)
+                            .start()
+                            .also { it.inputStream.bufferedReader().forEachLine { l -> logger.lifecycle(l) } }
+                            .waitFor()
+                    if (rc != 0) throw GradleException("command failed (${cmd.joinToString(" ")}): exit $rc")
+                }
+                run("git", "init", "boringssl", dir = scratch)
+                run("git", "remote", "add", "origin", "https://boringssl.googlesource.com/boringssl", dir = srcDir)
+                run("git", "fetch", "--depth", "1", "origin", boringSslCommit, dir = srcDir)
+                run("git", "checkout", "FETCH_HEAD", dir = srcDir)
+            }
+
+            val cmakeBuildDir = File(srcDir, "build-$arch")
+            if (cmakeBuildDir.exists()) cmakeBuildDir.deleteRecursively()
+            cmakeBuildDir.mkdirs()
+
+            val cmakeArgs =
+                mutableListOf(
+                    "cmake",
+                    "-DCMAKE_BUILD_TYPE=Release",
+                    "-DBUILD_SHARED_LIBS=OFF",
+                    "-DCMAKE_POSITION_INDEPENDENT_CODE=ON",
+                    "-DCMAKE_C_FLAGS=-fPIC",
+                    "-DCMAKE_CXX_FLAGS=-fPIC",
+                    "-G",
+                    "Unix Makefiles",
+                )
+            if (arch == "arm64" && System.getProperty("os.arch") != "aarch64") {
+                cmakeArgs.addAll(
+                    listOf(
+                        "-DCMAKE_SYSTEM_NAME=Linux",
+                        "-DCMAKE_SYSTEM_PROCESSOR=aarch64",
+                        "-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc",
+                        "-DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++",
+                        "-DCMAKE_C_FLAGS=-fPIC -mno-outline-atomics",
+                        "-DCMAKE_CXX_FLAGS=-fPIC -mno-outline-atomics",
+                    ),
+                )
+            }
+            cmakeArgs.add("..")
+
+            fun runIn(
+                dir: File,
+                vararg cmd: String,
+            ) {
+                val rc =
+                    ProcessBuilder(*cmd)
+                        .directory(dir)
+                        .redirectErrorStream(true)
+                        .start()
+                        .also { it.inputStream.bufferedReader().forEachLine { l -> logger.lifecycle(l) } }
+                        .waitFor()
+                if (rc != 0) throw GradleException("command failed (${cmd.joinToString(" ")}): exit $rc")
+            }
+
+            logger.lifecycle("Configuring BoringSSL for $arch ...")
+            runIn(cmakeBuildDir, *cmakeArgs.toTypedArray())
+            logger.lifecycle("Building BoringSSL crypto for $arch ...")
+            val cpu = Runtime.getRuntime().availableProcessors()
+            runIn(cmakeBuildDir, "make", "-j$cpu", "crypto")
+
+            outputDir.resolve("lib").mkdirs()
+            val cryptoLib =
+                cmakeBuildDir.walk().firstOrNull { it.name == "libcrypto.a" }
+                    ?: throw GradleException("libcrypto.a not found under ${cmakeBuildDir.absolutePath}")
+            cryptoLib.copyTo(outputDir.resolve("lib/libcrypto.a"), overwrite = true)
+
+            val includeOutput = outputDir.resolve("include")
+            val srcInclude = srcDir.resolve("src/include")
+            val topInclude = srcDir.resolve("include")
+            (if (srcInclude.exists()) srcInclude else topInclude).copyRecursively(includeOutput, overwrite = true)
+
+            markerFile.writeText("BoringSSL $boringSslCommit built ${System.currentTimeMillis()}")
+            logger.lifecycle("BoringSSL ($arch) provisioned at ${outputDir.absolutePath}")
+        }
+    }
+}
+
+val buildBoringSslX64 = createBuildBoringSslTask("x64")
+val buildBoringSslArm64 = createBuildBoringSslTask("arm64")
+
+fun KotlinNativeTarget.configureBoringSslCinterop(arch: String) {
+    val boringsslDir = project.projectDir.resolve("libs/boringssl/linux-$arch")
+    val libDir = boringsslDir.resolve("lib")
+    val incDir = boringsslDir.resolve("include")
+    val buildTask = if (arch == "x64") buildBoringSslX64 else buildBoringSslArm64
+
+    compilations.getByName("main").cinterops.create("boringsslcrypto") {
+        defFile(project.file("src/nativeInterop/cinterop/boringsslcrypto.def"))
+        includeDirs(incDir.absolutePath)
+        extraOpts("-libraryPath", libDir.absolutePath, "-staticLibrary", "libcrypto.a")
+        // Build BoringSSL on demand (no-op if libs/boringssl is already populated).
+        tasks.named(interopProcessingTaskName).configure { dependsOn(buildTask) }
+    }
+    binaries.all {
+        linkerOpts("-L${libDir.absolutePath}", "-lcrypto", "-lpthread")
+    }
+}
+
 kotlin {
     jvmToolchain(21)
 
@@ -169,11 +312,23 @@ kotlin {
             tvosSimulatorArm64()
             tvosX64()
         }
+        if (HostManager.hostIsLinux) {
+            // Linux native crypto via BoringSSL (libcrypto). linuxArm64 is registered so the klib
+            // is published; on an x64 CI runner its libcrypto.a is cross-built (mno-outline-atomics).
+            linuxX64()
+            linuxArm64()
+        }
     } else if (HostManager.hostIsMac) {
         if (System.getProperty("os.arch") == "aarch64") {
             macosArm64()
         } else {
             macosX64()
+        }
+    } else if (HostManager.hostIsLinux) {
+        if (System.getProperty("os.arch") == "aarch64") {
+            linuxArm64()
+        } else {
+            linuxX64()
         }
     }
 
@@ -181,7 +336,17 @@ kotlin {
     // SPI header and are absent from Kotlin/Native's platform.CoreCrypto binding. Bind them
     // via a small cinterop (forward declarations only; symbols resolve from libcommonCrypto).
     // Registered uniformly on every Apple target so the commonizer exposes it to appleMain.
-    targets.withType<org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget>().configureEach {
+    // Linux native targets: wire the BoringSSL cinterop + static libcrypto link.
+    targets.matching { it.name == "linuxX64" }.configureEach {
+        (this as KotlinNativeTarget).configureBoringSslCinterop("x64")
+    }
+    targets.matching { it.name == "linuxArm64" }.configureEach {
+        (this as KotlinNativeTarget).configureBoringSslCinterop("arm64")
+    }
+
+    // Apple native targets: CommonCrypto GCM + CryptoKit shim. Guarded to Apple konan targets so it
+    // never tries to bind CommonCrypto/Security headers on Linux.
+    targets.withType<KotlinNativeTarget>().matching { it.konanTarget.family.isAppleFamily }.configureEach {
         compilations.getByName("main").cinterops.create("commoncryptogcm") {
             defFile(project.file("src/nativeInterop/cinterop/commoncryptogcm.def"))
         }

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HkdfCore.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HkdfCore.kt
@@ -49,7 +49,9 @@ internal class HkdfEngine(
         if (salt != null && salt.remaining() > 0) {
             newMac(salt).also { it.update(ikm) }.doFinalInto(dest)
         } else {
-            // Empty salt → a block of zero bytes. The scratch buffer is zero-initialized.
+            // Empty salt → a block of zero bytes (RFC 5869). The secure [scratch] factory
+            // zero-initializes on allocate (see SecureBufferFactory), so this is guaranteed
+            // zero on every platform — not a reliance on the underlying allocator.
             scratch.allocate(hashLen).use { zeroSalt ->
                 newMac(zeroSalt).also { it.update(ikm) }.doFinalInto(dest)
             }

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/SecureBuffer.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/SecureBuffer.kt
@@ -66,12 +66,32 @@ internal class SecureBufferFactory(
     override fun allocate(
         size: Int,
         byteOrder: ByteOrder,
-    ): PlatformBuffer = SecureBuffer(delegate.allocate(size, byteOrder))
+    ): PlatformBuffer = SecureBuffer(zeroInit(delegate.allocate(size, byteOrder)))
 
     override fun wrap(
         array: ByteArray,
         byteOrder: ByteOrder,
     ): PlatformBuffer = SecureBuffer(delegate.wrap(array, byteOrder))
+
+    /**
+     * Zero-initializes the full backing of a freshly allocated buffer — the allocate-time mirror
+     * of [SecureBuffer]'s wipe-on-free. Secure scratch must be deterministically zero on every
+     * platform: crypto code (e.g. HKDF's empty-salt zero block) relies on a fresh secure buffer
+     * reading as zero, and the native Linux backing ([com.ditchoom.buffer.NativeBuffer], raw
+     * `malloc`) does not zero on its own. Zeros the whole capacity (not just `remaining()`) so no
+     * slack bytes carry prior contents, then restores the position/limit the delegate handed back
+     * so the `allocate` contract is unchanged (including pooled delegates where capacity > size).
+     */
+    private fun zeroInit(buffer: PlatformBuffer): PlatformBuffer {
+        val savedPosition = buffer.position()
+        val savedLimit = buffer.limit()
+        buffer.position(0)
+        buffer.setLimit(buffer.capacity)
+        buffer.fill(0)
+        buffer.position(savedPosition)
+        buffer.setLimit(savedLimit)
+        return buffer
+    }
 }
 
 /**

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/SecureBuffer.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/SecureBuffer.kt
@@ -43,7 +43,9 @@ class SecureBuffer internal constructor(
                 // position..limit, so widen the window to cover every byte first.
                 inner.position(0)
                 inner.setLimit(inner.capacity)
-                inner.fill(0)
+                // Byte fill (not the Int-pattern overload, which rejects non-multiple-of-4
+                // lengths) so buffers of any capacity — e.g. P-521's 66 bytes — are fully wiped.
+                inner.fill(0.toByte())
             } catch (_: Throwable) {
                 // A best-effort wipe must never mask the real free below; swallow and free.
             }
@@ -87,7 +89,9 @@ internal class SecureBufferFactory(
         val savedLimit = buffer.limit()
         buffer.position(0)
         buffer.setLimit(buffer.capacity)
-        buffer.fill(0)
+        // Byte fill, not the Int-pattern overload: the latter requires the length to be a
+        // multiple of 4 and throws otherwise (e.g. P-521's 66-byte scratch, odd sizes).
+        buffer.fill(0.toByte())
         buffer.position(savedPosition)
         buffer.setLimit(savedLimit)
         return buffer

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Aead.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Aead.linux.kt
@@ -37,28 +37,112 @@ actual val supportsSyncAesGcm: Boolean = true
 actual val supportsChaChaPoly: Boolean = true
 actual val supportsSyncChaChaPoly: Boolean = true
 
+/** Which BoringSSL AEAD wrapper a seal/open call dispatches to. */
+private enum class AeadAlg { AES_GCM, CHACHA }
+
 private fun requireNonce(nonce: ReadBuffer) {
     require(nonce.remaining() == AEAD_NONCE_BYTES) {
         "nonce must be $AEAD_NONCE_BYTES bytes, was ${nonce.remaining()}"
     }
 }
 
-/** A seal/open BoringSSL wrapper, distilled to the common pointer signature. */
-private typealias AeadFn = (
-    key: CPointer<ByteVar>, keyLen: Int,
-    nonce: CPointer<ByteVar>, nonceLen: Int,
-    aad: CPointer<ByteVar>, aadLen: Int,
-    data: CPointer<ByteVar>, dataLen: Int,
-    out: CPointer<ByteVar>, outCap: Int, outLen: CPointer<size_tVar>,
-) -> Int
+private fun sealCall(
+    alg: AeadAlg,
+    key: CPointer<ByteVar>,
+    keyLen: Int,
+    nonce: CPointer<ByteVar>,
+    nonceLen: Int,
+    aad: CPointer<ByteVar>,
+    aadLen: Int,
+    data: CPointer<ByteVar>,
+    dataLen: Int,
+    out: CPointer<ByteVar>,
+    outCap: Int,
+    outLen: CPointer<size_tVar>,
+): Int =
+    when (alg) {
+        AeadAlg.AES_GCM ->
+            bcl_aes_gcm_seal(
+                key.reinterpret(),
+                keyLen.convert(),
+                nonce.reinterpret(),
+                nonceLen.convert(),
+                aad.reinterpret(),
+                aadLen.convert(),
+                data.reinterpret(),
+                dataLen.convert(),
+                out.reinterpret(),
+                outCap.convert(),
+                outLen,
+            )
+        AeadAlg.CHACHA ->
+            bcl_chacha_seal(
+                key.reinterpret(),
+                keyLen.convert(),
+                nonce.reinterpret(),
+                nonceLen.convert(),
+                aad.reinterpret(),
+                aadLen.convert(),
+                data.reinterpret(),
+                dataLen.convert(),
+                out.reinterpret(),
+                outCap.convert(),
+                outLen,
+            )
+    }
+
+private fun openCall(
+    alg: AeadAlg,
+    key: CPointer<ByteVar>,
+    keyLen: Int,
+    nonce: CPointer<ByteVar>,
+    nonceLen: Int,
+    aad: CPointer<ByteVar>,
+    aadLen: Int,
+    data: CPointer<ByteVar>,
+    dataLen: Int,
+    out: CPointer<ByteVar>,
+    outCap: Int,
+    outLen: CPointer<size_tVar>,
+): Int =
+    when (alg) {
+        AeadAlg.AES_GCM ->
+            bcl_aes_gcm_open(
+                key.reinterpret(),
+                keyLen.convert(),
+                nonce.reinterpret(),
+                nonceLen.convert(),
+                aad.reinterpret(),
+                aadLen.convert(),
+                data.reinterpret(),
+                dataLen.convert(),
+                out.reinterpret(),
+                outCap.convert(),
+                outLen,
+            )
+        AeadAlg.CHACHA ->
+            bcl_chacha_open(
+                key.reinterpret(),
+                keyLen.convert(),
+                nonce.reinterpret(),
+                nonceLen.convert(),
+                aad.reinterpret(),
+                aadLen.convert(),
+                data.reinterpret(),
+                dataLen.convert(),
+                out.reinterpret(),
+                outCap.convert(),
+                outLen,
+            )
+    }
 
 private fun aeadSeal(
+    alg: AeadAlg,
     keyMaterial: ReadBuffer,
     nonce: ReadBuffer,
     aad: ReadBuffer?,
     plaintext: ReadBuffer,
     dest: WriteBuffer,
-    seal: AeadFn,
 ) {
     requireNonce(nonce)
     val ptLen = plaintext.remaining()
@@ -76,12 +160,19 @@ private fun aeadSeal(
                         // EVP_AEAD_CTX_seal writes ciphertext||tag contiguously straight into dest.
                         dest.withWritablePointer(sealedLen) { outPtr ->
                             status =
-                                seal(
-                                    keyPtr, keyLen,
-                                    ivPtr, ivLen,
-                                    aadPtr, aadLen,
-                                    ptPtr, ptLen,
-                                    outPtr, sealedLen, outLen.ptr,
+                                sealCall(
+                                    alg,
+                                    keyPtr,
+                                    keyLen,
+                                    ivPtr,
+                                    ivLen,
+                                    aadPtr,
+                                    aadLen,
+                                    ptPtr,
+                                    ptLen,
+                                    outPtr,
+                                    sealedLen,
+                                    outLen.ptr,
                                 )
                         }
                     }
@@ -89,17 +180,19 @@ private fun aeadSeal(
             }
         }
         check(status == BCL_OK) { "AEAD seal failed (status=$status)" }
-        check(outLen.value.toInt() == sealedLen) { "AEAD seal produced ${outLen.value} bytes, expected $sealedLen" }
+        check(outLen.value.toInt() == sealedLen) {
+            "AEAD seal produced ${outLen.value} bytes, expected $sealedLen"
+        }
     }
 }
 
 private fun aeadOpen(
+    alg: AeadAlg,
     keyMaterial: ReadBuffer,
     nonce: ReadBuffer,
     aad: ReadBuffer?,
     ciphertextAndTag: ReadBuffer,
     dest: WriteBuffer,
-    open: AeadFn,
 ) {
     requireNonce(nonce)
     require(ciphertextAndTag.remaining() >= AEAD_TAG_BYTES) {
@@ -119,12 +212,19 @@ private fun aeadOpen(
                         // mismatch it returns 0 (mapped to BCL_AUTH_FAIL) and never writes dest.
                         dest.withWritablePointer(ptLen) { outPtr ->
                             status =
-                                open(
-                                    keyPtr, keyLen,
-                                    ivPtr, ivLen,
-                                    aadPtr, aadLen,
-                                    ctPtr, ctLen,
-                                    outPtr, ptLen, outLen.ptr,
+                                openCall(
+                                    alg,
+                                    keyPtr,
+                                    keyLen,
+                                    ivPtr,
+                                    ivLen,
+                                    aadPtr,
+                                    aadLen,
+                                    ctPtr,
+                                    ctLen,
+                                    outPtr,
+                                    ptLen,
+                                    outLen.ptr,
                                 )
                         }
                     }
@@ -133,7 +233,9 @@ private fun aeadOpen(
         }
         if (status == BCL_AUTH_FAIL) throw VerificationFailed()
         check(status == BCL_OK) { "AEAD open failed (status=$status)" }
-        check(outLen.value.toInt() == ptLen) { "AEAD open produced ${outLen.value} bytes, expected $ptLen" }
+        check(outLen.value.toInt() == ptLen) {
+            "AEAD open produced ${outLen.value} bytes, expected $ptLen"
+        }
     }
 }
 
@@ -143,16 +245,7 @@ internal actual fun aesGcmSeal(
     aad: ReadBuffer?,
     plaintext: ReadBuffer,
     dest: WriteBuffer,
-) = aeadSeal(key.material, nonce, aad, plaintext, dest) {
-        keyPtr, keyLen, ivPtr, ivLen, aadPtr, aadLen, ptPtr, ptLen, outPtr, outCap, outLen ->
-    bcl_aes_gcm_seal(
-        keyPtr.reinterpret(), keyLen.convert(),
-        ivPtr.reinterpret(), ivLen.convert(),
-        aadPtr.reinterpret(), aadLen.convert(),
-        ptPtr.reinterpret(), ptLen.convert(),
-        outPtr.reinterpret(), outCap.convert(), outLen,
-    )
-}
+) = aeadSeal(AeadAlg.AES_GCM, key.material, nonce, aad, plaintext, dest)
 
 internal actual fun aesGcmOpen(
     key: AesGcmKey,
@@ -160,16 +253,7 @@ internal actual fun aesGcmOpen(
     aad: ReadBuffer?,
     ciphertextAndTag: ReadBuffer,
     dest: WriteBuffer,
-) = aeadOpen(key.material, nonce, aad, ciphertextAndTag, dest) {
-        keyPtr, keyLen, ivPtr, ivLen, aadPtr, aadLen, ctPtr, ctLen, outPtr, outCap, outLen ->
-    bcl_aes_gcm_open(
-        keyPtr.reinterpret(), keyLen.convert(),
-        ivPtr.reinterpret(), ivLen.convert(),
-        aadPtr.reinterpret(), aadLen.convert(),
-        ctPtr.reinterpret(), ctLen.convert(),
-        outPtr.reinterpret(), outCap.convert(), outLen,
-    )
-}
+) = aeadOpen(AeadAlg.AES_GCM, key.material, nonce, aad, ciphertextAndTag, dest)
 
 internal actual fun chaChaPolySeal(
     key: ChaChaPolyKey,
@@ -177,16 +261,7 @@ internal actual fun chaChaPolySeal(
     aad: ReadBuffer?,
     plaintext: ReadBuffer,
     dest: WriteBuffer,
-) = aeadSeal(key.material, nonce, aad, plaintext, dest) {
-        keyPtr, keyLen, ivPtr, ivLen, aadPtr, aadLen, ptPtr, ptLen, outPtr, outCap, outLen ->
-    bcl_chacha_seal(
-        keyPtr.reinterpret(), keyLen.convert(),
-        ivPtr.reinterpret(), ivLen.convert(),
-        aadPtr.reinterpret(), aadLen.convert(),
-        ptPtr.reinterpret(), ptLen.convert(),
-        outPtr.reinterpret(), outCap.convert(), outLen,
-    )
-}
+) = aeadSeal(AeadAlg.CHACHA, key.material, nonce, aad, plaintext, dest)
 
 internal actual fun chaChaPolyOpen(
     key: ChaChaPolyKey,
@@ -194,16 +269,7 @@ internal actual fun chaChaPolyOpen(
     aad: ReadBuffer?,
     ciphertextAndTag: ReadBuffer,
     dest: WriteBuffer,
-) = aeadOpen(key.material, nonce, aad, ciphertextAndTag, dest) {
-        keyPtr, keyLen, ivPtr, ivLen, aadPtr, aadLen, ctPtr, ctLen, outPtr, outCap, outLen ->
-    bcl_chacha_open(
-        keyPtr.reinterpret(), keyLen.convert(),
-        ivPtr.reinterpret(), ivLen.convert(),
-        aadPtr.reinterpret(), aadLen.convert(),
-        ctPtr.reinterpret(), ctLen.convert(),
-        outPtr.reinterpret(), outCap.convert(), outLen,
-    )
-}
+) = aeadOpen(AeadAlg.CHACHA, key.material, nonce, aad, ciphertextAndTag, dest)
 
 // Async wrappers — Linux has a synchronous native AEAD, so delegate to the framed one-shots.
 

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Aead.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Aead.linux.kt
@@ -1,0 +1,262 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.crypto.cinterop.boringssl.BCL_AUTH_FAIL
+import com.ditchoom.buffer.crypto.cinterop.boringssl.BCL_OK
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_aes_gcm_open
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_aes_gcm_seal
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_chacha_open
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_chacha_seal
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.CPointer
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.value
+import platform.posix.size_tVar
+
+/*
+ * Linux AEAD backed by BoringSSL's one-shot EVP_AEAD API.
+ *
+ * AES-128/256-GCM and ChaCha20-Poly1305 use EVP_AEAD_CTX_seal / EVP_AEAD_CTX_open with the
+ * RFC 5116 layout (ciphertext immediately followed by the 16-byte tag). On the open path
+ * BoringSSL authenticates first and writes plaintext only on a verified tag — so there is no
+ * unverified-plaintext release and no manual constant-time tag compare is needed; a failure
+ * surfaces as BCL_AUTH_FAIL and we raise the opaque VerificationFailed.
+ */
+
+actual val supportsSyncAesGcm: Boolean = true
+actual val supportsChaChaPoly: Boolean = true
+actual val supportsSyncChaChaPoly: Boolean = true
+
+private fun requireNonce(nonce: ReadBuffer) {
+    require(nonce.remaining() == AEAD_NONCE_BYTES) {
+        "nonce must be $AEAD_NONCE_BYTES bytes, was ${nonce.remaining()}"
+    }
+}
+
+/** A seal/open BoringSSL wrapper, distilled to the common pointer signature. */
+private typealias AeadFn = (
+    key: CPointer<ByteVar>, keyLen: Int,
+    nonce: CPointer<ByteVar>, nonceLen: Int,
+    aad: CPointer<ByteVar>, aadLen: Int,
+    data: CPointer<ByteVar>, dataLen: Int,
+    out: CPointer<ByteVar>, outCap: Int, outLen: CPointer<size_tVar>,
+) -> Int
+
+private fun aeadSeal(
+    keyMaterial: ReadBuffer,
+    nonce: ReadBuffer,
+    aad: ReadBuffer?,
+    plaintext: ReadBuffer,
+    dest: WriteBuffer,
+    seal: AeadFn,
+) {
+    requireNonce(nonce)
+    val ptLen = plaintext.remaining()
+    val sealedLen = ptLen + AEAD_TAG_BYTES
+    require(dest.remaining() >= sealedLen) {
+        "dest needs $sealedLen bytes remaining, has ${dest.remaining()}"
+    }
+    memScoped {
+        val outLen = alloc<size_tVar>()
+        var status = BCL_OK - 1
+        keyMaterial.withRemainingBytes { keyPtr, keyLen ->
+            nonce.withRemainingBytes { ivPtr, ivLen ->
+                withOptionalBytes(aad) { aadPtr, aadLen ->
+                    plaintext.withRemainingBytes2(ptLen) { ptPtr ->
+                        // EVP_AEAD_CTX_seal writes ciphertext||tag contiguously straight into dest.
+                        dest.withWritablePointer(sealedLen) { outPtr ->
+                            status =
+                                seal(
+                                    keyPtr, keyLen,
+                                    ivPtr, ivLen,
+                                    aadPtr, aadLen,
+                                    ptPtr, ptLen,
+                                    outPtr, sealedLen, outLen.ptr,
+                                )
+                        }
+                    }
+                }
+            }
+        }
+        check(status == BCL_OK) { "AEAD seal failed (status=$status)" }
+        check(outLen.value.toInt() == sealedLen) { "AEAD seal produced ${outLen.value} bytes, expected $sealedLen" }
+    }
+}
+
+private fun aeadOpen(
+    keyMaterial: ReadBuffer,
+    nonce: ReadBuffer,
+    aad: ReadBuffer?,
+    ciphertextAndTag: ReadBuffer,
+    dest: WriteBuffer,
+    open: AeadFn,
+) {
+    requireNonce(nonce)
+    require(ciphertextAndTag.remaining() >= AEAD_TAG_BYTES) {
+        "ciphertext+tag must be at least $AEAD_TAG_BYTES bytes"
+    }
+    val ctLen = ciphertextAndTag.remaining()
+    val ptLen = ctLen - AEAD_TAG_BYTES
+    require(dest.remaining() >= ptLen) { "dest needs $ptLen bytes remaining, has ${dest.remaining()}" }
+    memScoped {
+        val outLen = alloc<size_tVar>()
+        var status = BCL_OK - 1
+        keyMaterial.withRemainingBytes { keyPtr, keyLen ->
+            nonce.withRemainingBytes { ivPtr, ivLen ->
+                withOptionalBytes(aad) { aadPtr, aadLen ->
+                    ciphertextAndTag.withRemainingBytes2(ctLen) { ctPtr ->
+                        // EVP_AEAD_CTX_open authenticates before releasing any plaintext; on a tag
+                        // mismatch it returns 0 (mapped to BCL_AUTH_FAIL) and never writes dest.
+                        dest.withWritablePointer(ptLen) { outPtr ->
+                            status =
+                                open(
+                                    keyPtr, keyLen,
+                                    ivPtr, ivLen,
+                                    aadPtr, aadLen,
+                                    ctPtr, ctLen,
+                                    outPtr, ptLen, outLen.ptr,
+                                )
+                        }
+                    }
+                }
+            }
+        }
+        if (status == BCL_AUTH_FAIL) throw VerificationFailed()
+        check(status == BCL_OK) { "AEAD open failed (status=$status)" }
+        check(outLen.value.toInt() == ptLen) { "AEAD open produced ${outLen.value} bytes, expected $ptLen" }
+    }
+}
+
+internal actual fun aesGcmSeal(
+    key: AesGcmKey,
+    nonce: ReadBuffer,
+    aad: ReadBuffer?,
+    plaintext: ReadBuffer,
+    dest: WriteBuffer,
+) = aeadSeal(key.material, nonce, aad, plaintext, dest) {
+        keyPtr, keyLen, ivPtr, ivLen, aadPtr, aadLen, ptPtr, ptLen, outPtr, outCap, outLen ->
+    bcl_aes_gcm_seal(
+        keyPtr.reinterpret(), keyLen.convert(),
+        ivPtr.reinterpret(), ivLen.convert(),
+        aadPtr.reinterpret(), aadLen.convert(),
+        ptPtr.reinterpret(), ptLen.convert(),
+        outPtr.reinterpret(), outCap.convert(), outLen,
+    )
+}
+
+internal actual fun aesGcmOpen(
+    key: AesGcmKey,
+    nonce: ReadBuffer,
+    aad: ReadBuffer?,
+    ciphertextAndTag: ReadBuffer,
+    dest: WriteBuffer,
+) = aeadOpen(key.material, nonce, aad, ciphertextAndTag, dest) {
+        keyPtr, keyLen, ivPtr, ivLen, aadPtr, aadLen, ctPtr, ctLen, outPtr, outCap, outLen ->
+    bcl_aes_gcm_open(
+        keyPtr.reinterpret(), keyLen.convert(),
+        ivPtr.reinterpret(), ivLen.convert(),
+        aadPtr.reinterpret(), aadLen.convert(),
+        ctPtr.reinterpret(), ctLen.convert(),
+        outPtr.reinterpret(), outCap.convert(), outLen,
+    )
+}
+
+internal actual fun chaChaPolySeal(
+    key: ChaChaPolyKey,
+    nonce: ReadBuffer,
+    aad: ReadBuffer?,
+    plaintext: ReadBuffer,
+    dest: WriteBuffer,
+) = aeadSeal(key.material, nonce, aad, plaintext, dest) {
+        keyPtr, keyLen, ivPtr, ivLen, aadPtr, aadLen, ptPtr, ptLen, outPtr, outCap, outLen ->
+    bcl_chacha_seal(
+        keyPtr.reinterpret(), keyLen.convert(),
+        ivPtr.reinterpret(), ivLen.convert(),
+        aadPtr.reinterpret(), aadLen.convert(),
+        ptPtr.reinterpret(), ptLen.convert(),
+        outPtr.reinterpret(), outCap.convert(), outLen,
+    )
+}
+
+internal actual fun chaChaPolyOpen(
+    key: ChaChaPolyKey,
+    nonce: ReadBuffer,
+    aad: ReadBuffer?,
+    ciphertextAndTag: ReadBuffer,
+    dest: WriteBuffer,
+) = aeadOpen(key.material, nonce, aad, ciphertextAndTag, dest) {
+        keyPtr, keyLen, ivPtr, ivLen, aadPtr, aadLen, ctPtr, ctLen, outPtr, outCap, outLen ->
+    bcl_chacha_open(
+        keyPtr.reinterpret(), keyLen.convert(),
+        ivPtr.reinterpret(), ivLen.convert(),
+        aadPtr.reinterpret(), aadLen.convert(),
+        ctPtr.reinterpret(), ctLen.convert(),
+        outPtr.reinterpret(), outCap.convert(), outLen,
+    )
+}
+
+// Async wrappers — Linux has a synchronous native AEAD, so delegate to the framed one-shots.
+
+actual suspend fun aesGcmSealAsync(
+    key: AesGcmKey,
+    plaintext: ReadBuffer,
+    aad: ReadBuffer?,
+    factory: BufferFactory,
+): PlatformBuffer = aesGcmSeal(key, plaintext, aad, factory)
+
+actual suspend fun aesGcmOpenAsync(
+    sealed: ReadBuffer,
+    key: AesGcmKey,
+    aad: ReadBuffer?,
+    factory: BufferFactory,
+): PlatformBuffer = aesGcmOpen(sealed, key, aad, factory)
+
+actual suspend fun chaChaPolySealAsync(
+    key: ChaChaPolyKey,
+    plaintext: ReadBuffer,
+    aad: ReadBuffer?,
+    factory: BufferFactory,
+): PlatformBuffer = chaChaPolySeal(key, plaintext, aad, factory)
+
+actual suspend fun chaChaPolyOpenAsync(
+    sealed: ReadBuffer,
+    key: ChaChaPolyKey,
+    aad: ReadBuffer?,
+    factory: BufferFactory,
+): PlatformBuffer = chaChaPolyOpen(sealed, key, aad, factory)
+
+internal actual suspend fun aesGcmSealWithNonceAsync(
+    key: AesGcmKey,
+    nonce: ReadBuffer,
+    aad: ReadBuffer?,
+    plaintext: ReadBuffer,
+    factory: BufferFactory,
+): PlatformBuffer {
+    val out = factory.allocate(plaintext.remaining() + AEAD_TAG_BYTES)
+    aesGcmSeal(key, nonce, aad, plaintext, out)
+    out.resetForRead()
+    return out
+}
+
+internal actual suspend fun aesGcmOpenWithNonceAsync(
+    key: AesGcmKey,
+    nonce: ReadBuffer,
+    aad: ReadBuffer?,
+    ciphertextAndTag: ReadBuffer,
+    factory: BufferFactory,
+): PlatformBuffer {
+    val out = factory.allocate(maxOf(0, ciphertextAndTag.remaining() - AEAD_TAG_BYTES))
+    aesGcmOpen(key, nonce, aad, ciphertextAndTag, out)
+    out.resetForRead()
+    return out
+}

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/CryptoRandom.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/CryptoRandom.linux.kt
@@ -1,0 +1,22 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.crypto.cinterop.boringssl.BCL_OK
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_rand_bytes
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.reinterpret
+
+/** Linux CSPRNG backed by BoringSSL `RAND_bytes`, written straight into the buffer. */
+actual fun cryptoRandomInto(dest: WriteBuffer) {
+    val n = dest.remaining()
+    if (n == 0) return
+    dest.withWritablePointer(n) { ptr ->
+        // RAND_bytes never fails in BoringSSL, but surface a non-success status rather than
+        // hand back possibly-non-random bytes.
+        val status = bcl_rand_bytes(ptr.reinterpret(), n.convert())
+        check(status == BCL_OK) { "RAND_bytes failed (status=$status)" }
+    }
+}

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256Mac.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256Mac.linux.kt
@@ -1,0 +1,36 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_hmac_final
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_hmac_sha256_new
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_hmac_update
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.reinterpret
+
+/** Linux HMAC-SHA256 backed by BoringSSL (`HMAC_*`). Reads and writes via buffer pointers — no arrays. */
+actual class HmacSha256Mac actual constructor(
+    key: ReadBuffer,
+) {
+    private val ctx =
+        run {
+            var c = if (key.remaining() == 0) bcl_hmac_sha256_new(null, 0.convert()) else null
+            key.withRemainingBytes { ptr, len -> c = bcl_hmac_sha256_new(ptr.reinterpret(), len.convert()) }
+            c ?: error("HMAC_Init failed")
+        }
+    private var finalized = false
+
+    actual fun update(input: ReadBuffer): HmacSha256Mac {
+        input.withRemainingBytes { ptr, len -> bcl_hmac_update(ctx, ptr.reinterpret(), len.convert()) }
+        return this
+    }
+
+    actual fun doFinalInto(dest: WriteBuffer) {
+        check(!finalized) { "mac already finalized" }
+        finalized = true
+        dest.withWritablePointer(HMAC_SHA256_BYTES) { ptr -> bcl_hmac_final(ctx, ptr.reinterpret()) }
+    }
+}

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/HmacSha384Mac.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/HmacSha384Mac.linux.kt
@@ -1,0 +1,36 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_hmac_final
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_hmac_sha384_new
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_hmac_update
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.reinterpret
+
+/** Linux HMAC-SHA384 backed by BoringSSL (`HMAC_*`). Reads and writes via buffer pointers — no arrays. */
+actual class HmacSha384Mac actual constructor(
+    key: ReadBuffer,
+) {
+    private val ctx =
+        run {
+            var c = if (key.remaining() == 0) bcl_hmac_sha384_new(null, 0.convert()) else null
+            key.withRemainingBytes { ptr, len -> c = bcl_hmac_sha384_new(ptr.reinterpret(), len.convert()) }
+            c ?: error("HMAC_Init failed")
+        }
+    private var finalized = false
+
+    actual fun update(input: ReadBuffer): HmacSha384Mac {
+        input.withRemainingBytes { ptr, len -> bcl_hmac_update(ctx, ptr.reinterpret(), len.convert()) }
+        return this
+    }
+
+    actual fun doFinalInto(dest: WriteBuffer) {
+        check(!finalized) { "mac already finalized" }
+        finalized = true
+        dest.withWritablePointer(HMAC_SHA384_BYTES) { ptr -> bcl_hmac_final(ctx, ptr.reinterpret()) }
+    }
+}

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/HmacSha512Mac.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/HmacSha512Mac.linux.kt
@@ -1,0 +1,36 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_hmac_final
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_hmac_sha512_new
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_hmac_update
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.reinterpret
+
+/** Linux HMAC-SHA512 backed by BoringSSL (`HMAC_*`). Reads and writes via buffer pointers — no arrays. */
+actual class HmacSha512Mac actual constructor(
+    key: ReadBuffer,
+) {
+    private val ctx =
+        run {
+            var c = if (key.remaining() == 0) bcl_hmac_sha512_new(null, 0.convert()) else null
+            key.withRemainingBytes { ptr, len -> c = bcl_hmac_sha512_new(ptr.reinterpret(), len.convert()) }
+            c ?: error("HMAC_Init failed")
+        }
+    private var finalized = false
+
+    actual fun update(input: ReadBuffer): HmacSha512Mac {
+        input.withRemainingBytes { ptr, len -> bcl_hmac_update(ctx, ptr.reinterpret(), len.convert()) }
+        return this
+    }
+
+    actual fun doFinalInto(dest: WriteBuffer) {
+        check(!finalized) { "mac already finalized" }
+        finalized = true
+        dest.withWritablePointer(HMAC_SHA512_BYTES) { ptr -> bcl_hmac_final(ctx, ptr.reinterpret()) }
+    }
+}

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Hpke.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Hpke.linux.kt
@@ -1,0 +1,7 @@
+package com.ditchoom.buffer.crypto
+
+// Linux has a synchronous native AES-GCM (BoringSSL EVP_AEAD), so the HPKE AES-GCM path is available.
+internal actual val supportsAesGcmAnyPath: Boolean = supportsSyncAesGcm
+
+// Linux key agreement is synchronous and native (not the web WebCrypto path).
+internal actual val isWebPlatformKa: Boolean = false

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/KeyAgreement.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/KeyAgreement.linux.kt
@@ -3,6 +3,7 @@
 package com.ditchoom.buffer.crypto
 
 import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
 import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.crypto.cinterop.boringssl.BCL_OK
@@ -12,6 +13,7 @@ import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_x25519
 import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_x25519_keypair
 import kotlinx.cinterop.ByteVar
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.alloc
 import kotlinx.cinterop.allocArray
 import kotlinx.cinterop.convert
 import kotlinx.cinterop.get
@@ -80,8 +82,8 @@ private fun generateEc(curve: KeyAgreementCurve): KeyAgreementKeyPair {
     memScoped {
         val privOut = allocArray<ByteVar>(curve.privateKeyBytes)
         val pubOut = allocArray<ByteVar>(curve.publicKeyBytes)
-        val privLen = kotlinx.cinterop.alloc<size_tVar>()
-        val pubLen = kotlinx.cinterop.alloc<size_tVar>()
+        val privLen = alloc<size_tVar>()
+        val pubLen = alloc<size_tVar>()
         val status =
             bcl_ec_generate(
                 curveCode(curve),
@@ -171,7 +173,7 @@ private fun rawAgreeEc(
     val out = secureScratch.allocate(curve.sharedSecretBytes)
     memScoped {
         val secretOut = allocArray<ByteVar>(curve.sharedSecretBytes)
-        val secretLen = kotlinx.cinterop.alloc<size_tVar>()
+        val secretLen = alloc<size_tVar>()
         var status = -1
         privateKey.encoded.withRemainingBytes { privPtr, privLen ->
             peerPublicKey.encoded.withRemainingBytes { peerPtr, peerLen ->

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/KeyAgreement.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/KeyAgreement.linux.kt
@@ -1,0 +1,210 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.crypto.cinterop.boringssl.BCL_OK
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_ec_generate
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_ecdh
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_x25519
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_x25519_keypair
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.get
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.value
+import platform.posix.size_tVar
+
+/**
+ * Linux key agreement over **BoringSSL** (libcrypto).
+ *
+ * **ECDH P-256/384/521** uses the low-level EC API: the private key is the raw big-endian scalar,
+ * the peer public key the uncompressed SEC1 point `0x04 ‖ X ‖ Y`. The wrapper decodes the peer
+ * point with `EC_POINT_oct2point` and explicitly rejects off-curve / infinity points, surfaced as
+ * [InvalidPublicKey]. The raw secret is the big-endian X-coordinate of `priv · peer`, left-padded
+ * to the field width (RFC 5903 / SEC1) — matching JCA and Apple.
+ *
+ * **X25519** uses BoringSSL `X25519` (RFC 7748 raw 32-byte scalar / u-coordinate). The library
+ * returns 0 for a low-order / all-zero result; the shared [validateRawSecret] / [deriveFromRawSecret]
+ * post-check also enforces the RFC 7748 §6.1 all-zero rejection.
+ *
+ * Private scalars are stored in a wiped [SecureBuffer] (via [secureScratch]).
+ */
+
+actual val supportsSyncX25519: Boolean = true
+actual val supportsSyncEcdhP256: Boolean = true
+actual val supportsSyncEcdhP384: Boolean = true
+actual val supportsSyncEcdhP521: Boolean = true
+
+private fun curveCode(curve: KeyAgreementCurve): Int =
+    when (curve) {
+        KeyAgreementCurve.P256 -> 256
+        KeyAgreementCurve.P384 -> 384
+        KeyAgreementCurve.P521 -> 521
+        KeyAgreementCurve.X25519 -> error("X25519 is not a NIST curve code")
+    }
+
+actual fun generateKeyPair(curve: KeyAgreementCurve): KeyAgreementKeyPair =
+    if (curve == KeyAgreementCurve.X25519) generateX25519() else generateEc(curve)
+
+private fun generateX25519(): KeyAgreementKeyPair {
+    val curve = KeyAgreementCurve.X25519
+    val privBuf = secureScratch.allocate(curve.privateKeyBytes)
+    val pubBuf = BufferFactory.Default.allocate(curve.publicKeyBytes)
+    memScoped {
+        val pubOut = allocArray<ByteVar>(curve.publicKeyBytes)
+        val privOut = allocArray<ByteVar>(curve.privateKeyBytes)
+        val status = bcl_x25519_keypair(pubOut.reinterpret(), privOut.reinterpret())
+        check(status == BCL_OK) { "X25519 key generation failed (status=$status)" }
+        for (i in 0 until curve.privateKeyBytes) privBuf.writeByte(privOut[i])
+        for (i in 0 until curve.publicKeyBytes) pubBuf.writeByte(pubOut[i])
+    }
+    privBuf.resetForRead()
+    pubBuf.resetForRead()
+    return KeyAgreementKeyPair(
+        curve,
+        KeyAgreementPrivateKey(curve, privBuf),
+        KeyAgreementPublicKey(curve, pubBuf),
+    )
+}
+
+private fun generateEc(curve: KeyAgreementCurve): KeyAgreementKeyPair {
+    val privBuf = secureScratch.allocate(curve.privateKeyBytes)
+    val pubBuf = BufferFactory.Default.allocate(curve.publicKeyBytes)
+    memScoped {
+        val privOut = allocArray<ByteVar>(curve.privateKeyBytes)
+        val pubOut = allocArray<ByteVar>(curve.publicKeyBytes)
+        val privLen = kotlinx.cinterop.alloc<size_tVar>()
+        val pubLen = kotlinx.cinterop.alloc<size_tVar>()
+        val status =
+            bcl_ec_generate(
+                curveCode(curve),
+                privOut.reinterpret(),
+                curve.privateKeyBytes.convert(),
+                privLen.ptr,
+                pubOut.reinterpret(),
+                curve.publicKeyBytes.convert(),
+                pubLen.ptr,
+            )
+        check(status == BCL_OK) { "${curve.curveName} key generation failed (status=$status)" }
+        check(privLen.value.toInt() == curve.privateKeyBytes) { "unexpected scalar length" }
+        check(pubLen.value.toInt() == curve.publicKeyBytes) { "unexpected point length" }
+        for (i in 0 until curve.privateKeyBytes) privBuf.writeByte(privOut[i])
+        for (i in 0 until curve.publicKeyBytes) pubBuf.writeByte(pubOut[i])
+    }
+    privBuf.resetForRead()
+    pubBuf.resetForRead()
+    return KeyAgreementKeyPair(
+        curve,
+        KeyAgreementPrivateKey(curve, privBuf),
+        KeyAgreementPublicKey(curve, pubBuf),
+    )
+}
+
+actual fun deriveSharedSecret(
+    privateKey: KeyAgreementPrivateKey,
+    peerPublicKey: KeyAgreementPublicKey,
+    info: ReadBuffer,
+    length: Int,
+    salt: ReadBuffer?,
+    factory: BufferFactory,
+): ReadBuffer {
+    val curve = privateKey.curve
+    val raw = rawAgree(privateKey, peerPublicKey)
+    return deriveFromRawSecret(curve, raw, info, length, salt, factory)
+}
+
+internal actual suspend fun dhRawSecret(
+    privateKey: KeyAgreementPrivateKey,
+    peerPublicKey: KeyAgreementPublicKey,
+): PlatformBuffer = validateRawSecret(privateKey.curve, rawAgree(privateKey, peerPublicKey))
+
+/** Computes the raw DH secret into a wiped SecureBuffer; throws [InvalidPublicKey] on a bad point. */
+private fun rawAgree(
+    privateKey: KeyAgreementPrivateKey,
+    peerPublicKey: KeyAgreementPublicKey,
+): PlatformBuffer {
+    val curve = privateKey.curve
+    require(curve == peerPublicKey.curve) { "private/public key curve mismatch" }
+    return if (curve == KeyAgreementCurve.X25519) {
+        rawAgreeX25519(privateKey, peerPublicKey)
+    } else {
+        rawAgreeEc(privateKey, peerPublicKey)
+    }
+}
+
+private fun rawAgreeX25519(
+    privateKey: KeyAgreementPrivateKey,
+    peerPublicKey: KeyAgreementPublicKey,
+): PlatformBuffer {
+    val curve = KeyAgreementCurve.X25519
+    val out = secureScratch.allocate(curve.sharedSecretBytes)
+    memScoped {
+        val secretOut = allocArray<ByteVar>(curve.sharedSecretBytes)
+        var status = -1
+        privateKey.encoded.withRemainingBytes { privPtr, _ ->
+            peerPublicKey.encoded.withRemainingBytes { peerPtr, _ ->
+                status = bcl_x25519(privPtr.reinterpret(), peerPtr.reinterpret(), secretOut.reinterpret())
+            }
+        }
+        if (status != BCL_OK) {
+            out.freeNativeMemory()
+            throw InvalidPublicKey(curve.curveName)
+        }
+        for (i in 0 until curve.sharedSecretBytes) out.writeByte(secretOut[i])
+    }
+    out.resetForRead()
+    return out
+}
+
+private fun rawAgreeEc(
+    privateKey: KeyAgreementPrivateKey,
+    peerPublicKey: KeyAgreementPublicKey,
+): PlatformBuffer {
+    val curve = privateKey.curve
+    val out = secureScratch.allocate(curve.sharedSecretBytes)
+    memScoped {
+        val secretOut = allocArray<ByteVar>(curve.sharedSecretBytes)
+        val secretLen = kotlinx.cinterop.alloc<size_tVar>()
+        var status = -1
+        privateKey.encoded.withRemainingBytes { privPtr, privLen ->
+            peerPublicKey.encoded.withRemainingBytes { peerPtr, peerLen ->
+                status =
+                    bcl_ecdh(
+                        curveCode(curve),
+                        privPtr.reinterpret(),
+                        privLen.convert(),
+                        peerPtr.reinterpret(),
+                        peerLen.convert(),
+                        secretOut.reinterpret(),
+                        curve.sharedSecretBytes.convert(),
+                        secretLen.ptr,
+                    )
+            }
+        }
+        if (status != BCL_OK || secretLen.value.toInt() != curve.sharedSecretBytes) {
+            out.freeNativeMemory()
+            throw InvalidPublicKey(curve.curveName)
+        }
+        for (i in 0 until curve.sharedSecretBytes) out.writeByte(secretOut[i])
+    }
+    out.resetForRead()
+    return out
+}
+
+actual suspend fun generateKeyPairAsync(curve: KeyAgreementCurve): KeyAgreementKeyPair = generateKeyPair(curve)
+
+actual suspend fun deriveSharedSecretAsync(
+    privateKey: KeyAgreementPrivateKey,
+    peerPublicKey: KeyAgreementPublicKey,
+    info: ReadBuffer,
+    length: Int,
+    salt: ReadBuffer?,
+    factory: BufferFactory,
+): ReadBuffer = deriveSharedSecret(privateKey, peerPublicKey, info, length, salt, factory)

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/LinuxCryptoBridge.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/LinuxCryptoBridge.linux.kt
@@ -1,0 +1,114 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.managedMemoryAccess
+import com.ditchoom.buffer.nativeMemoryAccess
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.CPointer
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.toCPointer
+import kotlinx.cinterop.usePinned
+
+/**
+ * Shared Kotlin/Native buffer-pointer helpers for the Linux BoringSSL backend. These mirror the
+ * Apple backend's [AppleCryptoBridge] helpers exactly — they are platform-agnostic K/Native
+ * primitives (pin a heap array, or hand over a native pointer) and depend only on cinterop, not on
+ * any Apple type. Kept in `linuxMain` so they do not collide with the Apple copies.
+ */
+
+/**
+ * Invokes [block] with a pointer to this buffer's remaining bytes and their length, without
+ * disturbing the buffer's position or allocating any array. Native buffers hand over their memory
+ * pointer directly; heap buffers pin their own backing array. No-op when there are no remaining
+ * bytes. The pointer is valid only for the duration of [block].
+ */
+internal inline fun ReadBuffer.withRemainingBytes(block: (CPointer<ByteVar>, length: Int) -> Unit) {
+    val n = remaining()
+    if (n == 0) return
+    val pos = position()
+    val managed = managedMemoryAccess
+    if (managed != null) {
+        managed.backingArray.usePinned { block(it.addressOf(managed.arrayOffset + pos), n) }
+        return
+    }
+    val native = nativeMemoryAccess
+    val ptr = native?.let { (it.nativeAddress + pos).toCPointer<ByteVar>() }
+    requireNotNull(ptr) { "buffer must expose native or managed memory" }
+    block(ptr, n)
+}
+
+/**
+ * Like [withRemainingBytes] but with the length pinned to [count] (the caller already knows it).
+ * Tolerates an empty buffer by pinning a 1-byte placeholder, so callers can pass a length-0
+ * pointer to BoringSSL (which accepts a non-null pointer with length 0).
+ */
+internal inline fun ReadBuffer.withRemainingBytes2(
+    count: Int,
+    block: (CPointer<ByteVar>) -> Unit,
+) {
+    if (count == 0) {
+        ByteArray(1).usePinned { block(it.addressOf(0)) }
+        return
+    }
+    withRemainingBytes { ptr, _ -> block(ptr) }
+}
+
+/**
+ * Invokes [block] with a pointer to [aad]'s remaining bytes and their length, or with a harmless
+ * pointer and length 0 when [aad] is null/empty.
+ */
+internal inline fun withOptionalBytes(
+    aad: ReadBuffer?,
+    block: (CPointer<ByteVar>, length: Int) -> Unit,
+) {
+    val n = aad?.remaining() ?: 0
+    if (aad == null || n == 0) {
+        ByteArray(1).usePinned { block(it.addressOf(0), 0) }
+        return
+    }
+    aad.withRemainingBytes { ptr, len -> block(ptr, len) }
+}
+
+/**
+ * Invokes [block] with a pointer to [count] writable bytes at this buffer's current position, then
+ * advances the position by [count]. Native buffers expose their memory pointer; heap buffers pin
+ * their own backing array. [count] must fit within `remaining()`.
+ */
+internal inline fun WriteBuffer.withWritablePointer(
+    count: Int,
+    block: (CPointer<ByteVar>) -> Unit,
+) {
+    require(remaining() >= count) { "dest needs $count bytes remaining, has ${remaining()}" }
+    val pos = position()
+    val managed = managedMemoryAccess
+    if (managed != null) {
+        managed.backingArray.usePinned { block(it.addressOf(managed.arrayOffset + pos)) }
+        position(pos + count)
+        return
+    }
+    val native = nativeMemoryAccess
+    val ptr = native?.let { (it.nativeAddress + pos).toCPointer<ByteVar>() }
+    requireNotNull(ptr) { "dest must expose native or managed memory" }
+    block(ptr)
+    position(pos + count)
+}
+
+/** A non-destructive read-ready view of [length] bytes of [source] starting at absolute [from]. */
+internal fun absoluteView(
+    source: ReadBuffer,
+    from: Int,
+    length: Int,
+): ReadBuffer {
+    val savedPos = source.position()
+    val savedLimit = source.limit()
+    source.position(from)
+    source.setLimit(from + length)
+    val view = source.slice()
+    source.position(savedPos)
+    source.setLimit(savedLimit)
+    return view
+}

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/LinuxCryptoBridge.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/LinuxCryptoBridge.linux.kt
@@ -13,11 +13,11 @@ import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.toCPointer
 import kotlinx.cinterop.usePinned
 
-/**
+/*
  * Shared Kotlin/Native buffer-pointer helpers for the Linux BoringSSL backend. These mirror the
- * Apple backend's [AppleCryptoBridge] helpers exactly — they are platform-agnostic K/Native
+ * Apple backend's AppleCryptoBridge helpers exactly — they are platform-agnostic K/Native
  * primitives (pin a heap array, or hand over a native pointer) and depend only on cinterop, not on
- * any Apple type. Kept in `linuxMain` so they do not collide with the Apple copies.
+ * any Apple type. Kept in linuxMain so they do not collide with the Apple copies.
  */
 
 /**
@@ -83,6 +83,12 @@ internal inline fun WriteBuffer.withWritablePointer(
     block: (CPointer<ByteVar>) -> Unit,
 ) {
     require(remaining() >= count) { "dest needs $count bytes remaining, has ${remaining()}" }
+    if (count == 0) {
+        // Nothing to write; hand BoringSSL a valid non-null 1-byte scratch pointer (it accepts a
+        // length-0 output). Calling addressOf on a possibly-empty backing array would AIOOBE.
+        ByteArray(1).usePinned { block(it.addressOf(0)) }
+        return
+    }
     val pos = position()
     val managed = managedMemoryAccess
     if (managed != null) {

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Sha256Digest.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Sha256Digest.linux.kt
@@ -1,0 +1,29 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_sha256_final
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_sha256_new
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_sha256_update
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.reinterpret
+
+/** Linux SHA-256 backed by BoringSSL (`SHA256_*`). Reads and writes via buffer pointers — no arrays. */
+actual class Sha256Digest actual constructor() {
+    private val ctx = bcl_sha256_new() ?: error("SHA256_Init failed")
+    private var finalized = false
+
+    actual fun update(input: ReadBuffer): Sha256Digest {
+        input.withRemainingBytes { ptr, len -> bcl_sha256_update(ctx, ptr.reinterpret(), len.convert()) }
+        return this
+    }
+
+    actual fun digestInto(dest: WriteBuffer) {
+        check(!finalized) { "digest already finalized" }
+        finalized = true
+        dest.withWritablePointer(SHA256_DIGEST_BYTES) { ptr -> bcl_sha256_final(ctx, ptr.reinterpret()) }
+    }
+}

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Sha384Digest.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Sha384Digest.linux.kt
@@ -1,0 +1,29 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_sha384_final
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_sha384_new
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_sha384_update
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.reinterpret
+
+/** Linux SHA-384 backed by BoringSSL (`SHA384_*`). Reads and writes via buffer pointers — no arrays. */
+actual class Sha384Digest actual constructor() {
+    private val ctx = bcl_sha384_new() ?: error("SHA384_Init failed")
+    private var finalized = false
+
+    actual fun update(input: ReadBuffer): Sha384Digest {
+        input.withRemainingBytes { ptr, len -> bcl_sha384_update(ctx, ptr.reinterpret(), len.convert()) }
+        return this
+    }
+
+    actual fun digestInto(dest: WriteBuffer) {
+        check(!finalized) { "digest already finalized" }
+        finalized = true
+        dest.withWritablePointer(SHA384_DIGEST_BYTES) { ptr -> bcl_sha384_final(ctx, ptr.reinterpret()) }
+    }
+}

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Sha512Digest.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Sha512Digest.linux.kt
@@ -1,0 +1,29 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_sha512_final
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_sha512_new
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_sha512_update
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.reinterpret
+
+/** Linux SHA-512 backed by BoringSSL (`SHA512_*`). Reads and writes via buffer pointers — no arrays. */
+actual class Sha512Digest actual constructor() {
+    private val ctx = bcl_sha512_new() ?: error("SHA512_Init failed")
+    private var finalized = false
+
+    actual fun update(input: ReadBuffer): Sha512Digest {
+        input.withRemainingBytes { ptr, len -> bcl_sha512_update(ctx, ptr.reinterpret(), len.convert()) }
+        return this
+    }
+
+    actual fun digestInto(dest: WriteBuffer) {
+        check(!finalized) { "digest already finalized" }
+        finalized = true
+        dest.withWritablePointer(SHA512_DIGEST_BYTES) { ptr -> bcl_sha512_final(ctx, ptr.reinterpret()) }
+    }
+}

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Signatures.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Signatures.linux.kt
@@ -104,13 +104,15 @@ private fun isCanonicalEcdsaDer(
     val n = signature.remaining()
     if (n < 8) return false
     val b = ByteArray(n) { signature.get(start + it) }
+
     fun u(i: Int) = b[i].toInt() and 0xFF
     if (u(0) != 0x30) return false
     var p: Int
     val seqLen: Int
     when {
         u(1) < 0x80 -> {
-            seqLen = u(1); p = 2
+            seqLen = u(1)
+            p = 2
         }
         u(1) == 0x81 -> {
             if (n < 3) return false

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Signatures.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Signatures.linux.kt
@@ -1,0 +1,308 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.crypto.cinterop.boringssl.BCL_OK
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_ecdsa_sign
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_ecdsa_verify
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_ed25519_sign
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_ed25519_verify
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.get
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.reinterpret
+
+/**
+ * Linux signature bridge over **BoringSSL** (libcrypto).
+ *
+ * **ECDSA** P-256/384/521: hash-then-sign with SHA-256/384/512 via `EVP_DigestSign`, producing and
+ * consuming **DER/X9.62** signatures — so [ecdsaSignatureEncoding] is `Der`, matching JVM and Apple.
+ * The signing key is the raw private scalar ([supportsEcdsaSigningFromScalar] = `true`); the verify
+ * key is the uncompressed SEC1 point `0x04 ‖ X ‖ Y`.
+ *
+ * BoringSSL's verify is already strict about DER, but to hold the exact cross-platform contract (and
+ * the Wycheproof `invalid` vectors for non-canonical BER, superfluous padding, trailing bytes, and
+ * `r`/`s` out of `[1, n)`) we enforce strict canonical DER + range ourselves before delegating, the
+ * same gate the JVM backend applies.
+ *
+ * **Ed25519**: raw 32-byte seed / public key, 64-byte signature, via BoringSSL `ED25519_sign` /
+ * `ED25519_verify`. [supportsSyncEd25519] is `true`.
+ */
+
+actual val supportsSyncEd25519: Boolean = true
+actual val supportsSyncEcdsa: Boolean = true
+actual val ecdsaSignatureEncoding: EcdsaSignatureEncoding = EcdsaSignatureEncoding.Der
+actual val supportsEcdsaSigningFromScalar: Boolean = true
+
+private fun ecdsaCurveCode(scheme: SignatureScheme): Int =
+    when (scheme) {
+        SignatureScheme.EcdsaP256 -> 256
+        SignatureScheme.EcdsaP384 -> 384
+        SignatureScheme.EcdsaP521 -> 521
+        SignatureScheme.Ed25519 -> error("not an ECDSA scheme")
+    }
+
+// ---------------------------------------------------------------------------
+// Strict canonical-DER ECDSA-signature validation (matches Signatures.jvmCommon).
+// ---------------------------------------------------------------------------
+
+/** Curve order n; r and s must lie in [1, n). */
+private fun curveOrderHex(scheme: SignatureScheme): String =
+    when (scheme) {
+        SignatureScheme.EcdsaP256 ->
+            "ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551"
+        SignatureScheme.EcdsaP384 ->
+            "ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf" +
+                "581a0db248b0a77aecec196accc52973"
+        SignatureScheme.EcdsaP521 ->
+            "01ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" +
+                "fa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409"
+        SignatureScheme.Ed25519 -> error("not ECDSA")
+    }
+
+/** Big-endian unsigned compare of [value] (DER integer bytes, minimal) against the hex order. */
+private fun inRangeOneToOrder(
+    value: ByteArray,
+    orderHex: String,
+): Boolean {
+    // value is a minimal big-endian magnitude with no leading zero (canonical DER, sign bit clear).
+    // Reject zero.
+    if (value.all { it.toInt() == 0 }) return false
+    // Build order bytes (even-length hex, big-endian).
+    val order = ByteArray(orderHex.length / 2) { i -> orderHex.substring(i * 2, i * 2 + 2).toInt(16).toByte() }
+    // Strip leading zeros from order for a magnitude compare.
+    val orderMag = order.dropWhile { it.toInt() == 0 }.toByteArray()
+    val valMag = value.dropWhile { it.toInt() == 0 }.toByteArray()
+    if (valMag.size != orderMag.size) return valMag.size < orderMag.size
+    for (i in valMag.indices) {
+        val a = valMag[i].toInt() and 0xFF
+        val b = orderMag[i].toInt() and 0xFF
+        if (a != b) return a < b
+    }
+    return false // equal to order ⇒ not < n
+}
+
+/**
+ * Strict canonical-DER check for `SEQUENCE { INTEGER r, INTEGER s }` with `r,s ∈ [1, n)`. Returns
+ * true iff the signature is strictly canonical. Mirrors `parseCanonicalEcdsaDer` on the JVM.
+ */
+private fun isCanonicalEcdsaDer(
+    signature: ReadBuffer,
+    scheme: SignatureScheme,
+): Boolean {
+    val start = signature.position()
+    val n = signature.remaining()
+    if (n < 8) return false
+    val b = ByteArray(n) { signature.get(start + it) }
+    fun u(i: Int) = b[i].toInt() and 0xFF
+    if (u(0) != 0x30) return false
+    var p: Int
+    val seqLen: Int
+    when {
+        u(1) < 0x80 -> {
+            seqLen = u(1); p = 2
+        }
+        u(1) == 0x81 -> {
+            if (n < 3) return false
+            seqLen = u(2)
+            if (seqLen < 0x80) return false // long form must be minimal
+            p = 3
+        }
+        else -> return false
+    }
+    if (p + seqLen != n) return false
+
+    fun readInt(): ByteArray? {
+        if (p + 2 > n || u(p) != 0x02) return null
+        val len = u(p + 1)
+        if (len == 0 || len >= 0x80) return null
+        val s = p + 2
+        if (s + len > n) return null
+        if (len > 1 && u(s) == 0x00 && (u(s + 1) and 0x80) == 0) return null // superfluous 0x00
+        if (u(s) and 0x80 != 0) return null // negative
+        val out = ByteArray(len) { b[s + it] }
+        p = s + len
+        return out
+    }
+
+    val r = readInt() ?: return false
+    val s = readInt() ?: return false
+    if (p != n) return false
+    val orderHex = curveOrderHex(scheme)
+    return inRangeOneToOrder(r, orderHex) && inRangeOneToOrder(s, orderHex)
+}
+
+// ---------------------------------------------------------------------------
+// Sign / verify
+// ---------------------------------------------------------------------------
+
+private fun ed25519Sign(
+    key: SigningKey,
+    message: ReadBuffer,
+): ByteArray {
+    val seed = key.requireOpen()
+    require(seed.remaining() == 32) { "Ed25519 seed must be 32 bytes" }
+    val msgLen = message.remaining()
+    return memScoped {
+        val sigOut = allocArray<ByteVar>(64)
+        var status = -1
+        seed.withRemainingBytes { seedPtr, _ ->
+            message.withRemainingBytes2(msgLen) { msgPtr ->
+                status =
+                    bcl_ed25519_sign(
+                        seedPtr.reinterpret(),
+                        msgPtr.reinterpret(),
+                        msgLen.convert(),
+                        sigOut.reinterpret(),
+                    )
+            }
+        }
+        check(status == BCL_OK) { "Ed25519 sign failed (status=$status)" }
+        ByteArray(64) { sigOut[it] }
+    }
+}
+
+private fun ecdsaSign(
+    key: SigningKey,
+    message: ReadBuffer,
+): ByteArray {
+    val scalar = key.requireOpen()
+    val cap = maxSignatureBytes(key.scheme)
+    val curveCode = ecdsaCurveCode(key.scheme)
+    val msgLen = message.remaining()
+    return memScoped {
+        val sigOut = allocArray<ByteVar>(cap)
+        val sigLen = kotlinx.cinterop.alloc<platform.posix.size_tVar>()
+        var status = -1
+        scalar.withRemainingBytes { keyPtr, keyLen ->
+            message.withRemainingBytes2(msgLen) { msgPtr ->
+                status =
+                    bcl_ecdsa_sign(
+                        curveCode,
+                        keyPtr.reinterpret(),
+                        keyLen.convert(),
+                        msgPtr.reinterpret(),
+                        msgLen.convert(),
+                        sigOut.reinterpret(),
+                        cap.convert(),
+                        sigLen.ptr,
+                    )
+            }
+        }
+        check(status == BCL_OK) { "ECDSA sign failed (status=$status)" }
+        val n = sigLen.value.toInt()
+        ByteArray(n) { sigOut[it] }
+    }
+}
+
+private fun signToByteArray(
+    key: SigningKey,
+    message: ReadBuffer,
+): ByteArray =
+    if (key.scheme == SignatureScheme.Ed25519) {
+        ed25519Sign(key, message)
+    } else {
+        ecdsaSign(key, message)
+    }
+
+private fun ed25519Verify(
+    key: VerifyKey,
+    message: ReadBuffer,
+    signature: ReadBuffer,
+): Boolean {
+    if (key.material.remaining() != 32) return false
+    if (signature.remaining() != 64) return false
+    val msgLen = message.remaining()
+    var status = -1
+    key.material.withRemainingBytes { pubPtr, _ ->
+        message.withRemainingBytes2(msgLen) { msgPtr ->
+            signature.withRemainingBytes { sigPtr, _ ->
+                status =
+                    bcl_ed25519_verify(
+                        pubPtr.reinterpret(),
+                        msgPtr.reinterpret(),
+                        msgLen.convert(),
+                        sigPtr.reinterpret(),
+                    )
+            }
+        }
+    }
+    return status == BCL_OK
+}
+
+private fun ecdsaVerify(
+    key: VerifyKey,
+    message: ReadBuffer,
+    signature: ReadBuffer,
+): Boolean {
+    // Enforce strict canonical DER + r,s range before trusting BoringSSL's verify.
+    if (!isCanonicalEcdsaDer(signature, key.scheme)) return false
+    val curveCode = ecdsaCurveCode(key.scheme)
+    val msgLen = message.remaining()
+    var status = -1
+    key.material.withRemainingBytes { pubPtr, pubLen ->
+        message.withRemainingBytes2(msgLen) { msgPtr ->
+            signature.withRemainingBytes { sigPtr, sigLen ->
+                status =
+                    bcl_ecdsa_verify(
+                        curveCode,
+                        pubPtr.reinterpret(),
+                        pubLen.convert(),
+                        msgPtr.reinterpret(),
+                        msgLen.convert(),
+                        sigPtr.reinterpret(),
+                        sigLen.convert(),
+                    )
+            }
+        }
+    }
+    return status == BCL_OK
+}
+
+actual fun signInto(
+    key: SigningKey,
+    message: ReadBuffer,
+    dest: WriteBuffer,
+): Int {
+    val sig = signToByteArray(key, message)
+    require(dest.remaining() >= sig.size) { "dest needs ${sig.size} bytes remaining, has ${dest.remaining()}" }
+    dest.writeBytes(sig)
+    return sig.size
+}
+
+actual fun verify(
+    key: VerifyKey,
+    message: ReadBuffer,
+    signature: ReadBuffer,
+): Boolean =
+    if (key.scheme == SignatureScheme.Ed25519) {
+        ed25519Verify(key, message, signature)
+    } else {
+        ecdsaVerify(key, message, signature)
+    }
+
+actual suspend fun signAsync(
+    key: SigningKey,
+    message: ReadBuffer,
+    factory: BufferFactory,
+): ReadBuffer {
+    val sig = signToByteArray(key, message)
+    val out = factory.allocate(sig.size)
+    out.writeBytes(sig)
+    out.resetForRead()
+    return out
+}
+
+actual suspend fun verifyAsync(
+    key: VerifyKey,
+    message: ReadBuffer,
+    signature: ReadBuffer,
+): Boolean = verify(key, message, signature)
+
+actual suspend fun ed25519AsyncAvailable(): Boolean = true

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Signatures.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Signatures.linux.kt
@@ -12,11 +12,15 @@ import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_ed25519_sign
 import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_ed25519_verify
 import kotlinx.cinterop.ByteVar
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.alloc
 import kotlinx.cinterop.allocArray
 import kotlinx.cinterop.convert
 import kotlinx.cinterop.get
 import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
 import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.value
+import platform.posix.size_tVar
 
 /**
  * Linux signature bridge over **BoringSSL** (libcrypto).
@@ -178,7 +182,7 @@ private fun ecdsaSign(
     val msgLen = message.remaining()
     return memScoped {
         val sigOut = allocArray<ByteVar>(cap)
-        val sigLen = kotlinx.cinterop.alloc<platform.posix.size_tVar>()
+        val sigLen = alloc<size_tVar>()
         var status = -1
         scalar.withRemainingBytes { keyPtr, keyLen ->
             message.withRemainingBytes2(msgLen) { msgPtr ->

--- a/buffer-crypto/src/linuxTest/kotlin/com/ditchoom/buffer/crypto/KeyAgreementTestSupport.linux.kt
+++ b/buffer-crypto/src/linuxTest/kotlin/com/ditchoom/buffer/crypto/KeyAgreementTestSupport.linux.kt
@@ -1,0 +1,10 @@
+package com.ditchoom.buffer.crypto
+
+// Linux has a synchronous native KA (BoringSSL); the async path delegates to it, so support matches
+// the sync flag.
+actual fun asyncAgreementSupported(curve: KeyAgreementCurve): Boolean = supportsSync(curve)
+
+actual val isWebPlatform: Boolean = false
+
+// BoringSSL imports raw private scalars directly (EC_KEY_set_private_key / X25519 raw scalar).
+actual fun supportsRawScalarKat(curve: KeyAgreementCurve): Boolean = supportsSync(curve)

--- a/buffer-crypto/src/nativeInterop/cinterop/boringsslcrypto.def
+++ b/buffer-crypto/src/nativeInterop/cinterop/boringsslcrypto.def
@@ -419,9 +419,16 @@ static inline int bcl_ecdsa_sign(
     mdctx = EVP_MD_CTX_new();
     if (!mdctx) goto done;
     if (!EVP_DigestSignInit(mdctx, NULL, md, NULL, pkey)) goto done;
+    if (!EVP_DigestSignUpdate(mdctx, msg, msg_len)) goto done;
     {
-        size_t out_len = sig_cap;
-        if (!EVP_DigestSign(mdctx, out_sig, &out_len, msg, msg_len)) goto done;
+        /* DER ECDSA signatures top out at ~139 bytes (P-521); sign into a generous local scratch so
+         * BoringSSL's worst-case length estimate never collides with the caller's cap, then copy out
+         * only the bytes actually produced. */
+        uint8_t scratch[160];
+        size_t out_len = sizeof(scratch);
+        if (!EVP_DigestSignFinal(mdctx, scratch, &out_len)) goto done;
+        if (out_len > sig_cap) goto done;
+        memcpy(out_sig, scratch, out_len);
         *out_sig_len = out_len;
         rc = BCL_OK;
     }
@@ -476,7 +483,8 @@ static inline int bcl_ecdsa_verify(
     mdctx = EVP_MD_CTX_new();
     if (!mdctx) goto done;
     if (!EVP_DigestVerifyInit(mdctx, NULL, md, NULL, pkey)) goto done;
-    if (EVP_DigestVerify(mdctx, sig, sig_len, msg, msg_len) == 1) {
+    if (!EVP_DigestVerifyUpdate(mdctx, msg, msg_len)) goto done;
+    if (EVP_DigestVerifyFinal(mdctx, sig, sig_len) == 1) {
         rc = BCL_OK;
     }
 done:

--- a/buffer-crypto/src/nativeInterop/cinterop/boringsslcrypto.def
+++ b/buffer-crypto/src/nativeInterop/cinterop/boringsslcrypto.def
@@ -1,0 +1,490 @@
+language = C
+package = com.ditchoom.buffer.crypto.cinterop.boringssl
+
+# Linux native crypto backend for :buffer-crypto, wrapping BoringSSL's libcrypto.
+#
+# KEY GOTCHA (mirrors the sibling :socket: module's BoringSslX509.def): Kotlin/Native
+# cinterop returns EMPTY bindings for BoringSSL/OpenSSL functions declared only via
+# `headers =`. Every BoringSSL entry point this backend uses is therefore wrapped in a
+# `static inline` C function defined in the ---/.def body below, and Kotlin calls those
+# wrappers — never the raw library symbols. This keeps the crypto logic in C (matching the
+# Apple backend's CommonCrypto shape) and gives a stable, fully-bound surface.
+#
+# The libcrypto.a / libssl.a static archives, their headers, and the link directives
+# (libraryPaths / staticLibraries) are injected by buffer-crypto/build.gradle.kts so the
+# same .def works for both the reused prebuilt (alien dev box) and the CI-built BoringSSL.
+
+headers = openssl/evp.h openssl/sha.h openssl/hmac.h openssl/aead.h openssl/ec.h openssl/ec_key.h openssl/ecdsa.h openssl/ecdh.h openssl/curve25519.h openssl/nid.h openssl/bn.h openssl/rand.h openssl/hkdf.h openssl/mem.h openssl/err.h openssl/crypto.h stdint.h string.h
+
+compilerOpts.linux = -D_GNU_SOURCE
+
+---
+
+#include <stdint.h>
+#include <string.h>
+
+/* Status codes returned by the wrappers below. */
+#define BCL_OK 0
+#define BCL_ERR (-1)
+#define BCL_AUTH_FAIL (-2)
+
+/* ===========================================================================
+ * Hashes: SHA-256 / SHA-384 / SHA-512 streaming contexts.
+ * BoringSSL's SHA*_Init/Update/Final operate on caller-allocated context structs.
+ * We expose opaque heap-allocated contexts so Kotlin never has to know the layout.
+ * =========================================================================== */
+
+static inline SHA256_CTX *bcl_sha256_new(void) {
+    SHA256_CTX *c = (SHA256_CTX *)OPENSSL_malloc(sizeof(SHA256_CTX));
+    if (c) SHA256_Init(c);
+    return c;
+}
+static inline void bcl_sha256_update(SHA256_CTX *c, const uint8_t *data, size_t len) {
+    SHA256_Update(c, data, len);
+}
+static inline void bcl_sha256_final(SHA256_CTX *c, uint8_t *out32) {
+    SHA256_Final(out32, c);
+    OPENSSL_free(c);
+}
+
+static inline SHA512_CTX *bcl_sha384_new(void) {
+    SHA512_CTX *c = (SHA512_CTX *)OPENSSL_malloc(sizeof(SHA512_CTX));
+    if (c) SHA384_Init(c);
+    return c;
+}
+static inline void bcl_sha384_update(SHA512_CTX *c, const uint8_t *data, size_t len) {
+    SHA384_Update(c, data, len);
+}
+static inline void bcl_sha384_final(SHA512_CTX *c, uint8_t *out48) {
+    SHA384_Final(out48, c);
+    OPENSSL_free(c);
+}
+
+static inline SHA512_CTX *bcl_sha512_new(void) {
+    SHA512_CTX *c = (SHA512_CTX *)OPENSSL_malloc(sizeof(SHA512_CTX));
+    if (c) SHA512_Init(c);
+    return c;
+}
+static inline void bcl_sha512_update(SHA512_CTX *c, const uint8_t *data, size_t len) {
+    SHA512_Update(c, data, len);
+}
+static inline void bcl_sha512_final(SHA512_CTX *c, uint8_t *out64) {
+    SHA512_Final(out64, c);
+    OPENSSL_free(c);
+}
+
+/* ===========================================================================
+ * HMAC: SHA-256 / SHA-384 / SHA-512 streaming contexts via HMAC_CTX.
+ * =========================================================================== */
+
+static inline HMAC_CTX *bcl_hmac_new(const EVP_MD *md, const uint8_t *key, size_t key_len) {
+    HMAC_CTX *c = HMAC_CTX_new();
+    if (!c) return NULL;
+    /* BoringSSL accepts a NULL key only with len 0; pass a 1-byte stub for empty keys
+     * (HMAC of an empty key still pads to the block size). */
+    static const uint8_t empty = 0;
+    const uint8_t *k = (key_len == 0) ? &empty : key;
+    if (!HMAC_Init_ex(c, k, key_len, md, NULL)) {
+        HMAC_CTX_free(c);
+        return NULL;
+    }
+    return c;
+}
+static inline HMAC_CTX *bcl_hmac_sha256_new(const uint8_t *key, size_t key_len) {
+    return bcl_hmac_new(EVP_sha256(), key, key_len);
+}
+static inline HMAC_CTX *bcl_hmac_sha384_new(const uint8_t *key, size_t key_len) {
+    return bcl_hmac_new(EVP_sha384(), key, key_len);
+}
+static inline HMAC_CTX *bcl_hmac_sha512_new(const uint8_t *key, size_t key_len) {
+    return bcl_hmac_new(EVP_sha512(), key, key_len);
+}
+static inline void bcl_hmac_update(HMAC_CTX *c, const uint8_t *data, size_t len) {
+    HMAC_Update(c, data, len);
+}
+static inline void bcl_hmac_final(HMAC_CTX *c, uint8_t *out) {
+    unsigned int out_len = 0;
+    HMAC_Final(c, out, &out_len);
+    HMAC_CTX_free(c);
+}
+
+/* ===========================================================================
+ * AEAD: AES-128/256-GCM and ChaCha20-Poly1305 (one-shot, RFC 5116 layout).
+ * Tag is the trailing 16 bytes of the sealed output (EVP_AEAD seal appends it).
+ * =========================================================================== */
+
+static inline const EVP_AEAD *bcl_aead_for_aes_gcm(size_t key_len) {
+    if (key_len == 16) return EVP_aead_aes_128_gcm();
+    if (key_len == 32) return EVP_aead_aes_256_gcm();
+    return NULL;
+}
+
+/* Seals plaintext, writing ciphertext||tag into out (capacity out_cap). On success writes the
+ * produced length to *out_len and returns BCL_OK. */
+static inline int bcl_aead_seal(
+    const EVP_AEAD *aead,
+    const uint8_t *key, size_t key_len,
+    const uint8_t *nonce, size_t nonce_len,
+    const uint8_t *aad, size_t aad_len,
+    const uint8_t *pt, size_t pt_len,
+    uint8_t *out, size_t out_cap, size_t *out_len) {
+    if (!aead) return BCL_ERR;
+    EVP_AEAD_CTX *ctx = EVP_AEAD_CTX_new(aead, key, key_len, EVP_AEAD_DEFAULT_TAG_LENGTH);
+    if (!ctx) return BCL_ERR;
+    int ok = EVP_AEAD_CTX_seal(ctx, out, out_len, out_cap, nonce, nonce_len, pt, pt_len, aad, aad_len);
+    EVP_AEAD_CTX_free(ctx);
+    return ok ? BCL_OK : BCL_ERR;
+}
+
+/* Opens ciphertext||tag, writing plaintext into out. Returns BCL_AUTH_FAIL on tag mismatch
+ * (no plaintext released), BCL_ERR on other failure, BCL_OK on success. */
+static inline int bcl_aead_open(
+    const EVP_AEAD *aead,
+    const uint8_t *key, size_t key_len,
+    const uint8_t *nonce, size_t nonce_len,
+    const uint8_t *aad, size_t aad_len,
+    const uint8_t *ct, size_t ct_len,
+    uint8_t *out, size_t out_cap, size_t *out_len) {
+    if (!aead) return BCL_ERR;
+    EVP_AEAD_CTX *ctx = EVP_AEAD_CTX_new(aead, key, key_len, EVP_AEAD_DEFAULT_TAG_LENGTH);
+    if (!ctx) return BCL_ERR;
+    int ok = EVP_AEAD_CTX_open(ctx, out, out_len, out_cap, nonce, nonce_len, ct, ct_len, aad, aad_len);
+    EVP_AEAD_CTX_free(ctx);
+    return ok ? BCL_OK : BCL_AUTH_FAIL;
+}
+
+static inline int bcl_aes_gcm_seal(
+    const uint8_t *key, size_t key_len,
+    const uint8_t *nonce, size_t nonce_len,
+    const uint8_t *aad, size_t aad_len,
+    const uint8_t *pt, size_t pt_len,
+    uint8_t *out, size_t out_cap, size_t *out_len) {
+    return bcl_aead_seal(bcl_aead_for_aes_gcm(key_len), key, key_len, nonce, nonce_len,
+                         aad, aad_len, pt, pt_len, out, out_cap, out_len);
+}
+static inline int bcl_aes_gcm_open(
+    const uint8_t *key, size_t key_len,
+    const uint8_t *nonce, size_t nonce_len,
+    const uint8_t *aad, size_t aad_len,
+    const uint8_t *ct, size_t ct_len,
+    uint8_t *out, size_t out_cap, size_t *out_len) {
+    return bcl_aead_open(bcl_aead_for_aes_gcm(key_len), key, key_len, nonce, nonce_len,
+                         aad, aad_len, ct, ct_len, out, out_cap, out_len);
+}
+static inline int bcl_chacha_seal(
+    const uint8_t *key, size_t key_len,
+    const uint8_t *nonce, size_t nonce_len,
+    const uint8_t *aad, size_t aad_len,
+    const uint8_t *pt, size_t pt_len,
+    uint8_t *out, size_t out_cap, size_t *out_len) {
+    return bcl_aead_seal(EVP_aead_chacha20_poly1305(), key, key_len, nonce, nonce_len,
+                         aad, aad_len, pt, pt_len, out, out_cap, out_len);
+}
+static inline int bcl_chacha_open(
+    const uint8_t *key, size_t key_len,
+    const uint8_t *nonce, size_t nonce_len,
+    const uint8_t *aad, size_t aad_len,
+    const uint8_t *ct, size_t ct_len,
+    uint8_t *out, size_t out_cap, size_t *out_len) {
+    return bcl_aead_open(EVP_aead_chacha20_poly1305(), key, key_len, nonce, nonce_len,
+                         aad, aad_len, ct, ct_len, out, out_cap, out_len);
+}
+
+/* ===========================================================================
+ * CSPRNG
+ * =========================================================================== */
+
+static inline int bcl_rand_bytes(uint8_t *out, size_t len) {
+    return RAND_bytes(out, len) == 1 ? BCL_OK : BCL_ERR;
+}
+
+/* ===========================================================================
+ * Ed25519 (raw 32-byte seed / public key, 64-byte signature).
+ * BoringSSL's ED25519_keypair returns the 64-byte private key (seed||public); we accept
+ * the 32-byte seed and rebuild the expanded private the library's sign expects.
+ * =========================================================================== */
+
+static inline int bcl_ed25519_keypair(uint8_t *out_pub32, uint8_t *out_seed32) {
+    uint8_t priv64[64];
+    ED25519_keypair(out_pub32, priv64);
+    /* The first 32 bytes of BoringSSL's private key is the seed. */
+    memcpy(out_seed32, priv64, 32);
+    OPENSSL_cleanse(priv64, sizeof(priv64));
+    return BCL_OK;
+}
+
+/* Signs msg with a 32-byte seed. BoringSSL ED25519_sign wants the 64-byte private
+ * (seed||public); derive the public from the seed via ED25519_keypair_from_seed. */
+static inline int bcl_ed25519_sign(
+    const uint8_t *seed32,
+    const uint8_t *msg, size_t msg_len,
+    uint8_t *out_sig64) {
+    uint8_t pub[32];
+    uint8_t priv64[64];
+    ED25519_keypair_from_seed(pub, priv64, seed32);
+    int ok = ED25519_sign(out_sig64, msg, msg_len, priv64);
+    OPENSSL_cleanse(priv64, sizeof(priv64));
+    return ok ? BCL_OK : BCL_ERR;
+}
+
+static inline int bcl_ed25519_verify(
+    const uint8_t *pub32,
+    const uint8_t *msg, size_t msg_len,
+    const uint8_t *sig64) {
+    return ED25519_verify(msg, msg_len, sig64, pub32) == 1 ? BCL_OK : BCL_ERR;
+}
+
+/* ===========================================================================
+ * X25519 (RFC 7748 raw 32-byte scalar / u-coordinate).
+ * =========================================================================== */
+
+static inline int bcl_x25519_keypair(uint8_t *out_pub32, uint8_t *out_priv32) {
+    X25519_keypair(out_pub32, out_priv32);
+    return BCL_OK;
+}
+
+static inline int bcl_x25519(
+    const uint8_t *priv32, const uint8_t *peer_pub32, uint8_t *out_shared32) {
+    /* X25519 returns 0 for an all-zero / small-order result; surface as error. */
+    return X25519(out_shared32, priv32, peer_pub32) == 1 ? BCL_OK : BCL_ERR;
+}
+
+/* ===========================================================================
+ * ECDH on NIST P-256 / P-384 / P-521.
+ * Private key is the raw big-endian scalar; public key is the uncompressed SEC1
+ * point 0x04||X||Y. Output is the big-endian X-coordinate of the shared point,
+ * left-zero-padded to the field width (RFC 5903 / SEC1) — matching JCA/Apple.
+ * =========================================================================== */
+
+static inline int bcl_ec_nid(int curve_code) {
+    switch (curve_code) {
+        case 256: return NID_X9_62_prime256v1;
+        case 384: return NID_secp384r1;
+        case 521: return NID_secp521r1;
+        default: return 0;
+    }
+}
+
+static inline int bcl_ecdh(
+    int curve_code,
+    const uint8_t *priv_scalar, size_t priv_len,
+    const uint8_t *peer_point, size_t peer_len,
+    uint8_t *out_secret, size_t out_cap, size_t *out_len) {
+    int rc = BCL_ERR;
+    int nid = bcl_ec_nid(curve_code);
+    if (nid == 0) return BCL_ERR;
+
+    EC_GROUP *group = EC_GROUP_new_by_curve_name(nid);
+    BIGNUM *priv_bn = NULL;
+    EC_KEY *priv_key = NULL;
+    EC_POINT *peer = NULL;
+    EC_POINT *shared = NULL;
+    BIGNUM *x = NULL;
+    BN_CTX *bnctx = NULL;
+    if (!group) goto done;
+
+    bnctx = BN_CTX_new();
+    if (!bnctx) goto done;
+
+    /* Build the private EC_KEY from the raw scalar. */
+    priv_bn = BN_bin2bn(priv_scalar, (int)priv_len, NULL);
+    if (!priv_bn) goto done;
+    priv_key = EC_KEY_new();
+    if (!priv_key) goto done;
+    if (!EC_KEY_set_group(priv_key, group)) goto done;
+    if (!EC_KEY_set_private_key(priv_key, priv_bn)) goto done;
+
+    /* Decode and validate the peer point (rejects off-curve / infinity). */
+    peer = EC_POINT_new(group);
+    if (!peer) goto done;
+    if (!EC_POINT_oct2point(group, peer, peer_point, peer_len, bnctx)) goto done;
+    if (!EC_POINT_is_on_curve(group, peer, bnctx)) goto done;
+    if (EC_POINT_is_at_infinity(group, peer)) goto done;
+
+    /* shared = priv * peer ; secret is the affine X coordinate, fixed width. */
+    shared = EC_POINT_new(group);
+    if (!shared) goto done;
+    if (!EC_POINT_mul(group, shared, NULL, peer, priv_bn, bnctx)) goto done;
+    if (EC_POINT_is_at_infinity(group, shared)) goto done;
+
+    x = BN_new();
+    if (!x) goto done;
+    if (!EC_POINT_get_affine_coordinates_GFp(group, shared, x, NULL, bnctx)) goto done;
+
+    {
+        size_t field_bytes = (size_t)((EC_GROUP_get_degree(group) + 7) / 8);
+        if (field_bytes > out_cap) goto done;
+        if (!BN_bn2bin_padded(out_secret, field_bytes, x)) goto done;
+        *out_len = field_bytes;
+        rc = BCL_OK;
+    }
+
+done:
+    if (x) BN_free(x);
+    if (shared) EC_POINT_free(shared);
+    if (peer) EC_POINT_free(peer);
+    if (priv_key) EC_KEY_free(priv_key);
+    if (priv_bn) BN_clear_free(priv_bn);
+    if (bnctx) BN_CTX_free(bnctx);
+    if (group) EC_GROUP_free(group);
+    return rc;
+}
+
+/* Generates an EC key pair: raw scalar (left-padded to field width) and uncompressed point. */
+static inline int bcl_ec_generate(
+    int curve_code,
+    uint8_t *out_priv, size_t priv_cap, size_t *out_priv_len,
+    uint8_t *out_pub, size_t pub_cap, size_t *out_pub_len) {
+    int rc = BCL_ERR;
+    int nid = bcl_ec_nid(curve_code);
+    if (nid == 0) return BCL_ERR;
+    EC_KEY *key = EC_KEY_new_by_curve_name(nid);
+    BN_CTX *bnctx = NULL;
+    if (!key) return BCL_ERR;
+    bnctx = BN_CTX_new();
+    if (!bnctx) goto done;
+    if (!EC_KEY_generate_key(key)) goto done;
+    {
+        const EC_GROUP *group = EC_KEY_get0_group(key);
+        size_t field_bytes = (size_t)((EC_GROUP_get_degree(group) + 7) / 8);
+        const BIGNUM *priv = EC_KEY_get0_private_key(key);
+        if (field_bytes > priv_cap) goto done;
+        if (!BN_bn2bin_padded(out_priv, field_bytes, priv)) goto done;
+        *out_priv_len = field_bytes;
+
+        size_t pub_len = EC_POINT_point2oct(group, EC_KEY_get0_public_key(key),
+                                            POINT_CONVERSION_UNCOMPRESSED, out_pub, pub_cap, bnctx);
+        if (pub_len == 0) goto done;
+        *out_pub_len = pub_len;
+        rc = BCL_OK;
+    }
+done:
+    if (bnctx) BN_CTX_free(bnctx);
+    EC_KEY_free(key);
+    return rc;
+}
+
+/* ===========================================================================
+ * ECDSA on NIST P-256 / P-384 / P-521. Hash-then-sign with SHA-256/384/512.
+ * Private key = raw scalar; public key = uncompressed point. Signatures are DER.
+ * =========================================================================== */
+
+static inline const EVP_MD *bcl_ecdsa_md(int curve_code) {
+    switch (curve_code) {
+        case 256: return EVP_sha256();
+        case 384: return EVP_sha384();
+        case 521: return EVP_sha512();
+        default: return NULL;
+    }
+}
+
+/* Signs msg under the raw scalar, emitting a DER signature into out_sig (capacity sig_cap). */
+static inline int bcl_ecdsa_sign(
+    int curve_code,
+    const uint8_t *priv_scalar, size_t priv_len,
+    const uint8_t *msg, size_t msg_len,
+    uint8_t *out_sig, size_t sig_cap, size_t *out_sig_len) {
+    int rc = BCL_ERR;
+    int nid = bcl_ec_nid(curve_code);
+    const EVP_MD *md = bcl_ecdsa_md(curve_code);
+    if (nid == 0 || !md) return BCL_ERR;
+
+    EC_GROUP *group = EC_GROUP_new_by_curve_name(nid);
+    BIGNUM *priv_bn = NULL;
+    EC_KEY *key = NULL;
+    EC_POINT *pub_pt = NULL;
+    EVP_PKEY *pkey = NULL;
+    EVP_MD_CTX *mdctx = NULL;
+    BN_CTX *bnctx = NULL;
+    if (!group) return BCL_ERR;
+    bnctx = BN_CTX_new();
+    if (!bnctx) goto done;
+
+    priv_bn = BN_bin2bn(priv_scalar, (int)priv_len, NULL);
+    if (!priv_bn) goto done;
+    key = EC_KEY_new();
+    if (!key) goto done;
+    if (!EC_KEY_set_group(key, group)) goto done;
+    if (!EC_KEY_set_private_key(key, priv_bn)) goto done;
+    /* Derive and set the public point (pub = priv * G); EVP signing needs it present. */
+    pub_pt = EC_POINT_new(group);
+    if (!pub_pt) goto done;
+    if (!EC_POINT_mul(group, pub_pt, priv_bn, NULL, NULL, bnctx)) goto done;
+    if (!EC_KEY_set_public_key(key, pub_pt)) goto done;
+
+    pkey = EVP_PKEY_new();
+    if (!pkey) goto done;
+    if (!EVP_PKEY_set1_EC_KEY(pkey, key)) goto done;
+
+    mdctx = EVP_MD_CTX_new();
+    if (!mdctx) goto done;
+    if (!EVP_DigestSignInit(mdctx, NULL, md, NULL, pkey)) goto done;
+    {
+        size_t out_len = sig_cap;
+        if (!EVP_DigestSign(mdctx, out_sig, &out_len, msg, msg_len)) goto done;
+        *out_sig_len = out_len;
+        rc = BCL_OK;
+    }
+done:
+    if (mdctx) EVP_MD_CTX_free(mdctx);
+    if (pkey) EVP_PKEY_free(pkey);
+    if (pub_pt) EC_POINT_free(pub_pt);
+    if (key) EC_KEY_free(key);
+    if (priv_bn) BN_clear_free(priv_bn);
+    if (bnctx) BN_CTX_free(bnctx);
+    if (group) EC_GROUP_free(group);
+    return rc;
+}
+
+/* Verifies a DER signature under the uncompressed public point.
+ * Returns BCL_OK on a valid signature, BCL_ERR otherwise (bad point or bad signature). */
+static inline int bcl_ecdsa_verify(
+    int curve_code,
+    const uint8_t *pub_point, size_t pub_len,
+    const uint8_t *msg, size_t msg_len,
+    const uint8_t *sig, size_t sig_len) {
+    int rc = BCL_ERR;
+    int nid = bcl_ec_nid(curve_code);
+    const EVP_MD *md = bcl_ecdsa_md(curve_code);
+    if (nid == 0 || !md) return BCL_ERR;
+
+    EC_GROUP *group = EC_GROUP_new_by_curve_name(nid);
+    EC_KEY *key = NULL;
+    EC_POINT *pub_pt = NULL;
+    EVP_PKEY *pkey = NULL;
+    EVP_MD_CTX *mdctx = NULL;
+    BN_CTX *bnctx = NULL;
+    if (!group) return BCL_ERR;
+    bnctx = BN_CTX_new();
+    if (!bnctx) goto done;
+
+    key = EC_KEY_new();
+    if (!key) goto done;
+    if (!EC_KEY_set_group(key, group)) goto done;
+    pub_pt = EC_POINT_new(group);
+    if (!pub_pt) goto done;
+    if (!EC_POINT_oct2point(group, pub_pt, pub_point, pub_len, bnctx)) goto done;
+    if (!EC_POINT_is_on_curve(group, pub_pt, bnctx)) goto done;
+    if (EC_POINT_is_at_infinity(group, pub_pt)) goto done;
+    if (!EC_KEY_set_public_key(key, pub_pt)) goto done;
+    if (!EC_KEY_check_key(key)) goto done;
+
+    pkey = EVP_PKEY_new();
+    if (!pkey) goto done;
+    if (!EVP_PKEY_set1_EC_KEY(pkey, key)) goto done;
+
+    mdctx = EVP_MD_CTX_new();
+    if (!mdctx) goto done;
+    if (!EVP_DigestVerifyInit(mdctx, NULL, md, NULL, pkey)) goto done;
+    if (EVP_DigestVerify(mdctx, sig, sig_len, msg, msg_len) == 1) {
+        rc = BCL_OK;
+    }
+done:
+    if (mdctx) EVP_MD_CTX_free(mdctx);
+    if (pkey) EVP_PKEY_free(pkey);
+    if (pub_pt) EC_POINT_free(pub_pt);
+    if (key) EC_KEY_free(key);
+    if (bnctx) BN_CTX_free(bnctx);
+    if (group) EC_GROUP_free(group);
+    return rc;
+}

--- a/buffer/src/linuxMain/kotlin/com/ditchoom/buffer/NativeBuffer.kt
+++ b/buffer/src/linuxMain/kotlin/com/ditchoom/buffer/NativeBuffer.kt
@@ -89,6 +89,12 @@ class NativeBuffer private constructor(
             val ptr =
                 malloc(size.convert())?.reinterpret<ByteVar>()
                     ?: throw OutOfMemoryError("Failed to allocate $size bytes")
+            // Zero-initialize so freshly allocated native memory matches every other platform
+            // backing (JVM direct ByteBuffer, Apple NSMutableData, Kotlin ByteArray, WASM linear
+            // memory all hand out zeroed bytes). Code that relies on a fresh buffer being zero —
+            // e.g. HKDF's empty-salt zero block in buffer-crypto — would otherwise read malloc
+            // garbage only on Linux.
+            if (size > 0) memset(ptr, 0, size.convert())
             return NativeBuffer(ptr, size, byteOrder)
         }
 

--- a/buffer/src/linuxMain/kotlin/com/ditchoom/buffer/NativeBuffer.kt
+++ b/buffer/src/linuxMain/kotlin/com/ditchoom/buffer/NativeBuffer.kt
@@ -89,12 +89,6 @@ class NativeBuffer private constructor(
             val ptr =
                 malloc(size.convert())?.reinterpret<ByteVar>()
                     ?: throw OutOfMemoryError("Failed to allocate $size bytes")
-            // Zero-initialize so freshly allocated native memory matches every other platform
-            // backing (JVM direct ByteBuffer, Apple NSMutableData, Kotlin ByteArray, WASM linear
-            // memory all hand out zeroed bytes). Code that relies on a fresh buffer being zero —
-            // e.g. HKDF's empty-salt zero block in buffer-crypto — would otherwise read malloc
-            // garbage only on Linux.
-            if (size > 0) memset(ptr, 0, size.convert())
             return NativeBuffer(ptr, size, byteOrder)
         }
 


### PR DESCRIPTION
## Summary

Adds a **Linux native crypto backend wrapping BoringSSL (libcrypto)** to `:buffer-crypto`, registering `linuxX64` + `linuxArm64` actuals for **every** primitive family. Closes #202.

Previously buffer-crypto registered no Linux target at all; the module didn't build crypto for Linux.

## Primitive families (all enabled)

| Family | BoringSSL primitive |
|--------|--------------------|
| Hashes | SHA-256/384/512 (`SHA*_*`) |
| HMAC | HMAC-SHA-256/384/512 (`HMAC_*`) |
| AEAD | AES-128/256-GCM, ChaCha20-Poly1305 (`EVP_AEAD_CTX_seal/open`, RFC 5116) |
| Signatures | ECDSA P-256/384/521 (DER, hash-then-sign via `EVP_DigestSign*`), Ed25519 (`ED25519_*`) |
| Key agreement | ECDH P-256/384/521 (low-level EC), X25519 (`X25519`) + HPKE `dhRawSecret` seam |
| CSPRNG | `RAND_bytes` |

## Capability flags flipped `true` on Linux
`supportsSyncAesGcm`, `supportsChaChaPoly`, `supportsSyncChaChaPoly`, `supportsSyncEd25519`, `supportsSyncEcdsa`, `supportsEcdsaSigningFromScalar`, `supportsSyncX25519`, `supportsSyncEcdhP256/384/521`, `supportsAesGcmAnyPath`. `ecdsaSignatureEncoding = Der` (matches JVM/Apple). `isWebPlatformKa = false`.

## Implementation notes
- **cinterop**: every BoringSSL call is wrapped in a `static inline` C function in the `.def` body (raw header decls come back empty from K/N cinterop — same wall the sibling `:socket:` module hits). Kotlin calls the wrappers.
- **Strict-canonical-DER ECDSA verify**: BER / superfluous padding / trailing bytes / `r,s ∉ [1,n)` are rejected before delegating, matching the JVM gate and the Wycheproof `invalid` vectors.
- **Secrets** live in the existing `SecureBuffer` discipline; AEAD open authenticates before releasing plaintext (no unverified-plaintext, no manual tag compare needed).
- Buffer access goes through `nativeMemoryAccess`/`managedMemoryAccess` so it works transparently through wrapper buffers.
- Incidental `:buffer` fix: Linux `NativeBuffer.allocate` now zero-initializes its malloc'd memory, matching every other platform backing (JVM/Apple/JS/WASM all hand out zeroed bytes). HKDF's empty-salt zero block was reading malloc garbage only on Linux.

## Test evidence (alien Linux box)
**`:buffer-crypto:linuxX64Test` — 129 tests, 0 failures, 0 skipped (GREEN).** The full common suite (KAT + Wycheproof + tamper/negative + capability + HPKE RFC 9180 vectors) runs over the BoringSSL backend. Verified against **both** a reused prebuilt and a **fully self-built** BoringSSL. `linuxArm64` cross-build + test-binary link verified.

## BoringSSL provisioning (self-contained for CI)
A `buildBoringssl<Arch>` Gradle task shallow-clones BoringSSL from the **GitHub mirror** (reliable `git fetch <sha>`, pinned commit), cmake-builds `libcrypto.a`, and provisions into `libs/boringssl/linux-$arch` (gitignored — no binaries committed). The build is skipped if the libs already exist, so a dev box can drop in a prebuilt tree. libcrypto is built with `-U_FORTIFY_SOURCE -fno-stack-protector` + an `__isoc23_strtoull` compat shim so the archive only references symbols present in Kotlin/Native's bundled (older) glibc — otherwise a modern-Ubuntu build links against `__*_chk` / `__isoc23_*` symbols K/N's `ld.lld` can't resolve.

**build-linux CI**: the workflow now runs `:buffer-crypto:linuxX64Test` and `:buffer-crypto:linkDebugTestLinuxArm64`, provisioning BoringSSL via the task (go/cmake are on the runner; `g++-aarch64-linux-gnu` added for the arm64 cross-build). The self-provisioning path was validated end-to-end on the alien box (clean clone → build → 129/129 green), so build-linux should pass. The one CI element not reproducible off-GitHub is the QEMU **execution** of the arm64 binary (needs the arm64 runtime libs the workflow installs); the arm64 **link** is verified.

## Files added/changed
- `buffer-crypto/src/nativeInterop/cinterop/boringsslcrypto.def` — static-inline BoringSSL wrappers
- `buffer-crypto/src/linuxMain/.../crypto/*.linux.kt` — actuals (hashes, HMAC, AEAD, signatures, key agreement, CSPRNG, HPKE flags, bridge helpers)
- `buffer-crypto/src/linuxTest/.../KeyAgreementTestSupport.linux.kt`
- `buffer-crypto/build.gradle.kts` — linuxX64/linuxArm64 targets, BoringSSL build task + cinterop wiring, Apple cinterop guarded to the Apple family
- `buffer-crypto/.gitignore` — `libs/boringssl/`
- `buffer/src/linuxMain/.../NativeBuffer.kt` — zero-init malloc
- `.github/workflows/build-linux.yaml` — run crypto suite + arm64 cross-build deps

Do not merge — opening for review.