### PR TITLE
ci(buffer-crypto): run linuxArm64 crypto tests under QEMU

### DIFF
--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -135,6 +135,9 @@ jobs:
       - name: Run buffer-codec-test ARM64 tests via QEMU
         run: qemu-aarch64-static -L /usr/aarch64-linux-gnu ./buffer-codec-test/build/bin/linuxArm64/debugTest/test.kexe
 
+      - name: Run buffer-crypto ARM64 tests via QEMU
+        run: qemu-aarch64-static -L /usr/aarch64-linux-gnu ./buffer-crypto/build/bin/linuxArm64/debugTest/test.kexe
+
       - name: Publish to Maven Local
         run: ./gradlew publishToMavenLocal --no-build-cache ${{ inputs.gradle-args }}
 


### PR DESCRIPTION
## What

build-linux already cross-links `:buffer-crypto:linkDebugTestLinuxArm64` (alongside the other modules) but never executed the resulting `test.kexe` — so the arm64 BoringSSL crypto backend was compiled but its KAT/Wycheproof/tamper suite never ran on arm64. This adds the missing QEMU run step, mirroring the existing buffer / buffer-compression / buffer-flow / buffer-codec-test steps.

## Why

Closes the arm64 crypto test gap: x64 already runs the full `:buffer-crypto:linuxX64Test` suite; arm64 was build-only.

## Risk

CI-only, no source/runtime change. `skip-release`.