### PR TITLE
feat(buffer-crypto): CryptoCapabilities feature-detection facade

### DIFF
--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/CryptoCapabilities.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/CryptoCapabilities.kt
@@ -1,0 +1,80 @@
+package com.ditchoom.buffer.crypto
+
+/**
+ * One discoverable surface for the per-platform crypto capability flags that are otherwise spread
+ * across [Aead], [Signatures], [KeyAgreement], and [Hpke]. Every member here is a thin alias over
+ * an existing `supports*` declaration — the underlying `expect val`s remain the source of truth;
+ * this only gathers them so a caller can branch on availability (and pick the synchronous vs
+ * `suspend` path) from a single place.
+ *
+ * Availability has **two axes**:
+ *  - [AeadAvailability.anyPath] / "available at all": the primitive works on this platform via
+ *    *some* path — a synchronous call or a `suspend` `*Async` call. WebCrypto primitives on
+ *    JS/WASM are async-only, so they are `anyPath = true` but `sync = false`.
+ *  - [AeadAvailability.sync] / the `*Sync` booleans: a synchronous (non-`suspend`) entry point
+ *    exists. When sync is `false` but the primitive is available, use the `*Async` variant.
+ *
+ * ```kotlin
+ * // AEAD: prefer the sync one-shot, fall back to the async path where only that exists (web).
+ * val sealed =
+ *     if (CryptoCapabilities.aesGcm.sync) aesGcmSeal(key, nonce, plaintext, dest)
+ *     else aesGcmSealAsync(key, nonce, plaintext, dest)
+ *
+ * // HPKE: check the whole suite before use.
+ * if (CryptoCapabilities.hpke(suite)) { /* setup sender/receiver */ }
+ * ```
+ */
+object CryptoCapabilities {
+    /**
+     * Availability of an AEAD primitive.
+     *
+     * @property sync a synchronous one-shot entry point exists on this platform
+     * @property anyPath the primitive is usable via some path — synchronous or `suspend` async
+     */
+    data class AeadAvailability internal constructor(
+        val sync: Boolean,
+        val anyPath: Boolean,
+    )
+
+    /**
+     * AES-GCM (128/256-bit). Synchronous on JVM/Android/Apple; async-only on JS/WASM (WebCrypto's
+     * `SubtleCrypto` is `suspend`) — so [AeadAvailability.anyPath] is `true` everywhere but
+     * [AeadAvailability.sync] is `false` on the web.
+     */
+    val aesGcm: AeadAvailability = AeadAvailability(sync = supportsSyncAesGcm, anyPath = supportsAesGcmAnyPath)
+
+    /**
+     * ChaCha20-Poly1305. Not part of WebCrypto and never polyfilled, so it is unavailable on
+     * JS/WASM by **either** path ([AeadAvailability.anyPath] is `false` there); elsewhere it is
+     * synchronous.
+     */
+    val chaChaPoly: AeadAvailability = AeadAvailability(sync = supportsSyncChaChaPoly, anyPath = supportsChaChaPoly)
+
+    /** Availability of the AEAD named by an HPKE [aead] id. */
+    fun aead(aead: HpkeAead): AeadAvailability =
+        when (aead) {
+            HpkeAead.Aes128Gcm, HpkeAead.Aes256Gcm -> aesGcm
+            HpkeAead.ChaCha20Poly1305 -> chaChaPoly
+        }
+
+    /**
+     * Whether Ed25519 sign/verify is available synchronously (JVM 15+, Apple, Android API 34+).
+     * `false` on JS/WASM (use the `*Async` sign/verify there).
+     */
+    val ed25519Sync: Boolean get() = supportsSyncEd25519
+
+    /** Whether ECDSA sign/verify over the NIST P-curves is available synchronously. */
+    val ecdsaSync: Boolean get() = supportsSyncEcdsa
+
+    /**
+     * Whether ECDSA **signing from a bare private scalar** is supported (`false` on Apple, which
+     * needs the full X9.63 private representation). ECDSA *verification* is available regardless.
+     */
+    val ecdsaSigningFromScalar: Boolean get() = supportsEcdsaSigningFromScalar
+
+    /** Whether key agreement over [curve] (X25519 / P-256 / P-384 / P-521) has a synchronous path here. */
+    fun keyAgreementSync(curve: KeyAgreementCurve): Boolean = supportsSync(curve)
+
+    /** Whether the HPKE [suite] is usable on this platform — its KEM curve and AEAD are both available. */
+    fun hpke(suite: HpkeSuite): Boolean = hpkeSupported(suite)
+}

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/CryptoCapabilitiesTest.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/CryptoCapabilitiesTest.kt
@@ -1,0 +1,44 @@
+package com.ditchoom.buffer.crypto
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The facade must stay a faithful alias of the underlying `supports*` source-of-truth flags — these
+ * assertions fail if the two ever drift apart, on whatever platform the suite runs.
+ */
+class CryptoCapabilitiesTest {
+    @Test
+    fun aesGcmMirrorsUnderlyingFlags() {
+        assertEquals(supportsSyncAesGcm, CryptoCapabilities.aesGcm.sync)
+        assertEquals(supportsAesGcmAnyPath, CryptoCapabilities.aesGcm.anyPath)
+    }
+
+    @Test
+    fun chaChaPolyMirrorsUnderlyingFlags() {
+        assertEquals(supportsSyncChaChaPoly, CryptoCapabilities.chaChaPoly.sync)
+        assertEquals(supportsChaChaPoly, CryptoCapabilities.chaChaPoly.anyPath)
+    }
+
+    @Test
+    fun aeadDispatchMapsToTheRightPrimitive() {
+        assertEquals(CryptoCapabilities.aesGcm, CryptoCapabilities.aead(HpkeAead.Aes128Gcm))
+        assertEquals(CryptoCapabilities.aesGcm, CryptoCapabilities.aead(HpkeAead.Aes256Gcm))
+        assertEquals(CryptoCapabilities.chaChaPoly, CryptoCapabilities.aead(HpkeAead.ChaCha20Poly1305))
+    }
+
+    @Test
+    fun signatureFlagsMirrorUnderlying() {
+        assertEquals(supportsSyncEd25519, CryptoCapabilities.ed25519Sync)
+        assertEquals(supportsSyncEcdsa, CryptoCapabilities.ecdsaSync)
+        assertEquals(supportsEcdsaSigningFromScalar, CryptoCapabilities.ecdsaSigningFromScalar)
+    }
+
+    @Test
+    fun keyAgreementMirrorsUnderlyingForEveryCurve() {
+        val curves = listOf(KeyAgreementCurve.X25519, KeyAgreementCurve.P256, KeyAgreementCurve.P384, KeyAgreementCurve.P521)
+        for (curve in curves) {
+            assertEquals(supportsSync(curve), CryptoCapabilities.keyAgreementSync(curve), "curve $curve")
+        }
+    }
+}

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/CryptoCapabilitiesTest.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/CryptoCapabilitiesTest.kt
@@ -36,7 +36,13 @@ class CryptoCapabilitiesTest {
 
     @Test
     fun keyAgreementMirrorsUnderlyingForEveryCurve() {
-        val curves = listOf(KeyAgreementCurve.X25519, KeyAgreementCurve.P256, KeyAgreementCurve.P384, KeyAgreementCurve.P521)
+        val curves =
+            listOf(
+                KeyAgreementCurve.X25519,
+                KeyAgreementCurve.P256,
+                KeyAgreementCurve.P384,
+                KeyAgreementCurve.P521,
+            )
         for (curve in curves) {
             assertEquals(supportsSync(curve), CryptoCapabilities.keyAgreementSync(curve), "curve $curve")
         }


### PR DESCRIPTION
## Why

Per-platform crypto capability flags already exist (`supportsSyncAesGcm`, `supportsChaChaPoly`, `supportsSyncEd25519`, `supportsSync(curve)`, `HpkeSuite.isSupported`, …) but are scattered across `Aead`, `Signatures`, `KeyAgreement`, and `Hpke`. This adds one discoverable surface so callers can detect availability — and choose the synchronous vs `*Async` path — from a single place.

## What

`object CryptoCapabilities` (commonMain), thin aliases over the existing `expect val supports*` flags (which remain the source of truth):

- `aesGcm` / `chaChaPoly` → `AeadAvailability(sync, anyPath)`, plus `aead(HpkeAead)`
- `ed25519Sync`, `ecdsaSync`, `ecdsaSigningFromScalar`
- `keyAgreementSync(curve)`, `hpke(suite)`

Models the **two axes of availability**: `anyPath` (works via sync *or* `suspend` async — WebCrypto on JS/WASM is async-only) vs `sync` (a non-`suspend` entry point exists).

```kotlin
val ct = if (CryptoCapabilities.aesGcm.sync) aesGcmSeal(key, nonce, pt, dest)
         else aesGcmSealAsync(key, nonce, pt, dest)
if (CryptoCapabilities.hpke(suite)) { /* … */ }
```

## Tests

`CryptoCapabilitiesTest` asserts the facade stays a faithful alias of every underlying flag (fails on drift), on whatever platform the suite runs. JVM green.

## Notes
- New public API ⇒ `minor`. Labeled `minor` for discoverability, but to keep **one** deployment it should be merged **before** #221 so it rides into 5.15.0 (#221 stays the sole publishing merge); if you'd rather, drop this to `skip-release`.
- Pairs with #219's recipe; I'll point the docs at `CryptoCapabilities` once both land.
- Touches no build/CI files — independent of #219/#220/#221.