### PR TITLE
feat(flow+buffer): raw ByteStreamMux, non-consuming peek, CountingBufferFactory

### DIFF
--- a/buffer-flow/api/android/buffer-flow.api
+++ b/buffer-flow/api/android/buffer-flow.api
@@ -1,0 +1,212 @@
+public final class com/ditchoom/buffer/flow/BufferedByteSource : com/ditchoom/buffer/flow/ByteSource {
+	public fun <init> (Lcom/ditchoom/buffer/flow/ByteSource;Lcom/ditchoom/buffer/BufferFactory;)V
+	public synthetic fun <init> (Lcom/ditchoom/buffer/flow/ByteSource;Lcom/ditchoom/buffer/BufferFactory;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun buffered ()I
+	public fun getReadPolicy ()Lcom/ditchoom/buffer/flow/ReadPolicy;
+	public fun isOpen ()Z
+	public final fun peek (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun peek-8Mi8wO0 (IJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun read (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun read-VtjQ1oo (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/ditchoom/buffer/flow/ByteSink {
+	public fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getWritePolicy ()Lcom/ditchoom/buffer/flow/WritePolicy;
+	public abstract fun isOpen ()Z
+	public abstract fun write-OVV_2m0 (Lcom/ditchoom/buffer/ReadBuffer;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun write-egxuoLU (Lcom/ditchoom/buffer/ReadBuffer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun writeGathered-OVV_2m0 (Ljava/util/List;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun writeGathered-egxuoLU (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/ditchoom/buffer/flow/ByteSink$DefaultImpls {
+	public static fun close (Lcom/ditchoom/buffer/flow/ByteSink;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun write-egxuoLU (Lcom/ditchoom/buffer/flow/ByteSink;Lcom/ditchoom/buffer/ReadBuffer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun writeGathered-OVV_2m0 (Lcom/ditchoom/buffer/flow/ByteSink;Ljava/util/List;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun writeGathered-egxuoLU (Lcom/ditchoom/buffer/flow/ByteSink;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/ditchoom/buffer/flow/ByteSource {
+	public abstract fun getReadPolicy ()Lcom/ditchoom/buffer/flow/ReadPolicy;
+	public abstract fun isOpen ()Z
+	public fun read (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun read-VtjQ1oo (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/ditchoom/buffer/flow/ByteSource$DefaultImpls {
+	public static fun read (Lcom/ditchoom/buffer/flow/ByteSource;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/ditchoom/buffer/flow/ByteStream : com/ditchoom/buffer/flow/ByteSink, com/ditchoom/buffer/flow/ByteSource {
+	public abstract fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/ditchoom/buffer/flow/ByteStream$DefaultImpls {
+	public static fun read (Lcom/ditchoom/buffer/flow/ByteStream;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun write-egxuoLU (Lcom/ditchoom/buffer/flow/ByteStream;Lcom/ditchoom/buffer/ReadBuffer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun writeGathered-OVV_2m0 (Lcom/ditchoom/buffer/flow/ByteStream;Ljava/util/List;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun writeGathered-egxuoLU (Lcom/ditchoom/buffer/flow/ByteStream;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/ditchoom/buffer/flow/ByteStreamMux {
+	public abstract fun acceptBidirectional (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun acceptUnidirectional (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun openBidirectional (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun openUnidirectional (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/ditchoom/buffer/flow/BytesWritten {
+	public static final synthetic fun box-impl (I)Lcom/ditchoom/buffer/flow/BytesWritten;
+	public static fun constructor-impl (I)I
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (ILjava/lang/Object;)Z
+	public static final fun equals-impl0 (II)Z
+	public final fun getCount ()I
+	public fun hashCode ()I
+	public static fun hashCode-impl (I)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (I)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()I
+}
+
+public abstract interface class com/ditchoom/buffer/flow/Connection : com/ditchoom/buffer/flow/Receiver, com/ditchoom/buffer/flow/Sender {
+	public abstract fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getId ()J
+}
+
+public final class com/ditchoom/buffer/flow/FlowExtensionsKt {
+	public static final fun asStringFlow (Lkotlinx/coroutines/flow/Flow;Lcom/ditchoom/buffer/Charset;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun asStringFlow$default (Lkotlinx/coroutines/flow/Flow;Lcom/ditchoom/buffer/Charset;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun lines (Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun mapBuffer (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public abstract interface class com/ditchoom/buffer/flow/HalfCloseable : com/ditchoom/buffer/flow/ByteStream {
+	public abstract fun shutdownSend (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/ditchoom/buffer/flow/HalfCloseable$DefaultImpls {
+	public static fun read (Lcom/ditchoom/buffer/flow/HalfCloseable;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun write-egxuoLU (Lcom/ditchoom/buffer/flow/HalfCloseable;Lcom/ditchoom/buffer/ReadBuffer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun writeGathered-OVV_2m0 (Lcom/ditchoom/buffer/flow/HalfCloseable;Ljava/util/List;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun writeGathered-egxuoLU (Lcom/ditchoom/buffer/flow/HalfCloseable;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/ditchoom/buffer/flow/MapKt {
+	public static final fun mapNotNull (Lcom/ditchoom/buffer/flow/Connection;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)Lcom/ditchoom/buffer/flow/Connection;
+}
+
+public abstract interface class com/ditchoom/buffer/flow/ReadPolicy {
+	public fun toDeadline-UwyO8pc ()J
+}
+
+public final class com/ditchoom/buffer/flow/ReadPolicy$Bounded : com/ditchoom/buffer/flow/ReadPolicy {
+	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-UwyO8pc ()J
+	public final fun copy-LRDsOJo (J)Lcom/ditchoom/buffer/flow/ReadPolicy$Bounded;
+	public static synthetic fun copy-LRDsOJo$default (Lcom/ditchoom/buffer/flow/ReadPolicy$Bounded;JILjava/lang/Object;)Lcom/ditchoom/buffer/flow/ReadPolicy$Bounded;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeadline-UwyO8pc ()J
+	public fun hashCode ()I
+	public fun toDeadline-UwyO8pc ()J
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/flow/ReadPolicy$DefaultImpls {
+	public static fun toDeadline-UwyO8pc (Lcom/ditchoom/buffer/flow/ReadPolicy;)J
+}
+
+public final class com/ditchoom/buffer/flow/ReadPolicy$UntilClosed : com/ditchoom/buffer/flow/ReadPolicy {
+	public static final field INSTANCE Lcom/ditchoom/buffer/flow/ReadPolicy$UntilClosed;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toDeadline-UwyO8pc ()J
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/ditchoom/buffer/flow/ReadResult {
+}
+
+public final class com/ditchoom/buffer/flow/ReadResult$Data : com/ditchoom/buffer/flow/ReadResult {
+	public static final synthetic fun box-impl (Lcom/ditchoom/buffer/ReadBuffer;)Lcom/ditchoom/buffer/flow/ReadResult$Data;
+	public static fun constructor-impl (Lcom/ditchoom/buffer/ReadBuffer;)Lcom/ditchoom/buffer/ReadBuffer;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Lcom/ditchoom/buffer/ReadBuffer;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/ReadBuffer;)Z
+	public final fun getBuffer ()Lcom/ditchoom/buffer/ReadBuffer;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Lcom/ditchoom/buffer/ReadBuffer;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Lcom/ditchoom/buffer/ReadBuffer;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Lcom/ditchoom/buffer/ReadBuffer;
+}
+
+public final class com/ditchoom/buffer/flow/ReadResult$End : com/ditchoom/buffer/flow/ReadResult {
+	public static final field INSTANCE Lcom/ditchoom/buffer/flow/ReadResult$End;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/flow/ReadResult$Reset : com/ditchoom/buffer/flow/ReadResult {
+	public static final field INSTANCE Lcom/ditchoom/buffer/flow/ReadResult$Reset;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/ditchoom/buffer/flow/Receiver {
+	public abstract fun receive ()Lkotlinx/coroutines/flow/Flow;
+}
+
+public abstract interface class com/ditchoom/buffer/flow/Resettable {
+	public abstract fun reset (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/ditchoom/buffer/flow/Sender {
+	public fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getId ()J
+	public abstract fun send (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/ditchoom/buffer/flow/Sender$DefaultImpls {
+	public static fun close (Lcom/ditchoom/buffer/flow/Sender;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getId (Lcom/ditchoom/buffer/flow/Sender;)J
+}
+
+public abstract interface class com/ditchoom/buffer/flow/StreamMux {
+	public abstract fun acceptBidirectional (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun acceptUnidirectional (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun openBidirectional (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun openUnidirectional (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/ditchoom/buffer/flow/WritePolicy {
+	public fun toDeadline-UwyO8pc ()J
+}
+
+public final class com/ditchoom/buffer/flow/WritePolicy$Bounded : com/ditchoom/buffer/flow/WritePolicy {
+	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-UwyO8pc ()J
+	public final fun copy-LRDsOJo (J)Lcom/ditchoom/buffer/flow/WritePolicy$Bounded;
+	public static synthetic fun copy-LRDsOJo$default (Lcom/ditchoom/buffer/flow/WritePolicy$Bounded;JILjava/lang/Object;)Lcom/ditchoom/buffer/flow/WritePolicy$Bounded;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeadline-UwyO8pc ()J
+	public fun hashCode ()I
+	public fun toDeadline-UwyO8pc ()J
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/flow/WritePolicy$DefaultImpls {
+	public static fun toDeadline-UwyO8pc (Lcom/ditchoom/buffer/flow/WritePolicy;)J
+}
+
+public final class com/ditchoom/buffer/flow/WritePolicy$UntilClosed : com/ditchoom/buffer/flow/WritePolicy {
+	public static final field INSTANCE Lcom/ditchoom/buffer/flow/WritePolicy$UntilClosed;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toDeadline-UwyO8pc ()J
+	public fun toString ()Ljava/lang/String;
+}
+

--- a/buffer-flow/api/jvm/buffer-flow.api
+++ b/buffer-flow/api/jvm/buffer-flow.api
@@ -1,0 +1,212 @@
+public final class com/ditchoom/buffer/flow/BufferedByteSource : com/ditchoom/buffer/flow/ByteSource {
+	public fun <init> (Lcom/ditchoom/buffer/flow/ByteSource;Lcom/ditchoom/buffer/BufferFactory;)V
+	public synthetic fun <init> (Lcom/ditchoom/buffer/flow/ByteSource;Lcom/ditchoom/buffer/BufferFactory;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun buffered ()I
+	public fun getReadPolicy ()Lcom/ditchoom/buffer/flow/ReadPolicy;
+	public fun isOpen ()Z
+	public final fun peek (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun peek-8Mi8wO0 (IJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun read (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun read-VtjQ1oo (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/ditchoom/buffer/flow/ByteSink {
+	public fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getWritePolicy ()Lcom/ditchoom/buffer/flow/WritePolicy;
+	public abstract fun isOpen ()Z
+	public abstract fun write-OVV_2m0 (Lcom/ditchoom/buffer/ReadBuffer;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun write-egxuoLU (Lcom/ditchoom/buffer/ReadBuffer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun writeGathered-OVV_2m0 (Ljava/util/List;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun writeGathered-egxuoLU (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/ditchoom/buffer/flow/ByteSink$DefaultImpls {
+	public static fun close (Lcom/ditchoom/buffer/flow/ByteSink;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun write-egxuoLU (Lcom/ditchoom/buffer/flow/ByteSink;Lcom/ditchoom/buffer/ReadBuffer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun writeGathered-OVV_2m0 (Lcom/ditchoom/buffer/flow/ByteSink;Ljava/util/List;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun writeGathered-egxuoLU (Lcom/ditchoom/buffer/flow/ByteSink;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/ditchoom/buffer/flow/ByteSource {
+	public abstract fun getReadPolicy ()Lcom/ditchoom/buffer/flow/ReadPolicy;
+	public abstract fun isOpen ()Z
+	public fun read (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun read-VtjQ1oo (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/ditchoom/buffer/flow/ByteSource$DefaultImpls {
+	public static fun read (Lcom/ditchoom/buffer/flow/ByteSource;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/ditchoom/buffer/flow/ByteStream : com/ditchoom/buffer/flow/ByteSink, com/ditchoom/buffer/flow/ByteSource {
+	public abstract fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/ditchoom/buffer/flow/ByteStream$DefaultImpls {
+	public static fun read (Lcom/ditchoom/buffer/flow/ByteStream;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun write-egxuoLU (Lcom/ditchoom/buffer/flow/ByteStream;Lcom/ditchoom/buffer/ReadBuffer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun writeGathered-OVV_2m0 (Lcom/ditchoom/buffer/flow/ByteStream;Ljava/util/List;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun writeGathered-egxuoLU (Lcom/ditchoom/buffer/flow/ByteStream;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/ditchoom/buffer/flow/ByteStreamMux {
+	public abstract fun acceptBidirectional (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun acceptUnidirectional (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun openBidirectional (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun openUnidirectional (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/ditchoom/buffer/flow/BytesWritten {
+	public static final synthetic fun box-impl (I)Lcom/ditchoom/buffer/flow/BytesWritten;
+	public static fun constructor-impl (I)I
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (ILjava/lang/Object;)Z
+	public static final fun equals-impl0 (II)Z
+	public final fun getCount ()I
+	public fun hashCode ()I
+	public static fun hashCode-impl (I)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (I)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()I
+}
+
+public abstract interface class com/ditchoom/buffer/flow/Connection : com/ditchoom/buffer/flow/Receiver, com/ditchoom/buffer/flow/Sender {
+	public abstract fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getId ()J
+}
+
+public final class com/ditchoom/buffer/flow/FlowExtensionsKt {
+	public static final fun asStringFlow (Lkotlinx/coroutines/flow/Flow;Lcom/ditchoom/buffer/Charset;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun asStringFlow$default (Lkotlinx/coroutines/flow/Flow;Lcom/ditchoom/buffer/Charset;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun lines (Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun mapBuffer (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public abstract interface class com/ditchoom/buffer/flow/HalfCloseable : com/ditchoom/buffer/flow/ByteStream {
+	public abstract fun shutdownSend (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/ditchoom/buffer/flow/HalfCloseable$DefaultImpls {
+	public static fun read (Lcom/ditchoom/buffer/flow/HalfCloseable;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun write-egxuoLU (Lcom/ditchoom/buffer/flow/HalfCloseable;Lcom/ditchoom/buffer/ReadBuffer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun writeGathered-OVV_2m0 (Lcom/ditchoom/buffer/flow/HalfCloseable;Ljava/util/List;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun writeGathered-egxuoLU (Lcom/ditchoom/buffer/flow/HalfCloseable;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/ditchoom/buffer/flow/MapKt {
+	public static final fun mapNotNull (Lcom/ditchoom/buffer/flow/Connection;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)Lcom/ditchoom/buffer/flow/Connection;
+}
+
+public abstract interface class com/ditchoom/buffer/flow/ReadPolicy {
+	public fun toDeadline-UwyO8pc ()J
+}
+
+public final class com/ditchoom/buffer/flow/ReadPolicy$Bounded : com/ditchoom/buffer/flow/ReadPolicy {
+	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-UwyO8pc ()J
+	public final fun copy-LRDsOJo (J)Lcom/ditchoom/buffer/flow/ReadPolicy$Bounded;
+	public static synthetic fun copy-LRDsOJo$default (Lcom/ditchoom/buffer/flow/ReadPolicy$Bounded;JILjava/lang/Object;)Lcom/ditchoom/buffer/flow/ReadPolicy$Bounded;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeadline-UwyO8pc ()J
+	public fun hashCode ()I
+	public fun toDeadline-UwyO8pc ()J
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/flow/ReadPolicy$DefaultImpls {
+	public static fun toDeadline-UwyO8pc (Lcom/ditchoom/buffer/flow/ReadPolicy;)J
+}
+
+public final class com/ditchoom/buffer/flow/ReadPolicy$UntilClosed : com/ditchoom/buffer/flow/ReadPolicy {
+	public static final field INSTANCE Lcom/ditchoom/buffer/flow/ReadPolicy$UntilClosed;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toDeadline-UwyO8pc ()J
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/ditchoom/buffer/flow/ReadResult {
+}
+
+public final class com/ditchoom/buffer/flow/ReadResult$Data : com/ditchoom/buffer/flow/ReadResult {
+	public static final synthetic fun box-impl (Lcom/ditchoom/buffer/ReadBuffer;)Lcom/ditchoom/buffer/flow/ReadResult$Data;
+	public static fun constructor-impl (Lcom/ditchoom/buffer/ReadBuffer;)Lcom/ditchoom/buffer/ReadBuffer;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Lcom/ditchoom/buffer/ReadBuffer;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/ReadBuffer;)Z
+	public final fun getBuffer ()Lcom/ditchoom/buffer/ReadBuffer;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Lcom/ditchoom/buffer/ReadBuffer;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Lcom/ditchoom/buffer/ReadBuffer;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Lcom/ditchoom/buffer/ReadBuffer;
+}
+
+public final class com/ditchoom/buffer/flow/ReadResult$End : com/ditchoom/buffer/flow/ReadResult {
+	public static final field INSTANCE Lcom/ditchoom/buffer/flow/ReadResult$End;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/flow/ReadResult$Reset : com/ditchoom/buffer/flow/ReadResult {
+	public static final field INSTANCE Lcom/ditchoom/buffer/flow/ReadResult$Reset;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/ditchoom/buffer/flow/Receiver {
+	public abstract fun receive ()Lkotlinx/coroutines/flow/Flow;
+}
+
+public abstract interface class com/ditchoom/buffer/flow/Resettable {
+	public abstract fun reset (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/ditchoom/buffer/flow/Sender {
+	public fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getId ()J
+	public abstract fun send (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/ditchoom/buffer/flow/Sender$DefaultImpls {
+	public static fun close (Lcom/ditchoom/buffer/flow/Sender;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getId (Lcom/ditchoom/buffer/flow/Sender;)J
+}
+
+public abstract interface class com/ditchoom/buffer/flow/StreamMux {
+	public abstract fun acceptBidirectional (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun acceptUnidirectional (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun openBidirectional (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun openUnidirectional (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/ditchoom/buffer/flow/WritePolicy {
+	public fun toDeadline-UwyO8pc ()J
+}
+
+public final class com/ditchoom/buffer/flow/WritePolicy$Bounded : com/ditchoom/buffer/flow/WritePolicy {
+	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-UwyO8pc ()J
+	public final fun copy-LRDsOJo (J)Lcom/ditchoom/buffer/flow/WritePolicy$Bounded;
+	public static synthetic fun copy-LRDsOJo$default (Lcom/ditchoom/buffer/flow/WritePolicy$Bounded;JILjava/lang/Object;)Lcom/ditchoom/buffer/flow/WritePolicy$Bounded;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeadline-UwyO8pc ()J
+	public fun hashCode ()I
+	public fun toDeadline-UwyO8pc ()J
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/flow/WritePolicy$DefaultImpls {
+	public static fun toDeadline-UwyO8pc (Lcom/ditchoom/buffer/flow/WritePolicy;)J
+}
+
+public final class com/ditchoom/buffer/flow/WritePolicy$UntilClosed : com/ditchoom/buffer/flow/WritePolicy {
+	public static final field INSTANCE Lcom/ditchoom/buffer/flow/WritePolicy$UntilClosed;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toDeadline-UwyO8pc ()J
+	public fun toString ()Ljava/lang/String;
+}
+

--- a/buffer-flow/build.gradle.kts
+++ b/buffer-flow/build.gradle.kts
@@ -14,7 +14,18 @@ plugins {
     alias(libs.plugins.maven.publish)
     alias(libs.plugins.dokka)
     alias(libs.plugins.kotlinx.benchmark)
+    alias(libs.plugins.binary.compatibility.validator)
     signing
+}
+
+// Binary-compatibility validation locks the published public ABI so additive minors (e.g. the raw
+// ByteStreamMux primitive) are proven non-breaking by `apiCheck`. Like :buffer-crypto we validate
+// the JVM ABI only: it is host-independent and the common public surface is wholly contained in
+// the JVM dump; klib validation would diverge between partial-target dev hosts and CI runners.
+apiValidation {
+    klib {
+        enabled = false
+    }
 }
 
 // Required for JMH @State classes

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/BufferedByteSource.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/BufferedByteSource.kt
@@ -1,0 +1,125 @@
+package com.ditchoom.buffer.flow
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.ReadBuffer
+import kotlin.time.Duration
+import kotlin.time.TimeSource
+
+/**
+ * A [ByteSource] wrapper that adds a **non-consuming [peek]** by owning a small look-ahead buffer.
+ *
+ * Heterogeneous stream demux needs to *classify* an accepted stream before choosing how to decode
+ * it — e.g. an HTTP/3 unidirectional stream is self-describing via a leading stream-type varint
+ * (RFC 9114 §6.2). Classification must not consume the prefix (some layers re-parse it) and must
+ * not copy the payload. [peek] reads ahead without consuming: the peeked bytes are retained in a
+ * look-ahead queue and re-delivered, unchanged and uncopied, by subsequent [read] calls.
+ *
+ * ### Zero-copy contract
+ * - When the first buffered chunk already covers the requested [peek] length, the returned buffer
+ *   is a zero-copy *view* of that chunk — no allocation at all.
+ * - Only when the requested range spans multiple upstream chunks is a staging buffer allocated,
+ *   sized to the requested length (a classification prefix is ≤ 8 bytes — never the payload).
+ *   The staging buffer comes from [factory], so an accounting test can pin this with
+ *   `BufferFactory.counting()`.
+ * - [read] hands back the buffered chunks themselves (ownership transfer), never a copy.
+ *
+ * ### Aliasing
+ * A buffer returned by [peek] may share storage with a buffer later returned by [read] (the
+ * zero-copy view case). Consume the peeked view before mutating or releasing the read buffer.
+ *
+ * **Thread safety:** NOT thread-safe. Confine [peek]/[read] to a single coroutine, matching the
+ * [ByteSource] contract.
+ *
+ * @param upstream the raw source to buffer; [readPolicy] and liveness are inherited from it
+ * @param factory allocator for the (header-sized) staging buffer in the chunk-spanning peek case
+ */
+class BufferedByteSource(
+    private val upstream: ByteSource,
+    private val factory: BufferFactory = BufferFactory.Default,
+) : ByteSource {
+    private val lookAhead = ArrayDeque<ReadBuffer>()
+
+    /** Terminal result ([ReadResult.End] or [ReadResult.Reset]) seen while filling; sticky. */
+    private var terminal: ReadResult? = null
+
+    override val isOpen: Boolean get() = lookAhead.isNotEmpty() || upstream.isOpen
+
+    override val readPolicy: ReadPolicy get() = upstream.readPolicy
+
+    /** Total bytes currently held in the look-ahead queue. */
+    fun buffered(): Int = lookAhead.sumOf { it.remaining() }
+
+    /**
+     * Reads **up to** [n] bytes without consuming them, waiting at most [deadline] in total.
+     *
+     * Fills the look-ahead queue from [upstream] until [n] bytes are buffered, the stream ends,
+     * or the deadline is exhausted. Returns:
+     * - [ReadResult.Data] with `min(n, available)` bytes if any bytes are buffered — check
+     *   `buffer.remaining()`, a clean EOF after fewer than [n] bytes yields a short peek;
+     * - [ReadResult.End] / [ReadResult.Reset] if the stream terminated with nothing buffered.
+     *
+     * A later [read] re-delivers the same bytes; peeking is idempotent.
+     */
+    suspend fun peek(
+        n: Int,
+        deadline: Duration,
+    ): ReadResult {
+        require(n > 0) { "peek length must be positive, was $n" }
+        fillLookAhead(n, deadline)
+        val available = buffered()
+        if (available == 0) return terminal ?: ReadResult.End
+        val length = minOf(n, available)
+        val head = lookAhead.first()
+        if (head.remaining() >= length) {
+            // Zero-copy: a view over the head chunk, limited to the requested length.
+            return ReadResult.Data(head.slice().readBytes(length))
+        }
+        // Spanning case: assemble a header-sized staging buffer via absolute reads
+        // (positions of the buffered chunks are untouched).
+        val staging = factory.allocate(length)
+        var copied = 0
+        for (chunk in lookAhead) {
+            var index = chunk.position()
+            while (index < chunk.limit() && copied < length) {
+                staging.writeByte(chunk[index])
+                index++
+                copied++
+            }
+            if (copied == length) break
+        }
+        staging.resetForRead()
+        return ReadResult.Data(staging)
+    }
+
+    /** Peeks up to [n] bytes using the inherited [readPolicy] deadline. */
+    suspend fun peek(n: Int): ReadResult = peek(n, readPolicy.toDeadline())
+
+    override suspend fun read(deadline: Duration): ReadResult {
+        val head = lookAhead.removeFirstOrNull()
+        if (head != null) return ReadResult.Data(head)
+        terminal?.let { return it }
+        return upstream.read(deadline)
+    }
+
+    private suspend fun fillLookAhead(
+        n: Int,
+        deadline: Duration,
+    ) {
+        val start = if (deadline.isInfinite()) null else TimeSource.Monotonic.markNow()
+        while (buffered() < n && terminal == null) {
+            val budget =
+                if (start == null) {
+                    deadline
+                } else {
+                    val left = deadline - start.elapsedNow()
+                    if (left <= Duration.ZERO) return
+                    left
+                }
+            when (val result = upstream.read(budget)) {
+                is ReadResult.Data -> if (result.buffer.hasRemaining()) lookAhead.addLast(result.buffer)
+                ReadResult.End, ReadResult.Reset -> terminal = result
+            }
+        }
+    }
+}

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/BufferedByteSource.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/BufferedByteSource.kt
@@ -71,12 +71,27 @@ class BufferedByteSource(
         if (available == 0) return terminal ?: ReadResult.End
         val length = minOf(n, available)
         val head = lookAhead.first()
-        if (head.remaining() >= length) {
+        return if (head.remaining() >= length) {
             // Zero-copy: a view over the head chunk, limited to the requested length.
-            return ReadResult.Data(head.slice().readBytes(length))
+            ReadResult.Data(head.slice().readBytes(length))
+        } else {
+            ReadResult.Data(stageSpanningPeek(length))
         }
-        // Spanning case: assemble a header-sized staging buffer via absolute reads
-        // (positions of the buffered chunks are untouched).
+    }
+
+    /** Peeks up to [n] bytes using the inherited [readPolicy] deadline. */
+    suspend fun peek(n: Int): ReadResult = peek(n, readPolicy.toDeadline())
+
+    override suspend fun read(deadline: Duration): ReadResult {
+        val head = lookAhead.removeFirstOrNull()
+        return if (head != null) ReadResult.Data(head) else terminal ?: upstream.read(deadline)
+    }
+
+    /**
+     * Spanning-peek case: assembles a header-sized staging buffer via absolute reads —
+     * the positions of the buffered chunks are untouched.
+     */
+    private fun stageSpanningPeek(length: Int): ReadBuffer {
         val staging = factory.allocate(length)
         var copied = 0
         for (chunk in lookAhead) {
@@ -89,17 +104,7 @@ class BufferedByteSource(
             if (copied == length) break
         }
         staging.resetForRead()
-        return ReadResult.Data(staging)
-    }
-
-    /** Peeks up to [n] bytes using the inherited [readPolicy] deadline. */
-    suspend fun peek(n: Int): ReadResult = peek(n, readPolicy.toDeadline())
-
-    override suspend fun read(deadline: Duration): ReadResult {
-        val head = lookAhead.removeFirstOrNull()
-        if (head != null) return ReadResult.Data(head)
-        terminal?.let { return it }
-        return upstream.read(deadline)
+        return staging
     }
 
     private suspend fun fillLookAhead(

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/ByteStreamMux.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/ByteStreamMux.kt
@@ -1,0 +1,47 @@
+package com.ditchoom.buffer.flow
+
+/**
+ * A multiplexed connection over **raw byte streams** — no codec fixed at the mux level.
+ *
+ * This is the heterogeneous-mux primitive. [StreamMux] fixes one codec across every stream,
+ * which fits transports where all streams speak the same wire format. Some protocols instead
+ * make each stream self-describing: HTTP/3 (RFC 9114 §6.2) prefixes each peer-initiated
+ * unidirectional stream with a stream-type varint (control, QPACK encoder/decoder, push, …),
+ * and each type is a *different* codec. The codec cannot be chosen until the prefix has been
+ * read off the accepted stream — structurally impossible when accept is typed up front.
+ *
+ * `accept*` therefore returns the **raw** stream so the caller can classify it — typically by
+ * wrapping it in a [BufferedByteSource] and [BufferedByteSource.peek]ing the self-describing
+ * prefix without consuming it — and then attach the right decoder per stream. A single-codec
+ * typed view (a [StreamMux]) can be layered on top by wrapping each raw stream in a codec
+ * adapter; that view lives with the codec-over-bytestream wrappers, outside this module.
+ *
+ * The four methods mirror [StreamMux] and return the tightest byte-level type per direction,
+ * preventing impossible states at compile time:
+ *
+ * - [openBidirectional]: [ByteStream] — can send and receive
+ * - [openUnidirectional]: [ByteSink] — send-only (announce end-of-send via [ByteSink.close])
+ * - [acceptBidirectional]: [ByteStream] — peer-initiated duplex, raw
+ * - [acceptUnidirectional]: [ByteSource] — peer-initiated receive-only, raw
+ *
+ * **Thread safety:** Implementations are NOT assumed to be thread-safe. Concurrent calls to
+ * open/accept methods require external synchronization unless the implementation explicitly
+ * documents otherwise.
+ *
+ * **Lifecycle:** ByteStreamMux does not own the connection lifecycle — the transport scope
+ * does, exactly as for [StreamMux]. When the transport scope ends, all streams are
+ * force-closed via structured concurrency.
+ */
+interface ByteStreamMux {
+    /** Opens a client-initiated bidirectional stream. */
+    suspend fun openBidirectional(): ByteStream
+
+    /** Opens a client-initiated unidirectional (send-only) stream. */
+    suspend fun openUnidirectional(): ByteSink
+
+    /** Accepts a peer-initiated bidirectional stream. Suspends until one is opened by the peer. */
+    suspend fun acceptBidirectional(): ByteStream
+
+    /** Accepts a peer-initiated unidirectional (receive-only) stream. Suspends until one is opened by the peer. */
+    suspend fun acceptUnidirectional(): ByteSource
+}

--- a/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/BufferedByteSourceTest.kt
+++ b/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/BufferedByteSourceTest.kt
@@ -1,0 +1,220 @@
+package com.ditchoom.buffer.flow
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.counting
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Spike 3a/3b: non-consuming peek + the "no copy on classify" accounting guard.
+ *
+ * The zero-copy claims are pinned with [com.ditchoom.buffer.CountingBufferFactory] counts, not
+ * by eyeballing: classification (peek a self-describing stream-type prefix, then hand the raw
+ * stream on) must never allocate a payload-sized buffer. A future refactor that regresses into
+ * copy-the-remainder fails these tests.
+ */
+class BufferedByteSourceTest {
+    /** Decodes a QUIC variable-length integer (RFC 9000 §16) relative to the buffer position. */
+    private fun decodeQuicVarInt(buffer: ReadBuffer): Long {
+        val first = buffer.readByte().toInt() and 0xFF
+        val length = 1 shl ((first ushr 6) and 0x3)
+        var value = (first and 0x3F).toLong()
+        repeat(length - 1) {
+            value = (value shl 8) or (buffer.readByte().toLong() and 0xFF)
+        }
+        return value
+    }
+
+    private fun bufferOf(vararg bytes: Int): ReadBuffer {
+        val buffer = BufferFactory.Default.allocate(bytes.size)
+        for (b in bytes) buffer.writeByte(b.toByte())
+        buffer.resetForRead()
+        return buffer
+    }
+
+    // Stream type 0x54 encodes as the 2-byte QUIC varint [0x40, 0x54].
+    private val streamType = 0x54L
+
+    private fun prefixedPayload(payloadSize: Int): ReadBuffer {
+        val buffer = BufferFactory.Default.allocate(2 + payloadSize)
+        buffer.writeByte(0x40)
+        buffer.writeByte(0x54)
+        repeat(payloadSize) { buffer.writeByte((it % 251).toByte()) }
+        buffer.resetForRead()
+        return buffer
+    }
+
+    @Test
+    fun peekThenReadRedeliversTheSameBytes() =
+        runTest {
+            val channel = Channel<ReadBuffer>(Channel.UNLIMITED)
+            val original = prefixedPayload(payloadSize = 64)
+            channel.send(original)
+            channel.close()
+            val source = BufferedByteSource(ChannelByteSource(channel))
+
+            val peeked = source.peek(8)
+            assertIs<ReadResult.Data>(peeked)
+            assertEquals(8, peeked.buffer.remaining())
+            assertEquals(streamType, decodeQuicVarInt(peeked.buffer))
+
+            // The first real read still returns ALL the bytes, prefix included.
+            val read = source.read()
+            assertIs<ReadResult.Data>(read)
+            assertEquals(2 + 64, read.buffer.remaining())
+            assertEquals(streamType, decodeQuicVarInt(read.buffer))
+            assertEquals(ReadResult.End, source.read())
+        }
+
+    @Test
+    fun peekIsIdempotent() =
+        runTest {
+            val channel = Channel<ReadBuffer>(Channel.UNLIMITED)
+            channel.send(prefixedPayload(payloadSize = 16))
+            val source = BufferedByteSource(ChannelByteSource(channel))
+
+            val first = source.peek(8)
+            val second = source.peek(8)
+            assertIs<ReadResult.Data>(first)
+            assertIs<ReadResult.Data>(second)
+            assertEquals(streamType, decodeQuicVarInt(first.buffer))
+            assertEquals(streamType, decodeQuicVarInt(second.buffer))
+        }
+
+    @Test
+    fun peekWithinOneChunkAllocatesNothing() =
+        runTest {
+            val counting = BufferFactory.Default.counting()
+            val channel = Channel<ReadBuffer>(Channel.UNLIMITED)
+            channel.send(prefixedPayload(payloadSize = 4096))
+            val source = BufferedByteSource(ChannelByteSource(channel), counting)
+
+            val peeked = source.peek(8)
+            assertIs<ReadResult.Data>(peeked)
+            assertEquals(streamType, decodeQuicVarInt(peeked.buffer))
+            assertEquals(0L, counting.allocationCount, "single-chunk peek must be a zero-copy view")
+        }
+
+    @Test
+    fun peekSpanningChunksAllocatesOnlyTheHeader() =
+        runTest {
+            val counting = BufferFactory.Default.counting()
+            val channel = Channel<ReadBuffer>(Channel.UNLIMITED)
+            // The varint prefix arrives split across two 1-byte chunks, then the payload.
+            channel.send(bufferOf(0x40))
+            channel.send(bufferOf(0x54))
+            val payloadSize = 4096
+            val payload = BufferFactory.Default.allocate(payloadSize)
+            repeat(payloadSize) { payload.writeByte((it % 251).toByte()) }
+            payload.resetForRead()
+            channel.send(payload)
+            channel.close()
+            val source = BufferedByteSource(ChannelByteSource(channel), counting)
+
+            val peeked = source.peek(2)
+            assertIs<ReadResult.Data>(peeked)
+            assertEquals(streamType, decodeQuicVarInt(peeked.buffer))
+            assertEquals(1L, counting.allocationCount, "spanning peek stages exactly once")
+            assertEquals(2, counting.largestAllocationSize, "staging is header-sized, never payload-sized")
+
+            // Reads re-deliver every buffered chunk, in order, uncopied.
+            assertEquals(0x40, (source.read() as ReadResult.Data).buffer.readByte().toInt())
+            assertEquals(0x54, (source.read() as ReadResult.Data).buffer.readByte().toInt())
+            val readPayload = source.read()
+            assertIs<ReadResult.Data>(readPayload)
+            assertSame(payload, readPayload.buffer, "payload chunk is ownership-transferred, not copied")
+            assertEquals(1L, counting.allocationCount, "reads after peek allocate nothing")
+            assertEquals(ReadResult.End, source.read())
+        }
+
+    @Test
+    fun peekOnEmptyClosedStreamReturnsEnd() =
+        runTest {
+            val channel = Channel<ReadBuffer>(Channel.UNLIMITED)
+            channel.close()
+            val source = BufferedByteSource(ChannelByteSource(channel))
+            assertEquals(ReadResult.End, source.peek(8))
+            assertEquals(ReadResult.End, source.read())
+        }
+
+    @Test
+    fun peekAtEofReturnsShortData() =
+        runTest {
+            val channel = Channel<ReadBuffer>(Channel.UNLIMITED)
+            channel.send(bufferOf(0x00))
+            channel.close()
+            val source = BufferedByteSource(ChannelByteSource(channel))
+
+            val peeked = source.peek(8)
+            assertIs<ReadResult.Data>(peeked)
+            assertEquals(1, peeked.buffer.remaining())
+
+            val read = source.read()
+            assertIs<ReadResult.Data>(read)
+            assertEquals(1, read.buffer.remaining())
+            assertEquals(ReadResult.End, source.read())
+        }
+
+    @Test
+    fun readWithoutPeekPassesThrough() =
+        runTest {
+            val counting = BufferFactory.Default.counting()
+            val channel = Channel<ReadBuffer>(Channel.UNLIMITED)
+            val original = bufferOf(1, 2, 3)
+            channel.send(original)
+            val source = BufferedByteSource(ChannelByteSource(channel), counting)
+
+            val read = source.read()
+            assertIs<ReadResult.Data>(read)
+            assertSame(original, read.buffer)
+            assertEquals(0L, counting.allocationCount)
+        }
+
+    /**
+     * Spike 3b end-to-end: accept a raw self-describing stream off a [ByteStreamMux], classify it
+     * by peeking the stream-type varint, then consume it — with **zero** allocations attributable
+     * to classification. This is the guard for the whole peek-then-wrap demux path.
+     */
+    @Test
+    fun classifyingAnAcceptedStreamCopiesNothing() =
+        runTest {
+            val mux = MemoryByteStreamMux()
+            val sender = mux.openUnidirectional()
+            val payloadSize = 4096
+            val original = prefixedPayload(payloadSize)
+            sender.write(original)
+            sender.close()
+
+            val counting = BufferFactory.Default.counting()
+            val accepted = BufferedByteSource(mux.acceptUnidirectional(), counting)
+
+            // Classify: peek the (≤ 8 byte) stream-type prefix without consuming it.
+            val peeked = accepted.peek(8)
+            assertIs<ReadResult.Data>(peeked)
+            assertEquals(streamType, decodeQuicVarInt(peeked.buffer))
+
+            // Consume: the classified stream re-delivers the untouched original buffer.
+            val read = accepted.read()
+            assertIs<ReadResult.Data>(read)
+            assertSame(original, read.buffer, "classified stream hands back the transport buffer itself")
+            assertEquals(streamType, decodeQuicVarInt(read.buffer))
+            assertEquals(payloadSize, read.buffer.remaining())
+            var index = 0
+            while (read.buffer.hasRemaining()) {
+                assertEquals((index % 251).toByte(), read.buffer.readByte())
+                index++
+            }
+
+            assertEquals(0L, counting.allocationCount, "classification must not allocate")
+            assertEquals(0L, counting.wrapCount, "classification must not wrap")
+            assertTrue(counting.allocatedBytes == 0L)
+            assertEquals(ReadResult.End, accepted.read())
+        }
+}

--- a/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/ByteStreamMuxTest.kt
+++ b/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/ByteStreamMuxTest.kt
@@ -1,0 +1,69 @@
+package com.ditchoom.buffer.flow
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.ReadBuffer
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class ByteStreamMuxTest {
+    private fun textBuffer(text: String): ReadBuffer {
+        val bytes = text.encodeToByteArray()
+        val buffer = BufferFactory.Default.allocate(bytes.size)
+        buffer.writeBytes(bytes)
+        buffer.resetForRead()
+        return buffer
+    }
+
+    private fun ReadResult.text(): String {
+        val data = assertIs<ReadResult.Data>(this)
+        return data.buffer.readByteArray(data.buffer.remaining()).decodeToString()
+    }
+
+    @Test
+    fun openBidirectionalReturnsRawByteStream() =
+        runTest {
+            val mux = MemoryByteStreamMux()
+            val client = mux.openBidirectional()
+            assertIs<ByteStream>(client)
+            val server = mux.acceptBidirectional()
+
+            client.write(textBuffer("hello"))
+            assertEquals("hello", server.read().text())
+            server.write(textBuffer("world"))
+            assertEquals("world", client.read().text())
+
+            client.close()
+            assertEquals(ReadResult.End, server.read())
+        }
+
+    @Test
+    fun openUnidirectionalReturnsSinkAndAcceptReturnsSource() =
+        runTest {
+            val mux = MemoryByteStreamMux()
+            val sink = mux.openUnidirectional()
+            assertIs<ByteSink>(sink)
+            val source = mux.acceptUnidirectional()
+            assertIs<ByteSource>(source)
+
+            sink.write(textBuffer("fire-and-forget"))
+            sink.close()
+            assertEquals("fire-and-forget", source.read().text())
+            assertEquals(ReadResult.End, source.read())
+        }
+
+    @Test
+    fun acceptedStreamsArriveInOpenOrder() =
+        runTest {
+            val mux = MemoryByteStreamMux()
+            val first = mux.openUnidirectional()
+            val second = mux.openUnidirectional()
+            first.write(textBuffer("first"))
+            second.write(textBuffer("second"))
+
+            assertEquals("first", mux.acceptUnidirectional().read().text())
+            assertEquals("second", mux.acceptUnidirectional().read().text())
+        }
+}

--- a/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/MemoryByteStream.kt
+++ b/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/MemoryByteStream.kt
@@ -1,0 +1,109 @@
+package com.ditchoom.buffer.flow
+
+import com.ditchoom.buffer.ReadBuffer
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.withTimeout
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * In-memory [ByteSource] over a channel of buffers. Buffers are delivered as-is
+ * (ownership transfer, zero-copy) — the same contract a real transport read path has.
+ */
+internal class ChannelByteSource(
+    private val inbound: Channel<ReadBuffer>,
+) : ByteSource {
+    override val isOpen: Boolean get() = !inbound.isClosedForReceive
+
+    override val readPolicy: ReadPolicy = ReadPolicy.Bounded(5.seconds)
+
+    override suspend fun read(deadline: Duration): ReadResult {
+        suspend fun receive(): ReadResult {
+            val result = inbound.receiveCatching()
+            val buffer = result.getOrNull()
+            return when {
+                buffer != null -> ReadResult.Data(buffer)
+                result.isClosed -> ReadResult.End
+                else -> throw result.exceptionOrNull() ?: IllegalStateException("receive failed")
+            }
+        }
+        return if (deadline.isInfinite()) receive() else withTimeout(deadline) { receive() }
+    }
+}
+
+/** In-memory [ByteSink] over a channel of buffers. [close] closes the channel (a FIN). */
+internal class ChannelByteSink(
+    private val outbound: Channel<ReadBuffer>,
+) : ByteSink {
+    override val isOpen: Boolean get() = !outbound.isClosedForSend
+
+    override val writePolicy: WritePolicy = WritePolicy.Bounded(5.seconds)
+
+    override suspend fun write(
+        buffer: ReadBuffer,
+        deadline: Duration,
+    ): BytesWritten {
+        val size = buffer.remaining()
+        outbound.send(buffer)
+        return BytesWritten(size)
+    }
+
+    override suspend fun close() {
+        outbound.close()
+    }
+}
+
+/** In-memory duplex [ByteStream] composing a [ChannelByteSource] and [ChannelByteSink]. */
+internal class MemoryByteStream(
+    inbound: Channel<ReadBuffer>,
+    outbound: Channel<ReadBuffer>,
+) : ByteStream {
+    private val source = ChannelByteSource(inbound)
+    private val sink = ChannelByteSink(outbound)
+
+    override val isOpen: Boolean get() = source.isOpen || sink.isOpen
+
+    override val readPolicy: ReadPolicy get() = source.readPolicy
+
+    override val writePolicy: WritePolicy get() = sink.writePolicy
+
+    override suspend fun read(deadline: Duration): ReadResult = source.read(deadline)
+
+    override suspend fun write(
+        buffer: ReadBuffer,
+        deadline: Duration,
+    ): BytesWritten = sink.write(buffer, deadline)
+
+    override suspend fun close() {
+        sink.close()
+    }
+}
+
+/** A connected pair of in-memory byte streams: bytes written to one are read from the other. */
+internal fun memoryByteStreamPair(): Pair<ByteStream, ByteStream> {
+    val aToB = Channel<ReadBuffer>(Channel.UNLIMITED)
+    val bToA = Channel<ReadBuffer>(Channel.UNLIMITED)
+    return MemoryByteStream(bToA, aToB) to MemoryByteStream(aToB, bToA)
+}
+
+/** In-memory [ByteStreamMux] for testing raw accept + peek-then-classify flows. */
+internal class MemoryByteStreamMux : ByteStreamMux {
+    private val bidiQueue = Channel<ByteStream>(Channel.UNLIMITED)
+    private val uniQueue = Channel<ByteSource>(Channel.UNLIMITED)
+
+    override suspend fun openBidirectional(): ByteStream {
+        val (local, remote) = memoryByteStreamPair()
+        bidiQueue.send(remote)
+        return local
+    }
+
+    override suspend fun openUnidirectional(): ByteSink {
+        val channel = Channel<ReadBuffer>(Channel.UNLIMITED)
+        uniQueue.send(ChannelByteSource(channel))
+        return ChannelByteSink(channel)
+    }
+
+    override suspend fun acceptBidirectional(): ByteStream = bidiQueue.receive()
+
+    override suspend fun acceptUnidirectional(): ByteSource = uniQueue.receive()
+}

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/CountingBufferFactory.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/CountingBufferFactory.kt
@@ -1,0 +1,86 @@
+package com.ditchoom.buffer
+
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.AtomicLong
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+
+/**
+ * Returns a factory that counts every allocation and wrap that flows through it.
+ *
+ * The returned [CountingBufferFactory] is a transparent decorator: buffers are produced by the
+ * delegate unchanged; only the counters are updated. Use it to make allocation behavior
+ * *assertable* — e.g. a zero-copy regression test pins "classifying a stream must not copy the
+ * payload" by asserting [CountingBufferFactory.allocationCount] and
+ * [CountingBufferFactory.largestAllocationSize] instead of eyeballing the implementation:
+ *
+ * ```kotlin
+ * val counting = BufferFactory.Default.counting()
+ * val source = BufferedByteSource(rawSource, counting)
+ * classify(source)
+ * assertEquals(0, counting.allocationCount) // classification allocated nothing
+ * ```
+ */
+fun BufferFactory.counting(): CountingBufferFactory = CountingBufferFactory(this)
+
+/**
+ * A [BufferFactory] decorator that counts allocations and wraps flowing through it.
+ *
+ * Counters are updated atomically and can be read at any time; [reset] zeroes them. Buffers are
+ * not wrapped or altered — [decorate] forwards to the delegate so inner wrapping decorators
+ * (e.g. a secure-erase factory) still apply.
+ *
+ * Create via [BufferFactory.counting].
+ */
+@OptIn(ExperimentalAtomicApi::class)
+class CountingBufferFactory internal constructor(
+    private val delegate: BufferFactory,
+) : BufferFactory {
+    private val allocations = AtomicLong(0L)
+    private val bytes = AtomicLong(0L)
+    private val largest = AtomicInt(0)
+    private val wraps = AtomicLong(0L)
+
+    /** Number of [allocate] calls since creation or the last [reset]. */
+    val allocationCount: Long get() = allocations.load()
+
+    /** Total bytes requested across all counted [allocate] calls. */
+    val allocatedBytes: Long get() = bytes.load()
+
+    /** Size of the single largest counted [allocate] call, or 0 if none. */
+    val largestAllocationSize: Int get() = largest.load()
+
+    /** Number of [wrap] calls since creation or the last [reset]. */
+    val wrapCount: Long get() = wraps.load()
+
+    /** Zeroes all counters. */
+    fun reset() {
+        allocations.store(0L)
+        bytes.store(0L)
+        largest.store(0)
+        wraps.store(0L)
+    }
+
+    override fun allocate(
+        size: Int,
+        byteOrder: ByteOrder,
+    ): PlatformBuffer {
+        allocations.fetchAndAdd(1L)
+        bytes.fetchAndAdd(size.toLong())
+        var current = largest.load()
+        while (size > current && !largest.compareAndSet(current, size)) {
+            current = largest.load()
+        }
+        return delegate.allocate(size, byteOrder)
+    }
+
+    override fun wrap(
+        array: ByteArray,
+        byteOrder: ByteOrder,
+    ): PlatformBuffer {
+        wraps.fetchAndAdd(1L)
+        return delegate.wrap(array, byteOrder)
+    }
+
+    // Transparent decorator: forward so an inner wrapping decorator (e.g. secure()) can wrap.
+    override fun decorate(buffer: PlatformBuffer): PlatformBuffer = delegate.decorate(buffer)
+}

--- a/buffer/src/commonTest/kotlin/com/ditchoom/buffer/CountingBufferFactoryTest.kt
+++ b/buffer/src/commonTest/kotlin/com/ditchoom/buffer/CountingBufferFactoryTest.kt
@@ -1,0 +1,61 @@
+package com.ditchoom.buffer
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CountingBufferFactoryTest {
+    @Test
+    fun countsAllocations() {
+        val counting = BufferFactory.Default.counting()
+        assertEquals(0L, counting.allocationCount)
+        counting.allocate(16)
+        counting.allocate(64)
+        counting.allocate(32)
+        assertEquals(3L, counting.allocationCount)
+        assertEquals(112L, counting.allocatedBytes)
+        assertEquals(64, counting.largestAllocationSize)
+        assertEquals(0L, counting.wrapCount)
+    }
+
+    @Test
+    fun countsWraps() {
+        val counting = BufferFactory.Default.counting()
+        counting.wrap(byteArrayOf(1, 2, 3))
+        assertEquals(1L, counting.wrapCount)
+        assertEquals(0L, counting.allocationCount)
+        assertEquals(0L, counting.allocatedBytes)
+    }
+
+    @Test
+    fun resetZeroesAllCounters() {
+        val counting = BufferFactory.managed().counting()
+        counting.allocate(128)
+        counting.wrap(byteArrayOf(1))
+        counting.reset()
+        assertEquals(0L, counting.allocationCount)
+        assertEquals(0L, counting.allocatedBytes)
+        assertEquals(0, counting.largestAllocationSize)
+        assertEquals(0L, counting.wrapCount)
+    }
+
+    @Test
+    fun producedBuffersComeFromTheDelegateUnchanged() {
+        val counting = BufferFactory.managed().counting()
+        val buffer = counting.allocate(8)
+        buffer.writeLong(0x1122334455667788L)
+        buffer.resetForRead()
+        assertEquals(0x1122334455667788L, buffer.readLong())
+
+        val wrapped = counting.wrap(byteArrayOf(7, 8, 9))
+        assertEquals(7, wrapped.readByte())
+    }
+
+    @Test
+    fun composesWithOtherDecorators() {
+        val counting = BufferFactory.Default.counting()
+        val limited = counting.withSizeLimit(1024)
+        limited.allocate(512)
+        assertEquals(1L, counting.allocationCount)
+        assertEquals(512L, counting.allocatedBytes)
+    }
+}


### PR DESCRIPTION
## Summary

Lifts the `StreamMux<T>` single-codec limit with a raw heterogeneous-mux primitive, so muxes whose peer-initiated streams are self-describing (e.g. HTTP/3 stream-type varints, RFC 9114 §6.2) can classify each accepted stream before choosing its decoder. **Additive only → `minor`.**

- **`ByteStreamMux`** (buffer-flow): the codec-free mirror of `StreamMux` — open/accept returning raw `ByteStream` / `ByteSink` / `ByteSource`. A single-codec typed view can be layered on top downstream; nothing here depends on buffer-codec.
- **`BufferedByteSource`** (buffer-flow): non-consuming `peek(n, deadline)` over any `ByteSource` via a small look-ahead queue. Zero-copy view when one buffered chunk covers the request; stages at most a header-sized (never payload-sized) buffer when the request spans chunks. `read()` re-delivers buffered chunks by ownership transfer, never a copy.
- **`CountingBufferFactory`** (buffer): transparent decorator (`BufferFactory.counting()`) counting allocations/wraps, following the `RequiringFactory` wrapper pattern. Makes allocation behavior assertable — the "no copy on classify" regression test pins zero allocations for the peek-then-consume path with counter assertions instead of eyeballing.
- **buffer-flow apiCheck**: enable binary-compatibility-validator (JVM/Android dumps, klib off — same rationale as buffer-crypto) and commit the API baseline.

## Test plan

- [x] `BufferedByteSourceTest` (8): varint-prefix peek→read re-delivery, idempotent peek, zero-alloc single-chunk peek, header-only staging on spanning peek, EOF/short-peek edges, end-to-end "classifying an accepted stream copies nothing" guard
- [x] `ByteStreamMuxTest` (3) + in-memory `ByteStream`/`ByteStreamMux` fixture
- [x] `CountingBufferFactoryTest` (5)
- [x] Green on jvm / jsNode / wasmJsNode / macosArm64; `ktlintCheck` + `apiCheck` clean