### PR TITLE
fix(ci): merge Apple metadata (PSM) for buffer-codec & buffer-crypto

### DIFF
--- a/.github/workflows/validate-artifacts.yaml
+++ b/.github/workflows/validate-artifacts.yaml
@@ -40,7 +40,35 @@ jobs:
           mkdir -p /tmp/maven-local/com
           cp -r "$LINUX_BASE" /tmp/maven-local/com/
 
-          for module in buffer buffer-compression buffer-flow; do
+          # Single source of truth: the KMP modules that publish Apple targets and
+          # therefore need Linux+Apple metadata reconciliation. A module qualifies when
+          # its Apple-host umbrella metadata JAR declares an `appleMain` source set in
+          # its PSM (kotlin-project-structure-metadata.json). Only the umbrella metadata
+          # JAR carries that file, so leaf/JVM-only modules are naturally excluded. This
+          # list is exported and reused by every loop below (merge + validation guards)
+          # so they can't drift as modules are added or removed.
+          APPLE_MODULES=""
+          for dir in "$APPLE_BASE"/*/; do
+            [ -d "$dir" ] || continue
+            module=$(basename "$dir")
+            jar="$APPLE_BASE/$module/$version/$module-$version.jar"
+            [ -f "$jar" ] || continue
+            psm=$(unzip -p "$jar" META-INF/kotlin-project-structure-metadata.json 2>/dev/null) || continue
+            [ -n "$psm" ] || continue
+            if printf '%s' "$psm" | jq -e '.projectStructure.sourceSets[]? | select(.name == "appleMain")' >/dev/null 2>&1; then
+              APPLE_MODULES="$APPLE_MODULES $module"
+            fi
+          done
+          APPLE_MODULES=$(echo "$APPLE_MODULES" | tr ' ' '\n' | grep -v '^$' | sort | tr '\n' ' ')
+          echo "Detected Apple-publishing modules: ${APPLE_MODULES}"
+
+          if [ -z "$(echo "$APPLE_MODULES" | tr -d ' ')" ]; then
+            echo "FAIL: no Apple-publishing modules detected — Apple artifact download or PSM layout changed"
+            exit 1
+          fi
+          echo "APPLE_MODULES=${APPLE_MODULES}" >> "$GITHUB_ENV"
+
+          for module in $APPLE_MODULES; do
             echo "=== Merging ${module} ==="
 
             # Copy Apple per-target artifact directories
@@ -176,13 +204,12 @@ jobs:
           echo ""
 
           # 1. Root module metadata - all platform variants
-          # buffer has wasmJs; buffer-compression and buffer-flow do not
-          BUFFER_PLATFORMS="jvm js linuxx64 linuxarm64 macosarm64 macosx64 iosarm64 iossimulatorarm64 wasmJs"
-          COMPRESSION_PLATFORMS="jvm js linuxx64 linuxarm64 macosarm64 macosx64 iosarm64 iossimulatorarm64"
-          FLOW_PLATFORMS="jvm js linuxx64 linuxarm64 macosarm64 macosx64 iosarm64 iossimulatorarm64"
-          CODEC_PLATFORMS="jvm js linuxx64 linuxarm64 macosarm64 macosx64 iosarm64 iossimulatorarm64"
+          # Expected platform variants per module — an intentional assertion, not derived.
+          # The apple+linux+jvm+js set is shared; buffer and buffer-crypto additionally
+          # publish a wasmJs variant in their root .module.
+          COMMON_PLATFORMS="jvm js linuxx64 linuxarm64 macosarm64 macosx64 iosarm64 iossimulatorarm64"
 
-          for module in buffer buffer-compression buffer-flow buffer-codec; do
+          for module in $APPLE_MODULES; do
             echo "--- ${module} module metadata ---"
             MODULE_FILE="${BASE}/${module}/${version}/${module}-${version}.module"
             if [ ! -f "$MODULE_FILE" ]; then
@@ -190,15 +217,10 @@ jobs:
               FAILED=true
               continue
             fi
-            if [ "$module" = "buffer" ]; then
-              platforms="$BUFFER_PLATFORMS"
-            elif [ "$module" = "buffer-flow" ]; then
-              platforms="$FLOW_PLATFORMS"
-            elif [ "$module" = "buffer-codec" ]; then
-              platforms="$CODEC_PLATFORMS"
-            else
-              platforms="$COMPRESSION_PLATFORMS"
-            fi
+            case "$module" in
+              buffer|buffer-crypto) platforms="$COMMON_PLATFORMS wasmJs" ;;
+              *)                    platforms="$COMMON_PLATFORMS" ;;
+            esac
             for platform in $platforms; do
               if grep -q "$platform" "$MODULE_FILE"; then
                 echo "  $platform variant present"
@@ -313,7 +335,7 @@ jobs:
 
           # 6. Android AAR and kotlin-tooling-metadata presence
           echo "--- Android & Metadata Artifacts ---"
-          for module in buffer buffer-compression buffer-flow buffer-codec; do
+          for module in $APPLE_MODULES; do
             AAR_DIR="${BASE}/${module}-android/${version}"
             if [ -d "$AAR_DIR" ]; then
               AAR=$(find "$AAR_DIR" -name "*.aar" | head -1)
@@ -335,7 +357,7 @@ jobs:
 
           # 7. Metadata JAR Apple source sets
           echo "--- Metadata JAR Apple Source Sets ---"
-          for module in buffer buffer-compression buffer-flow; do
+          for module in $APPLE_MODULES; do
             METADATA_JAR="${BASE}/${module}/${version}/${module}-${version}.jar"
             if [ ! -f "$METADATA_JAR" ]; then
               echo "  WARN: ${module} metadata JAR not found"

--- a/buffer-codec/build.gradle.kts
+++ b/buffer-codec/build.gradle.kts
@@ -223,25 +223,14 @@ mavenPublishing {
     }
 }
 
-// Split publishing metadata fix (see buffer/build.gradle.kts for details)
-afterEvaluate {
-    if (isRunningOnGithub) {
-        if (HostManager.hostIsLinux) {
-            tasks.named("generateMetadataFileForKotlinMultiplatformPublication") {
-                doLast {
-                    val moduleFile = outputs.files.singleFile
-                    injectAppleVariantsIntoModuleMetadata(moduleFile, project.version.toString(), "buffer-codec")
-                }
-            }
-        }
-        if (HostManager.hostIsMac) {
-            tasks
-                .matching {
-                    it.name.startsWith("publishKotlinMultiplatformPublication")
-                }.configureEach { enabled = false }
-        }
-    }
-}
+// Apple metadata reconciliation is handled by the two-host release merge in
+// .github/workflows/validate-artifacts.yaml (same as buffer, buffer-compression,
+// buffer-flow and buffer-crypto): each host publishes its own umbrella metadata
+// module, and CI unions the .module variants and the umbrella JAR's PSM
+// (kotlin-project-structure-metadata.json). Publishing the umbrella on both hosts
+// (rather than disabling it on macOS and hand-injecting Apple variants into the
+// Linux .module) is what lets the merged PSM carry the Apple source sets that
+// downstream `compileAppleMainKotlinMetadata` needs.
 
 ktlint {
     verbose.set(true)
@@ -264,73 +253,4 @@ dokka {
         }
         reportUndocumented.set(false)
     }
-}
-
-/** See buffer/build.gradle.kts for full documentation. */
-@Suppress("UNCHECKED_CAST")
-fun injectAppleVariantsIntoModuleMetadata(
-    moduleFile: File,
-    version: String,
-    artifactId: String,
-) {
-    val appleTargets =
-        listOf(
-            "iosArm64" to "ios_arm64",
-            "iosSimulatorArm64" to "ios_simulator_arm64",
-            "iosX64" to "ios_x64",
-            "macosArm64" to "macos_arm64",
-            "macosX64" to "macos_x64",
-            "tvosArm64" to "tvos_arm64",
-            "tvosSimulatorArm64" to "tvos_simulator_arm64",
-            "tvosX64" to "tvos_x64",
-            "watchosArm64" to "watchos_arm64",
-            "watchosSimulatorArm64" to "watchos_simulator_arm64",
-            "watchosX64" to "watchos_x64",
-        )
-
-    val json = groovy.json.JsonSlurper().parseText(moduleFile.readText()) as MutableMap<String, Any>
-    val variants = json["variants"] as MutableList<Any>
-
-    appleTargets.forEach { (gradleName, konanName) ->
-        val moduleName = "$artifactId-${gradleName.lowercase()}"
-        val availableAt =
-            mapOf(
-                "url" to "../../$moduleName/$version/$moduleName-$version.module",
-                "group" to "com.ditchoom",
-                "module" to moduleName,
-                "version" to version,
-            )
-        variants.add(
-            mapOf(
-                "name" to "${gradleName}ApiElements-published",
-                "attributes" to
-                    mapOf(
-                        "org.gradle.category" to "library",
-                        "org.gradle.jvm.environment" to "non-jvm",
-                        "org.gradle.usage" to "kotlin-api",
-                        "org.jetbrains.kotlin.native.target" to konanName,
-                        "org.jetbrains.kotlin.platform.type" to "native",
-                    ),
-                "available-at" to availableAt,
-            ),
-        )
-        variants.add(
-            mapOf(
-                "name" to "${gradleName}SourcesElements-published",
-                "attributes" to
-                    mapOf(
-                        "org.gradle.category" to "documentation",
-                        "org.gradle.dependency.bundling" to "external",
-                        "org.gradle.docstype" to "sources",
-                        "org.gradle.jvm.environment" to "non-jvm",
-                        "org.gradle.usage" to "kotlin-runtime",
-                        "org.jetbrains.kotlin.native.target" to konanName,
-                        "org.jetbrains.kotlin.platform.type" to "native",
-                    ),
-                "available-at" to availableAt,
-            ),
-        )
-    }
-
-    moduleFile.writeText(groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson(json)))
 }


