### PR TITLE
feat(buffer-crypto): secure() DoS cap + supply-chain CI hardening

### DIFF
--- a/.github/workflows/android_integration.yaml
+++ b/.github/workflows/android_integration.yaml
@@ -6,6 +6,10 @@ on:
     types:
       - synchronize
       - opened
+
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -36,9 +40,9 @@ jobs:
             arch: x86_64
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
         with:
           distribution: 'zulu'
           java-version: '21'
@@ -81,7 +85,7 @@ jobs:
       # across hosts. We still cache ~/.android/avd/* so the AVD disk itself is
       # reused (skips re-creation); only the fragile snapshot is dropped.
       - name: AVD cache (restore)
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         id: avd-cache
         with:
           path: |
@@ -93,7 +97,7 @@ jobs:
 
       - name: create AVD for caching (no snapshot)
         if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}
@@ -107,7 +111,7 @@ jobs:
 
       - name: AVD cache (save pristine AVD)
         if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             ~/.android/avd/*
@@ -115,7 +119,7 @@ jobs:
           key: avd-${{ matrix.api-level }}-${{ matrix.target }}-${{ matrix.arch }}-${{ hashFiles('.ci/debug.keystore') }}
 
       - name: run tests
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}

--- a/.github/workflows/build-apple.yaml
+++ b/.github/workflows/build-apple.yaml
@@ -13,6 +13,9 @@ on:
         description: "Computed next version"
         value: ${{ jobs.build.outputs.version }}
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: "Apple Targets"
@@ -21,17 +24,17 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
         with:
           distribution: 'zulu'
           java-version: '21'
           cache: gradle
 
       - name: Cache Konan
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.konan
           key: konan-macos-${{ hashFiles('gradle/libs.versions.toml') }}
@@ -48,7 +51,7 @@ jobs:
         run: ./gradlew publishToMavenLocal --no-build-cache ${{ inputs.gradle-args }}
 
       - name: Upload Maven local artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: maven-local-apple
           path: ~/.m2/repository/com/ditchoom

--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -13,6 +13,9 @@ on:
         description: "Computed next version"
         value: ${{ jobs.build.outputs.version }}
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: "Linux / JVM / JS / WASM / Android"
@@ -21,36 +24,36 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
         with:
           distribution: 'zulu'
           java-version: '21'
           cache: gradle
 
       - name: Setup Chrome
-        uses: browser-actions/setup-chrome@v2
+        uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd # v2
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v4
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4
 
       - name: Cache Konan
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.konan
           key: konan-linux-${{ hashFiles('gradle/libs.versions.toml') }}
           restore-keys: konan-linux-
 
       - name: Cache simdutf x64
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: buffer/build/simdutf/libs/linux-x64
           key: simdutf-linux-x64-${{ hashFiles('gradle/libs.versions.toml', 'buffer/src/nativeInterop/cinterop/simdutf_wrapper.cpp') }}
 
       - name: Cache simdutf ARM64
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: buffer/build/simdutf/libs/linux-arm64
           key: simdutf-linux-arm64-${{ hashFiles('gradle/libs.versions.toml', 'buffer/src/nativeInterop/cinterop/simdutf_wrapper.cpp') }}
@@ -136,7 +139,7 @@ jobs:
         run: ./gradlew publishToMavenLocal --no-build-cache ${{ inputs.gradle-args }}
 
       - name: Upload Maven local artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: maven-local-linux
           path: ~/.m2/repository/com/ditchoom

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,45 @@
+name: "CodeQL"
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "**/*.md"
+  push:
+    branches: [main]
+  schedule:
+    - cron: "41 3 * * 1" # weekly, Monday 03:41 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload CodeQL results to code scanning
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # Kotlin sources (incl. the JS/WASM/native actuals) are analyzed as java-kotlin.
+        # build-mode "none" analyzes source directly — no multiplatform Gradle build, which
+        # autobuild cannot reliably drive across all KMP targets.
+        language: [java-kotlin]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+          queries: security-extended
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -15,31 +15,38 @@ permissions:
 
 jobs:
   analyze:
