### PR TITLE
feat(buffer-codec): @Count element-count-prefixed list framing

### DIFF
--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecAnalyzer.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecAnalyzer.kt
@@ -496,6 +496,7 @@ internal fun analyzeField(
     var remainingBytesAnn: KSAnnotation? = null
     var wireBytesAnn: KSAnnotation? = null
     var useCodecAnn: KSAnnotation? = null
+    var countAnn: KSAnnotation? = null
     for (ann in param.annotations) {
         when (ann.shortName.asString()) {
             "WireOrder" -> { /* allowed on scalars */ }
@@ -504,6 +505,7 @@ internal fun analyzeField(
             "RemainingBytes" -> remainingBytesAnn = ann
             "WireBytes" -> wireBytesAnn = ann
             "UseCodec" -> useCodecAnn = ann
+            "Count" -> countAnn = ann
             else ->
                 return FieldAnalysis.Err(
                     Diagnostic(
@@ -524,6 +526,36 @@ internal fun analyzeField(
         return FieldAnalysis.Err(
             Diagnostic("nullable field type requires @When (T? without @When is unsupported)", param),
         )
+    }
+
+    // `@Count val: List<@ProtocolMessage T>` — an element-count-prefixed
+    // list (varint(N) + N self-delimiting elements). Mutually exclusive with
+    // the byte-length list framings (@LengthPrefixed / @LengthFrom /
+    // @RemainingBytes) and with @WireBytes / @UseCodec — combining any is a
+    // compile error. The field-count framing is self-delimiting, so unlike
+    // the drain-to-limit shapes it is not terminal-only.
+    if (countAnn != null) {
+        if (lengthPrefixed != null || lengthFromAnn != null || remainingBytesAnn != null) {
+            return FieldAnalysis.Err(
+                Diagnostic(
+                    "@Count cannot be combined with @LengthPrefixed/@LengthFrom/@RemainingBytes " +
+                        "on the same field — these are alternative list framings (element-count " +
+                        "prefix vs. byte-length bound). Choose one.",
+                    param,
+                ),
+            )
+        }
+        if (wireBytesAnn != null || useCodecAnn != null) {
+            return FieldAnalysis.Err(
+                Diagnostic("@Count cannot be combined with @WireBytes/@UseCodec", param),
+            )
+        }
+        if (type.declaration.qualifiedName?.asString() != "kotlin.collections.List") {
+            return FieldAnalysis.Err(
+                Diagnostic("@Count supports only List<@ProtocolMessage>", param),
+            )
+        }
+        return analyzeCountListField(param, type, ownerSimpleName)
     }
 
     if (remainingBytesAnn != null) {
@@ -1312,6 +1344,77 @@ internal fun analyzeRemainingBytesProtocolMessageListField(
     }
     return FieldAnalysis.Ok(
         FieldSpec.RemainingBytesProtocolMessageList(
+            name = name,
+            ownerSimpleName = ownerSimpleName,
+            elementClassName = classNameOf(elementDecl),
+            elementCodecClassName =
+                ClassName(
+                    elementDecl.packageName.asString(),
+                    elementDecl.flattenedCodecName(),
+                ),
+            elementIsBackPatch = detectElementBackPatch(elementDecl),
+        ),
+    )
+}
+
+/**
+ * `@Count val: List<T>` where `T` is a `@ProtocolMessage data class`
+ * (or a sealed parent with `@DispatchOn`). The element-count complement to
+ * [analyzeRemainingBytesProtocolMessageListField]: same element-type
+ * universe (data class OR sealed parent, `@ProtocolMessage`-annotated,
+ * non-payload-generic) and the same by-name `${T.simpleName}Codec`
+ * resolution; only the framing differs (a varint element count vs. a
+ * caller-set byte limit). Produces [FieldSpec.CountPrefixedProtocolMessageList].
+ */
+internal fun analyzeCountListField(
+    param: KSValueParameter,
+    listType: KSType,
+    ownerSimpleName: String,
+): FieldAnalysis {
+    val name =
+        param.name?.asString() ?: return FieldAnalysis.Err(Diagnostic("field has no name", param))
+    val typeArgs = listType.arguments
+    if (typeArgs.size != 1) {
+        return FieldAnalysis.Err(Diagnostic("@Count List must have exactly one type argument", param))
+    }
+    val elementType =
+        typeArgs[0].type?.resolve()
+            ?: return FieldAnalysis.Err(Diagnostic("@Count List element type does not resolve", param))
+    if (elementType.isError || elementType.isMarkedNullable) {
+        return FieldAnalysis.Err(
+            Diagnostic("@Count List element must be a resolvable non-nullable type", param),
+        )
+    }
+    val elementDecl =
+        elementType.declaration as? KSClassDeclaration
+            ?: return FieldAnalysis.Err(Diagnostic("@Count List element is not a class declaration", param))
+    val isDataClass = Modifier.DATA in elementDecl.modifiers
+    val isSealed = Modifier.SEALED in elementDecl.modifiers
+    if (!isDataClass && !isSealed) {
+        return FieldAnalysis.Err(
+            Diagnostic("@Count List element must be a @ProtocolMessage data class or sealed parent", param),
+        )
+    }
+    val isProtocolMessage =
+        elementDecl.annotations.any { ann ->
+            ann.shortName.asString() == "ProtocolMessage" &&
+                ann.annotationType
+                    .resolve()
+                    .declaration.qualifiedName
+                    ?.asString() == PROTOCOL_MESSAGE_QNAME
+        }
+    if (!isProtocolMessage) {
+        return FieldAnalysis.Err(
+            Diagnostic("@Count List element must be annotated @ProtocolMessage", param),
+        )
+    }
+    if (detectPayloadTypeParameter(elementDecl) != null) {
+        return FieldAnalysis.Err(
+            Diagnostic("@Count List element cannot carry a <P : Payload> type parameter", param),
+        )
+    }
+    return FieldAnalysis.Ok(
+        FieldSpec.CountPrefixedProtocolMessageList(
             name = name,
             ownerSimpleName = ownerSimpleName,
             elementClassName = classNameOf(elementDecl),
@@ -2975,6 +3078,19 @@ internal fun classifyVariantWireSize(shape: CodecShape): VariantWireSize {
     ) {
         return VariantWireSize.BackPatch
     }
+    // `@Count List<E>` with a BackPatch-shaped element collapses to
+    // BackPatch for the same reason — see [buildWireSizeFun].
+    if (shape.fields.any { it is FieldSpec.CountPrefixedProtocolMessageList && it.elementIsBackPatch }) {
+        return VariantWireSize.BackPatch
+    }
+    // A `@Count List<E>` (Exact-element) is runtime-Exact: the variant
+    // codec's own wireSize sums the varint count width and the element
+    // wireSizes (the `as Exact` cast); the dispatcher forwards without
+    // re-deriving. Early-return (like the enum case) so a non-terminal
+    // `@Count` field isn't dropped by the terminal `when`'s FixedSize sum.
+    if (shape.fields.any { it is FieldSpec.CountPrefixedProtocolMessageList }) {
+        return VariantWireSize.RuntimeExact
+    }
     // Non-terminal `@RemainingBytes*` collapses the variant
     // codec's wireSize to BackPatch (see [buildWireSizeFun] above);
     // the dispatcher's per-variant size table mirrors that.
@@ -3013,6 +3129,10 @@ internal fun classifyVariantWireSize(shape: CodecShape): VariantWireSize {
         // sum of element wireSizes via runtime `as Exact` cast); the
         // dispatcher forwards without re-deriving.
         is FieldSpec.RemainingBytesProtocolMessageList -> VariantWireSize.RuntimeExact
+        // Handled by the upfront `any CountPrefixedProtocolMessageList` early-returns above
+        // (BackPatch for BackPatch-element, RuntimeExact otherwise); defensive branch keeps
+        // the `when` exhaustive.
+        is FieldSpec.CountPrefixedProtocolMessageList -> VariantWireSize.RuntimeExact
         is FieldSpec.Scalar, is FieldSpec.ValueClassScalar, null ->
             VariantWireSize.LiteralExact(shape.fields.sumOfFixedWireBytes().requireFixed("sumOfFixedWireBytes"))
         is FieldSpec.LengthPrefixedString, is FieldSpec.Conditional -> VariantWireSize.BackPatch

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecAnalyzer.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecAnalyzer.kt
@@ -1365,7 +1365,12 @@ internal fun analyzeRemainingBytesProtocolMessageListField(
  * non-payload-generic) and the same by-name `${T.simpleName}Codec`
  * resolution; only the framing differs (a varint element count vs. a
  * caller-set byte limit). Produces [FieldSpec.CountPrefixedProtocolMessageList].
+ *
+ * Uses early returns as guard clauses to reject unsupported element shapes one validation
+ * step at a time (mirroring [analyzeRemainingBytesProtocolMessageListField]); collapsing them
+ * into a single exit would obscure which specific constraint failed.
  */
+@Suppress("ReturnCount")
 internal fun analyzeCountListField(
     param: KSValueParameter,
     listType: KSType,

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
@@ -770,6 +770,8 @@ internal class CodecEmitter(
             is FieldSpec.LengthFromMessage -> appendDecodeLengthFromMessage(body, field)
             is FieldSpec.RemainingBytesProtocolMessageList ->
                 appendDecodeRemainingBytesProtocolMessageList(body, field)
+            is FieldSpec.CountPrefixedProtocolMessageList ->
+                appendDecodeCountPrefixedProtocolMessageList(body, field)
             is FieldSpec.RemainingBytesPayload -> appendDecodeRemainingBytesPayload(body, field)
             is FieldSpec.RemainingBytesString -> appendDecodeRemainingBytesString(body, field)
             is FieldSpec.UseCodecScalar -> appendDecodeUseCodecScalar(body, field)
@@ -853,6 +855,8 @@ internal class CodecEmitter(
             is FieldSpec.LengthFromMessage -> appendEncodeLengthFromMessage(body, field)
             is FieldSpec.RemainingBytesProtocolMessageList ->
                 appendEncodeRemainingBytesProtocolMessageList(body, field)
+            is FieldSpec.CountPrefixedProtocolMessageList ->
+                appendEncodeCountPrefixedProtocolMessageList(body, field)
             is FieldSpec.RemainingBytesPayload -> appendEncodeRemainingBytesPayload(body, field)
             is FieldSpec.RemainingBytesString -> appendEncodeRemainingBytesString(body, field)
             is FieldSpec.UseCodecScalar -> appendEncodeUseCodecScalar(body, field, shape)
@@ -1796,6 +1800,11 @@ internal class CodecEmitter(
             is FieldSpec.LengthFromString -> ClassName("kotlin", "String")
             is FieldSpec.LengthFromMessage -> field.messageType
             is FieldSpec.LengthFromList ->
+                ClassName("kotlin.collections", "List").parameterizedBy(field.elementClassName)
+            is FieldSpec.CountPrefixedProtocolMessageList ->
+                // Self-delimiting, so a `@Count` list may sit as a non-terminal
+                // header field ahead of a trailing RemainingBytesPayload; map it
+                // to its `List<Element>` Kotlin type (mirror of LengthFromList).
                 ClassName("kotlin.collections", "List").parameterizedBy(field.elementClassName)
             is FieldSpec.RemainingBytesProtocolMessageList ->
                 error(

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterConstants.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterConstants.kt
@@ -106,3 +106,10 @@ internal val STRING_NULLABLE_TN = ClassName("kotlin", "String").copy(nullable = 
 
 // The shipped unsigned-LEB128 codec a generated enum field rides its ordinal on.
 internal val UNSIGNED_VARINT_CODEC_CN = ClassName("com.ditchoom.buffer.codec", "UnsignedVarIntCodec")
+
+// Upper bound on the initial capacity a `@Count` list decode pre-allocates from
+// the decoded element count. A hostile varint can request up to 2^31-1 elements;
+// pre-sizing to that would let a few header bytes force a huge allocation. The
+// list still grows past this cap when a frame legitimately carries more elements
+// (the underlying buffer reads fail fast long before that on a truncated frame).
+internal const val COUNT_PREFETCH_CAP = 1024

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterFields.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterFields.kt
@@ -1566,6 +1566,59 @@ internal fun appendEncodeRemainingBytesProtocolMessageList(
 }
 
 /**
+ * Emit decode for `@Count val: List<T>` where `T` is a `@ProtocolMessage`
+ * element. Reads the element COUNT as an unsigned LEB128 varint (the shipped
+ * `UnsignedVarIntCodec`, the same self-delimiting encoding an enum ordinal
+ * rides on), then loops exactly that many times decoding one element each
+ * iteration. Self-delimiting — no buffer-limit bound is consulted.
+ *
+ * Generated shape:
+ * ```
+ * val __<name>Count = UnsignedVarIntCodec.decode(buffer, context).toInt()
+ * val <name> = ArrayList<ElementType>(__<name>Count.coerceAtMost(<CAP>))
+ * repeat(__<name>Count) {
+ *     <name> += ElementCodec.decode(buffer, context)
+ * }
+ * ```
+ */
+internal fun appendDecodeCountPrefixedProtocolMessageList(
+    body: CodeBlock.Builder,
+    field: FieldSpec.CountPrefixedProtocolMessageList,
+) {
+    val countVar = "__${field.name}Count"
+    body.addStatement("val %L = %T.decode(buffer, context).toInt()", countVar, UNSIGNED_VARINT_CODEC_CN)
+    // Pre-size the list to the count, capped so a hostile varint can't
+    // request a multi-gigabyte allocation up front; the element decodes
+    // still fail fast on a truncated buffer well before the list grows.
+    body.addStatement(
+        "val %L = ArrayList<%T>(%L.coerceIn(0, %L))",
+        field.name,
+        field.elementClassName,
+        countVar,
+        COUNT_PREFETCH_CAP,
+    )
+    body.beginControlFlow("repeat(%L)", countVar)
+    body.addStatement("%L += %T.decode(buffer, context)", field.name, field.elementCodecClassName)
+    body.endControlFlow()
+}
+
+/**
+ * Emit encode for `@Count val: List<T>`. Writes the element count as an
+ * unsigned LEB128 varint, then each element via the element codec. The count
+ * is derived from `list.size`, so the wire form is always self-consistent —
+ * no user-trust contract (unlike the byte-length `@LengthFrom` list shapes).
+ */
+internal fun appendEncodeCountPrefixedProtocolMessageList(
+    body: CodeBlock.Builder,
+    field: FieldSpec.CountPrefixedProtocolMessageList,
+) {
+    body.addStatement("%T.encode(buffer, value.%L.size.toUInt(), context)", UNSIGNED_VARINT_CODEC_CN, field.name)
+    body.beginControlFlow("for (__elem in value.%L)", field.name)
+    body.addStatement("%T.encode(buffer, __elem, context)", field.elementCodecClassName)
+    body.endControlFlow()
+}
+
+/**
  * Emit decode for bare `@UseCodec val: <scalar>`.
  * Delegates to the user-supplied codec object's `decode(buffer,
  * context)`. When the codec implements [BoundingLengthCodec], the

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterPeek.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterPeek.kt
@@ -223,6 +223,16 @@ internal fun buildPeekFrameFun(shape: CodecShape): FunSpec {
         builder.addStatement("return %T.NoFraming", PEEK_RESULT_CN)
         return builder.build()
     }
+    // `@Count List<@ProtocolMessage T>` collapses peek to NoFraming. The
+    // element-count prefix gives the number of elements, not a byte span, so
+    // the total frame size can only be recovered by decoding each element
+    // (variable-width) — which peek must not do. A stream-side consumer frames
+    // such a message via its outer protocol, identical to the byte-length list
+    // shapes above.
+    if (shape.fields.any { it is FieldSpec.CountPrefixedProtocolMessageList }) {
+        builder.addStatement("return %T.NoFraming", PEEK_RESULT_CN)
+        return builder.build()
+    }
     // Same NoFraming collapse for `@RemainingBytes
     // @UseCodec val: P`. Body byte count is whatever the user codec
     // reads against the caller-set limit; 's outer
@@ -816,6 +826,11 @@ internal fun appendSequentialPeek(
                     "RemainingBytesProtocolMessageList should be handled by " +
                         "buildPeekFrameFun's upfront NoFraming short-circuit before reaching " +
                         "the sequential walk.",
+                )
+            is FieldSpec.CountPrefixedProtocolMessageList ->
+                error(
+                    "CountPrefixedProtocolMessageList should be handled by buildPeekFrameFun's " +
+                        "upfront NoFraming short-circuit before reaching the sequential walk.",
                 )
             is FieldSpec.RemainingBytesPayload ->
                 error(

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterWireSize.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterWireSize.kt
@@ -127,14 +127,26 @@ internal fun buildWireSizeFun(
         builder.addStatement("return %T.BackPatch", WIRE_SIZE_CN)
         return builder.build()
     }
+    // `@Count List<E>` with a BackPatch-shaped element collapses to BackPatch
+    // for the same reason `@RemainingBytes List<E>` does: the runtime-Exact emit
+    // below casts each element wireSize `as Exact`, which would CCE on a
+    // BackPatch element variant.
+    if (shape.fields.any { it is FieldSpec.CountPrefixedProtocolMessageList && it.elementIsBackPatch }) {
+        builder.addStatement("return %T.BackPatch", WIRE_SIZE_CN)
+        return builder.build()
+    }
 
     // Runtime-Exact: the message's only variable-width fields are runtime-Exact — a
-    // `VariableLengthCodec`-backed `@UseCodec` scalar (reports `Exact(encodedLength)`), or an enum
-    // whose ordinal rides as an `UnsignedVarIntCodec` varint — and every other field is FixedSize.
+    // `VariableLengthCodec`-backed `@UseCodec` scalar (reports `Exact(encodedLength)`), an enum
+    // whose ordinal rides as an `UnsignedVarIntCodec` varint, or a `@Count` element-count list
+    // (varint(N) + sum of element wireSizes) — and every other field is FixedSize.
     // Sum the compile-time fixed bytes with each variable field's runtime `Exact` (the same
     // `as Exact` cast LengthPrefixedMessage uses) so enclosing messages keep the precompute path
     // instead of degrading to BackPatch. Mirrors the peekFrameSize walk's shape.
-    fun isRuntimeExactVar(f: FieldSpec): Boolean = (f is FieldSpec.UseCodecScalar && f.isVariableLength) || f is FieldSpec.EnumScalar
+    fun isRuntimeExactVar(f: FieldSpec): Boolean =
+        (f is FieldSpec.UseCodecScalar && f.isVariableLength) ||
+            f is FieldSpec.EnumScalar ||
+            f is FieldSpec.CountPrefixedProtocolMessageList
     val runtimeExactVarFields = shape.fields.filter { isRuntimeExactVar(it) }
     if (runtimeExactVarFields.isNotEmpty() &&
         shape.fields.all { it is FieldSpec.FixedSize || isRuntimeExactVar(it) }
@@ -158,6 +170,8 @@ internal fun buildWireSizeFun(
                         f.name,
                         WIRE_SIZE_CN,
                     )
+                is FieldSpec.CountPrefixedProtocolMessageList ->
+                    appendCountListWireSizeLocal(builder, f)
                 else -> {}
             }
         }
@@ -257,4 +271,34 @@ internal fun buildWireSizeFun(
         }
     }
     return builder.build()
+}
+
+/**
+ * Emit the `__<name>Size` local for a `@Count` element-count list inside the
+ * runtime-Exact wireSize sum: the varint width of the element count plus the
+ * sum of element wireSizes (each cast `as Exact`, the same convention the other
+ * runtime-Exact summations use). A BackPatch element variant CCEs on the cast —
+ * such shapes are diverted to BackPatch by the upfront `elementIsBackPatch`
+ * guard, so this branch only runs for Exact-measured elements.
+ */
+internal fun appendCountListWireSizeLocal(
+    builder: FunSpec.Builder,
+    field: FieldSpec.CountPrefixedProtocolMessageList,
+) {
+    val countSizeVar = "__${field.name}CountSize"
+    builder.addStatement(
+        "val %L = (%T.wireSize(value.%L.size.toUInt(), context) as %T.Exact).bytes",
+        countSizeVar,
+        UNSIGNED_VARINT_CODEC_CN,
+        field.name,
+        WIRE_SIZE_CN,
+    )
+    builder.addStatement(
+        "val %L = %L + value.%L.sumOf { (%T.wireSize(it, context) as %T.Exact).bytes }",
+        "__${field.name}Size",
+        countSizeVar,
+        field.name,
+        field.elementCodecClassName,
+        WIRE_SIZE_CN,
+    )
 }

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecIr.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecIr.kt
@@ -842,6 +842,41 @@ internal sealed interface FieldSpec {
     ) : FieldSpec
 
     /**
+     * `@Count val: List<T>` where `T` is a `@ProtocolMessage data class`
+     * (or a sealed parent with `@DispatchOn`). The element-count complement
+     * to the byte-length list framings ([RemainingBytesProtocolMessageList],
+     * [LengthFromList]): instead of a byte span that the decoder drains to a
+     * limit, an unsigned LEB128 varint carries the element COUNT `N`, and the
+     * decoder reads exactly `N` elements via the element codec.
+     *
+     * Wire shape: `varint(N)` (the shipped `UnsignedVarIntCodec`, the same
+     * self-delimiting encoding an enum ordinal rides on) followed by `N`
+     * self-delimiting elements. Because the count is explicit the field is
+     * self-delimiting — unlike the drain-to-limit list shapes it need NOT be
+     * the terminal constructor parameter.
+     *
+     * Decode: read the varint count, then `repeat(N)` appending
+     * `<E>Codec.decode(buffer, context)`. Encode: write
+     * `UnsignedVarIntCodec.encode(buffer, list.size.toUInt(), context)` then
+     * iterate. wireSize = varint width of the count + sum of element
+     * wireSizes (each cast to `Exact` at runtime — same convention as
+     * [RemainingBytesProtocolMessageList]); the containing message collapses
+     * to BackPatch when the element is BackPatch-shaped.
+     *
+     * `elementIsBackPatch` mirrors [RemainingBytesProtocolMessageList]'s flag:
+     * when `true` the containing message's wireSize / variant classification
+     * collapses to BackPatch (the runtime `as Exact` cast would CCE on
+     * BackPatch element variants).
+     */
+    data class CountPrefixedProtocolMessageList(
+        override val name: String,
+        val ownerSimpleName: String,
+        val elementClassName: ClassName,
+        val elementCodecClassName: ClassName,
+        val elementIsBackPatch: Boolean,
+    ) : FieldSpec
+
+    /**
      * /
      * `@LengthFrom("ref") val: String`. The body wire bytes are
      * determined by a non-adjacent length carrier decoded

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecSchemaDescriptor.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecSchemaDescriptor.kt
@@ -140,6 +140,8 @@ internal object CodecSchemaDescriptor {
                     "codec=${field.payloadCodecType.canonicalName}"
             is FieldSpec.RemainingBytesProtocolMessageList ->
                 "list:${field.elementClassName.canonicalName} remaining reserved=${field.reservedTrailingBytes}B"
+            is FieldSpec.CountPrefixedProtocolMessageList ->
+                "list:${field.elementClassName.canonicalName} count-prefixed"
             is FieldSpec.LengthFromList ->
                 "list:${field.elementClassName.canonicalName} len-from=${describeLengthSource(field.source)}"
             is FieldSpec.LengthFromString ->

--- a/buffer-codec-processor/src/test/kotlin/com/ditchoom/buffer/codec/processor/CodecSchemaDescriptorTest.kt
+++ b/buffer-codec-processor/src/test/kotlin/com/ditchoom/buffer/codec/processor/CodecSchemaDescriptorTest.kt
@@ -330,6 +330,7 @@ class CodecSchemaDescriptorTest {
             FieldSpec.LengthPrefixedUseCodecList("props", "Owner", listSpec),
             FieldSpec.LengthPrefixedUseCodecPayload("blob", "Owner", cn, codec, 2, Endianness.Big),
             FieldSpec.RemainingBytesProtocolMessageList("topics", "Owner", cn, codec, elementIsBackPatch = false),
+            FieldSpec.CountPrefixedProtocolMessageList("points", "Owner", cn, codec, elementIsBackPatch = false),
             FieldSpec.LengthFromList("items", "Owner", LengthSource.Sibling("count", ScalarKind.UByte), cn, codec),
             FieldSpec.LengthFromString("text", "Owner", LengthSource.Sibling("len", ScalarKind.UShort)),
             FieldSpec.ValueClassScalar("packetId", "Owner", cn, ScalarKind.UShort, "raw", 2, Endianness.Big),

--- a/buffer-codec-processor/src/test/kotlin/com/ditchoom/buffer/codec/processor/CountValidatorTest.kt
+++ b/buffer-codec-processor/src/test/kotlin/com/ditchoom/buffer/codec/processor/CountValidatorTest.kt
@@ -1,0 +1,161 @@
+package com.ditchoom.buffer.codec.processor
+
+import com.tschuchort.compiletesting.JvmCompilationResult
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import com.tschuchort.compiletesting.configureKsp
+import com.tschuchort.compiletesting.useKsp2
+import org.intellij.lang.annotations.Language
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Compile-time validator coverage for `@Count` (element-count-prefixed lists).
+ *
+ * `@Count` is mutually exclusive with the byte-length list framings
+ * (`@LengthPrefixed` / `@LengthFrom` / `@RemainingBytes`) on the same field —
+ * they are alternative ways to frame a list (element count vs. byte span) and
+ * combining them is meaningless. Each combination is a KSP compile error.
+ */
+class CountValidatorTest {
+    @Test
+    fun acceptsCountOnProtocolMessageList() {
+        val result =
+            compile(
+                """
+                package test
+
+                import com.ditchoom.buffer.codec.annotations.Count
+                import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+
+                @ProtocolMessage
+                data class Elem(val a: UByte, val b: UByte)
+
+                @ProtocolMessage
+                data class Holder(
+                    val id: UByte,
+                    @Count val elems: List<Elem>,
+                )
+                """.trimIndent(),
+            )
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+    }
+
+    @Test
+    fun firesWhenCombinedWithRemainingBytes() {
+        val result =
+            compile(
+                """
+                package test
+
+                import com.ditchoom.buffer.codec.annotations.Count
+                import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+                import com.ditchoom.buffer.codec.annotations.RemainingBytes
+
+                @ProtocolMessage
+                data class Elem(val a: UByte)
+
+                @ProtocolMessage
+                data class Holder(
+                    @Count @RemainingBytes val elems: List<Elem>,
+                )
+                """.trimIndent(),
+            )
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode, result.messages)
+        assertContainsCountExclusionError(result)
+    }
+
+    @Test
+    fun firesWhenCombinedWithLengthPrefixed() {
+        val result =
+            compile(
+                """
+                package test
+
+                import com.ditchoom.buffer.codec.annotations.Count
+                import com.ditchoom.buffer.codec.annotations.LengthPrefixed
+                import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+
+                @ProtocolMessage
+                data class Elem(val a: UByte)
+
+                @ProtocolMessage
+                data class Holder(
+                    @Count @LengthPrefixed val elems: List<Elem>,
+                )
+                """.trimIndent(),
+            )
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode, result.messages)
+        assertContainsCountExclusionError(result)
+    }
+
+    @Test
+    fun firesWhenCombinedWithLengthFrom() {
+        val result =
+            compile(
+                """
+                package test
+
+                import com.ditchoom.buffer.codec.annotations.Count
+                import com.ditchoom.buffer.codec.annotations.LengthFrom
+                import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+
+                @ProtocolMessage
+                data class Elem(val a: UByte)
+
+                @ProtocolMessage
+                data class Holder(
+                    val len: UShort,
+                    @Count @LengthFrom("len") val elems: List<Elem>,
+                )
+                """.trimIndent(),
+            )
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode, result.messages)
+        assertContainsCountExclusionError(result)
+    }
+
+    @Test
+    fun firesWhenAppliedToNonList() {
+        val result =
+            compile(
+                """
+                package test
+
+                import com.ditchoom.buffer.codec.annotations.Count
+                import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+
+                @ProtocolMessage
+                data class Holder(
+                    @Count val notAList: UByte,
+                )
+                """.trimIndent(),
+            )
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode, result.messages)
+        assertTrue(
+            result.messages.contains("@Count supports only List"),
+            "diagnostic should explain @Count requires a List. Messages:\n${result.messages}",
+        )
+    }
+
+    private fun assertContainsCountExclusionError(result: JvmCompilationResult) {
+        assertTrue(
+            result.messages.contains("@Count cannot be combined with"),
+            "diagnostic should name the @Count mutual-exclusion rule. Messages:\n${result.messages}",
+        )
+    }
+
+    private fun compile(
+        @Language("kotlin") source: String,
+    ): JvmCompilationResult =
+        KotlinCompilation()
+            .apply {
+                sources = listOf(SourceFile.kotlin("Test.kt", source))
+                inheritClassPath = true
+                messageOutputStream = System.out
+                useKsp2()
+                configureKsp {
+                    symbolProcessorProviders += ProtocolMessageProcessorProvider()
+                }
+            }.compile()
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountFixedListCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountFixedListCodec.kt
@@ -1,0 +1,44 @@
+package com.ditchoom.buffer.codec.test.protocols.count
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.UnsignedVarIntCodec
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object CountFixedListCodec : Codec<CountFixedList> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): CountFixedList {
+    val id = buffer.readUByte()
+    val __pointsCount = UnsignedVarIntCodec.decode(buffer, context).toInt()
+    val points = ArrayList<CountPoint>(__pointsCount.coerceIn(0, 1_024))
+    repeat(__pointsCount) {
+      points += CountPointCodec.decode(buffer, context)
+    }
+    return CountFixedList(id = id, points = points)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: CountFixedList,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.id)
+    UnsignedVarIntCodec.encode(buffer, value.points.size.toUInt(), context)
+    for (__elem in value.points) {
+      CountPointCodec.encode(buffer, __elem, context)
+    }
+  }
+
+  override fun wireSize(`value`: CountFixedList, context: EncodeContext): WireSize {
+    val __pointsCountSize = (UnsignedVarIntCodec.wireSize(value.points.size.toUInt(), context) as WireSize.Exact).bytes
+    val __pointsSize = __pointsCountSize + value.points.sumOf { (CountPointCodec.wireSize(it, context) as WireSize.Exact).bytes }
+    return WireSize.Exact(1 + __pointsSize)
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountNamedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountNamedCodec.kt
@@ -1,0 +1,64 @@
+package com.ditchoom.buffer.codec.test.protocols.count
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object CountNamedCodec : Codec<CountNamed> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): CountNamed {
+    val namePrefixB0 = buffer.readUByte().toUInt()
+    val namePrefixB1 = buffer.readUByte().toUInt()
+    val namePrefix = ((namePrefixB0 shl 8) or namePrefixB1)
+    if (namePrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "CountNamed.name", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = namePrefix.toString())
+    }
+    val nameLength = namePrefix.toInt()
+    val name = buffer.readString(nameLength, Charset.UTF8)
+    return CountNamed(name = name)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: CountNamed,
+    context: EncodeContext,
+  ) {
+    val nameSizePosition = buffer.position()
+    buffer.position(nameSizePosition + 2)
+    val nameBodyStart = buffer.position()
+    buffer.writeString(value.name, Charset.UTF8)
+    val nameEndPosition = buffer.position()
+    val nameByteCount = nameEndPosition - nameBodyStart
+    if (nameByteCount > 65_535) {
+      throw EncodeException(fieldPath = "CountNamed.name", reason = """UTF-8 byte length ${nameByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(nameSizePosition)
+    val namePrefix = nameByteCount.toUInt()
+    buffer.writeUByte(((namePrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((namePrefix and 0xFFu).toUByte())
+    buffer.position(nameEndPosition)
+  }
+
+  override fun wireSize(`value`: CountNamed, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val namePrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val namePrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val namePrefix = ((namePrefixB0 shl 8) or namePrefixB1).toUInt()
+    if (namePrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "CountNamed.name", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + namePrefix.toInt()}""")
+    }
+    __offset += 2 + namePrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountPointCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountPointCodec.kt
@@ -1,0 +1,36 @@
+package com.ditchoom.buffer.codec.test.protocols.count
+
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import com.ditchoom.buffer.swapBytes
+import kotlin.Int
+
+public object CountPointCodec : Codec<CountPoint> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): CountPoint {
+    val xRaw = buffer.readShort()
+    val x = (if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) xRaw else swapBytes(xRaw)).toUShort()
+    val y = buffer.readUByte()
+    return CountPoint(x = x, y = y)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: CountPoint,
+    context: EncodeContext,
+  ) {
+    val xRaw = value.x.toShort()
+    buffer.writeShort(if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) xRaw else swapBytes(xRaw))
+    buffer.writeUByte(value.y)
+  }
+
+  override fun wireSize(`value`: CountPoint, context: EncodeContext): WireSize = WireSize.Exact(3)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 3) PeekResult.Complete(3) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountThenTrailerCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountThenTrailerCodec.kt
@@ -1,0 +1,48 @@
+package com.ditchoom.buffer.codec.test.protocols.count
+
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.UnsignedVarIntCodec
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import com.ditchoom.buffer.swapBytes
+import kotlin.Int
+
+public object CountThenTrailerCodec : Codec<CountThenTrailer> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): CountThenTrailer {
+    val __pointsCount = UnsignedVarIntCodec.decode(buffer, context).toInt()
+    val points = ArrayList<CountPoint>(__pointsCount.coerceIn(0, 1_024))
+    repeat(__pointsCount) {
+      points += CountPointCodec.decode(buffer, context)
+    }
+    val trailerRaw = buffer.readInt()
+    val trailer = (if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) trailerRaw else swapBytes(trailerRaw)).toUInt()
+    return CountThenTrailer(points = points, trailer = trailer)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: CountThenTrailer,
+    context: EncodeContext,
+  ) {
+    UnsignedVarIntCodec.encode(buffer, value.points.size.toUInt(), context)
+    for (__elem in value.points) {
+      CountPointCodec.encode(buffer, __elem, context)
+    }
+    val trailerRaw = value.trailer.toInt()
+    buffer.writeInt(if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) trailerRaw else swapBytes(trailerRaw))
+  }
+
+  override fun wireSize(`value`: CountThenTrailer, context: EncodeContext): WireSize {
+    val __pointsCountSize = (UnsignedVarIntCodec.wireSize(value.points.size.toUInt(), context) as WireSize.Exact).bytes
+    val __pointsSize = __pointsCountSize + value.points.sumOf { (CountPointCodec.wireSize(it, context) as WireSize.Exact).bytes }
+    return WireSize.Exact(4 + __pointsSize)
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountVariableListCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountVariableListCodec.kt
@@ -1,0 +1,38 @@
+package com.ditchoom.buffer.codec.test.protocols.count
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.UnsignedVarIntCodec
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object CountVariableListCodec : Codec<CountVariableList> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): CountVariableList {
+    val __namesCount = UnsignedVarIntCodec.decode(buffer, context).toInt()
+    val names = ArrayList<CountNamed>(__namesCount.coerceIn(0, 1_024))
+    repeat(__namesCount) {
+      names += CountNamedCodec.decode(buffer, context)
+    }
+    return CountVariableList(names = names)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: CountVariableList,
+    context: EncodeContext,
+  ) {
+    UnsignedVarIntCodec.encode(buffer, value.names.size.toUInt(), context)
+    for (__elem in value.names) {
+      CountNamedCodec.encode(buffer, __elem, context)
+    }
+  }
+
+  override fun wireSize(`value`: CountVariableList, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+}

--- a/buffer-codec-test/src/codecSchema/codec-schema.txt
+++ b/buffer-codec-test/src/codecSchema/codec-schema.txt
@@ -114,6 +114,19 @@ message com.ditchoom.buffer.codec.test.protocols.batch.SignedAndUnsignedMix
 message com.ditchoom.buffer.codec.test.protocols.batch.ValueClassBatch
   0 header valueclass:com.ditchoom.buffer.codec.test.protocols.batch.HeaderByte scalar:UByte wire=1B order=Default
   1 tail valueclass:com.ditchoom.buffer.codec.test.protocols.batch.HeaderByte scalar:UByte wire=1B order=Default
+message com.ditchoom.buffer.codec.test.protocols.count.CountFixedList
+  0 id scalar:UByte wire=1B order=Big
+  1 points list:com.ditchoom.buffer.codec.test.protocols.count.CountPoint count-prefixed
+message com.ditchoom.buffer.codec.test.protocols.count.CountNamed
+  0 name string len-prefix=2B/Big
+message com.ditchoom.buffer.codec.test.protocols.count.CountPoint
+  0 x scalar:UShort wire=2B order=Big
+  1 y scalar:UByte wire=1B order=Big
+message com.ditchoom.buffer.codec.test.protocols.count.CountThenTrailer
+  0 points list:com.ditchoom.buffer.codec.test.protocols.count.CountPoint count-prefixed
+  1 trailer scalar:UInt wire=4B order=Big
+message com.ditchoom.buffer.codec.test.protocols.count.CountVariableList
+  0 names list:com.ditchoom.buffer.codec.test.protocols.count.CountNamed count-prefixed
 message com.ditchoom.buffer.codec.test.protocols.dns.DnsHeader
   0 id scalar:UShort wire=2B order=Big
   1 flags scalar:UShort wire=2B order=Big

--- a/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/count/CountPrefixedLists.kt
+++ b/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/count/CountPrefixedLists.kt
@@ -1,0 +1,73 @@
+package com.ditchoom.buffer.codec.test.protocols.count
+
+import com.ditchoom.buffer.codec.annotations.Count
+import com.ditchoom.buffer.codec.annotations.Endianness
+import com.ditchoom.buffer.codec.annotations.LengthPrefixed
+import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+
+/*
+ * `@Count` fixtures — element-count-prefixed lists. A `@Count` list rides on
+ * the wire as a self-delimiting `varint(N)` element count followed by exactly
+ * `N` self-delimiting elements (each via its own codec). This is the
+ * element-count complement to the byte-length list framings
+ * (`@RemainingBytes` / `@LengthFrom` / `@LengthPrefixed`), which bound a list
+ * by a byte span and drain to a buffer limit.
+ *
+ * The count varint is the shipped unsigned-LEB128 `UnsignedVarIntCodec` — the
+ * same self-delimiting encoding an enum ordinal rides on — so counts 0..127
+ * cost one byte.
+ */
+
+/** Fixed-width element: 3 bytes (UShort BE + UByte). */
+@ProtocolMessage(wireOrder = Endianness.Big)
+data class CountPoint(
+    val x: UShort,
+    val y: UByte,
+)
+
+/**
+ * Fixed-width-element `@Count` list. Wire = id (1 byte) + varint(N) +
+ * 3 × N bytes.
+ *
+ * ```text
+ *   id   count   point_0           point_1 …
+ *   01   02      00 10 00          00 20 01
+ * ```
+ */
+@ProtocolMessage(wireOrder = Endianness.Big)
+data class CountFixedList(
+    val id: UByte,
+    @Count val points: List<CountPoint>,
+)
+
+/** Variable-width element: a length-prefixed UTF-8 name. */
+@ProtocolMessage(wireOrder = Endianness.Big)
+data class CountNamed(
+    @LengthPrefixed val name: String,
+)
+
+/**
+ * Variable-width-element `@Count` list. Each element carries its own 2-byte
+ * length prefix, so the element width varies — exercising the self-delimiting
+ * count loop independent of any byte bound.
+ */
+@ProtocolMessage(wireOrder = Endianness.Big)
+data class CountVariableList(
+    @Count val names: List<CountNamed>,
+)
+
+/**
+ * Non-terminal `@Count` list followed by a trailing fixed-size field —
+ * demonstrating that the field-count framing is self-delimiting and need not
+ * be the last constructor parameter (unlike the drain-to-limit list shapes).
+ *
+ * ```text
+ *   count   point_0     point_1     trailer (UInt BE)
+ *   02      00 01 02    00 03 04    DE AD BE EF
+ * ```
+ */
+@ProtocolMessage(wireOrder = Endianness.Big)
+data class CountThenTrailer(
+    @Count val points: List<CountPoint>,
+    val trailer: UInt,
+)

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/count/CountPrefixedListCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/count/CountPrefixedListCodecTest.kt
@@ -1,0 +1,268 @@
+package com.ditchoom.buffer.codec.test.protocols.count
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+/**
+ * Round-trip + byte-identity coverage for `@Count` element-count-prefixed
+ * lists across empty / one / many elements, a fixed-width element type
+ * (`CountPoint`), a variable-width element type (`CountNamed`, length-prefixed
+ * string), and a non-terminal `@Count` list followed by a fixed trailer.
+ *
+ * Count rides as an unsigned-LEB128 `varint(N)` — one byte for N in 0..127.
+ */
+class CountPrefixedListCodecTest {
+    // ---- fixed-width element list ----------------------------------------
+
+    @Test
+    fun encodesEmptyCountListByteExact() {
+        val msg = CountFixedList(id = 0x01u, points = emptyList())
+        // id + varint(0)
+        encodeAndAssertBytes(msg, byteArrayOf(0x01, 0x00))
+    }
+
+    @Test
+    fun encodesSingleElementByteExact() {
+        val msg = CountFixedList(id = 0x01u, points = listOf(CountPoint(x = 0x0010u, y = 0x00u)))
+        encodeAndAssertBytes(
+            msg,
+            byteArrayOf(
+                0x01, // id
+                0x01, // varint count = 1
+                0x00,
+                0x10,
+                0x00, // point 0
+            ),
+        )
+    }
+
+    @Test
+    fun encodesManyElementsByteExact() {
+        val msg =
+            CountFixedList(
+                id = 0x01u,
+                points =
+                    listOf(
+                        CountPoint(x = 0x0010u, y = 0x00u),
+                        CountPoint(x = 0x0020u, y = 0x01u),
+                        CountPoint(x = 0x0030u, y = 0x80u),
+                    ),
+            )
+        encodeAndAssertBytes(
+            msg,
+            byteArrayOf(
+                0x01, // id
+                0x03, // varint count = 3
+                0x00,
+                0x10,
+                0x00,
+                0x00,
+                0x20,
+                0x01,
+                0x00,
+                0x30,
+                0x80.toByte(),
+            ),
+        )
+    }
+
+    @Test
+    fun roundTripsFixedListEmptyOneMany() {
+        for (
+        points in
+        listOf(
+            emptyList(),
+            listOf(CountPoint(0x0100u, 0x00u)),
+            listOf(CountPoint(0x0100u, 0x00u), CountPoint(0x0200u, 0x02u), CountPoint(0xFFFFu, 0xFEu)),
+        )
+        ) {
+            val original = CountFixedList(id = 0x2Au, points = points)
+            val buf = encode(original)
+            buf.resetForRead()
+            assertEquals(original, CountFixedListCodec.decode(buf, DecodeContext.Empty))
+        }
+    }
+
+    @Test
+    fun wireSizeFixedListIsExact() {
+        // 1 (id) + 1 (varint count) + 3 × N.
+        val three =
+            CountFixedList(
+                id = 1u,
+                points = listOf(CountPoint(0u, 0u), CountPoint(1u, 1u), CountPoint(2u, 2u)),
+            )
+        assertEquals(WireSize.Exact(1 + 1 + 9), CountFixedListCodec.wireSize(three, EncodeContext.Empty))
+        val empty = CountFixedList(id = 1u, points = emptyList())
+        assertEquals(WireSize.Exact(2), CountFixedListCodec.wireSize(empty, EncodeContext.Empty))
+    }
+
+    @Test
+    fun decodeStopsAtCountNotBufferEnd() {
+        // Wire holds the message then trailing bytes that must remain
+        // unconsumed: count is self-delimiting, so decode stops after N.
+        val buf = BufferFactory.Default.allocate(16, ByteOrder.BIG_ENDIAN)
+        buf.writeByte(0x07.toByte()) // id
+        buf.writeByte(0x02.toByte()) // count = 2
+        buf.writeShort(0x0001.toShort())
+        buf.writeByte(0x00.toByte())
+        buf.writeShort(0x0002.toShort())
+        buf.writeByte(0x01.toByte())
+        // Trailing bytes — next frame, must not be consumed.
+        buf.writeByte(0xDE.toByte())
+        buf.writeByte(0xAD.toByte())
+        buf.resetForRead()
+
+        val decoded = CountFixedListCodec.decode(buf, DecodeContext.Empty)
+        assertEquals(2, decoded.points.size)
+        assertEquals(8, buf.position(), "decode advanced exactly past the counted elements")
+    }
+
+    // ---- variable-width element list -------------------------------------
+
+    @Test
+    fun encodesVariableListByteExact() {
+        val msg = CountVariableList(names = listOf(CountNamed("hi"), CountNamed("abc")))
+        val expected =
+            byteArrayOf(
+                0x02, // varint count = 2
+                0x00,
+                0x02,
+                'h'.code.toByte(),
+                'i'.code.toByte(), // LP "hi"
+                0x00,
+                0x03,
+                'a'.code.toByte(),
+                'b'.code.toByte(),
+                'c'.code.toByte(), // LP "abc"
+            )
+        val buf = buildBuffer { CountVariableListCodec.encode(it, msg, EncodeContext.Empty) }
+        assertEquals(expected.size, buf.position())
+        buf.resetForRead()
+        assertContentEquals(expected, buf.readByteArray(expected.size))
+    }
+
+    @Test
+    fun roundTripsVariableListEmptyOneMany() {
+        for (
+        names in
+        listOf(
+            emptyList(),
+            listOf(CountNamed("solo")),
+            listOf(CountNamed(""), CountNamed("a"), CountNamed("longer name here")),
+        )
+        ) {
+            val original = CountVariableList(names = names)
+            val buf = buildBuffer { CountVariableListCodec.encode(it, original, EncodeContext.Empty) }
+            buf.resetForRead()
+            assertEquals(original, CountVariableListCodec.decode(buf, DecodeContext.Empty))
+        }
+    }
+
+    @Test
+    fun wireSizeVariableListIsBackPatch() {
+        // The element `CountNamed` carries a `@LengthPrefixed String`, so its
+        // wireSize is BackPatch; a `@Count` list of BackPatch-shaped elements
+        // collapses the containing message to BackPatch (the encode path uses a
+        // growable buffer and reports the actual byte count after the body).
+        val msg = CountVariableList(names = listOf(CountNamed("hi"), CountNamed("abc")))
+        assertEquals(WireSize.BackPatch, CountVariableListCodec.wireSize(msg, EncodeContext.Empty))
+    }
+
+    // ---- non-terminal @Count + trailer -----------------------------------
+
+    @Test
+    fun roundTripsCountThenTrailer() {
+        val original =
+            CountThenTrailer(
+                points = listOf(CountPoint(0x0001u, 0x02u), CountPoint(0x0003u, 0x04u)),
+                trailer = 0xDEADBEEFu,
+            )
+        val buf = buildBuffer { CountThenTrailerCodec.encode(it, original, EncodeContext.Empty) }
+        buf.resetForRead()
+        assertEquals(original, CountThenTrailerCodec.decode(buf, DecodeContext.Empty))
+    }
+
+    @Test
+    fun encodesCountThenTrailerByteExact() {
+        val msg =
+            CountThenTrailer(
+                points = listOf(CountPoint(0x0001u, 0x02u), CountPoint(0x0003u, 0x04u)),
+                trailer = 0xDEADBEEFu,
+            )
+        val buf = buildBuffer { CountThenTrailerCodec.encode(it, msg, EncodeContext.Empty) }
+        val expected =
+            byteArrayOf(
+                0x02, // count = 2
+                0x00,
+                0x01,
+                0x02,
+                0x00,
+                0x03,
+                0x04,
+                0xDE.toByte(),
+                0xAD.toByte(),
+                0xBE.toByte(),
+                0xEF.toByte(), // trailer
+            )
+        assertEquals(expected.size, buf.position())
+        buf.resetForRead()
+        assertContentEquals(expected, buf.readByteArray(expected.size))
+    }
+
+    @Test
+    fun wireSizeCountThenTrailerIsExact() {
+        val msg =
+            CountThenTrailer(
+                points = listOf(CountPoint(0u, 0u), CountPoint(1u, 1u)),
+                trailer = 0u,
+            )
+        // varint(2) + 3 × 2 + 4 (trailer) = 1 + 6 + 4.
+        assertEquals(WireSize.Exact(1 + 6 + 4), CountThenTrailerCodec.wireSize(msg, EncodeContext.Empty))
+    }
+
+    // ---- peek -------------------------------------------------------------
+
+    @Test
+    fun peekFrameSizeReportsNoFraming() {
+        // A @Count list's frame size needs per-element decode (count is an
+        // element count, not a byte span) — peek conservatively reports
+        // NoFraming, consistent with the byte-length list shapes.
+        val pool = BufferPool()
+        val stream = StreamProcessor.create(pool, ByteOrder.BIG_ENDIAN)
+        try {
+            assertEquals(PeekResult.NoFraming, CountFixedListCodec.peekFrameSize(stream))
+        } finally {
+            stream.release()
+            pool.clear()
+        }
+    }
+
+    // ---- helpers ----------------------------------------------------------
+
+    private fun encodeAndAssertBytes(
+        msg: CountFixedList,
+        expected: ByteArray,
+    ) {
+        val buf = encode(msg)
+        assertEquals(expected.size, buf.position(), "encoded byte count matches wire layout")
+        buf.resetForRead()
+        assertContentEquals(expected, buf.readByteArray(expected.size), "encoded bytes match expected wire layout")
+    }
+
+    private fun encode(v: CountFixedList) = buildBuffer { CountFixedListCodec.encode(it, v, EncodeContext.Empty) }
+
+    private fun buildBuffer(
+        capacity: Int = 64,
+        block: (com.ditchoom.buffer.PlatformBuffer) -> Unit,
+    ) = BufferFactory.Default.allocate(capacity, ByteOrder.BIG_ENDIAN).also(block)
+}

--- a/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/annotations/Annotations.kt
+++ b/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/annotations/Annotations.kt
@@ -271,6 +271,52 @@ annotation class LengthFrom(
 )
 
 /**
+ * Marks an element-count-prefixed list field: a self-delimiting count of
+ * `N` elements (encoded as an unsigned LEB128 variable-length integer via
+ * the shipped `UnsignedVarIntCodec`), followed by exactly `N` encoded
+ * elements. Each element is self-delimiting through its own codec, so the
+ * decoder reads the count and then loops exactly `N` times — no byte-length
+ * bound is required.
+ *
+ * This is the element-count complement to the byte-length list framings
+ * ([LengthPrefixed], [LengthFrom], [RemainingBytes]), which all bound a
+ * list by a *byte span* and drain to a buffer limit. `@Count` instead
+ * carries the element *count*, so the field is self-delimiting and need
+ * not be the terminal constructor parameter.
+ *
+ * Accepted on `List<T>` where `T` is a `@ProtocolMessage` data class or
+ * sealed parent (the same element-type universe as `@RemainingBytes
+ * val: List<T>` / `@LengthFrom val: List<T>`). The element codec resolves
+ * by-name to `${T.simpleName}Codec` in `T`'s package.
+ *
+ * ```kotlin
+ * @ProtocolMessage
+ * data class Point(val x: Short, val y: Short)
+ *
+ * @ProtocolMessage
+ * data class Path(
+ *     val id: UInt,
+ *     @Count val points: List<Point>,   // varint(points.size) then each Point
+ * )
+ * ```
+ *
+ * Wire layout:
+ * ```text
+ *   +---------------------+----------------------------+
+ *   | varint(N)           | element_0 element_1 …      |
+ *   +---------------------+----------------------------+
+ * ```
+ *
+ * **Mutually exclusive** with [LengthPrefixed], [LengthFrom], and
+ * [RemainingBytes] on the same parameter — those are the alternative
+ * byte-length list framings. Combining `@Count` with any of them is a
+ * compile error.
+ */
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.BINARY)
+annotation class Count
+
+/**
  * Overrides the wire width of a numeric field. The [value] specifies the number
  * of bytes on the wire (1-8). Must not exceed the Kotlin type's natural size.
  * Cannot be used on `Float`, `Double`, or `Boolean`.


### PR DESCRIPTION
## Summary

Adds `@Count`, the **element-count** complement to the existing **byte-length** list framings (`@LengthPrefixed` / `@LengthFrom` / `@RemainingBytes`). Those bound a list by a byte span and drain to a buffer limit; `@Count` instead writes a self-delimiting `varint(N)` element count followed by exactly `N` self-delimiting elements.

```kotlin
@ProtocolMessage
data class Path(
    val id: UInt,
    @Count val points: List<Point>,   // varint(points.size) then each Point
)
```

The count varint reuses the shipped unsigned-LEB128 `UnsignedVarIntCodec` (the same self-delimiting encoding an enum ordinal rides on) — no new varint primitive. Because the count is explicit the field is self-delimiting and, unlike the drain-to-limit list shapes, need not be the terminal constructor parameter.

## What changed

- **IR** (`CodecIr.kt`): new `FieldSpec.CountPrefixedProtocolMessageList` (mirrors `RemainingBytesProtocolMessageList`, carries `elementIsBackPatch`).
- **Analyzer** (`CodecAnalyzer.kt`): `@Count` recognized on `List<@ProtocolMessage>`; per-variant wireSize classification handles it (RuntimeExact, or BackPatch when the element is BackPatch-shaped).
- **Emitter**: decode reads the varint count then `repeat(N)`; encode writes `varint(list.size)` then each element (`CodecEmitterFields.kt`); wireSize = varint width of the count + sum of element wireSizes via the runtime `as Exact` cast (`CodecEmitterWireSize.kt`); `peekFrameSize` returns `NoFraming` (the prefix is an element count, not a byte span, so total size needs per-element decode) (`CodecEmitterPeek.kt`).
- **Schema descriptor** (`CodecSchemaDescriptor.kt`): `count-prefixed` field record.

## Compile-time rules

`@Count` is a KSP compile **error** when combined with `@LengthPrefixed` / `@LengthFrom` / `@RemainingBytes` (alternative list framings) — also `@WireBytes` / `@UseCodec` — on the same field, and when applied to a non-`List` type.

## Tests

- `CountValidatorTest` — compile-fail coverage for each mutual-exclusion combination + the non-list case, plus an accepts case.
- `CountPrefixedListCodecTest` — round-trip + byte-identity for fixed-width and variable-width (length-prefixed string) element types across empty / one / many, a non-terminal `@Count` list with a trailing fixed field, wireSize, and the `NoFraming` peek result.

`./gradlew :buffer-codec-processor:test`, `:buffer-codec-test:jvmTest`, and `ktlintCheck` all pass; codec snapshots and the schema-drift baseline regenerated (additive only).