### PR DESCRIPTION
## Summary

Two independent defects caused `buffer-codec` **and** `buffer-crypto` 6.0.0 to ship umbrella metadata JARs whose `META-INF/kotlin-project-structure-metadata.json` (PSM) had **zero Apple source sets/variants**. Any downstream KMP module that shares Apple code through an intermediate `appleMain` metadata source set then fails `compileAppleMainKotlinMetadata` with `Unresolved reference 'Codec' / 'DecodeContext' / 'decode'`.

This PR fixes both. **No target gating and no library code changed.**

## Root cause 1 — CI merge/guard loops omitted codec & crypto (`buffer-crypto` fix)

The release builds on two hosts (`build-apple.yaml` on macOS, `build-linux.yaml` on Linux), each running `publishToMavenLocal`. `validate-artifacts.yaml`'s **"Merge artifacts and module metadata"** step seeds from the Linux base and unions each host's PSM — but its module loop only covered `buffer buffer-compression buffer-flow`, so `buffer-crypto` (which *does* publish an Apple umbrella JAR) kept the Linux-only, Apple-less PSM. The **"Metadata JAR Apple Source Sets"** guard that should have caught it *also* skipped codec/crypto.

**Fix (drift-proof):** derive the Apple-publishing module set once — the modules whose Apple-host umbrella metadata JAR declares an `appleMain` source set in its PSM — export it via `$GITHUB_ENV`, and drive every loop (merge + all three validation guards) from that single list. Leaf/JVM-only modules are excluded automatically; a guard fails the job if the derived set is empty. `buffer-crypto`'s `wasmJs` variant assertion is added via a `case` map.