-    name: Analyze (${{ matrix.language }})
+    name: Analyze (java-kotlin)
     runs-on: ubuntu-latest
     permissions:
       security-events: write # upload CodeQL results to code scanning
       actions: read
       contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        # Kotlin sources (incl. the JS/WASM/native actuals) are analyzed as java-kotlin.
-        # build-mode "none" analyzes source directly — no multiplatform Gradle build, which
-        # autobuild cannot reliably drive across all KMP targets.
-        language: [java-kotlin]
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
+      - name: Set up JDK 21
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
+        with:
+          distribution: "zulu"
+          java-version: "21"
+          cache: gradle
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
-          languages: ${{ matrix.language }}
-          build-mode: none
+          languages: java-kotlin
+          # Kotlin extraction requires a traced compile — build-mode "none" sees no source
+          # in an all-Kotlin project ("no source code seen"). Compile the JVM target under
+          # CodeQL's tracer instead; this covers commonMain + the jvm/android actuals (the
+          # security-relevant glue). Kotlin/Native + JS/WASM actuals are not analyzable by CodeQL.
+          build-mode: manual
           queries: security-extended
+
+      - name: Compile Kotlin (JVM) for extraction
+        run: ./gradlew compileKotlinJvm --no-daemon --no-configuration-cache
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
-          category: "/language:${{ matrix.language }}"
+          category: "/language:java-kotlin"

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -28,22 +28,22 @@ jobs:
   build:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
         with:
           distribution: 'zulu'
           java-version: '21'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
 
       - name: Generate API Documentation with Dokka
         run: ./gradlew copyDokkaToDocusaurus
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -58,10 +58,10 @@ jobs:
         run: npm run build
 
       - name: Setup Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: docs/build
 
@@ -74,4 +74,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/merged.yaml
+++ b/.github/workflows/merged.yaml
@@ -23,8 +23,10 @@ on:
           - dry-run
         default: release
 
+# Least privilege: this workflow runs on pull_request_target (merged PRs), so the default
+# token is read-only and write is granted per-job only where actually needed (tag/release).
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: deploy
@@ -35,11 +37,14 @@ jobs:
     name: Check if release is needed
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read  # lists the merged PR's changed files via the REST API
     outputs:
       flow: ${{ steps.check.outputs.flow }}
       gradle-args: ${{ steps.check.outputs.gradle-args }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
       - name: Determine release flow
@@ -143,8 +148,12 @@ jobs:
     needs: [check-release, build-linux, publish]
     if: always() && needs.check-release.outputs.flow != 'skip' && needs.check-release.outputs.flow != 'dry-run'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # pushes the version tag and creates the GitHub release
+      id-token: write # OIDC for SLSA build-provenance attestation
+      attestations: write # write provenance + SBOM attestations to the GitHub attestation store
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Create draft GitHub release
         if: needs.check-release.outputs.flow == 'draft' && needs.publish.result == 'success'
@@ -208,3 +217,52 @@ jobs:
           **Maven Central:** [com.ditchoom:buffer:${version}](${maven_url})
           EOF
           )"
