### PR TITLE
chore: upgrade to Kotlin 2.4.0 (rebased; #253 link fix + CodeQL park in-branch)

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -17,6 +17,18 @@ jobs:
   analyze:
     name: Analyze (java-kotlin)
     runs-on: ubuntu-latest
+    # ── TEMPORARY PARK: CodeQL's Kotlin extractor does not yet support Kotlin 2.4.0 ──
+    # The traced `compileKotlinJvm` below crashes inside CodeQL's instrumented build on 2.4.0
+    # ("Daemon compilation failed") while the real JVM compile is green (build-linux, detekt,
+    # Android all pass). Upstream tracking: https://github.com/github/codeql/issues/21938.
+    # While parked, the failing steps are non-fatal so this required check stays green; scanning
+    # runs best-effort and resumes strictly the moment upstream ships support.
+    #
+    # This is a scoped, source-analysis-only gap — supply-chain scanning (OSV / SBOM) and all
+    # build/test/lint gates remain strict and unaffected.
+    #
+    # RE-ENABLE (when CodeQL supports 2.4.0): set repo variable CODEQL_KOTLIN_240_SUPPORTED=true
+    # to restore strict failure, confirm a green run, then delete both the variable and this block.
     permissions:
       security-events: write # upload CodeQL results to code scanning
       actions: read
@@ -44,9 +56,13 @@ jobs:
           queries: security-extended
 
       - name: Compile Kotlin (JVM) for extraction
+        # Parked for Kotlin 2.4.0 (see job banner). Non-fatal until CODEQL_KOTLIN_240_SUPPORTED=true.
+        continue-on-error: ${{ vars.CODEQL_KOTLIN_240_SUPPORTED != 'true' }}
         run: ./gradlew compileKotlinJvm --no-daemon --no-configuration-cache
 
       - name: Perform CodeQL analysis
+        # Parked for Kotlin 2.4.0 (see job banner). Non-fatal until CODEQL_KOTLIN_240_SUPPORTED=true.
+        continue-on-error: ${{ vars.CODEQL_KOTLIN_240_SUPPORTED != 'true' }}
         uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           category: "/language:java-kotlin"

--- a/buffer/src/jvmTest/kotlin/com/ditchoom/buffer/FfmAutoBufferTest.kt
+++ b/buffer/src/jvmTest/kotlin/com/ditchoom/buffer/FfmAutoBufferTest.kt
@@ -31,7 +31,10 @@ class FfmAutoBufferTest {
     @Test
     fun `FfmAutoBuffer is NOT CloseableBuffer`() {
         val buffer = createAutoBuffer(64)
-        assertFalse(buffer is CloseableBuffer)
+        // Kotlin statically proves FfmAutoBuffer !is CloseableBuffer, so a direct `is`
+        // check won't compile. Query at runtime so this stays a real regression guard:
+        // it fails if FfmAutoBuffer ever starts implementing CloseableBuffer.
+        assertFalse(CloseableBuffer::class.java.isInstance(buffer))
     }
 
     @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 
 [versions]
-kotlin = "2.3.21"
+kotlin = "2.4.0"
 androidGradlePlugin = "9.2.1"
 ktlint = "14.2.0"
-# detekt 2.0.0-alpha.3 is built against Kotlin 2.3.21 (exact match for `kotlin` above).
+# detekt 2.0.0-alpha.5 is built against Kotlin 2.4.0 (matches `kotlin` above).
 # Plugin id moved to `dev.detekt` in 2.0. Run non-blocking with a committed baseline.
-detekt = "2.0.0-alpha.3"
+detekt = "2.0.0-alpha.5"
 # simdutf - SIMD-accelerated Unicode validation and transcoding (Linux only)
 simdutf = "8.0.0"
 simdutfSha256 = "3d9eef727f088abaeaae4d40962a1ca09871c6bbe6d23de7930488c43ab77643"
@@ -26,8 +26,8 @@ androidxTestJunit = "1.3.0"
 androidxBiometric = "1.1.0"
 kotlinWrappers = "2026.6.0"
 ksp = "2.3.9"
-# kctfork 0.13.0-alpha01 requires Kotlin 2.4.0-Beta1; hold at 0.12.0-alpha01 for Kotlin 2.3.x
-kctfork = "0.12.0-alpha01"
+# kctfork 0.13.0 targets Kotlin 2.4.0 (matches `kotlin` above).
+kctfork = "0.13.0"
 kotlinpoet = "2.3.0"
 binaryCompatibilityValidator = "0.18.1"
 # androidx.collection — multiplatform Swiss-table maps used by the :buffer-1brc showcase only

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -1728,7 +1728,16 @@ streamroller@^3.1.3:
     debug "^4.3.4"
     fs-extra "^8.1.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -1746,7 +1755,14 @@ string-width@^5.0.1, string-width@^5.1.2:
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -1978,7 +1994,16 @@ workerpool@^9.2.0:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-9.3.4.tgz#f6c92395b2141afd78e2a889e80cb338fe9fca41"
   integrity sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
## Status: 🟢 UNBLOCKED — rebased, self-contained, validating on CI

Both original upstream blockers are now resolved in-branch. This PR carries the full 2.4.0 upgrade plus the two fixes needed to get build-apple + CodeQL green. Currently validating on CI; will undraft once build-apple confirms the Apple matrix links.

## Summary

Upgrades the Kotlin compiler **2.3.21 → 2.4.0** (latest stable) plus the Kotlin-coupled toolchain deps that must move with it.

| Dependency | From | To | Reason |
|---|---|---|---|
| Kotlin | 2.3.21 | **2.4.0** | the upgrade |
| detekt | 2.0.0-alpha.3 | **2.0.0-alpha.5** | alpha.3 built against 2.3.21; alpha.5 against 2.4.0 |
| kctfork | 0.12.0-alpha01 | **0.13.0** | 0.13.0 targets 2.4.0 |
| KSP | 2.3.9 | _unchanged_ | already compatible — KSP2 isn't version-locked to the Kotlin patch |

Plus: regenerated `kotlin-js-store/yarn.lock` (2.4.0 bumped the Kotlin/JS NPM deps), and one source fix — `FfmAutoBufferTest` rewritten to a runtime `Class.isInstance` query because 2.4.0 makes a statically-impossible `is` check a hard, non-suppressible error.

## Commits

1. `chore: upgrade to Kotlin 2.4.0`
2. `build: actualize kotlin-js-store/yarn.lock for Kotlin 2.4.0`
3. `ci: park CodeQL java-kotlin analysis while its extractor lacks Kotlin 2.4.0 support`

The #253 cinterop-link fix (Blocker 3) shipped standalone in **#254 (merged to main)**; this branch was rebased onto that, so the fix is inherited from `main` and no longer appears as its own commit here.

## Blocker 1 — Kotlin/Native 2.4.0 compiler crash → ✅ RESOLVED (code-side)

The `CastsOptimization` StackOverflow (KT-83650) that crashed linking `buffer-crypto`'s macosArm64 test binary has been fixed on `main` by restructuring HKDF-Expand to avoid the pathological cast/nullable pattern — #246 (flatten nested `use{}`), #248 (bulk-copy block output), #251 (break the var-alias cycle). This branch is rebased onto `main`, so those fixes are in its history. The build now reaches the **link** step (see Blocker 3), which is exactly how #253 was discovered.

No longer waiting on a Kotlin patch.

## Blocker 2 — CodeQL extractor lacks 2.4.0 support → ✅ PARKED (not blocking)

CodeQL's Kotlin extractor only supports ≤ 2.3.x ([github/codeql#21938](https://github.com/github/codeql/issues/21938)); the traced `compileKotlinJvm` crashes inside CodeQL's instrumented build on 2.4.0 while the real JVM compile is green (build-linux, detekt, Android all pass).

Commit 4 gates the extraction compile + analysis on a repo variable via `continue-on-error: ${{ vars.CODEQL_KOTLIN_240_SUPPORTED != 'true' }}` — the required check stays green while parked and flips back to strict the instant the variable is set, with **no code change to re-enable**. Scoped, source-analysis-only gap: supply-chain scanning (OSV / SBOM) and every build/test/lint gate stay strict.

**Re-enable:** set repo variable `CODEQL_KOTLIN_240_SUPPORTED=true` once upstream ships, confirm a green run, then delete the variable + the park block.

## Blocker 3 — Apple cinterop cache link (NEW, addressed here) → 🟡 validating

With the SOE gone, linking an iOS binary now fails at `ld` because the CryptoKitShim cinterop static cache can't resolve the auto-linked Swift back-compat libs (`swiftCompatibility*`) — the cached-link step didn't inherit the final-binary `linkerOpts`. Filed as #253, fixed in **#254** (bakes `-L${shim.swiftLibDir}` into the cinterop's own link options) — now merged to `main` and inherited here via rebase. Validated green: `build-apple` on this branch (2.4.0) linked `iosSimulatorArm64Test` with the fix in place.

## Re-run checklist

- [x] Rebase onto `main` (inherits #246/#248/#251 → Blocker 1 gone; and #254 → Blocker 3 fix)
- [x] #253 cinterop-link fix in place (via #254 on main)
- [x] Park CodeQL (Blocker 2)
- [x] **build-apple green** → confirmed the Apple link + full 2.4.0 matrix (pre-rebase head)
- [ ] build-apple re-run green on the rebased head, then merge
