### PR TITLE
perf(buffer-crypto): bulk copies + Long-XOR nonce in HPKE

### DIFF
--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/Hpke.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/Hpke.kt
@@ -508,14 +508,20 @@ internal fun i2osp2(
     dest.writeByte((value and 0xFF).toByte())
 }
 
-/** Copies [source]'s remaining bytes into [dest] non-destructively (absolute reads). */
+/**
+ * Copies [source]'s remaining bytes into [dest] without consuming [source]: the bulk
+ * [WriteBuffer.write] advances the source to its limit, so its position is saved and restored.
+ * Callers reuse the same source across calls (e.g. `suite_id` and the key-schedule `secret`),
+ * so the non-destructive contract is load-bearing.
+ */
 internal fun copyInto(
     source: ReadBuffer,
     dest: WriteBuffer,
 ) {
-    val start = source.position()
-    val n = source.remaining()
-    for (i in 0 until n) dest.writeByte(source.get(start + i))
+    if (source.remaining() == 0) return
+    val mark = source.position()
+    dest.write(source)
+    source.position(mark)
 }
 
 /** A fresh read-ready copy of [source]'s remaining bytes from [factory]. */

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HpkeContext.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HpkeContext.kt
@@ -50,14 +50,14 @@ sealed class HpkeContext protected constructor(
         // bytes (96 bits) so seq can never reach the true limit before Long overflow; still, guard
         // explicitly against the documented overflow boundary.
         if (seq == Long.MAX_VALUE) throw MessageLimitReached()
+        // nonce = base_nonce XOR I2OSP(seq, Nn). Default allocation is big-endian, so copy the base
+        // nonce in bulk and XOR the sequence number straight into the trailing 8 bytes as one Long:
+        // I2OSP(seq, Nn) is right-aligned and Nn (12) >= 8, so the leading Nn-8 bytes XOR with zero.
         val nonce = BufferFactory.Default.allocate(nn)
-        // XOR the big-endian seq into the low bytes of base_nonce.
-        val baseStart = baseNonce.position()
-        for (i in 0 until nn) {
-            val shift = (nn - 1 - i) * 8
-            val seqByte = if (shift < 64) ((seq ushr shift) and 0xFF).toInt() else 0
-            nonce.writeByte((baseNonce.get(baseStart + i).toInt() xor seqByte).toByte())
-        }
+        copyInto(baseNonce, nonce)
+        val tailOffset = nn - 8
+        nonce.position(tailOffset)
+        nonce.writeLong(nonce.getLong(tailOffset) xor seq)
         nonce.resetForRead()
         return nonce
     }
@@ -472,13 +472,12 @@ internal fun labeledExtract(
     ikm: ReadBuffer,
     dest: WriteBuffer,
 ) {
-    val suiteIdStart = suiteId.position()
     val suiteIdLen = suiteId.remaining()
     val len = HPKE_V1.size + suiteIdLen + label.size + ikm.remaining()
     val labeled = secureScratch.allocate(len)
     try {
         labeled.writeBytes(HPKE_V1)
-        for (i in 0 until suiteIdLen) labeled.writeByte(suiteId.get(suiteIdStart + i))
+        copyInto(suiteId, labeled)
         labeled.writeBytes(label)
         copyInto(ikm, labeled)
         labeled.resetForRead()
@@ -502,7 +501,6 @@ internal fun labeledExpand(
     length: Int,
     dest: WriteBuffer,
 ) {
-    val suiteIdStart = suiteId.position()
     val suiteIdLen = suiteId.remaining()
     val infoLen = info?.remaining() ?: 0
     val len = 2 + HPKE_V1.size + suiteIdLen + label.size + infoLen
@@ -510,7 +508,7 @@ internal fun labeledExpand(
     try {
         i2osp2(length, labeled)
         labeled.writeBytes(HPKE_V1)
-        for (i in 0 until suiteIdLen) labeled.writeByte(suiteId.get(suiteIdStart + i))
+        copyInto(suiteId, labeled)
         labeled.writeBytes(label)
         if (info != null) copyInto(info, labeled)
         labeled.resetForRead()


### PR DESCRIPTION
Internal optimization in the HPKE/DHKEM code — **no API or wire-format change**, byte-for-byte identical output (proven by the RFC 9180 KAT).

## What
1. **`copyInto`** — replace the byte-by-byte absolute-read loop with the bulk `WriteBuffer.write(source)` primitive, saving/restoring the source position so the **non-destructive contract is preserved** (`suite_id`, the key-schedule `secret`, and `ksc` are each read by multiple consumers). Biggest win: the **unbounded** `info` / `exporterContext` / `ikm` copies in `LabeledExtract`/`LabeledExpand` were previously O(n) `writeByte` calls.
2. **suite_id inline loops** — the two identical `for … writeByte(get())` loops in `labeledExtract`/`labeledExpand` now call `copyInto` (bulk + de-duplicated).
3. **`computeNonce` (per-message `seal`/`open` hot path)** — bulk-copy `base_nonce`, then XOR the sequence number into the trailing 8 bytes as one big-endian `Long` instead of a 12-iteration byte loop. (`xorMask` is a *repeating-4-byte* WebSocket primitive and does **not** fit `base_nonce XOR I2OSP(seq, Nn)`, where `seq` is a single right-aligned counter — so a plain `Long` XOR is the correct bulk form.)

## Why it's safe
- `fill`/`write` overload notes aside, output is unchanged: the RFC 9180 **KAT pins per-message nonces at seq 0/1/2/4/255/256** and every labeled extract/expand, so any byte-order or copy slip fails the suite.
- Non-destructive `copyInto` semantics retained via save/restore of the source position.

## Verified
`./gradlew :buffer-crypto:jvmTest :buffer-crypto:ktlintCheck` → **BUILD SUCCESSFUL** (KAT + round-trip + tamper + backing-matrix). CI covers Linux/Apple/JS/WASM/Android.

Pure-internal refactor → patch release.