### PR TITLE
feat(buffer-crypto): secure() + pool composition via BufferFactory.decorate

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -118,6 +118,27 @@ BufferFactory.deterministic().allocate(1024).use { buffer ->
 | WASM | LinearBuffer (already deterministic) |
 | JS | JsBuffer (GC-managed, no alternative) |
 
+## Secure Buffers (`buffer-crypto`)
+
+For repeatedly held, fixed-size key material, **`secureFixedPool(size)` is the hot-path choice** — it
+reuses pooled buffers (no native alloc/free per operation) while keeping the zero-init/wipe at
+O(size). `SecurePoolBenchmark` (alloc → write a 32-byte key → free), ops/sec, higher is better:
+
+| Strategy | JVM | macOS arm64 |
+|----------|-----|-------------|
+| `BufferFactory.deterministic()` (no secure layer, baseline) | 7,270,877 | 6,710,915 |
+| **`secureFixedPool(32)`** | **7,235,088** | **6,906,352** |
+| `deterministic().secure()` (non-pooled) | 4,216,004 | 5,453,803 |
+| secure over a 64 KiB shared pool (O(capacity) wipe) | 34,227 | 945,480 |
+
+Takeaways:
+- `secureFixedPool` matches the plain-allocation baseline — the secure layer is essentially free —
+  and is **1.7× (JVM) / 1.3× (Native)** faster than non-pooled `deterministic().secure()`. The two
+  per-op wrappers (pooled + secure) do not dominate, even on Kotlin/Native.
+- **Never pool key material in a large shared pool.** The wipe is O(capacity), so wiping a 64 KiB
+  buffer to protect a 32-byte key is 211× (JVM) / 7× (Native) slower. `BufferPool.withSecureBuffer`
+  is for convenience/correctness on an existing pool, not a hot path; reach for `secureFixedPool`.
+
 ## Running Benchmarks
 
 ### kotlinx-benchmark (JVM, JS, WasmJS, Native)

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/SecureBuffer.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/SecureBuffer.kt
@@ -86,7 +86,7 @@ internal class SecureBufferFactory(
         require(size in 0..maxAllocationBytes) {
             "secure allocation of $size bytes exceeds the configured maximum of $maxAllocationBytes"
         }
-        return SecureBuffer(zeroInit(delegate.allocate(size, byteOrder)))
+        return SecureBuffer(zeroInitBuffer(delegate.allocate(size, byteOrder)))
     }
 
     override fun wrap(
@@ -96,31 +96,70 @@ internal class SecureBufferFactory(
         require(array.size <= maxAllocationBytes) {
             "secure wrap of ${array.size} bytes exceeds the configured maximum of $maxAllocationBytes"
         }
+        // wrap takes ownership of an array whose existing contents are the secret to protect —
+        // so it does NOT zero-init (that would destroy the caller's data). The wipe still runs
+        // on free. This mirrors the difference between allocate (fresh, zeroed scratch) and
+        // wrap (adopt existing bytes).
         return SecureBuffer(delegate.wrap(array, byteOrder))
     }
 
     /**
-     * Zero-initializes the full backing of a freshly allocated buffer — the allocate-time mirror
-     * of [SecureBuffer]'s wipe-on-free. Secure scratch must be deterministically zero on every
-     * platform: crypto code (e.g. HKDF's empty-salt zero block) relies on a fresh secure buffer
-     * reading as zero, and the native Linux backing ([com.ditchoom.buffer.NativeBuffer], raw
-     * `malloc`) does not zero on its own. Zeros the whole capacity (not just `remaining()`) so no
-     * slack bytes carry prior contents, then restores the position/limit the delegate handed back
-     * so the `allocate` contract is unchanged (including pooled delegates where capacity > size).
+     * Wraps a pool-borrowed (or otherwise already-allocated) buffer in a [SecureBuffer], zeroing
+     * its full backing first. This is the allocate-equivalent for a borrowed buffer: it clears any
+     * data the previous borrower left behind (a lingering secret, or stale bytes a fresh secure
+     * allocation would never expose) before the buffer is used, and the [SecureBuffer] wipes again
+     * on free before returning the buffer to the pool.
+     *
+     * The [maxAllocationBytes] cap is intentionally NOT re-checked here: `decorate` receives an
+     * existing buffer rather than a caller-supplied length, so there is no untrusted size to bound.
+     * On the `secure().withPooling(pool)` path the requested size reaches the pool before this
+     * wrap, so that composition defers sizing to the pool — use `withPooling(pool).secure()`
+     * (secure outermost) or `.withSizeLimit(n)` when an attacker controls the length.
      */
-    private fun zeroInit(buffer: PlatformBuffer): PlatformBuffer {
-        val savedPosition = buffer.position()
-        val savedLimit = buffer.limit()
-        buffer.position(0)
-        buffer.setLimit(buffer.capacity)
-        // Byte fill, not the Int-pattern overload: the latter requires the length to be a
-        // multiple of 4 and throws otherwise (e.g. P-521's 66-byte scratch, odd sizes).
-        buffer.fill(0.toByte())
-        buffer.position(savedPosition)
-        buffer.setLimit(savedLimit)
-        return buffer
-    }
+    override fun decorate(buffer: PlatformBuffer): PlatformBuffer = SecureBuffer(zeroInitBuffer(buffer))
 }
+
+/**
+ * Zero-initializes the full backing of [buffer] — the allocate-time mirror of [SecureBuffer]'s
+ * wipe-on-free. Secure scratch must be deterministically zero on every platform: crypto code
+ * (e.g. HKDF's empty-salt zero block) relies on a fresh secure buffer reading as zero, and the
+ * native Linux backing ([com.ditchoom.buffer.NativeBuffer], raw `malloc`) does not zero on its
+ * own. Zeros the whole capacity (not just `remaining()`) so no slack bytes carry prior contents,
+ * then restores the position/limit the buffer had so the `allocate` contract is unchanged
+ * (including pooled buffers where capacity > requested size).
+ */
+internal fun zeroInitBuffer(buffer: PlatformBuffer): PlatformBuffer {
+    val savedPosition = buffer.position()
+    val savedLimit = buffer.limit()
+    buffer.position(0)
+    buffer.setLimit(buffer.capacity)
+    // Byte fill, not the Int-pattern overload: the latter requires the length to be a
+    // multiple of 4 and throws otherwise (e.g. P-521's 66-byte scratch, odd sizes).
+    buffer.fill(0.toByte())
+    buffer.position(savedPosition)
+    buffer.setLimit(savedLimit)
+    return buffer
+}
+
+/**
+ * Wraps this buffer in a [SecureBuffer] so its full backing is zeroed when it is freed — the
+ * public, à-la-carte entry point to the secure-erase behavior that [BufferFactory.secure] applies
+ * at the factory level.
+ *
+ * The wipe runs only on an explicit teardown — `use {}`, `freeNativeMemory()`, `freeIfNeeded()`,
+ * or `freeAll()` — because there is no GC finalizer hook. A buffer that is never freed is never
+ * wiped, so prefer a deterministic backing and `use {}`, or the scoped helpers
+ * [withSecureBuffer][com.ditchoom.buffer.pool.BufferPool] / [secureFixedPool] which guarantee the
+ * wipe runs:
+ * ```kotlin
+ * BufferFactory.deterministic().allocate(32).toSecureBuffer().use { key -> /* ... */ }
+ * ```
+ *
+ * @param zeroFirst if true, zero the full backing *before* returning (use when adopting a reused
+ *   or pooled buffer whose prior contents must not leak in). Defaults to false — wrapping a buffer
+ *   whose existing bytes are the secret you want protected, which must not be destroyed.
+ */
+fun PlatformBuffer.toSecureBuffer(zeroFirst: Boolean = false): PlatformBuffer = SecureBuffer(if (zeroFirst) zeroInitBuffer(this) else this)
 
 /**
  * Returns a factory whose buffers zero their backing storage when freed (see [SecureBuffer]).

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/SecureBuffer.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/SecureBuffer.kt
@@ -159,7 +159,9 @@ internal fun zeroInitBuffer(buffer: PlatformBuffer): PlatformBuffer {
  *   or pooled buffer whose prior contents must not leak in). Defaults to false — wrapping a buffer
  *   whose existing bytes are the secret you want protected, which must not be destroyed.
  */
-fun PlatformBuffer.toSecureBuffer(zeroFirst: Boolean = false): PlatformBuffer = SecureBuffer(if (zeroFirst) zeroInitBuffer(this) else this)
+fun PlatformBuffer.toSecureBuffer(zeroFirst: Boolean = false): PlatformBuffer = SecureBuffer(zeroInitIf(zeroFirst))
+
+private fun PlatformBuffer.zeroInitIf(zero: Boolean): PlatformBuffer = if (zero) zeroInitBuffer(this) else this
 
 /**
  * Returns a factory whose buffers zero their backing storage when freed (see [SecureBuffer]).

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/SecurePool.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/SecurePool.kt
@@ -1,0 +1,91 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.deterministic
+import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.buffer.pool.ThreadingMode
+import com.ditchoom.buffer.withPooling
+
+/**
+ * Borrows a buffer from this pool, hands the block a [secure][toSecureBuffer] view of it, and
+ * guarantees the backing is wiped before the buffer returns to the pool.
+ *
+ * This is the instance-level "borrow and upgrade" path: the buffer is acquired from the pool,
+ * zero-initialized (so no secret a previous borrower left behind leaks in), used inside [block],
+ * then wiped and released back to the pool. Because the wipe runs in the `finally`, it happens on
+ * every exit including exceptions — unlike a bare [toSecureBuffer], which only wipes if the caller
+ * remembers to free.
+ *
+ * Prefer this (or [secureFixedPool]) over pooling key material by hand: a general pool reuses
+ * buffers, so a secret written into a pooled buffer would otherwise linger in the pool's free list
+ * for the next, possibly unrelated, borrower to read.
+ *
+ * ```kotlin
+ * pool.withSecureBuffer(32) { key ->
+ *     deriveKeyInto(key)
+ *     encrypt(message, key)
+ * } // key zeroed, buffer returned to pool
+ * ```
+ *
+ * **Wipe cost is O(capacity), not O(minSize).** A shared pool hands out its largest cached buffer,
+ * so `withSecureBuffer(32)` on a 64 KiB pool wipes 64 KiB. For hot, fixed-size key material use a
+ * dedicated [secureFixedPool] where capacity == size, so the wipe is O(size) and reuse is perfect.
+ *
+ * @param minSize minimum capacity to borrow
+ * @param block runs against the secure view; do not let the buffer escape the block
+ */
+inline fun <T> BufferPool.withSecureBuffer(
+    minSize: Int = 0,
+    block: (PlatformBuffer) -> T,
+): T {
+    val pooled = acquire(minSize) as PlatformBuffer
+    val secure = pooled.toSecureBuffer(zeroFirst = true)
+    return try {
+        block(secure)
+    } finally {
+        // SecureBuffer.freeNativeMemory wipes the full backing, then the underlying PooledBuffer
+        // returns the (now-zeroed) raw buffer to the pool via its reference count.
+        secure.freeNativeMemory()
+    }
+}
+
+/**
+ * A [BufferFactory] for hot, fixed-size cryptographic buffers: every allocation borrows a buffer
+ * from a dedicated pool and wraps it secure, so freeing it wipes the backing and returns it to the
+ * pool for reuse — no native malloc/free per operation, and the wipe stays O([bufferSize]).
+ *
+ * Because the pool is homogeneous (every buffer is [bufferSize]) reuse is perfect, and since the
+ * whole buffer is the secret the whole-buffer wipe has no "did I bound it right" risk. This is the
+ * recommended shape for repeatedly deriving/holding same-size key material:
+ *
+ * ```kotlin
+ * val keyPool = secureFixedPool(bufferSize = 32)
+ * keyPool.allocate(32).use { key ->     // borrowed + zeroed
+ *     deriveKeyInto(key)
+ *     encrypt(message, key)
+ * }                                      // wiped, returned to the pool
+ * ```
+ *
+ * The secure layer wraps the pool-borrowed buffer (via [BufferFactory.decorate]), so the buffer
+ * cached in the pool is the plain backing — no [SecureBuffer] wrapper lingers between borrows.
+ *
+ * @param bufferSize the fixed capacity, in bytes, of every buffer in the pool
+ * @param maxPoolSize maximum number of buffers the pool retains
+ * @param threadingMode [ThreadingMode.SingleThreaded] (default, fastest) or
+ *   [ThreadingMode.MultiThreaded] for concurrent access
+ * @param base the underlying allocation strategy for the pool's buffers; defaults to
+ *   [deterministic][BufferFactory.Companion.deterministic] so the wipe is guaranteed to run
+ */
+fun secureFixedPool(
+    bufferSize: Int,
+    maxPoolSize: Int = 64,
+    threadingMode: ThreadingMode = ThreadingMode.SingleThreaded,
+    base: BufferFactory = BufferFactory.deterministic(),
+): BufferFactory {
+    require(bufferSize >= 1) { "bufferSize must be >= 1, was $bufferSize" }
+    val pool = BufferPool(threadingMode, maxPoolSize, defaultBufferSize = bufferSize, factory = base)
+    // secure() is the delegate; withPooling borrows from `pool` and applies secure().decorate()
+    // to the borrowed buffer → SecureBuffer(zeroInit(pooled)), wipe-then-return-to-pool on free.
+    return base.secure(maxAllocationBytes = bufferSize).withPooling(pool)
+}

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/SecurePoolTest.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/SecurePoolTest.kt
@@ -1,0 +1,250 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.managed
+import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.buffer.withPooling
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class SecurePoolTest {
+    // A managed (heap) delegate keeps the raw backing readable AFTER it returns to the pool
+    // (managed free is a GC no-op), so a test can inspect what the wipe left behind. The factory
+    // also records every raw buffer it hands the pool, so a test can read the exact backing the
+    // PooledBuffer wraps — the SecureBuffer/PooledBuffer wrappers throw after free, the raw does not.
+    private class CapturingFactory(
+        private val delegate: BufferFactory = BufferFactory.managed(),
+    ) : BufferFactory {
+        val allocated = mutableListOf<PlatformBuffer>()
+
+        override fun allocate(
+            size: Int,
+            byteOrder: ByteOrder,
+        ): PlatformBuffer = delegate.allocate(size, byteOrder).also { allocated += it }
+
+        override fun wrap(
+            array: ByteArray,
+            byteOrder: ByteOrder,
+        ): PlatformBuffer = delegate.wrap(array, byteOrder).also { allocated += it }
+    }
+
+    private fun PlatformBuffer.writeAllFF(n: Int) = repeat(n) { writeByte(0xFF.toByte()) }
+
+    private fun PlatformBuffer.assertAllZero(n: Int) {
+        for (i in 0 until n) assertEquals(0, get(i).toInt(), "byte $i not wiped")
+    }
+
+    // --- The headline fix: both composition orders wipe-then-return-to-pool ---
+
+    @Test
+    fun secureInnermostPooled_wipesAndReturnsToPool() {
+        val raws = CapturingFactory()
+        val pool = BufferPool(defaultBufferSize = 16, factory = raws)
+        // secure() is the delegate; withPooling borrows from the pool and decorates the borrow.
+        val factory = BufferFactory.managed().secure().withPooling(pool)
+
+        val buf = factory.allocate(16)
+        assertTrue(buf is SecureBuffer, "borrowed buffer should be secure-wrapped")
+        buf.writeAllFF(16)
+        buf.freeNativeMemory()
+
+        assertEquals(1, raws.allocated.size, "exactly one raw buffer should have been allocated")
+        raws.allocated[0].assertAllZero(16)
+        assertEquals(1, pool.stats().currentPoolSize, "wiped buffer should be back in the pool")
+    }
+
+    @Test
+    fun secureOutermostPooled_wipesAndReturnsToPool() {
+        val raws = CapturingFactory()
+        val pool = BufferPool(defaultBufferSize = 16, factory = raws)
+        // Opposite order: pool first, then secure on the outside.
+        val factory = BufferFactory.managed().withPooling(pool).secure()
+
+        val buf = factory.allocate(16)
+        assertTrue(buf is SecureBuffer, "borrowed buffer should be secure-wrapped")
+        buf.writeAllFF(16)
+        buf.freeNativeMemory()
+
+        assertEquals(1, raws.allocated.size)
+        raws.allocated[0].assertAllZero(16)
+        assertEquals(1, pool.stats().currentPoolSize)
+    }
+
+    @Test
+    fun bothOrders_reuseTheSamePooledBacking() {
+        // Prove the buffer actually returns to the pool and is reused (pool hit), not re-allocated.
+        val raws = CapturingFactory()
+        val pool = BufferPool(defaultBufferSize = 16, factory = raws)
+        val factory = BufferFactory.managed().secure().withPooling(pool)
+
+        factory.allocate(16).also { it.writeAllFF(16) }.freeNativeMemory()
+        factory.allocate(16).freeNativeMemory()
+
+        assertEquals(1, raws.allocated.size, "second allocation should reuse the pooled backing, not allocate")
+        assertTrue(pool.stats().poolHits >= 1, "second acquire should be a pool hit")
+    }
+
+    // --- decorate() semantics ---
+
+    @Test
+    fun decorate_zeroInitsTheBorrowedBuffer() {
+        val raw = BufferFactory.managed().allocate(16)
+        raw.writeAllFF(16)
+        val secure = BufferFactory.managed().secure().decorate(raw)
+        assertTrue(secure is SecureBuffer)
+        secure.assertAllZero(16) // zero-init cleared the prior contents
+    }
+
+    @Test
+    fun decorate_defaultIsIdentityOnNonWrappingFactories() {
+        val raw = BufferFactory.managed().allocate(8)
+        assertSame(raw, BufferFactory.managed().decorate(raw))
+        assertSame(raw, BufferFactory.Default.decorate(raw))
+    }
+
+    // --- non-secure pooling is unchanged (decorate == identity) ---
+
+    @Test
+    fun nonSecurePooling_isNotWrappedAndNotWiped() {
+        val raws = CapturingFactory()
+        val pool = BufferPool(defaultBufferSize = 16, factory = raws)
+        val factory = BufferFactory.managed().withPooling(pool)
+
+        val buf = factory.allocate(16)
+        assertFalse(buf is SecureBuffer, "plain pooling must not secure-wrap")
+        buf.writeAllFF(16)
+        buf.freeNativeMemory()
+
+        // No secure layer → no wipe; the bytes survive in the pooled backing.
+        assertEquals(1, raws.allocated.size)
+        assertEquals(0xFF, raws.allocated[0].get(0).toInt() and 0xFF)
+        assertEquals(1, pool.stats().currentPoolSize, "plain pooling still returns to the pool")
+    }
+
+    // --- byte-order-mismatch fallback still decorates (allocates fresh secure, non-pooled) ---
+
+    @Test
+    fun byteOrderMismatch_fallsBackToFreshSecureBuffer() {
+        val raws = CapturingFactory()
+        // Pool hands out BIG_ENDIAN buffers; request LITTLE_ENDIAN to force the fallback path.
+        val pool = BufferPool(defaultBufferSize = 16, factory = raws)
+        val factory = BufferFactory.managed().secure().withPooling(pool)
+
+        val buf = factory.allocate(16, ByteOrder.LITTLE_ENDIAN)
+        assertTrue(buf is SecureBuffer, "fallback path must still be secure")
+        assertEquals(ByteOrder.LITTLE_ENDIAN, buf.byteOrder)
+    }
+
+    // --- documented cap asymmetry between the two orders ---
+
+    @Test
+    fun capAsymmetry_secureOutermostEnforces_innermostDefers() {
+        // secure() innermost: the requested size reaches the pool before the secure wrap, so the
+        // cap is NOT applied to the pooled path (sizing is deferred to the pool).
+        val innermost =
+            BufferFactory
+                .managed()
+                .secure(maxAllocationBytes = 64)
+                .withPooling(BufferPool(defaultBufferSize = 16, factory = BufferFactory.managed()))
+        innermost.allocate(128).freeNativeMemory() // does not throw
+
+        // secure() outermost: the cap is enforced before delegating to the pool.
+        val outermost =
+            BufferFactory
+                .managed()
+                .withPooling(BufferPool(defaultBufferSize = 16, factory = BufferFactory.managed()))
+                .secure(maxAllocationBytes = 64)
+        assertFailsWith<IllegalArgumentException> { outermost.allocate(128) }
+    }
+
+    // --- withSecureBuffer ---
+
+    @Test
+    fun withSecureBuffer_zeroInitsWipesAndReturns() {
+        val raws = CapturingFactory()
+        val pool = BufferPool(defaultBufferSize = 16, factory = raws)
+
+        pool.withSecureBuffer(16) { buf ->
+            buf.assertAllZero(16) // zero-init on borrow
+            buf.writeAllFF(16)
+        }
+
+        assertEquals(1, raws.allocated.size)
+        raws.allocated[0].assertAllZero(16) // wiped on the way back to the pool
+        assertEquals(1, pool.stats().currentPoolSize)
+
+        // Second borrow reuses the same wiped backing.
+        pool.withSecureBuffer(16) { /* no-op */ }
+        assertEquals(1, raws.allocated.size)
+        assertTrue(pool.stats().poolHits >= 1)
+    }
+
+    @Test
+    fun withSecureBuffer_wipesEvenWhenBlockThrows() {
+        val raws = CapturingFactory()
+        val pool = BufferPool(defaultBufferSize = 16, factory = raws)
+
+        assertFailsWith<IllegalStateException> {
+            pool.withSecureBuffer(16) { buf ->
+                buf.writeAllFF(16)
+                throw IllegalStateException("boom")
+            }
+        }
+        raws.allocated[0].assertAllZero(16) // finally{} wiped despite the exception
+    }
+
+    // --- secureFixedPool ---
+
+    @Test
+    fun secureFixedPool_wipesReusesAndStaysFixedSize() {
+        val raws = CapturingFactory()
+        val factory = secureFixedPool(bufferSize = 16, base = raws)
+
+        val first = factory.allocate(16)
+        assertTrue(first is SecureBuffer)
+        assertEquals(16, first.capacity)
+        first.writeAllFF(16)
+        first.freeNativeMemory()
+        raws.allocated[0].assertAllZero(16)
+
+        // Reuse: a second fixed-size allocation does not allocate a new backing.
+        factory.allocate(16).freeNativeMemory()
+        assertEquals(1, raws.allocated.size, "fixed pool should reuse the single backing")
+    }
+
+    @Test
+    fun secureFixedPool_rejectsNonPositiveSize() {
+        assertFailsWith<IllegalArgumentException> { secureFixedPool(bufferSize = 0) }
+    }
+
+    // --- toSecureBuffer extension ---
+
+    @Test
+    fun toSecureBuffer_preservesContentsByDefault_zeroFirstClears() {
+        val keep = BufferFactory.managed().allocate(8)
+        keep.writeAllFF(8)
+        val preserved = keep.toSecureBuffer()
+        assertEquals(0xFF, preserved.get(0).toInt() and 0xFF)
+
+        val dirty = BufferFactory.managed().allocate(8)
+        dirty.writeAllFF(8)
+        val cleared = dirty.toSecureBuffer(zeroFirst = true)
+        cleared.assertAllZero(8)
+    }
+
+    @Test
+    fun toSecureBuffer_wipesOnFree() {
+        val raw = BufferFactory.managed().allocate(8)
+        val secure = raw.toSecureBuffer()
+        repeat(8) { secure.writeByte(0xFF.toByte()) }
+        secure.freeNativeMemory()
+        raw.assertAllZero(8) // raw is the managed backing, still readable post-free
+    }
+}

--- a/buffer/build.gradle.kts
+++ b/buffer/build.gradle.kts
@@ -535,6 +535,13 @@ benchmark {
             iterations = 2
             include("BufferBaseline")
         }
+        register("securePool") {
+            warmups = 3
+            iterations = 5
+            iterationTime = 500
+            iterationTimeUnit = "ms"
+            include("SecurePool")
+        }
     }
 }
 

--- a/buffer/src/commonBenchmark/kotlin/com/ditchoom/buffer/benchmark/SecurePoolBenchmark.kt
+++ b/buffer/src/commonBenchmark/kotlin/com/ditchoom/buffer/benchmark/SecurePoolBenchmark.kt
@@ -1,0 +1,144 @@
+package com.ditchoom.buffer.benchmark
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.deterministic
+import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.buffer.withPooling
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.BenchmarkMode
+import kotlinx.benchmark.BenchmarkTimeUnit
+import kotlinx.benchmark.Measurement
+import kotlinx.benchmark.Mode
+import kotlinx.benchmark.OutputTimeUnit
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+import kotlinx.benchmark.Warmup
+
+/**
+ * Measures the per-operation cost of holding small, fixed-size key material in a secure buffer,
+ * to decide whether secure-pooling actually pays off versus a plain non-pooled secure allocation.
+ *
+ * The cost drivers are pure buffer-mechanism — wrapper allocation, double delegation, and the
+ * zero-init/wipe memset — so this uses a [WipeFactory]/[WipeBuffer] stand-in that mirrors the real
+ * `buffer-crypto` `SecureBufferFactory`/`SecureBuffer` exactly (zero-init on allocate/decorate,
+ * full-capacity `fill(0)` on free). The crypto module has no benchmark harness and can't be
+ * depended on from here (it depends on `:buffer`), so a faithful stand-in is the only way to get
+ * these numbers on the existing multi-platform harness.
+ *
+ * Compared per op (allocate → write a 32-byte "key" → free):
+ *  - [secureDeterministic]: non-pooled `deterministic().secure()` — one wrapper + native
+ *    alloc/free each op + O(32) wipe.
+ *  - [secureFixedPool]: `secureFixedPool(32)` — two wrappers (pooled + secure), NO native
+ *    alloc/free (perfect reuse), O(32) wipe.
+ *  - [secureSharedPool]: secure over a large shared pool (the `withSecureBuffer` cost) — two
+ *    wrappers, no alloc/free, but O(64 KiB) wipe because the wipe is O(capacity).
+ *  - [plainDeterministic]: baseline with no secure layer, to isolate the wrapper+wipe overhead.
+ *
+ * A secure `ScopedBuffer` (zero per-op wrappers) would be the ceiling for the hottest paths, but
+ * the scoped-buffer API is not on this branch, so it is out of scope here.
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(BenchmarkTimeUnit.SECONDS)
+open class SecurePoolBenchmark {
+    private val keySize = 32
+    private val sharedSize = 64 * 1024
+
+    private lateinit var secureDeterministic: BufferFactory
+    private lateinit var secureFixedPool: BufferFactory
+    private lateinit var secureSharedPool: BufferFactory
+    private lateinit var plainDeterministic: BufferFactory
+
+    @Setup
+    fun setup() {
+        secureDeterministic = WipeFactory(BufferFactory.deterministic())
+        secureFixedPool =
+            WipeFactory(BufferFactory.deterministic())
+                .withPooling(BufferPool(defaultBufferSize = keySize, factory = BufferFactory.deterministic()))
+        secureSharedPool =
+            WipeFactory(BufferFactory.Default)
+                .withPooling(BufferPool(defaultBufferSize = sharedSize, factory = BufferFactory.Default))
+        plainDeterministic = BufferFactory.deterministic()
+    }
+
+    /** Writes a 32-byte "key", reads one long back (defeats DCE), frees. */
+    private inline fun cycle(factory: BufferFactory): Long {
+        val buf = factory.allocate(keySize)
+        buf.writeLong(0x0102030405060708L)
+        buf.writeLong(0x1112131415161718L)
+        buf.writeLong(0x2122232425262728L)
+        buf.writeLong(0x3132333435363738L)
+        buf.position(0)
+        val first = buf.readLong()
+        buf.freeNativeMemory()
+        return first
+    }
+
+    @Benchmark
+    fun secureDeterministicCycle(): Long = cycle(secureDeterministic)
+
+    @Benchmark
+    fun secureFixedPoolCycle(): Long = cycle(secureFixedPool)
+
+    @Benchmark
+    fun secureSharedPoolCycle(): Long = cycle(secureSharedPool)
+
+    @Benchmark
+    fun plainDeterministicCycle(): Long = cycle(plainDeterministic)
+}
+
+/**
+ * Stand-in for `buffer-crypto`'s `SecureBuffer`: zeroes its full backing on free. Mirrors the real
+ * class's cost (one wrapper allocation + double delegation + an O(capacity) `fill(0)` memset).
+ */
+private class WipeBuffer(
+    private val inner: PlatformBuffer,
+) : PlatformBuffer by inner {
+    private var wiped = false
+
+    override fun freeNativeMemory() {
+        if (!wiped) {
+            wiped = true
+            inner.position(0)
+            inner.setLimit(inner.capacity)
+            inner.fill(0.toByte())
+        }
+        inner.freeNativeMemory()
+    }
+
+    override fun slice(byteOrder: ByteOrder): PlatformBuffer = inner.slice(byteOrder)
+}
+
+/** Stand-in for `SecureBufferFactory` — zero-inits on allocate/decorate, wraps in [WipeBuffer]. */
+private class WipeFactory(
+    private val delegate: BufferFactory,
+) : BufferFactory {
+    override fun allocate(
+        size: Int,
+        byteOrder: ByteOrder,
+    ): PlatformBuffer = WipeBuffer(zeroInit(delegate.allocate(size, byteOrder)))
+
+    override fun wrap(
+        array: ByteArray,
+        byteOrder: ByteOrder,
+    ): PlatformBuffer = WipeBuffer(delegate.wrap(array, byteOrder))
+
+    override fun decorate(buffer: PlatformBuffer): PlatformBuffer = WipeBuffer(zeroInit(buffer))
+
+    private fun zeroInit(buffer: PlatformBuffer): PlatformBuffer {
+        val savedPosition = buffer.position()
+        val savedLimit = buffer.limit()
+        buffer.position(0)
+        buffer.setLimit(buffer.capacity)
+        buffer.fill(0.toByte())
+        buffer.position(savedPosition)
+        buffer.setLimit(savedLimit)
+        return buffer
+    }
+}

--- a/buffer/src/commonBenchmark/kotlin/com/ditchoom/buffer/benchmark/SecurePoolBenchmark.kt
+++ b/buffer/src/commonBenchmark/kotlin/com/ditchoom/buffer/benchmark/SecurePoolBenchmark.kt
@@ -50,6 +50,12 @@ open class SecurePoolBenchmark {
     private val keySize = 32
     private val sharedSize = 64 * 1024
 
+    // Four distinct 8-byte lanes that fill the 32-byte test "key" — arbitrary non-zero patterns.
+    private val keyLane0 = 0x0102030405060708L
+    private val keyLane1 = 0x1112131415161718L
+    private val keyLane2 = 0x2122232425262728L
+    private val keyLane3 = 0x3132333435363738L
+
     private lateinit var secureDeterministic: BufferFactory
     private lateinit var secureFixedPool: BufferFactory
     private lateinit var secureSharedPool: BufferFactory
@@ -70,10 +76,10 @@ open class SecurePoolBenchmark {
     /** Writes a 32-byte "key", reads one long back (defeats DCE), frees. */
     private inline fun cycle(factory: BufferFactory): Long {
         val buf = factory.allocate(keySize)
-        buf.writeLong(0x0102030405060708L)
-        buf.writeLong(0x1112131415161718L)
-        buf.writeLong(0x2122232425262728L)
-        buf.writeLong(0x3132333435363738L)
+        buf.writeLong(keyLane0)
+        buf.writeLong(keyLane1)
+        buf.writeLong(keyLane2)
+        buf.writeLong(keyLane3)
         buf.position(0)
         val first = buf.readLong()
         buf.freeNativeMemory()

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/BufferFactoryInterface.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/BufferFactoryInterface.kt
@@ -94,6 +94,30 @@ interface BufferFactory {
         byteOrder: ByteOrder = ByteOrder.BIG_ENDIAN,
     ): PlatformBuffer
 
+    /**
+     * Wraps an **already-allocated** [buffer] in this factory's per-buffer decoration, if any.
+     *
+     * The default is the identity function: most factories add their behavior at allocation
+     * time and have nothing to layer onto a pre-existing buffer. Only *wrapping* decorators —
+     * factories whose contribution is a [PlatformBuffer] wrapper rather than an allocation
+     * strategy — override this. The canonical example is the secure-erase factory, whose
+     * `decorate` returns a wrapper that zeroes the backing on free.
+     *
+     * This exists so a wrapping decorator's behavior is preserved even when the buffer does
+     * not come from its own `allocate`. In particular [withPooling] borrows a buffer from a
+     * pool and then calls `delegate.decorate(borrowed)`, so `secure().withPooling(pool)` and
+     * `withPooling(pool).secure()` both yield a secure-wrapped pooled buffer (wipe-on-free,
+     * then return-to-pool) — the composition order stops mattering.
+     *
+     * Contract: `decorate` must **wrap an existing buffer, never allocate**. Transparent
+     * decorators that add no per-buffer wrapper should forward to their delegate's `decorate`
+     * so an inner wrapping decorator still gets a chance to wrap.
+     *
+     * @param buffer an existing buffer to decorate
+     * @return [buffer] wrapped in this factory's decoration, or [buffer] unchanged
+     */
+    fun decorate(buffer: PlatformBuffer): PlatformBuffer = buffer
+
     companion object
 }
 
@@ -289,6 +313,9 @@ internal class RequiringFactory(
         }
         return buffer
     }
+
+    // Transparent decorator: forward so an inner wrapping decorator (e.g. secure()) can wrap.
+    override fun decorate(buffer: PlatformBuffer): PlatformBuffer = delegate.decorate(buffer)
 }
 
 @PublishedApi
@@ -326,6 +353,9 @@ internal class PreferringFactory(
         array: ByteArray,
         byteOrder: ByteOrder,
     ): PlatformBuffer = delegate.wrap(array, byteOrder)
+
+    // Transparent decorator: forward so an inner wrapping decorator (e.g. secure()) can wrap.
+    override fun decorate(buffer: PlatformBuffer): PlatformBuffer = delegate.decorate(buffer)
 }
 
 internal class SizeLimitedFactory(
@@ -351,6 +381,10 @@ internal class SizeLimitedFactory(
         }
         return delegate.wrap(array, byteOrder)
     }
+
+    // Transparent decorator: the size guard is allocation-time only; forward so an inner
+    // wrapping decorator (e.g. secure()) can wrap a borrowed buffer.
+    override fun decorate(buffer: PlatformBuffer): PlatformBuffer = delegate.decorate(buffer)
 }
 
 internal class PoolingFactory(
@@ -362,8 +396,15 @@ internal class PoolingFactory(
         byteOrder: ByteOrder,
     ): PlatformBuffer {
         val buffer = pool.acquire(size)
-        if (buffer is PlatformBuffer && buffer.byteOrder == byteOrder) return buffer
-        // Byte order mismatch or not a PlatformBuffer — release back and allocate fresh
+        // Apply the delegate's per-buffer decoration to the pool-borrowed buffer. For a plain
+        // delegate this is identity; for a wrapping delegate like secure() it returns e.g.
+        // SecureBuffer(zeroInit(pooled)) so freeNativeMemory() wipes the buffer *then* returns
+        // it to the pool. This makes secure().withPooling(pool) wipe correctly — the secure
+        // layer no longer has to be the outermost factory.
+        if (buffer is PlatformBuffer && buffer.byteOrder == byteOrder) return delegate.decorate(buffer)
+        // Byte order mismatch or not a PlatformBuffer — release back and allocate fresh.
+        // delegate.allocate already applies the delegate's decoration (e.g. secure-wraps),
+        // so this fallback path is decorated too; just not pooled.
         pool.release(buffer)
         return delegate.allocate(size, byteOrder)
     }
@@ -372,4 +413,8 @@ internal class PoolingFactory(
         array: ByteArray,
         byteOrder: ByteOrder,
     ): PlatformBuffer = delegate.wrap(array, byteOrder)
+
+    // A pool cannot pool an externally-owned buffer, so decoration is the delegate's only
+    // contribution here — forward it. (PoolingFactory itself adds no per-buffer wrapper.)
+    override fun decorate(buffer: PlatformBuffer): PlatformBuffer = delegate.decorate(buffer)
 }


### PR DESCRIPTION
## Why

`secure().withPooling(pool)` (secure innermost) **silently bypassed the wipe**: `PoolingFactory.allocate` borrowed from the pool's own factory and ignored the secure delegate, so the `SecureBuffer` wrapper was never applied and key material returned to the pool un-wiped. The other order (`withPooling(pool).secure()`) worked. This fixes the footgun **by construction** rather than guarding against the order.

This is deferred follow-up #3 from the buffer-crypto supply-chain hardening effort (after #217 / 5.14.0).

## What

**Core (`:buffer`)**
- Add `BufferFactory.decorate(buffer): PlatformBuffer = buffer` (default identity). Only *wrapping* decorators override it; transparent decorators (`SizeLimited`/`Requiring`/`Preferring`) forward to their delegate.
- `PoolingFactory.allocate` now applies `delegate.decorate()` to the pool-borrowed buffer (and on the byte-order-match path). So **both** `secure().withPooling(pool)` and `withPooling(pool).secure()` collapse to `SecureBuffer(zeroInit(pooledBuffer))` → wipe-then-return-to-pool, **order-independent**. Non-secure pooling is byte-identical (`decorate == identity`).

**Secure layer (`:buffer-crypto`)**
- `SecureBufferFactory.decorate` zero-inits + secure-wraps; extracted reusable `zeroInitBuffer`.
- Public `PlatformBuffer.toSecureBuffer(zeroFirst = false)` — à-la-carte secure-wrap entry (the `SecureBuffer` ctor stays internal).
- `BufferPool.withSecureBuffer(minSize) { }` — borrow → secure (zero-init) → block → wipe + return-to-pool (wipes even on exception).
- `secureFixedPool(bufferSize)` — dedicated fixed-size secure pool: O(size) wipe, perfect reuse. The hot-path recommendation.

**Documented cap asymmetry:** the `secure()`-innermost pooled path defers sizing to the pool (the `maxAllocationBytes` DoS cap is enforced on the `secure()`-outermost order, or via `.withSizeLimit(n)`). Covered by a test.

## Benchmarks drove the design

`SecurePoolBenchmark` (alloc → write a 32-byte key → free), ops/sec, higher is better:

| Strategy | JVM | macOS arm64 |
|----------|-----|-------------|
| `deterministic()` (no secure, baseline) | 7,270,877 | 6,710,915 |
| **`secureFixedPool(32)`** | **7,235,088** | **6,906,352** |
| `deterministic().secure()` (non-pooled) | 4,216,004 | 5,453,803 |
| secure over a 64 KiB shared pool (O(capacity) wipe) | 34,227 | 945,480 |

- `secureFixedPool` **matches the plain-allocation baseline** on both platforms (the secure layer is essentially free) and beats non-pooled `deterministic().secure()` by **1.7× (JVM) / 1.3× (Native)**. The predicted Kotlin/Native penalty from the two per-op wrappers (pooled + secure) **does not materialize**.
- **Conclusion: no secure `ScopedBuffer` variant is warranted** — there's nothing for it to fix. (The `ScopedBuffer` API isn't on `main` regardless.) Left as a future option if a real workload ever shows wrapper churn dominating.
- The shared-pool row (211× / 7× slower) empirically justifies preferring `secureFixedPool` over `withSecureBuffer`-on-a-big-pool for hot paths. Documented in `PERFORMANCE.md`.

## Tests

16 new tests in `SecurePoolTest` (both orders wipe + reuse; `decorate` zero-inits / default identity; non-secure pooling unregressed; byte-order fallback stays secure; cap asymmetry; `withSecureBuffer` wipes-on-throw; `toSecureBuffer` preserve-vs-zero semantics + wipe-on-free). A capturing factory exposes the raw pooled backing post-free to assert the wipe. Existing `:buffer` factory/pool/wrapper suites and full `:buffer:jvmTest` / `:buffer-crypto:jvmTest` green. Benchmark verified on JVM + macosArm64; compiles on JS/WASM.

## Notes
- New public API ⇒ `minor`.
- Does **not** touch `build.gradle.kts` root or CI, so no conflict with the parallel docs (#219) / CI (#220) PRs.