### PR TITLE
ci: cache Gradle build outputs to speed up Apple/Linux CI

### DIFF
--- a/.github/workflows/build-apple.yaml
+++ b/.github/workflows/build-apple.yaml
@@ -8,6 +8,11 @@ on:
         required: false
         default: ""
         type: string
+      clean-publish:
+        description: "Publish with --no-build-cache (clean rebuild from source). Set true for the actual release/publish-to-Central path."
+        required: false
+        default: false
+        type: boolean
     outputs:
       version:
         description: "Computed next version"
@@ -47,15 +52,29 @@ jobs:
           key: konan-macos-${{ hashFiles('gradle/libs.versions.toml') }}
           restore-keys: konan-macos-
 
+      # Cache the Gradle module caches + local build cache (~/.gradle/caches/build-cache-1)
+      # so compiled klibs, cinterop klibs, and the per-target native shim archives survive
+      # across runs. Keyed on the build definition (version catalog, build scripts, wrapper);
+      # restore-keys fall back to the most recent partial match when those change.
+      - name: Cache Gradle build outputs
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+        with:
+          path: ~/.gradle/caches
+          key: gradle-macos-${{ hashFiles('gradle/libs.versions.toml', '**/*.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-macos-
+
       - name: Get version
         id: version
         run: echo "version=$(./gradlew -q nextVersion ${{ inputs.gradle-args }})" >> $GITHUB_OUTPUT
 
       - name: Run Apple target tests
-        run: ./gradlew macosArm64Test iosSimulatorArm64Test --no-build-cache ${{ inputs.gradle-args }}
+        run: ./gradlew macosArm64Test iosSimulatorArm64Test ${{ inputs.gradle-args }}
 
+      # The release/publish-to-Central path passes clean-publish: true to force a cold,
+      # cache-free rebuild of the published artifacts. PR validation reuses the build cache.
       - name: Publish to Maven Local
-        run: ./gradlew publishToMavenLocal --no-build-cache ${{ inputs.gradle-args }}
+        run: ./gradlew publishToMavenLocal ${{ inputs.clean-publish && '--no-build-cache' || '' }} ${{ inputs.gradle-args }}
 
       - name: Upload Maven local artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -8,6 +8,11 @@ on:
         required: false
         default: ""
         type: string
+      clean-publish:
+        description: "Publish with --no-build-cache (clean rebuild from source). Set true for the actual release/publish-to-Central path."
+        required: false
+        default: false
+        type: boolean
     outputs:
       version:
         description: "Computed next version"
@@ -58,6 +63,18 @@ jobs:
           path: buffer/build/simdutf/libs/linux-arm64
           key: simdutf-linux-arm64-${{ hashFiles('gradle/libs.versions.toml', 'buffer/src/nativeInterop/cinterop/simdutf_wrapper.cpp') }}
 
+      # Cache the Gradle module caches + local build cache (~/.gradle/caches/build-cache-1)
+      # so compiled klibs, cinterop klibs, and KSP/codegen outputs survive across runs.
+      # Keyed on the build definition (version catalog, build scripts, wrapper); restore-keys
+      # fall back to the most recent partial match when those change.
+      - name: Cache Gradle build outputs
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+        with:
+          path: ~/.gradle/caches
+          key: gradle-linux-${{ hashFiles('gradle/libs.versions.toml', '**/*.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-linux-
+
       - name: Install ARM64 dependencies
         run: |
           sudo apt-get update
@@ -83,7 +100,7 @@ jobs:
       - name: Run KSP processor tests
         run: >-
           ./gradlew :buffer-codec-processor:test
-          --no-build-cache ${{ inputs.gradle-args }}
+          ${{ inputs.gradle-args }}
 
       - name: Run JVM / JS / WASM / Android-host tests
         # The host-JVM Android unit tasks run here so contributors can reproduce
@@ -103,7 +120,7 @@ jobs:
           ./gradlew ktlintCheck
           jvmTest jsNodeTest jsBrowserTest wasmJsNodeTest wasmJsBrowserTest
           testDebugUnitTest testBenchmarkUnitTest
-          --no-build-cache ${{ inputs.gradle-args }}
+          ${{ inputs.gradle-args }}
 
       - name: Run Linux x64 tests
         # :buffer-crypto:linuxX64Test runs the full common crypto suite (KAT + Wycheproof +
@@ -113,7 +130,7 @@ jobs:
         run: >-
           ./gradlew :buffer:linuxX64Test :buffer-compression:linuxX64Test :buffer-flow:linuxX64Test
           :buffer-codec:linuxX64Test :buffer-codec-test:linuxX64Test :buffer-crypto:linuxX64Test
-          --no-build-cache ${{ inputs.gradle-args }}
+          ${{ inputs.gradle-args }}
 
       - name: Build ARM64 test binaries
         # buffer-crypto cross-builds its arm64 BoringSSL via buildBoringsslArm64 (uses the
@@ -121,7 +138,7 @@ jobs:
         run: >-
           ./gradlew :buffer:linkDebugTestLinuxArm64 :buffer-compression:linkDebugTestLinuxArm64 :buffer-flow:linkDebugTestLinuxArm64
           :buffer-codec-test:linkDebugTestLinuxArm64 :buffer-crypto:linkDebugTestLinuxArm64
-          --no-build-cache ${{ inputs.gradle-args }}
+          ${{ inputs.gradle-args }}
 
       - name: Run buffer ARM64 tests via QEMU
         run: qemu-aarch64-static -L /usr/aarch64-linux-gnu ./buffer/build/bin/linuxArm64/debugTest/test.kexe
@@ -138,8 +155,10 @@ jobs:
       - name: Run buffer-crypto ARM64 tests via QEMU
         run: qemu-aarch64-static -L /usr/aarch64-linux-gnu ./buffer-crypto/build/bin/linuxArm64/debugTest/test.kexe
 
+      # The release/publish-to-Central path passes clean-publish: true to force a cold,
+      # cache-free rebuild of the published artifacts. PR validation reuses the build cache.
       - name: Publish to Maven Local
-        run: ./gradlew publishToMavenLocal --no-build-cache ${{ inputs.gradle-args }}
+        run: ./gradlew publishToMavenLocal ${{ inputs.clean-publish && '--no-build-cache' || '' }} ${{ inputs.gradle-args }}
 
       - name: Upload Maven local artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/merged.yaml
+++ b/.github/workflows/merged.yaml
@@ -115,6 +115,9 @@ jobs:
     uses: ./.github/workflows/build-linux.yaml
     with:
       gradle-args: ${{ needs.check-release.outputs.gradle-args }}
+      # For an actual release/draft publish-to-Central, force a clean, cache-free rebuild
+      # of the published artifacts. Non-publishing flows (dry-run) reuse the build cache.
+      clean-publish: ${{ needs.check-release.outputs.flow == 'release' || needs.check-release.outputs.flow == 'draft' }}
 
   build-apple:
     needs: check-release
@@ -122,6 +125,9 @@ jobs:
     uses: ./.github/workflows/build-apple.yaml
     with:
       gradle-args: ${{ needs.check-release.outputs.gradle-args }}
+      # For an actual release/draft publish-to-Central, force a clean, cache-free rebuild
+      # of the published artifacts. Non-publishing flows (dry-run) reuse the build cache.
+      clean-publish: ${{ needs.check-release.outputs.flow == 'release' || needs.check-release.outputs.flow == 'draft' }}
 
   validate:
     needs: [check-release, build-linux, build-apple]


### PR DESCRIPTION
## Summary

The Apple build/test job (`build-apple.yaml`, runs on `macos-latest`) currently takes ~50+ minutes because:

- Both the test step and the `publishToMavenLocal` step pass `--no-build-cache`, which actively **disables** Gradle's build cache.
- Only `~/.konan` is cached — no compiled output (klibs, cinterop klibs, per-target native shim archives, KSP/codegen output, or the Gradle build cache itself) survives between runs. Every run is a cold native rebuild of the full ~10-target Apple matrix.

This PR enables Gradle's local build cache on the PR-validation path while keeping a clean, cache-free rebuild for the actual release/publish-to-Maven-Central path.

## Changes

- **Cache Gradle build outputs**: added an `actions/cache` step for `~/.gradle/caches` (which contains the local build cache at `build-cache-1`) to both `build-apple.yaml` and `build-linux.yaml`. Keyed on a hash of `gradle/libs.versions.toml`, `**/*.gradle.kts`, and `gradle/wrapper/gradle-wrapper.properties`, with `restore-keys` for partial hits. The action is pinned to the same SHA (`2c8a9bd7…` v6.0.0) already used by the existing Konan/simdutf cache steps. The existing Konan cache is kept.
- **Stop disabling the build cache on PR validation**: removed `--no-build-cache` from the test/compile steps (Apple tests; Linux KSP, JVM/JS/WASM/Android-host, Linux x64, ARM64 link steps) so the build cache is actually used.
- **Preserve a clean publish for releases**: added a `workflow_call` boolean input `clean-publish` (default `false`) to both reusable workflows. `--no-build-cache` is appended to `publishToMavenLocal` only when `clean-publish` is `true`. The release caller (`merged.yaml`) passes `clean-publish: true` for the `release` and `draft` flows, so the artifacts that go to Maven Central are still built from a cold, cache-free rebuild. The PR-validation caller (`review.yaml`) and the `dry-run` flow reuse the cache.
- `org.gradle.caching=true` was already present in `gradle.properties` (no change needed; verified it is not set to `false` anywhere).

## Correctness guarantee for the release path

The actual publish-to-Maven-Central artifacts are produced by `publishToMavenLocal` in the `release`/`draft` flows of `merged.yaml`, which now pass `clean-publish: true`. That keeps `--no-build-cache` on the publish command for releases, so the published binaries are built from a clean rebuild exactly as before. Only PR validation and the non-publishing `dry-run` flow reuse the cache.

## Expected impact

Target: bring the Apple job from ~50 min down to ~15–20 min on warm-cache PR runs (cold first run after a cache key change still pays the full cost). Linux validation also speeds up by reusing cached compiled outputs.

## Validation

- `actions/cache` pinned to the same SHA as the existing cache steps in these files.
- `actionlint` reports no new errors/warnings from these changes (the only findings are pre-existing shellcheck `info` notes on untouched `nextVersion`/`$GITHUB_OUTPUT` lines).
- `./gradlew help -q` parses `gradle.properties` cleanly with `org.gradle.caching=true`.

## Deferred follow-ups

- **Develocity / remote build cache** — would share cache across runners and machines, but needs credentials/server config; deferred.
- **Gradle configuration cache** (`org.gradle.configuration-cache`) — can break with incompatible plugins; risky, deferred.
- **Trimming the Apple target matrix on PRs** — would cut time further but is a larger change to validation coverage; deferred.
