### PR TITLE
ci(publish): treat PUBLISHING as success so releases don't time out

### DIFF
--- a/.github/workflows/publish-to-central.yaml
+++ b/.github/workflows/publish-to-central.yaml
@@ -116,7 +116,9 @@ jobs:
         run: |
           TOKEN=$(echo -n "${MAVEN_CENTRAL_USERNAME}:${MAVEN_CENTRAL_PASSWORD}" | base64)
           DEPLOYMENT_ID="${{ steps.upload.outputs.deployment-id }}"
-          MAX_ATTEMPTS=50
+          # Window only needs to cover PENDING -> VALIDATING -> (VALIDATED|PUBLISHING); we do NOT
+          # wait for the terminal PUBLISHED state (see below). 120 * 30s = 60min is ample headroom.
+          MAX_ATTEMPTS=120
           ATTEMPT=0
 
           while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
@@ -139,8 +141,15 @@ jobs:
             echo "Attempt ${ATTEMPT}/${MAX_ATTEMPTS}: ${STATE}"
 
             case "$STATE" in
-              VALIDATED|PUBLISHED)
-                echo "Deployment ${STATE} successfully!"
+              VALIDATED|PUBLISHING|PUBLISHED)
+                # VALIDATED  = signatures/POM/checksums all passed.
+                # PUBLISHING = Sonatype accepted it and is releasing to Central (AUTOMATIC); it
+                #              cannot fail from here, and the actual Central propagation is async.
+                # PUBLISHED  = terminal.
+                # Any of these means "accepted, will publish" — succeed now so the tag/release is
+                # cut, instead of blocking a runner until the slow terminal state (the cause of the
+                # 5.12.0 publish timeouts).
+                echo "Deployment ${STATE} — accepted, succeeding."
                 exit 0
                 ;;
               FAILED)
@@ -149,7 +158,7 @@ jobs:
                 exit 1
                 ;;
               *)
-                # PENDING, VALIDATING, PUBLISHING - keep polling
+                # PENDING, VALIDATING - keep polling
                 ;;
             esac
           done


### PR DESCRIPTION
## Problem
The Sonatype deployment poll in `publish-to-central.yaml` only succeeded on `VALIDATED|PUBLISHED` and treated `PUBLISHING` as *keep polling*. With `publishingType=AUTOMATIC`, a deployment routinely jumps straight to `PUBLISHING` and lingers there while Sonatype releases to Central (slow today). The loop polled 50×30s and **failed by timeout even though the artifact published fine** — which **skipped the git-tag step** (gated on publish success) and forced manual tagging of `v5.12.0`.

## Fix
Treat `VALIDATED`, `PUBLISHING`, and `PUBLISHED` as success. `PUBLISHING` is a strictly *later/safer* state than `VALIDATED` (already an exit-0): validation has passed, Sonatype is releasing, `AUTOMATIC` guarantees completion, and Central propagation is async anyway — so the job has nothing left to gate on and should cut the tag promptly. Only `FAILED` fails. Window bumped 50→120 (60 min) purely as headroom for a slow `VALIDATING` phase.

This is better than raising the window to hours (holds a runner idle near the 6h cap) or adding a separate recheck job (babysits a guaranteed publish): we simply stop waiting for the terminal state we never needed.

`skip-release` so this PR is a dry-run and doesn't itself publish.