+
+      # ---- Supply-chain: SBOM + SLSA build provenance for the published artifacts ----
+      # Runs whenever publish succeeded (draft or release). Uses the exact same artifact
+      # bundle the publish job uploaded to Maven Central, so the attested digests match
+      # what consumers download.
+      - name: Download published artifacts
+        if: needs.publish.result == 'success'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: maven-local-merged
+          path: /tmp/maven-repo
+
+      - name: Generate SBOM (CycloneDX)
+        if: needs.publish.result == 'success'
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
+        with:
+          path: /tmp/maven-repo
+          format: cyclonedx-json
+          output-file: /tmp/buffer-sbom.cdx.json
+          artifact-name: buffer-sbom.cdx.json
+
+      - name: Attest build provenance
+        if: needs.publish.result == 'success'
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          # The shipped binaries: JVM/Android jars+aars and Kotlin/Native klibs.
+          subject-path: |
+            /tmp/maven-repo/**/*.jar
+            /tmp/maven-repo/**/*.klib
+            /tmp/maven-repo/**/*.aar
+
+      - name: Attest SBOM
+        if: needs.publish.result == 'success'
+        uses: actions/attest-sbom@bd218ad0dbcb3e146bd073d1d9c6d78e08aa8a0b # v2
+        with:
+          subject-path: |
+            /tmp/maven-repo/**/*.jar
+            /tmp/maven-repo/**/*.klib
+            /tmp/maven-repo/**/*.aar
+          sbom-path: /tmp/buffer-sbom.cdx.json
+
+      - name: Attach SBOM to release
+        if: needs.check-release.outputs.flow == 'release' && needs.publish.result == 'success'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version="${{ needs.build-linux.outputs.version }}"
+          gh release upload "v${version}" /tmp/buffer-sbom.cdx.json \
+            --repo="$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/nightly-dependency-update.yaml
+++ b/.github/workflows/nightly-dependency-update.yaml
@@ -28,26 +28,26 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
         with:
           distribution: "zulu"
           java-version: "21"
           cache: gradle
 
       - name: Cache Konan
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.konan
           key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
           restore-keys: konan-${{ runner.os }}-
 
       - name: Claude — coordinated toolchain update
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@30544b674398ee15c84819bd87caf8a87e8c7b55 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--allowedTools Bash,Edit,Write,Read,Glob,Grep --max-turns 60"

--- a/.github/workflows/publish-to-central.yaml
+++ b/.github/workflows/publish-to-central.yaml
@@ -25,6 +25,10 @@ on:
         description: "Sonatype Central Portal deployment ID"
         value: ${{ jobs.publish.outputs.deployment-id }}
 
+# Downloads same-run artifacts and uploads to Sonatype (external); no repo write needed.
+permissions:
+  contents: read
+
 jobs:
   publish:
     name: "Sign, Bundle & Upload"
@@ -34,7 +38,7 @@ jobs:
       deployment-id: ${{ steps.upload.outputs.deployment-id }}
     steps:
       - name: Download merged artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: maven-local-merged
           path: /tmp/maven-repo

--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -7,6 +7,9 @@ on:
       - synchronize
       - opened
 
+permissions:
+  contents: read
+
 jobs:
   build-linux:
     uses: ./.github/workflows/build-linux.yaml
@@ -24,21 +27,21 @@ jobs:
     name: "Validate Docs Generation"
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
         with:
           distribution: 'zulu'
           java-version: '21'
           cache: gradle
       - name: Cache Konan
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.konan
           key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
           restore-keys: konan-${{ runner.os }}-
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -1,0 +1,47 @@
+name: "OpenSSF Scorecard"
+
+# Supply-chain security posture scoring (branch protection, pinned deps, token
+# permissions, dangerous workflow patterns, signed releases, ...). Results are
+# uploaded to the repo's code-scanning dashboard and published to the public
+# OpenSSF Scorecard API (powering the README badge).
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "27 3 * * 1" # weekly, Monday 03:27 UTC
+  push:
+    branches: [main]
+
+# Read-only by default; the analysis job elevates only what it needs.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload SARIF to code scanning
+      id-token: write # publish results to the OpenSSF API via OIDC
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@05b42c624433fc40578a4040d5cf5e36ddca8cde # v2.4.2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/validate-artifacts.yaml
+++ b/.github/workflows/validate-artifacts.yaml
@@ -8,6 +8,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: "Validate Artifacts"
@@ -15,13 +18,13 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Download Linux artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: maven-local-linux
           path: /tmp/linux-repo/com/ditchoom
 
       - name: Download Apple artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: maven-local-apple
           path: /tmp/apple-repo/com/ditchoom
@@ -133,14 +136,14 @@ jobs:
           done
 
       - name: Upload merged artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: maven-local-merged
           path: /tmp/maven-local
           retention-days: 3
 
       - name: Checkout validation project
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           sparse-checkout: |
             .ci/validate-resolution
@@ -148,13 +151,13 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
         with:
           distribution: 'zulu'
           java-version: '21'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
 
       - name: Validate with Gradle resolution
         run: |