## Root cause 2 — codec never published an Apple umbrella at all (`buffer-codec` fix)

Discovered while validating this PR's own dry-run `maven-local-merged` artifact: after fix 1, `buffer-crypto`'s merged PSM was correct but `buffer-codec`'s was **still** Apple-less. `buffer-codec` was the only KMP module still on the legacy split-publish hack (from #136): on macOS it **disabled** `publishKotlinMultiplatformPublication` entirely and on Linux it hand-injected Apple `available-at` variants into the umbrella `.module`. That patched Gradle *dependency resolution* but never the PSM — and because macOS published no codec umbrella JAR, the two-host merge had nothing to union for codec.

**Fix:** drop codec's bespoke `afterEvaluate` block and the `injectAppleVariants…` function so it publishes the umbrella metadata module on **both** hosts, exactly like the other four modules, and lets the CI merge do the reconciliation.

## Validation

- **Reproduced** the bug against the real cached (broken, Linux-only) `buffer-codec` 6.0.0 metadata JAR (Apple-less PSM).
- **Offline end-to-end harness** of the exact detection + merge-jq + guard logic under bash: detection selects the Apple-publishing modules and excludes `buffer-codec-processor`; the merge unions the PSMs to include `appleMain/iosMain/macosMain/tvosMain/watchosMain`; the extended guard passes.
- **codec build fix proven locally** by reproducing the CI macOS code path (`GITHUB_REPOSITORY` set → all Apple targets registered): the codec umbrella PSM then contains all five Apple source sets.
- **Pre-merge CI dry-run:** the previous push's `validate` run confirmed `buffer-crypto`'s merged PSM was fixed. This push re-runs the full two-host build → merge → validate; the extended guard now covers codec/crypto and the uploaded `maven-local-merged` will be inspected before merge.
- `actionlint` clean (no new shellcheck findings).

## Follow-up

`buffer-codec` and `buffer-crypto` must be **re-released** for the corrected Apple PSM to reach consumers. (`DitchOoM/websocket` already shipped a per-target workaround that can optionally be reverted afterward.)