### PR TITLE
feat(buffer-crypto): namespace crypto entry points + bulk copies + AutoCloseable AEAD keys

### DIFF
--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/Aead.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/Aead.kt
@@ -65,9 +65,22 @@ class AesGcmKey private constructor(
     /** 128 or 256 — the AES key size in bits. */
     val sizeBits: Int,
     internal val material: PlatformBuffer,
-) {
+) : AutoCloseable {
+    private var closed = false
+
     /** Key size in bytes (16 for AES-128, 32 for AES-256). */
     val sizeBytes: Int get() = sizeBits / 8
+
+    /**
+     * Zeroes and frees the key material (wipes when [material] is a secure buffer). Idempotent.
+     * Parity with the signing/key-agreement key types, which are already [AutoCloseable].
+     */
+    override fun close() {
+        if (!closed) {
+            closed = true
+            material.freeNativeMemory()
+        }
+    }
 
     companion object {
         /**
@@ -94,7 +107,20 @@ class AesGcmKey private constructor(
  */
 class ChaChaPolyKey private constructor(
     internal val material: PlatformBuffer,
-) {
+) : AutoCloseable {
+    private var closed = false
+
+    /**
+     * Zeroes and frees the key material (wipes when [material] is a secure buffer). Idempotent.
+     * Parity with the signing/key-agreement key types, which are already [AutoCloseable].
+     */
+    override fun close() {
+        if (!closed) {
+            closed = true
+            material.freeNativeMemory()
+        }
+    }
+
     companion object {
         /**
          * Wraps [key]'s remaining bytes as a ChaCha20-Poly1305 key. The length must be
@@ -118,14 +144,7 @@ class ChaChaPolyKey private constructor(
 private fun copyMaterial(
     source: ReadBuffer,
     factory: BufferFactory,
-): PlatformBuffer {
-    val n = source.remaining()
-    val start = source.position()
-    val out = factory.allocate(n)
-    for (i in 0 until n) out.writeByte(source.get(start + i))
-    out.resetForRead()
-    return out
-}
+): PlatformBuffer = copyBuffer(source, factory)
 
 // =============================================================================
 // Low-level one-shot primitives (synchronous, native-or-throw)
@@ -423,9 +442,9 @@ internal fun allocateFramed(
  */
 internal fun writeFreshNonce(dest: WriteBuffer): ReadBuffer {
     val nonce = cryptoRandom(AEAD_NONCE_BYTES)
-    // Copy the nonce bytes into dest's framing slot, then hand back the standalone nonce buffer.
-    val start = nonce.position()
-    for (i in 0 until AEAD_NONCE_BYTES) dest.writeByte(nonce.get(start + i))
+    // Bulk-copy the nonce into dest's framing slot, then hand back the standalone nonce buffer.
+    // copyInto is non-destructive, so the returned nonce stays read-ready at position 0.
+    copyInto(nonce, dest)
     return nonce
 }
 

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/CryptoFacade.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/CryptoFacade.kt
@@ -214,7 +214,11 @@ object Kex {
 /**
  * HPKE (RFC 9180) namespaced entry points: key handling, single-shot seal/open, and the
  * Base/PSK/Auth/AuthPSK setup variants. Delegates to the top-level `hpke*` functions.
+ *
+ * The four HPKE setup modes (Base/PSK/Auth/AuthPSK) each need key handling plus seal/open, so this
+ * cohesive namespace object necessarily exposes more than the default per-object function cap.
  */
+@Suppress("TooManyFunctions")
 object Hpke {
     /** @see hpkeSupported */
     fun supported(suite: HpkeSuite): Boolean = freeHpkeSupported(suite)

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/CryptoFacade.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/CryptoFacade.kt
@@ -1,0 +1,326 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.crypto.aesGcmOpen as freeAesGcmOpen
+import com.ditchoom.buffer.crypto.aesGcmOpenAsync as freeAesGcmOpenAsync
+import com.ditchoom.buffer.crypto.aesGcmSeal as freeAesGcmSeal
+import com.ditchoom.buffer.crypto.aesGcmSealAsync as freeAesGcmSealAsync
+import com.ditchoom.buffer.crypto.chaChaPolyOpen as freeChaChaPolyOpen
+import com.ditchoom.buffer.crypto.chaChaPolyOpenAsync as freeChaChaPolyOpenAsync
+import com.ditchoom.buffer.crypto.chaChaPolySeal as freeChaChaPolySeal
+import com.ditchoom.buffer.crypto.chaChaPolySealAsync as freeChaChaPolySealAsync
+import com.ditchoom.buffer.crypto.deriveSharedSecret as freeDeriveSharedSecret
+import com.ditchoom.buffer.crypto.deriveSharedSecretAsync as freeDeriveSharedSecretAsync
+import com.ditchoom.buffer.crypto.ed25519AsyncAvailable as freeEd25519AsyncAvailable
+import com.ditchoom.buffer.crypto.generateKeyPair as freeGenerateKeyPair
+import com.ditchoom.buffer.crypto.generateKeyPairAsync as freeGenerateKeyPairAsync
+import com.ditchoom.buffer.crypto.hpkeGenerateKeyPair as freeHpkeGenerateKeyPair
+import com.ditchoom.buffer.crypto.hpkeImportPrivateKey as freeHpkeImportPrivateKey
+import com.ditchoom.buffer.crypto.hpkeImportPublicKey as freeHpkeImportPublicKey
+import com.ditchoom.buffer.crypto.hpkeOpenBase as freeHpkeOpenBase
+import com.ditchoom.buffer.crypto.hpkeSealBase as freeHpkeSealBase
+import com.ditchoom.buffer.crypto.hpkeSetupAuthPskReceiver as freeHpkeSetupAuthPskReceiver
+import com.ditchoom.buffer.crypto.hpkeSetupAuthPskSender as freeHpkeSetupAuthPskSender
+import com.ditchoom.buffer.crypto.hpkeSetupAuthReceiver as freeHpkeSetupAuthReceiver
+import com.ditchoom.buffer.crypto.hpkeSetupAuthSender as freeHpkeSetupAuthSender
+import com.ditchoom.buffer.crypto.hpkeSetupBaseReceiver as freeHpkeSetupBaseReceiver
+import com.ditchoom.buffer.crypto.hpkeSetupBaseSender as freeHpkeSetupBaseSender
+import com.ditchoom.buffer.crypto.hpkeSetupPskReceiver as freeHpkeSetupPskReceiver
+import com.ditchoom.buffer.crypto.hpkeSetupPskSender as freeHpkeSetupPskSender
+import com.ditchoom.buffer.crypto.hpkeSupported as freeHpkeSupported
+import com.ditchoom.buffer.crypto.importPrivateKey as freeImportPrivateKey
+import com.ditchoom.buffer.crypto.maxSignatureBytes as freeMaxSignatureBytes
+import com.ditchoom.buffer.crypto.sign as freeSign
+import com.ditchoom.buffer.crypto.signAsync as freeSignAsync
+import com.ditchoom.buffer.crypto.signInto as freeSignInto
+import com.ditchoom.buffer.crypto.supportsSync as freeSupportsSync
+import com.ditchoom.buffer.crypto.verify as freeVerify
+import com.ditchoom.buffer.crypto.verifyAsync as freeVerifyAsync
+
+/*
+ * Namespaced entry points for the crypto primitive families.
+ *
+ * Each object below groups the family's free functions under a single discoverable name so IDE
+ * completion surfaces, e.g., `Aead.aesGcmSeal` / `Sign.sign` / `Kex.deriveSharedSecret` /
+ * `Hpke.sealBase` instead of a flat list of top-level functions. These are thin, additive
+ * facades: every member delegates to the existing top-level function of the same family (which
+ * remains the canonical, unchanged public API — many are `expect`/`internal`-backed and cannot
+ * move into an object). Nothing here is breaking; the original top-level functions are kept
+ * exactly as-is, so existing callers continue to compile unchanged.
+ */
+
+/**
+ * AEAD (AES-GCM, ChaCha20-Poly1305) namespaced entry points. Delegates to the top-level
+ * `aesGcm*` / `chaChaPoly*` functions. The self-framing helpers emit `nonce ‖ ciphertext ‖ tag`.
+ */
+object Aead {
+    /** @see aesGcmSeal */
+    fun aesGcmSeal(
+        key: AesGcmKey,
+        plaintext: ReadBuffer,
+        aad: ReadBuffer? = null,
+        factory: BufferFactory = BufferFactory.Default,
+    ): PlatformBuffer = freeAesGcmSeal(key, plaintext, aad, factory)
+
+    /** @see aesGcmOpen */
+    fun aesGcmOpen(
+        sealed: ReadBuffer,
+        key: AesGcmKey,
+        aad: ReadBuffer? = null,
+        factory: BufferFactory = BufferFactory.Default,
+    ): PlatformBuffer = freeAesGcmOpen(sealed, key, aad, factory)
+
+    /** @see chaChaPolySeal */
+    fun chaChaPolySeal(
+        key: ChaChaPolyKey,
+        plaintext: ReadBuffer,
+        aad: ReadBuffer? = null,
+        factory: BufferFactory = BufferFactory.Default,
+    ): PlatformBuffer = freeChaChaPolySeal(key, plaintext, aad, factory)
+
+    /** @see chaChaPolyOpen */
+    fun chaChaPolyOpen(
+        sealed: ReadBuffer,
+        key: ChaChaPolyKey,
+        aad: ReadBuffer? = null,
+        factory: BufferFactory = BufferFactory.Default,
+    ): PlatformBuffer = freeChaChaPolyOpen(sealed, key, aad, factory)
+
+    /** @see aesGcmSealAsync */
+    suspend fun aesGcmSealAsync(
+        key: AesGcmKey,
+        plaintext: ReadBuffer,
+        aad: ReadBuffer? = null,
+        factory: BufferFactory = BufferFactory.Default,
+    ): PlatformBuffer = freeAesGcmSealAsync(key, plaintext, aad, factory)
+
+    /** @see aesGcmOpenAsync */
+    suspend fun aesGcmOpenAsync(
+        sealed: ReadBuffer,
+        key: AesGcmKey,
+        aad: ReadBuffer? = null,
+        factory: BufferFactory = BufferFactory.Default,
+    ): PlatformBuffer = freeAesGcmOpenAsync(sealed, key, aad, factory)
+
+    /** @see chaChaPolySealAsync */
+    suspend fun chaChaPolySealAsync(
+        key: ChaChaPolyKey,
+        plaintext: ReadBuffer,
+        aad: ReadBuffer? = null,
+        factory: BufferFactory = BufferFactory.Default,
+    ): PlatformBuffer = freeChaChaPolySealAsync(key, plaintext, aad, factory)
+
+    /** @see chaChaPolyOpenAsync */
+    suspend fun chaChaPolyOpenAsync(
+        sealed: ReadBuffer,
+        key: ChaChaPolyKey,
+        aad: ReadBuffer? = null,
+        factory: BufferFactory = BufferFactory.Default,
+    ): PlatformBuffer = freeChaChaPolyOpenAsync(sealed, key, aad, factory)
+}
+
+/**
+ * Digital-signature (Ed25519, ECDSA P-256/P-384/P-521) namespaced entry points. Delegates to the
+ * top-level `sign*` / `verify*` functions.
+ */
+object Sign {
+    /** @see signInto */
+    fun signInto(
+        key: SigningKey,
+        message: ReadBuffer,
+        dest: WriteBuffer,
+    ): Int = freeSignInto(key, message, dest)
+
+    /** @see verify */
+    fun verify(
+        key: VerifyKey,
+        message: ReadBuffer,
+        signature: ReadBuffer,
+    ): Boolean = freeVerify(key, message, signature)
+
+    /** @see maxSignatureBytes */
+    fun maxSignatureBytes(scheme: SignatureScheme): Int = freeMaxSignatureBytes(scheme)
+
+    /** @see sign */
+    fun sign(
+        key: SigningKey,
+        message: ReadBuffer,
+        factory: BufferFactory = BufferFactory.Default,
+    ): ReadBuffer = freeSign(key, message, factory)
+
+    /** @see signAsync */
+    suspend fun signAsync(
+        key: SigningKey,
+        message: ReadBuffer,
+        factory: BufferFactory = BufferFactory.Default,
+    ): ReadBuffer = freeSignAsync(key, message, factory)
+
+    /** @see verifyAsync */
+    suspend fun verifyAsync(
+        key: VerifyKey,
+        message: ReadBuffer,
+        signature: ReadBuffer,
+    ): Boolean = freeVerifyAsync(key, message, signature)
+
+    /** @see ed25519AsyncAvailable */
+    suspend fun ed25519AsyncAvailable(): Boolean = freeEd25519AsyncAvailable()
+}
+
+/**
+ * Key-exchange / agreement (X25519, ECDH P-256/P-384/P-521) namespaced entry points. Delegates to
+ * the top-level `generateKeyPair*` / `importPrivateKey` / `deriveSharedSecret*` functions.
+ */
+object Kex {
+    /** @see generateKeyPair */
+    fun generateKeyPair(curve: KeyAgreementCurve): KeyAgreementKeyPair = freeGenerateKeyPair(curve)
+
+    /** @see importPrivateKey */
+    fun importPrivateKey(
+        curve: KeyAgreementCurve,
+        encoded: ReadBuffer,
+    ): KeyAgreementPrivateKey = freeImportPrivateKey(curve, encoded)
+
+    /** @see deriveSharedSecret */
+    fun deriveSharedSecret(
+        privateKey: KeyAgreementPrivateKey,
+        peerPublicKey: KeyAgreementPublicKey,
+        info: ReadBuffer,
+        length: Int,
+        salt: ReadBuffer? = null,
+        factory: BufferFactory = BufferFactory.Default,
+    ): ReadBuffer = freeDeriveSharedSecret(privateKey, peerPublicKey, info, length, salt, factory)
+
+    /** @see supportsSync */
+    fun supportsSync(curve: KeyAgreementCurve): Boolean = freeSupportsSync(curve)
+
+    /** @see generateKeyPairAsync */
+    suspend fun generateKeyPairAsync(curve: KeyAgreementCurve): KeyAgreementKeyPair = freeGenerateKeyPairAsync(curve)
+
+    /** @see deriveSharedSecretAsync */
+    suspend fun deriveSharedSecretAsync(
+        privateKey: KeyAgreementPrivateKey,
+        peerPublicKey: KeyAgreementPublicKey,
+        info: ReadBuffer,
+        length: Int,
+        salt: ReadBuffer? = null,
+        factory: BufferFactory = BufferFactory.Default,
+    ): ReadBuffer = freeDeriveSharedSecretAsync(privateKey, peerPublicKey, info, length, salt, factory)
+}
+
+/**
+ * HPKE (RFC 9180) namespaced entry points: key handling, single-shot seal/open, and the
+ * Base/PSK/Auth/AuthPSK setup variants. Delegates to the top-level `hpke*` functions.
+ */
+object Hpke {
+    /** @see hpkeSupported */
+    fun supported(suite: HpkeSuite): Boolean = freeHpkeSupported(suite)
+
+    /** @see hpkeGenerateKeyPair */
+    suspend fun generateKeyPair(kem: HpkeKem): HpkeKeyPair = freeHpkeGenerateKeyPair(kem)
+
+    /** @see hpkeImportPublicKey */
+    fun importPublicKey(
+        kem: HpkeKem,
+        encoded: ReadBuffer,
+    ): HpkePublicKey = freeHpkeImportPublicKey(kem, encoded)
+
+    /** @see hpkeImportPrivateKey */
+    fun importPrivateKey(
+        kem: HpkeKem,
+        privateEncoded: ReadBuffer,
+        publicEncoded: ReadBuffer,
+    ): HpkePrivateKey = freeHpkeImportPrivateKey(kem, privateEncoded, publicEncoded)
+
+    /** @see hpkeSealBase */
+    suspend fun sealBase(
+        suite: HpkeSuite,
+        recipientPublicKey: HpkePublicKey,
+        info: ReadBuffer,
+        plaintext: ReadBuffer,
+        aad: ReadBuffer? = null,
+        factory: BufferFactory = BufferFactory.Default,
+    ): HpkeSealed = freeHpkeSealBase(suite, recipientPublicKey, info, plaintext, aad, factory)
+
+    /** @see hpkeOpenBase */
+    suspend fun openBase(
+        suite: HpkeSuite,
+        recipientPrivateKey: HpkePrivateKey,
+        enc: ReadBuffer,
+        info: ReadBuffer,
+        ciphertext: ReadBuffer,
+        aad: ReadBuffer? = null,
+        factory: BufferFactory = BufferFactory.Default,
+    ): PlatformBuffer = freeHpkeOpenBase(suite, recipientPrivateKey, enc, info, ciphertext, aad, factory)
+
+    /** @see hpkeSetupBaseSender */
+    suspend fun setupBaseSender(
+        suite: HpkeSuite,
+        recipientPublicKey: HpkePublicKey,
+        info: ReadBuffer,
+    ): HpkeSenderSetup = freeHpkeSetupBaseSender(suite, recipientPublicKey, info)
+
+    /** @see hpkeSetupPskSender */
+    suspend fun setupPskSender(
+        suite: HpkeSuite,
+        recipientPublicKey: HpkePublicKey,
+        info: ReadBuffer,
+        psk: HpkePsk,
+    ): HpkeSenderSetup = freeHpkeSetupPskSender(suite, recipientPublicKey, info, psk)
+
+    /** @see hpkeSetupAuthSender */
+    suspend fun setupAuthSender(
+        suite: HpkeSuite,
+        recipientPublicKey: HpkePublicKey,
+        info: ReadBuffer,
+        senderPrivateKey: HpkePrivateKey,
+    ): HpkeSenderSetup = freeHpkeSetupAuthSender(suite, recipientPublicKey, info, senderPrivateKey)
+
+    /** @see hpkeSetupAuthPskSender */
+    suspend fun setupAuthPskSender(
+        suite: HpkeSuite,
+        recipientPublicKey: HpkePublicKey,
+        info: ReadBuffer,
+        psk: HpkePsk,
+        senderPrivateKey: HpkePrivateKey,
+    ): HpkeSenderSetup = freeHpkeSetupAuthPskSender(suite, recipientPublicKey, info, psk, senderPrivateKey)
+
+    /** @see hpkeSetupBaseReceiver */
+    suspend fun setupBaseReceiver(
+        suite: HpkeSuite,
+        recipientPrivateKey: HpkePrivateKey,
+        enc: ReadBuffer,
+        info: ReadBuffer,
+    ): HpkeContext.Receiver = freeHpkeSetupBaseReceiver(suite, recipientPrivateKey, enc, info)
+
+    /** @see hpkeSetupPskReceiver */
+    suspend fun setupPskReceiver(
+        suite: HpkeSuite,
+        recipientPrivateKey: HpkePrivateKey,
+        enc: ReadBuffer,
+        info: ReadBuffer,
+        psk: HpkePsk,
+    ): HpkeContext.Receiver = freeHpkeSetupPskReceiver(suite, recipientPrivateKey, enc, info, psk)
+
+    /** @see hpkeSetupAuthReceiver */
+    suspend fun setupAuthReceiver(
+        suite: HpkeSuite,
+        recipientPrivateKey: HpkePrivateKey,
+        enc: ReadBuffer,
+        info: ReadBuffer,
+        senderPublicKey: HpkePublicKey,
+    ): HpkeContext.Receiver = freeHpkeSetupAuthReceiver(suite, recipientPrivateKey, enc, info, senderPublicKey)
+
+    /** @see hpkeSetupAuthPskReceiver */
+    suspend fun setupAuthPskReceiver(
+        suite: HpkeSuite,
+        recipientPrivateKey: HpkePrivateKey,
+        enc: ReadBuffer,
+        info: ReadBuffer,
+        psk: HpkePsk,
+        senderPublicKey: HpkePublicKey,
+    ): HpkeContext.Receiver = freeHpkeSetupAuthPskReceiver(suite, recipientPrivateKey, enc, info, psk, senderPublicKey)
+}

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/KeyAgreement.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/KeyAgreement.kt
@@ -163,11 +163,7 @@ fun importPrivateKey(
     require(encoded.remaining() == curve.privateKeyBytes) {
         "${curve.curveName} private key must be ${curve.privateKeyBytes} bytes, was ${encoded.remaining()}"
     }
-    val secure = secureScratch.allocate(curve.privateKeyBytes)
-    val start = encoded.position()
-    for (i in 0 until curve.privateKeyBytes) secure.writeByte(encoded.get(start + i))
-    secure.resetForRead()
-    return KeyAgreementPrivateKey(curve, secure)
+    return KeyAgreementPrivateKey(curve, copyBuffer(encoded, secureScratch))
 }
 
 /**

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/Signatures.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/Signatures.kt
@@ -133,14 +133,7 @@ class SigningKey private constructor(
             scheme: SignatureScheme,
             raw: ReadBuffer,
             factory: BufferFactory,
-        ): SigningKey {
-            val n = raw.remaining()
-            val start = raw.position()
-            val secure = factory.allocate(n)
-            for (i in 0 until n) secure.writeByte(raw.get(start + i))
-            secure.resetForRead()
-            return SigningKey(scheme, secure)
-        }
+        ): SigningKey = SigningKey(scheme, copyBuffer(raw, factory))
     }
 }
 
@@ -171,14 +164,7 @@ class VerifyKey private constructor(
         private fun of(
             scheme: SignatureScheme,
             raw: ReadBuffer,
-        ): VerifyKey {
-            val n = raw.remaining()
-            val start = raw.position()
-            val copy = BufferFactory.Default.allocate(n)
-            for (i in 0 until n) copy.writeByte(raw.get(start + i))
-            copy.resetForRead()
-            return VerifyKey(scheme, copy)
-        }
+        ): VerifyKey = VerifyKey(scheme, copyBuffer(raw, BufferFactory.Default))
     }
 }
 

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/AeadKeyCloseTest.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/AeadKeyCloseTest.kt
@@ -1,0 +1,70 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.crypto.CryptoTestVectors.hexBuffer
+import com.ditchoom.buffer.managed
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The AEAD key wrappers are [AutoCloseable] for parity with [SigningKey] and
+ * [KeyAgreementPrivateKey]. Closing must zero the backing key material and be idempotent.
+ *
+ * A managed (heap) secure factory is used so the backing buffer stays readable AFTER close()
+ * (managed free is a GC no-op), letting the test observe the wipe in isolation — the same
+ * technique [SecureBufferTest] uses.
+ */
+class AeadKeyCloseTest {
+    private val secureManaged = BufferFactory.managed().secure()
+
+    private val aes128Key = "11754cd72aec309bf52f7687212e8957"
+    private val aes256Key = "feffe9928665731c6d6a8f9467308308feffe9928665731c6d6a8f9467308308"
+    private val chachaKey = "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f"
+
+    @Test
+    fun aesGcmKeyCloseWipesMaterial() {
+        val key = AesGcmKey.of(hexBuffer(aes128Key), secureManaged)
+        val len = key.material.limit()
+        assertEquals(AES_128_KEY_BYTES, len)
+        // Material is non-zero before close (it is the key bytes).
+        var anyNonZero = false
+        for (i in 0 until len) if (key.material.get(i).toInt() != 0) anyNonZero = true
+        assertEquals(true, anyNonZero, "key material should be non-zero before close")
+        key.close()
+        for (i in 0 until len) assertEquals(0, key.material.get(i).toInt(), "byte $i not wiped")
+    }
+
+    @Test
+    fun aesGcm256KeyCloseWipesMaterial() {
+        val key = AesGcmKey.of(hexBuffer(aes256Key), secureManaged)
+        val len = key.material.limit()
+        assertEquals(AES_256_KEY_BYTES, len)
+        key.close()
+        for (i in 0 until len) assertEquals(0, key.material.get(i).toInt(), "byte $i not wiped")
+    }
+
+    @Test
+    fun chaChaPolyKeyCloseWipesMaterial() {
+        val key = ChaChaPolyKey.of(hexBuffer(chachaKey), secureManaged)
+        val len = key.material.limit()
+        assertEquals(CHACHA_KEY_BYTES, len)
+        key.close()
+        for (i in 0 until len) assertEquals(0, key.material.get(i).toInt(), "byte $i not wiped")
+    }
+
+    @Test
+    fun aesGcmKeyCloseIsIdempotent() {
+        val key = AesGcmKey.of(hexBuffer(aes128Key), secureManaged)
+        key.close()
+        key.close() // second close must not throw
+        for (i in 0 until key.material.limit()) assertEquals(0, key.material.get(i).toInt())
+    }
+
+    @Test
+    fun chaChaPolyKeyCloseIsIdempotent() {
+        val key = ChaChaPolyKey.of(hexBuffer(chachaKey), secureManaged)
+        key.close()
+        key.close()
+        for (i in 0 until key.material.limit()) assertEquals(0, key.material.get(i).toInt())
+    }
+}

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/CryptoFacadeTest.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/CryptoFacadeTest.kt
@@ -1,0 +1,115 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.crypto.CryptoTestVectors.ascii
+import com.ditchoom.buffer.crypto.CryptoTestVectors.hexBuffer
+import com.ditchoom.buffer.crypto.CryptoTestVectors.toHex
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The namespaced facade objects ([Aead], [Sign], [Kex], [Hpke]) are thin delegates over the
+ * existing top-level functions. These tests prove the delegation is wired correctly and behaves
+ * identically to the top-level surface, on every platform (driving the async/cross-platform paths).
+ */
+class CryptoFacadeTest {
+    private val aes256Key = "feffe9928665731c6d6a8f9467308308feffe9928665731c6d6a8f9467308308"
+
+    @Test
+    fun aeadFacadeRoundTripMatchesTopLevel() =
+        runTest {
+            val key = AesGcmKey.of(hexBuffer(aes256Key))
+            val aad = ascii("context-v1")
+            val plaintext = ascii("namespaced AEAD round-trip")
+            val sealed = Aead.aesGcmSealAsync(key, plaintext, aad, BufferFactory.Default)
+            assertEquals(AEAD_NONCE_BYTES + plaintext.remaining() + AEAD_TAG_BYTES, sealed.remaining())
+            val opened = Aead.aesGcmOpenAsync(sealed, key, aad, BufferFactory.Default)
+            assertEquals(plaintext.toHex(), opened.toHex())
+        }
+
+    @Test
+    fun signFacadeMaxBytesMatchesTopLevel() {
+        val schemes =
+            listOf(
+                SignatureScheme.Ed25519,
+                SignatureScheme.EcdsaP256,
+                SignatureScheme.EcdsaP384,
+                SignatureScheme.EcdsaP521,
+            )
+        for (scheme in schemes) {
+            assertEquals(maxSignatureBytes(scheme), Sign.maxSignatureBytes(scheme))
+        }
+    }
+
+    @Test
+    fun signFacadeRoundTrips() =
+        runTest {
+            if (!ed25519AsyncAvailable()) return@runTest
+            // RFC 8032 §7.1 test vector 1 (matching seed/public-key pair).
+            val seed = hexBuffer("9d61b19deffebc3a6f689b25f8a1ada92a2c4a26e3aa1bd2f60ba844af492ec2")
+            val pub = hexBuffer("dacdbc0f4e3606de5619c8a565a6864275feddf264b11b130abc1167e4f5d034")
+            val signing = SigningKey.ed25519(seed)
+            val verify = VerifyKey.ed25519(pub)
+            val msg = ascii("namespaced signing")
+            val sig = Sign.signAsync(signing, msg, BufferFactory.Default)
+            assertTrue(Sign.verifyAsync(verify, msg, sig), "facade verify must accept facade signature")
+        }
+
+    @Test
+    fun kexFacadeDerivesSameSecretAsTopLevel() =
+        runTest {
+            val curve = KeyAgreementCurve.X25519
+            val a = generateKeyPairAsync(curve)
+            val b = generateKeyPairAsync(curve)
+            val info = ascii("kex-facade")
+            // Both sides derive the same shared secret; facade and top-level must agree.
+            val viaFacade = Kex.deriveSharedSecretAsync(a.privateKey, b.publicKey, info, 32, null, BufferFactory.Default)
+            val viaTopLevel =
+                deriveSharedSecretAsync(b.privateKey, a.publicKey, info, 32, null, BufferFactory.Default)
+            assertEquals(viaTopLevel.toHex(), viaFacade.toHex())
+            a.close()
+            b.close()
+        }
+
+    @Test
+    fun hpkeFacadeSupportedMatchesTopLevel() {
+        val suite =
+            HpkeSuite(
+                HpkeKem.DhkemX25519HkdfSha256,
+                HpkeKdf.HkdfSha256,
+                HpkeAead.ChaCha20Poly1305,
+            )
+        assertEquals(hpkeSupported(suite), Hpke.supported(suite))
+    }
+
+    @Test
+    fun hpkeFacadeSealOpenRoundTrips() =
+        runTest {
+            val suite =
+                HpkeSuite(
+                    HpkeKem.DhkemX25519HkdfSha256,
+                    HpkeKdf.HkdfSha256,
+                    HpkeAead.Aes256Gcm,
+                )
+            if (!Hpke.supported(suite)) return@runTest
+            val recipient = Hpke.generateKeyPair(suite.kem)
+            val info = ascii("hpke-facade")
+            val pt = ascii("namespaced HPKE")
+            val sealed = Hpke.sealBase(suite, recipient.publicKey, info, pt, null, BufferFactory.Default)
+            val opened =
+                Hpke.openBase(
+                    suite,
+                    recipient.privateKey,
+                    sealed.enc,
+                    info,
+                    sealed.ciphertext,
+                    null,
+                    BufferFactory.Default,
+                )
+            assertEquals(pt.toHex(), opened.toHex())
+            recipient.close()
+        }
+}

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/CryptoFacadeTest.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/CryptoFacadeTest.kt
@@ -66,7 +66,8 @@ class CryptoFacadeTest {
             val b = generateKeyPairAsync(curve)
             val info = ascii("kex-facade")
             // Both sides derive the same shared secret; facade and top-level must agree.
-            val viaFacade = Kex.deriveSharedSecretAsync(a.privateKey, b.publicKey, info, 32, null, BufferFactory.Default)
+            val viaFacade =
+                Kex.deriveSharedSecretAsync(a.privateKey, b.publicKey, info, 32, null, BufferFactory.Default)
             val viaTopLevel =
                 deriveSharedSecretAsync(b.privateKey, a.publicKey, info, 32, null, BufferFactory.Default)
             assertEquals(viaTopLevel.toHex(), viaFacade.toHex())


### PR DESCRIPTION
## Summary

Additive, source-compatible API polish for `:buffer-crypto`. No existing public API is changed or removed; everything here is purely additive.

### 1. Namespaced crypto entry points
Introduces four singleton facade objects — `Aead`, `Sign`, `Kex`, `Hpke` — that group the previously flat top-level free functions under a single discoverable name, cutting IDE-completion pollution (e.g. `Aead.aesGcmSealAsync`, `Sign.sign`, `Kex.deriveSharedSecretAsync`, `Hpke.sealBase`).

Each member is a thin delegate to the existing top-level function (referenced via aliased imports to avoid self-recursion). The original top-level functions are kept exactly as-is — many are `expect`/`internal`-backed and cannot move into an object — so existing callers compile unchanged. No deprecation shims were needed because nothing was relocated or removed.

### 2. Bulk buffer copies
Replaces hand-rolled per-byte absolute-read/write copy loops with the existing non-destructive bulk `copyBuffer`/`copyInto` helpers (which save/restore the source position around `WriteBuffer.write(source)`):
- `AesGcmKey.of` / `ChaChaPolyKey.of` (`copyMaterial`)
- AEAD nonce framing (`writeFreshNonce`)
- `SigningKey.of` / `VerifyKey.of`
- `KeyAgreement.importPrivateKey`

Non-destructive semantics are preserved. (`Hpke.kt` was already converted in an earlier change; the constant-time OR accumulators in `KeyAgreementKdf`/`KeyAgreementRaw` are intentionally left as-is — they are not copies.)

### 3. AutoCloseable AEAD keys
`AesGcmKey` and `ChaChaPolyKey` now implement `AutoCloseable`; `close()` wipes/frees the backing key material and is idempotent, matching the existing `SigningKey` / `KeyAgreementPrivateKey` pattern.

### Tests
- `CryptoFacadeTest` — proves each facade object delegates correctly and behaves identically to the top-level surface (AEAD round-trip, signing round-trip, key-agreement shared-secret agreement, HPKE seal/open, capability/`maxSignatureBytes` parity).
- `AeadKeyCloseTest` — proves `close()` zeroes every byte of the key material and is idempotent (using a managed secure factory so the wipe is observable, mirroring `SecureBufferTest`).

### Verification
- `./gradlew :buffer-crypto:jvmTest` — green (full suite, incl. 6 new facade + 5 new close tests).
- `./gradlew :buffer-crypto:ktlintCheck` — clean.

The buffer-native zero-copy design (SecureBuffer, buffer-in/buffer-out, HPKE) is untouched.