--- a/buffer-crypto/SECURITY.md
+++ b/buffer-crypto/SECURITY.md
@@ -149,6 +149,13 @@ prevented by API/type design · **(e)** out of scope / documented trust assumpti
 | Sender-auth (Auth/AuthPSK) forgery | **(a)** KAT + negative test: a receiver authenticating the wrong sender key fails to verify |
 | Suite primitive unavailable (ChaCha on web, X25519 where absent) | **(b)/(d)** gated `false` → `UnsupportedOperationException`, never a silent fallback + capability test |
 
+### Resource exhaustion / denial-of-service (cross-cutting)
+| Vector | Defense |
+|---|---|
+| Attacker-controlled length reaches a secure allocation (unbounded native-memory request) | **(b)/(d)** `BufferFactory.secure(maxAllocationBytes = …)` caps every secure `allocate`/`wrap`; an over-limit request throws `IllegalArgumentException` in common code **before** any platform allocation, so the bound is byte-identical on every target. Callers parsing untrusted, length-prefixed input set the cap to the largest secret their protocol can legitimately hold. |
+| Message-sequence overflow forcing nonce reuse | **(d)** HPKE per-context monotonic seq throws `MessageLimitReached` before wrap (see §3 HPKE) |
+| `L > 255·HashLen` HKDF expansion | **(a)/(b)** length cap (see §3 KDF/MAC) |
+
 ## 4. Platform support & capability gating
 
 These are tested error paths, not assumptions — the capability flag drives a `true`→works /
