### PR TITLE
ci: guard against Apple-leaf modules missing from the umbrella merge set

### DIFF
--- a/.github/workflows/validate-artifacts.yaml
+++ b/.github/workflows/validate-artifacts.yaml
@@ -66,6 +66,43 @@ jobs:
             echo "FAIL: no Apple-publishing modules detected — Apple artifact download or PSM layout changed"
             exit 1
           fi
+
+          # Regression guard: independently derive the set of modules that SHIP Apple
+          # leaf-target artifacts (buffer-codec-macosarm64, buffer-flow-iosarm64, …) and
+          # require every one of them to also appear in the detected umbrella set above.
+          # A module that publishes Apple leaf klibs but whose umbrella metadata JAR has
+          # no appleMain source set has regressed to the old split-publish hack (umbrella
+          # disabled on macOS + hand-injected .module variants) — exactly the failure that
+          # silently shipped Apple-less PSMs before. Detection alone can't catch it because
+          # such a module never appears in APPLE_MODULES; this cross-check makes it loud.
+          APPLE_TARGET_SUFFIXES="iosarm64 iossimulatorarm64 iosx64 macosarm64 macosx64 tvosarm64 tvossimulatorarm64 tvosx64 watchosarm64 watchossimulatorarm64 watchosx64 watchosdevicearm64"
+          EXPECTED_APPLE_MODULES=""
+          for dir in "$APPLE_BASE"/*/; do
+            [ -d "$dir" ] || continue
+            name=$(basename "$dir")
+            for suf in $APPLE_TARGET_SUFFIXES; do
+              case "$name" in
+                *-"$suf")
+                  EXPECTED_APPLE_MODULES="$EXPECTED_APPLE_MODULES ${name%-"$suf"}"
+                  break ;;
+              esac
+            done
+          done
+          EXPECTED_APPLE_MODULES=$(echo "$EXPECTED_APPLE_MODULES" | tr ' ' '\n' | grep -v '^$' | sort -u | tr '\n' ' ')
+          echo "Modules shipping Apple leaf targets: ${EXPECTED_APPLE_MODULES}"
+
+          MISSING_APPLE_MODULES=""
+          for m in $EXPECTED_APPLE_MODULES; do
+            case " $APPLE_MODULES " in
+              *" $m "*) ;;
+              *) MISSING_APPLE_MODULES="$MISSING_APPLE_MODULES $m" ;;
+            esac
+          done
+          if [ -n "$(echo "$MISSING_APPLE_MODULES" | tr -d ' ')" ]; then
+            echo "FAIL: these modules ship Apple leaf targets but their umbrella metadata JAR has no appleMain source set (regressed to a split-publish hack — publish the umbrella on macOS too):${MISSING_APPLE_MODULES}"
+            exit 1
+          fi
+
           echo "APPLE_MODULES=${APPLE_MODULES}" >> "$GITHUB_ENV"
 
           for module in $APPLE_MODULES; do


### PR DESCRIPTION
## Why

Follow-up hardening to #237. That PR made the Apple-module merge set **drift-proof for adding a normal KMP module** — it's derived from which umbrella metadata JARs declare an `appleMain` source set. But it has one residual blind spot: a module that regresses to the *old* split-publish hack (umbrella disabled on macOS + Apple variants hand-injected into the `.module`) never publishes an Apple umbrella JAR, so it never appears in the detected set — and the merge + every guard silently skip it and pass **vacuously**.

That is exactly how `buffer-codec` shipped an Apple-less PSM in 6.0.0, and (before this) the first CI run of #237 went green while codec was still broken — only manual artifact inspection caught it.

## What

Add an independent cross-check in the "Merge artifacts and module metadata" step:

1. Derive the set of modules that **ship Apple leaf-target artifacts** (`buffer-codec-macosarm64`, `buffer-flow-iosarm64`, …) straight from the Apple artifact tree.
2. Require every one of them to also appear in the detected umbrella set.
3. **Fail the step** (with the offending module names) if any is missing.

A module publishing Apple leaf klibs but no `appleMain` umbrella source set is the precise signature of the regression, so this makes it loud at merge time instead of shipping.

Self-contained — derived purely from the downloaded artifacts, no repo checkout needed.

## Validation

- Offline logic test of both paths: **fixed** layout (codec umbrella present) → PASS; **regressed** layout (codec ships `*-macosarm64`/`*-iosarm64` leaves but no umbrella `appleMain`) → FAIL naming `buffer-codec`. This mirrors the real broken-vs-fixed 6.0.x artifact trees.
- `actionlint` clean — no new shellcheck findings.

## Release impact

None — touches only `.github/workflows/`, so `merged.yaml`'s check-release classifies it as a non-code change (`flow=skip`) and no release is cut.