@@ -215,3 +222,28 @@ Runtime: `kotlinx-coroutines-core` (the `*Async` wrappers await WebCrypto promis
 `kotlinx-serialization-json` (parses vendored Wycheproof vectors; never shipped) and
 `kotlinx-coroutines-test`. No third-party cryptographic dependency is bundled — every primitive
 is the platform's own. No known-vulnerable dependency versions are in use.
+
+## 8. Supply-chain & build integrity
+
+The threat model extends past the source: a consumer must be able to trust that the published
+artifact was built from this repository by this CI, untampered. The controls, mapped to STRIDE
+**Tampering** and **Denial-of-Service** at the build layer:
+
+- **SLSA build provenance.** Every release attaches a signed provenance attestation
+  (`actions/attest-build-provenance`, GitHub OIDC) binding the published jars/klibs/aars to the
+  workflow, commit, and runner that produced them. Verify with
+  `gh attestation verify <artifact> --repo ditchoom/buffer`.
+- **SBOM.** A CycloneDX SBOM is generated from the exact published artifact set, attached to the
+  GitHub release, and itself attested.
+- **Pinned, immutable actions.** Every third-party GitHub Action is pinned to a full commit SHA
+  (with the human-readable tag in a trailing comment); Dependabot updates the pin + comment
+  together. A retagged/compromised action cannot silently enter the build.
+- **Least-privilege tokens.** Workflows default to a read-only `GITHUB_TOKEN`; write scopes
+  (`contents`, `attestations`, `id-token`) are granted per-job only where required. The
+  `pull_request_target` release workflow in particular runs read-only except for the single
+  tag/release/attestation job.
+- **Static analysis & posture scoring.** CodeQL (`security-extended`) runs on every PR and weekly;
+  OpenSSF Scorecard runs weekly and on push to `main`, surfacing branch-protection, token, and
+  pinning regressions.
+- **Signed publication.** Maven Central artifacts are PGP-signed (detached `.asc`) with checksums,
+  produced only on `main`.

--- a/buffer-crypto/SECURITY.md
+++ b/buffer-crypto/SECURITY.md
@@ -152,7 +152,7 @@ prevented by API/type design · **(e)** out of scope / documented trust assumpti
 ### Resource exhaustion / denial-of-service (cross-cutting)
 | Vector | Defense |
 |---|---|
-| Attacker-controlled length reaches a secure allocation (unbounded native-memory request) | **(b)/(d)** `BufferFactory.secure(maxAllocationBytes = …)` caps every secure `allocate`/`wrap`; an over-limit request throws `IllegalArgumentException` in common code **before** any platform allocation, so the bound is byte-identical on every target. Callers parsing untrusted, length-prefixed input set the cap to the largest secret their protocol can legitimately hold. |
+| Attacker-controlled length reaches a secure allocation (unbounded native-memory request) | **(b)/(d)** `BufferFactory.secure(maxAllocationBytes = …)` caps every secure `allocate`/`wrap`; an over-limit request throws `IllegalArgumentException` in common code **before** any platform allocation, so the bound is byte-identical on every target. The cap defaults to a 16 MiB backstop (`DEFAULT_MAX_SECURE_ALLOCATION_BYTES`) — secure-by-default — and callers parsing untrusted, length-prefixed input set a tighter, protocol-specific bound. |
 | Message-sequence overflow forcing nonce reuse | **(d)** HPKE per-context monotonic seq throws `MessageLimitReached` before wrap (see §3 HPKE) |
 | `L > 255·HashLen` HKDF expansion | **(a)/(b)** length cap (see §3 KDF/MAC) |
 

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/SecureBuffer.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/SecureBuffer.kt
@@ -132,11 +132,13 @@ internal class SecureBufferFactory(
  * secure.allocate(32).use { key -> /* ... */ } // zeroed at end of block
  * ```
  *
- * Pass [maxAllocationBytes] to bound every secure allocation/wrap — a defense against
+ * [maxAllocationBytes] bounds every secure allocation/wrap — a defense against
  * resource-exhaustion (DoS) when an untrusted, length-prefixed input can reach `allocate`.
  * Requests above the bound throw [IllegalArgumentException] before any memory is reserved.
- * The default is unbounded ([Int.MAX_VALUE]); set it to the largest secret your protocol can
- * legitimately hold (key material is normally well under a kilobyte):
+ * It defaults to a generous 16 MiB backstop ([DEFAULT_MAX_SECURE_ALLOCATION_BYTES]) so the
+ * safe behavior is the default — no realistic key material or crypto scratch approaches it.
+ * Pass a tighter, protocol-specific bound when an attacker controls the length (key material
+ * is normally well under a kilobyte):
  * ```kotlin
  * val secure = BufferFactory.deterministic().secure(maxAllocationBytes = 4 * 1024)
  * secure.allocate(attackerControlledLength) // throws if length > 4096
@@ -144,4 +146,12 @@ internal class SecureBufferFactory(
  *
  * @param maxAllocationBytes upper bound, in bytes, on a single secure buffer. Must be >= 1.
  */
-fun BufferFactory.secure(maxAllocationBytes: Int = Int.MAX_VALUE): BufferFactory = SecureBufferFactory(this, maxAllocationBytes)
+fun BufferFactory.secure(maxAllocationBytes: Int = DEFAULT_MAX_SECURE_ALLOCATION_BYTES): BufferFactory =
+    SecureBufferFactory(this, maxAllocationBytes)
+
+/**
+ * Default upper bound for [secure]: a 16 MiB backstop. Generous enough that no legitimate key
+ * material or crypto scratch reaches it, small enough to bound a runaway or attacker-driven
+ * allocation. Override with a tighter, protocol-specific cap when parsing untrusted input.
+ */
+const val DEFAULT_MAX_SECURE_ALLOCATION_BYTES: Int = 16 * 1024 * 1024

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/SecureBuffer.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/SecureBuffer.kt
@@ -61,19 +61,43 @@ class SecureBuffer internal constructor(
  * over any delegate factory — `BufferFactory.deterministic().secure()`,
  * `someFactory.withPooling(pool).secure()`, etc. — so the secure-erase behavior layers
  * on top of whatever allocation strategy the delegate provides.
+ *
+ * [maxAllocationBytes] is an explicit upper bound on any single secure allocation. Secure
+ * buffers hold key material and scratch, which is small; a request larger than the bound is
+ * almost always a bug or an attacker-supplied length reaching `allocate`. Enforcing the cap
+ * turns an unbounded native-memory request (a denial-of-service vector) into a deterministic
+ * [IllegalArgumentException], thrown in common code before any platform allocation, so the
+ * behavior is byte-identical on every target.
  */
 internal class SecureBufferFactory(
     private val delegate: BufferFactory,
+    private val maxAllocationBytes: Int,
 ) : BufferFactory {
+    init {
+        require(maxAllocationBytes >= 1) {
+            "maxAllocationBytes must be >= 1, was $maxAllocationBytes"
+        }
+    }
+
     override fun allocate(
         size: Int,
         byteOrder: ByteOrder,
-    ): PlatformBuffer = SecureBuffer(zeroInit(delegate.allocate(size, byteOrder)))
+    ): PlatformBuffer {
+        require(size in 0..maxAllocationBytes) {
+            "secure allocation of $size bytes exceeds the configured maximum of $maxAllocationBytes"
+        }
+        return SecureBuffer(zeroInit(delegate.allocate(size, byteOrder)))
+    }
 
     override fun wrap(
         array: ByteArray,
         byteOrder: ByteOrder,
-    ): PlatformBuffer = SecureBuffer(delegate.wrap(array, byteOrder))
+    ): PlatformBuffer {
+        require(array.size <= maxAllocationBytes) {
+            "secure wrap of ${array.size} bytes exceeds the configured maximum of $maxAllocationBytes"
+        }
+        return SecureBuffer(delegate.wrap(array, byteOrder))
+    }
 
     /**
      * Zero-initializes the full backing of a freshly allocated buffer — the allocate-time mirror
@@ -107,5 +131,17 @@ internal class SecureBufferFactory(
  * val secure = BufferFactory.deterministic().secure()
  * secure.allocate(32).use { key -> /* ... */ } // zeroed at end of block
  * ```
+ *
+ * Pass [maxAllocationBytes] to bound every secure allocation/wrap — a defense against
+ * resource-exhaustion (DoS) when an untrusted, length-prefixed input can reach `allocate`.
+ * Requests above the bound throw [IllegalArgumentException] before any memory is reserved.
+ * The default is unbounded ([Int.MAX_VALUE]); set it to the largest secret your protocol can
+ * legitimately hold (key material is normally well under a kilobyte):
+ * ```kotlin
+ * val secure = BufferFactory.deterministic().secure(maxAllocationBytes = 4 * 1024)
+ * secure.allocate(attackerControlledLength) // throws if length > 4096
+ * ```
+ *
+ * @param maxAllocationBytes upper bound, in bytes, on a single secure buffer. Must be >= 1.
  */
-fun BufferFactory.secure(): BufferFactory = SecureBufferFactory(this)
+fun BufferFactory.secure(maxAllocationBytes: Int = Int.MAX_VALUE): BufferFactory = SecureBufferFactory(this, maxAllocationBytes)

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/SecureBufferTest.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/SecureBufferTest.kt
@@ -75,8 +75,13 @@ class SecureBufferTest {
     }
 
     @Test
-    fun defaultCapIsUnbounded() {
-        // No cap argument == backward-compatible unbounded behavior.
-        assertTrue(BufferFactory.managed().secure().allocate(1 shl 20) is SecureBuffer)
+    fun defaultCapIsFiniteBackstop() {
+        val secure = BufferFactory.managed().secure() // default == DEFAULT_MAX_SECURE_ALLOCATION_BYTES
+        // A request above the default backstop is rejected before any allocation (no 16 MiB alloc).
+        assertFailsWith<IllegalArgumentException> {
+            secure.allocate(DEFAULT_MAX_SECURE_ALLOCATION_BYTES + 1)
+        }
+        // A normal key-material-sized allocation still succeeds.
+        assertTrue(secure.allocate(64) is SecureBuffer)
     }
 }

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/SecureBufferTest.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/SecureBufferTest.kt
@@ -4,6 +4,7 @@ import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.managed
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class SecureBufferTest {
@@ -42,5 +43,40 @@ class SecureBufferTest {
         buf.freeNativeMemory()
         buf.freeNativeMemory()
         for (i in 0 until 8) assertEquals(0, buf.get(i).toInt())
+    }
+
+    // --- DoS cap: maxAllocationBytes ---
+
+    @Test
+    fun allocateWithinCapSucceeds() {
+        val secure = BufferFactory.managed().secure(maxAllocationBytes = 64)
+        assertTrue(secure.allocate(64) is SecureBuffer)
+        assertTrue(secure.allocate(0) is SecureBuffer)
+    }
+
+    @Test
+    fun allocateAboveCapThrows() {
+        val secure = BufferFactory.managed().secure(maxAllocationBytes = 64)
+        assertFailsWith<IllegalArgumentException> { secure.allocate(65) }
+    }
+
+    @Test
+    fun wrapAboveCapThrows() {
+        val secure = BufferFactory.managed().secure(maxAllocationBytes = 4)
+        assertFailsWith<IllegalArgumentException> { secure.wrap(ByteArray(5)) }
+        // At the boundary it still succeeds.
+        assertTrue(secure.wrap(ByteArray(4)) is SecureBuffer)
+    }
+
+    @Test
+    fun nonPositiveCapIsRejected() {
+        assertFailsWith<IllegalArgumentException> { BufferFactory.managed().secure(maxAllocationBytes = 0) }
+        assertFailsWith<IllegalArgumentException> { BufferFactory.managed().secure(maxAllocationBytes = -1) }
+    }
+
+    @Test
+    fun defaultCapIsUnbounded() {
+        // No cap argument == backward-compatible unbounded behavior.
+        assertTrue(BufferFactory.managed().secure().allocate(1 shl 20) is SecureBuffer)
     }
 }


### PR DESCRIPTION
Hardens `:buffer-crypto` and the repo's CI supply chain. Three tracks:

## 1. `secure()` DoS cap (opt-in, backward-compatible)
`BufferFactory.secure(maxAllocationBytes = …)` bounds every secure `allocate`/`wrap`. An over-limit request throws `IllegalArgumentException` in common code **before any platform allocation** (byte-identical on all targets), closing the resource-exhaustion vector when an attacker-controlled length-prefix can reach `allocate()`.

- Defaults to a **16 MiB backstop** (`DEFAULT_MAX_SECURE_ALLOCATION_BYTES`) — secure-by-default; no realistic key material approaches it. Pass a tighter `maxAllocationBytes` when parsing untrusted length-prefixed input.
- 6 new `SecureBufferTest` cases (within/over cap, wrap-over-cap, non-positive cap rejected, default finite backstop). `jvmTest` + ktlint green locally.

```kotlin
val secure = BufferFactory.deterministic().secure(maxAllocationBytes = 4 * 1024)
secure.allocate(attackerControlledLength) // throws if > 4096
```

## 2. Supply-chain CI hardening
- **SHA-pinning** — all 42 third-party Action refs pinned to commit SHAs (tag kept as a comment; Dependabot updates pin + comment together).
- **Least-privilege `GITHUB_TOKEN`** — `merged.yaml` (runs on `pull_request_target`) drops from repo-wide `contents: write` to a read-only default; write granted per-job only to `check-release` (PR read) and `finalize` (tag/release/attestations). Added `contents: read` to the reusable/PR workflows that lacked a block.
- **SLSA build provenance + CycloneDX SBOM** on release (`finalize`): attests the published jars/klibs/aars, attests the SBOM, attaches the SBOM to the GitHub release. Verify with `gh attestation verify <artifact> --repo DitchOoM/buffer`.
- **`scorecard.yaml`** — OpenSSF Scorecard, weekly + push to main; SARIF to code scanning + public score.
- **`codeql.yaml`** — `security-extended`, `java-kotlin` with `build-mode: none` (avoids the fragile multiplatform Gradle autobuild), on PRs + weekly.

## 3. Threat model docs
`SECURITY.md`: new resource-exhaustion/DoS row in §3, and a new **§8 Supply-chain & build integrity** mapping the above to STRIDE Tampering + DoS at the build layer.

## Release safety
Labeled `draft-release` so the first merge stages to Sonatype as `USER_MANAGED` (reversible) **and** exercises the new SBOM/provenance/attestation steps in `finalize` — without an irreversible auto-publish. `minor` for the additive `secure()` parameter.

## Not verifiable locally
Scorecard / CodeQL / attestation / SBOM actions only run in GitHub Actions. YAML validated as parseable and all action SHAs resolve; provenance/SBOM steps are gated on `publish.result == 'success'`.
