### PR TITLE
fix(crypto): close HPKE contexts and key wrappers, guard closed/finalized state, wipe staging

### DIFF
--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256Mac.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256Mac.apple.kt
@@ -10,11 +10,13 @@ import kotlinx.cinterop.alloc
 import kotlinx.cinterop.convert
 import kotlinx.cinterop.nativeHeap
 import kotlinx.cinterop.ptr
+import kotlinx.cinterop.sizeOf
 import platform.CoreCrypto.CCHmacContext
 import platform.CoreCrypto.CCHmacFinal
 import platform.CoreCrypto.CCHmacInit
 import platform.CoreCrypto.CCHmacUpdate
 import platform.CoreCrypto.kCCHmacAlgSHA256
+import platform.posix.memset
 
 /** Apple HMAC-SHA256 backed by CommonCrypto (`CCHmac`). Reads and writes via buffer pointers — no arrays. */
 actual class HmacSha256Mac actual constructor(
@@ -32,16 +34,18 @@ actual class HmacSha256Mac actual constructor(
     }
 
     actual fun update(input: ReadBuffer): HmacSha256Mac {
+        check(!finalized) { "mac already finalized" }
         input.withRemainingBytes { ptr, len -> CCHmacUpdate(ctx.ptr, ptr, len.convert()) }
         return this
     }
 
     actual fun doFinalInto(dest: WriteBuffer) {
+        check(!finalized) { "mac already finalized" }
+        finalized = true
         // CommonCrypto writes the 32-byte tag straight into the destination buffer's memory.
         dest.withWritablePointer(SHA256_DIGEST_BYTES) { ptr -> CCHmacFinal(ctx.ptr, ptr) }
-        if (!finalized) {
-            finalized = true
-            nativeHeap.free(ctx.rawPtr)
-        }
+        // The context holds key-derived ipad/opad state; zero it before returning the allocation.
+        memset(ctx.ptr, 0, sizeOf<CCHmacContext>().convert())
+        nativeHeap.free(ctx.rawPtr)
     }
 }

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HmacSha384Mac.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HmacSha384Mac.apple.kt
@@ -10,11 +10,13 @@ import kotlinx.cinterop.alloc
 import kotlinx.cinterop.convert
 import kotlinx.cinterop.nativeHeap
 import kotlinx.cinterop.ptr
+import kotlinx.cinterop.sizeOf
 import platform.CoreCrypto.CCHmacContext
 import platform.CoreCrypto.CCHmacFinal
 import platform.CoreCrypto.CCHmacInit
 import platform.CoreCrypto.CCHmacUpdate
 import platform.CoreCrypto.kCCHmacAlgSHA384
+import platform.posix.memset
 
 /** Apple HMAC-SHA384 backed by CommonCrypto (`CCHmac`). Reads and writes via buffer pointers — no arrays. */
 actual class HmacSha384Mac actual constructor(
@@ -32,16 +34,18 @@ actual class HmacSha384Mac actual constructor(
     }
 
     actual fun update(input: ReadBuffer): HmacSha384Mac {
+        check(!finalized) { "mac already finalized" }
         input.withRemainingBytes { ptr, len -> CCHmacUpdate(ctx.ptr, ptr, len.convert()) }
         return this
     }
 
     actual fun doFinalInto(dest: WriteBuffer) {
+        check(!finalized) { "mac already finalized" }
+        finalized = true
         // CommonCrypto writes the 48-byte tag straight into the destination buffer's memory.
         dest.withWritablePointer(SHA384_DIGEST_BYTES) { ptr -> CCHmacFinal(ctx.ptr, ptr) }
-        if (!finalized) {
-            finalized = true
-            nativeHeap.free(ctx.rawPtr)
-        }
+        // The context holds key-derived ipad/opad state; zero it before returning the allocation.
+        memset(ctx.ptr, 0, sizeOf<CCHmacContext>().convert())
+        nativeHeap.free(ctx.rawPtr)
     }
 }

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HmacSha512Mac.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HmacSha512Mac.apple.kt
@@ -10,11 +10,13 @@ import kotlinx.cinterop.alloc
 import kotlinx.cinterop.convert
 import kotlinx.cinterop.nativeHeap
 import kotlinx.cinterop.ptr
+import kotlinx.cinterop.sizeOf
 import platform.CoreCrypto.CCHmacContext
 import platform.CoreCrypto.CCHmacFinal
 import platform.CoreCrypto.CCHmacInit
 import platform.CoreCrypto.CCHmacUpdate
 import platform.CoreCrypto.kCCHmacAlgSHA512
+import platform.posix.memset
 
 /** Apple HMAC-SHA512 backed by CommonCrypto (`CCHmac`). Reads and writes via buffer pointers — no arrays. */
 actual class HmacSha512Mac actual constructor(
@@ -32,16 +34,18 @@ actual class HmacSha512Mac actual constructor(
     }
 
     actual fun update(input: ReadBuffer): HmacSha512Mac {
+        check(!finalized) { "mac already finalized" }
         input.withRemainingBytes { ptr, len -> CCHmacUpdate(ctx.ptr, ptr, len.convert()) }
         return this
     }
 
     actual fun doFinalInto(dest: WriteBuffer) {
+        check(!finalized) { "mac already finalized" }
+        finalized = true
         // CommonCrypto writes the 64-byte tag straight into the destination buffer's memory.
         dest.withWritablePointer(SHA512_DIGEST_BYTES) { ptr -> CCHmacFinal(ctx.ptr, ptr) }
-        if (!finalized) {
-            finalized = true
-            nativeHeap.free(ctx.rawPtr)
-        }
+        // The context holds key-derived ipad/opad state; zero it before returning the allocation.
+        memset(ctx.ptr, 0, sizeOf<CCHmacContext>().convert())
+        nativeHeap.free(ctx.rawPtr)
     }
 }

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/Sha256Digest.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/Sha256Digest.apple.kt
@@ -11,10 +11,12 @@ import kotlinx.cinterop.convert
 import kotlinx.cinterop.nativeHeap
 import kotlinx.cinterop.ptr
 import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.sizeOf
 import platform.CoreCrypto.CC_SHA256_CTX
 import platform.CoreCrypto.CC_SHA256_Final
 import platform.CoreCrypto.CC_SHA256_Init
 import platform.CoreCrypto.CC_SHA256_Update
+import platform.posix.memset
 
 /** Apple SHA-256 backed by CommonCrypto (`CC_SHA256`). Reads and writes via buffer pointers — no arrays. */
 actual class Sha256Digest actual constructor() {
@@ -26,16 +28,18 @@ actual class Sha256Digest actual constructor() {
     }
 
     actual fun update(input: ReadBuffer): Sha256Digest {
+        check(!finalized) { "digest already finalized" }
         input.withRemainingBytes { ptr, len -> CC_SHA256_Update(ctx.ptr, ptr, len.convert()) }
         return this
     }
 
     actual fun digestInto(dest: WriteBuffer) {
+        check(!finalized) { "digest already finalized" }
+        finalized = true
         // CommonCrypto writes the 32-byte digest straight into the destination buffer's memory.
         dest.withWritablePointer(SHA256_DIGEST_BYTES) { ptr -> CC_SHA256_Final(ptr.reinterpret(), ctx.ptr) }
-        if (!finalized) {
-            finalized = true
-            nativeHeap.free(ctx.rawPtr)
-        }
+        // The context still holds absorbed state; zero it before returning the allocation.
+        memset(ctx.ptr, 0, sizeOf<CC_SHA256_CTX>().convert())
+        nativeHeap.free(ctx.rawPtr)
     }
 }

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/Sha384Digest.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/Sha384Digest.apple.kt
@@ -11,10 +11,12 @@ import kotlinx.cinterop.convert
 import kotlinx.cinterop.nativeHeap
 import kotlinx.cinterop.ptr
 import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.sizeOf
 import platform.CoreCrypto.CC_SHA384_Final
 import platform.CoreCrypto.CC_SHA384_Init
 import platform.CoreCrypto.CC_SHA384_Update
 import platform.CoreCrypto.CC_SHA512_CTX
+import platform.posix.memset
 
 /**
  * Apple SHA-384 backed by CommonCrypto (`CC_SHA384`). SHA-384 shares SHA-512's context type
@@ -29,16 +31,18 @@ actual class Sha384Digest actual constructor() {
     }
 
     actual fun update(input: ReadBuffer): Sha384Digest {
+        check(!finalized) { "digest already finalized" }
         input.withRemainingBytes { ptr, len -> CC_SHA384_Update(ctx.ptr, ptr, len.convert()) }
         return this
     }
 
     actual fun digestInto(dest: WriteBuffer) {
+        check(!finalized) { "digest already finalized" }
+        finalized = true
         // CommonCrypto writes the 48-byte digest straight into the destination buffer's memory.
         dest.withWritablePointer(SHA384_DIGEST_BYTES) { ptr -> CC_SHA384_Final(ptr.reinterpret(), ctx.ptr) }
-        if (!finalized) {
-            finalized = true
-            nativeHeap.free(ctx.rawPtr)
-        }
+        // The context still holds absorbed state; zero it before returning the allocation.
+        memset(ctx.ptr, 0, sizeOf<CC_SHA512_CTX>().convert())
+        nativeHeap.free(ctx.rawPtr)
     }
 }

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/Sha512Digest.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/Sha512Digest.apple.kt
@@ -11,10 +11,12 @@ import kotlinx.cinterop.convert
 import kotlinx.cinterop.nativeHeap
 import kotlinx.cinterop.ptr
 import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.sizeOf
 import platform.CoreCrypto.CC_SHA512_CTX
 import platform.CoreCrypto.CC_SHA512_Final
 import platform.CoreCrypto.CC_SHA512_Init
 import platform.CoreCrypto.CC_SHA512_Update
+import platform.posix.memset
 
 /** Apple SHA-512 backed by CommonCrypto (`CC_SHA512`). Reads and writes via buffer pointers — no arrays. */
 actual class Sha512Digest actual constructor() {
@@ -26,16 +28,18 @@ actual class Sha512Digest actual constructor() {
     }
 
     actual fun update(input: ReadBuffer): Sha512Digest {
+        check(!finalized) { "digest already finalized" }
         input.withRemainingBytes { ptr, len -> CC_SHA512_Update(ctx.ptr, ptr, len.convert()) }
         return this
     }
 
     actual fun digestInto(dest: WriteBuffer) {
+        check(!finalized) { "digest already finalized" }
+        finalized = true
         // CommonCrypto writes the 64-byte digest straight into the destination buffer's memory.
         dest.withWritablePointer(SHA512_DIGEST_BYTES) { ptr -> CC_SHA512_Final(ptr.reinterpret(), ctx.ptr) }
-        if (!finalized) {
-            finalized = true
-            nativeHeap.free(ctx.rawPtr)
-        }
+        // The context still holds absorbed state; zero it before returning the allocation.
+        memset(ctx.ptr, 0, sizeOf<CC_SHA512_CTX>().convert())
+        nativeHeap.free(ctx.rawPtr)
     }
 }

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/Aead.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/Aead.kt
@@ -121,7 +121,7 @@ sealed interface SyncCapableAesGcmKey : AesGcmKey
 /** In-memory [AesGcmKey]: holds the raw key bytes, freed (and wiped, on a secure buffer) on [close]. */
 internal class InMemoryAesGcmKey(
     override val sizeBits: Int,
-    val material: PlatformBuffer,
+    private val material: PlatformBuffer,
 ) : SyncCapableAesGcmKey {
     override val provenance: KeyProvenance get() = KeyProvenance.Software
     private var closed = false
@@ -131,6 +131,12 @@ internal class InMemoryAesGcmKey(
             closed = true
             material.freeNativeMemory()
         }
+    }
+
+    /** The live key material; throws if the key has been [close]d. */
+    fun requireOpen(): PlatformBuffer {
+        check(!closed) { "AesGcmKey already closed" }
+        return material
     }
 }
 
@@ -165,7 +171,7 @@ sealed interface ChaChaPolyKey :
 
 /** In-memory [ChaChaPolyKey]: holds the raw key bytes, freed (and wiped) on [close]. */
 internal class InMemoryChaChaPolyKey(
-    val material: PlatformBuffer,
+    private val material: PlatformBuffer,
 ) : ChaChaPolyKey {
     override val provenance: KeyProvenance get() = KeyProvenance.Software
     private var closed = false
@@ -176,16 +182,24 @@ internal class InMemoryChaChaPolyKey(
             material.freeNativeMemory()
         }
     }
+
+    /** The live key material; throws if the key has been [close]d. */
+    fun requireOpen(): PlatformBuffer {
+        check(!closed) { "ChaChaPolyKey already closed" }
+        return material
+    }
 }
 
 /**
- * The in-memory key material, for the blocking native primitives. A hardware-backed key (added
- * later) holds no exportable material and would route through the async provider path instead, so
- * this seam is only reached for in-memory keys.
+ * The in-memory key material, for the blocking native primitives; throws if the key has been
+ * closed (a closed secure backing is zeroed, a closed deterministic backing is freed — sealing
+ * with either would be silently wrong). A hardware-backed key (added later) holds no exportable
+ * material and would route through the async provider path instead, so this seam is only reached
+ * for in-memory keys.
  */
 internal fun AesGcmKey.requireInMemoryMaterial(): PlatformBuffer =
     when (this) {
-        is InMemoryAesGcmKey -> material
+        is InMemoryAesGcmKey -> requireOpen()
         // A hardware key holds no exportable material, so the synchronous/material-reading path is
         // not supported for it — hardware keys operate only through the async witness ops, which
         // dispatch to the gated closures and never reach here. This throw is the safety net if a
@@ -196,7 +210,7 @@ internal fun AesGcmKey.requireInMemoryMaterial(): PlatformBuffer =
 /** See [AesGcmKey.requireInMemoryMaterial]. */
 internal fun ChaChaPolyKey.requireInMemoryMaterial(): PlatformBuffer =
     when (this) {
-        is InMemoryChaChaPolyKey -> material
+        is InMemoryChaChaPolyKey -> requireOpen()
     }
 
 /**

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256.kt
@@ -21,6 +21,7 @@ const val HMAC_SHA256_BYTES = SHA256_DIGEST_BYTES
  * Reads are non-destructive (operate on `slice()`s).
  *
  * Not thread-safe — use one instance per MAC. Key-bearing intermediates are wiped after use.
+ * One-shot: [update] or [doFinalInto] after finalization throws [IllegalStateException].
  */
 expect class HmacSha256Mac(
     key: ReadBuffer,

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha384.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha384.kt
@@ -21,6 +21,7 @@ const val HMAC_SHA384_BYTES = SHA384_DIGEST_BYTES
  * 48-byte tag into a caller-owned destination. Reads are non-destructive.
  *
  * Not thread-safe — one instance per MAC. Key-bearing intermediates are wiped after use.
+ * One-shot: [update] or [doFinalInto] after finalization throws [IllegalStateException].
  */
 expect class HmacSha384Mac(
     key: ReadBuffer,

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha512.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha512.kt
@@ -21,6 +21,7 @@ const val HMAC_SHA512_BYTES = SHA512_DIGEST_BYTES
  * 64-byte tag into a caller-owned destination. Reads are non-destructive.
  *
  * Not thread-safe — one instance per MAC. Key-bearing intermediates are wiped after use.
+ * One-shot: [update] or [doFinalInto] after finalization throws [IllegalStateException].
  */
 expect class HmacSha512Mac(
     key: ReadBuffer,

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/Hpke.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/Hpke.kt
@@ -297,11 +297,23 @@ sealed interface HpkeMode {
  * [pskId] is not secret and is held in an ordinary buffer.
  */
 class HpkePsk private constructor(
-    internal val psk: PlatformBuffer,
+    private val psk: PlatformBuffer,
     internal val pskId: ReadBuffer,
 ) : AutoCloseable {
+    private var closed = false
+
+    /** Zeroes and frees the PSK bytes. Idempotent. */
     override fun close() {
-        psk.freeNativeMemory()
+        if (!closed) {
+            closed = true
+            psk.freeNativeMemory()
+        }
+    }
+
+    /** The live PSK bytes; throws if the PSK has been [close]d. */
+    internal fun requireOpen(): PlatformBuffer {
+        check(!closed) { "HpkePsk already closed" }
+        return psk
     }
 
     companion object {
@@ -721,7 +733,8 @@ class HpkeSenderSetup internal constructor(
 /**
  * Single-shot HPKE seal (RFC 9180 §6.1, Base mode): encapsulates to [recipientPublicKey],
  * encrypts [plaintext] with [aad], and returns `enc || ciphertext` framing via [HpkeSealed].
- * The returned context-equivalent state is discarded (single message).
+ * The context exists for the single message only and is closed (its derived AEAD key, base
+ * nonce, and exporter secret wiped) before returning; the outputs are independent copies.
  */
 internal suspend fun hpkeSealBase(
     suite: HpkeSuite,
@@ -732,8 +745,12 @@ internal suspend fun hpkeSealBase(
     factory: BufferFactory = BufferFactory.Default,
 ): HpkeSealed {
     val setup = hpkeSetupBaseSender(suite, recipientPublicKey, info)
-    val ct = setup.context.seal(plaintext, aad.toAad(), factory)
-    return HpkeSealed(copyBuffer(setup.enc, factory), ct)
+    return try {
+        val ct = setup.context.seal(plaintext, aad.toAad(), factory)
+        HpkeSealed(copyBuffer(setup.enc, factory), ct)
+    } finally {
+        setup.context.close()
+    }
 }
 
 /** Single-shot HPKE open (RFC 9180 §6.1, Base mode): decapsulates [enc] and decrypts. */
@@ -747,7 +764,11 @@ internal suspend fun hpkeOpenBase(
     factory: BufferFactory = BufferFactory.Default,
 ): PlatformBuffer {
     val ctx = hpkeSetupBaseReceiver(suite, recipientPrivateKey, enc, info)
-    return ctx.open(ciphertext, aad.toAad(), factory)
+    return try {
+        ctx.open(ciphertext, aad.toAad(), factory)
+    } finally {
+        ctx.close()
+    }
 }
 
 /** `enc || ciphertext` output of [hpkeSealBase]. Both buffers are read-ready. */

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HpkeAeadGlue.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HpkeAeadGlue.kt
@@ -6,7 +6,8 @@ import com.ditchoom.buffer.ReadBuffer
 
 /*
  * Bridges the HPKE per-message AEAD ops onto the landed AEAD primitive family, keyed by the
- * already-derived HPKE key (HpkeAead.nk bytes) and the per-message explicit nonce.
+ * already-derived HPKE key (wrapped once per context via [hpkeAeadKeyOf]) and the per-message
+ * explicit nonce.
  *
  * - AES-GCM uses the explicit-nonce async seam (aesGcmSealWithNonceAsync / aesGcmOpenWithNonceAsync),
  *   which works on every platform including the web (WebCrypto).
@@ -17,56 +18,68 @@ import com.ditchoom.buffer.ReadBuffer
  * from the context's base nonce and sequence number.
  */
 
-/** Seals [plaintext] under the HPKE AEAD [aead], [key] (the derived AEAD key), and explicit [nonce]. */
-internal suspend fun hpkeAeadSeal(
+/**
+ * Wraps the derived HPKE AEAD key (`HpkeAead.nk` bytes) as a typed AEAD key. Created once per
+ * context at key-schedule time; the wrapper holds its own secure-scratch copy of the material,
+ * which [closeMaterial] (driven by [HpkeContext.close]) zeroes.
+ */
+internal fun hpkeAeadKeyOf(
     aead: HpkeAead,
     key: ReadBuffer,
+): AeadKey =
+    when (aead) {
+        HpkeAead.Aes128Gcm, HpkeAead.Aes256Gcm -> AesGcmKey.of(viewRemaining(key), secureScratch)
+        HpkeAead.ChaCha20Poly1305 -> ChaChaPolyKey.of(viewRemaining(key), secureScratch)
+    }
+
+/** Zeroes and frees the wrapper's copied key material (each AEAD key family is closeable). */
+internal fun AeadKey.closeMaterial() {
+    when (this) {
+        is AesGcmKey -> close()
+        is ChaChaPolyKey -> close()
+    }
+}
+
+/** Seals [plaintext] under the context's wrapped AEAD [key] and explicit [nonce]. */
+internal suspend fun hpkeAeadSeal(
+    key: AeadKey,
     nonce: ReadBuffer,
     aad: ReadBuffer?,
     plaintext: ReadBuffer,
     factory: BufferFactory,
 ): PlatformBuffer =
-    when (aead) {
-        HpkeAead.Aes128Gcm, HpkeAead.Aes256Gcm -> {
-            val gcmKey = AesGcmKey.of(viewRemaining(key), secureScratch)
-            aesGcmSealWithNonceAsync(gcmKey, nonce, aad, plaintext, factory)
-        }
-        HpkeAead.ChaCha20Poly1305 -> {
+    when (key) {
+        is AesGcmKey -> aesGcmSealWithNonceAsync(key, nonce, aad, plaintext, factory)
+        is ChaChaPolyKey -> {
             if (!chaChaPolyReachable) {
                 throw UnsupportedOperationException("ChaCha20-Poly1305 is not supported on this platform")
             }
-            val ccKey = ChaChaPolyKey.of(viewRemaining(key), secureScratch)
             val dest = factory.allocate(plaintext.remaining() + AEAD_TAG_BYTES)
-            chaChaPolySeal(ccKey, nonce, aad, plaintext, dest)
+            chaChaPolySeal(key, nonce, aad, plaintext, dest)
             dest.resetForRead()
             dest
         }
     }
 
-/** Opens a `ct || tag` blob under the HPKE AEAD [aead], [key], and explicit [nonce]. */
+/** Opens a `ct || tag` blob under the context's wrapped AEAD [key] and explicit [nonce]. */
 internal suspend fun hpkeAeadOpen(
-    aead: HpkeAead,
-    key: ReadBuffer,
+    key: AeadKey,
     nonce: ReadBuffer,
     aad: ReadBuffer?,
     ciphertextAndTag: ReadBuffer,
     factory: BufferFactory,
 ): PlatformBuffer =
-    when (aead) {
-        HpkeAead.Aes128Gcm, HpkeAead.Aes256Gcm -> {
-            val gcmKey = AesGcmKey.of(viewRemaining(key), secureScratch)
-            aesGcmOpenWithNonceAsync(gcmKey, nonce, aad, ciphertextAndTag, factory)
-        }
-        HpkeAead.ChaCha20Poly1305 -> {
+    when (key) {
+        is AesGcmKey -> aesGcmOpenWithNonceAsync(key, nonce, aad, ciphertextAndTag, factory)
+        is ChaChaPolyKey -> {
             if (!chaChaPolyReachable) {
                 throw UnsupportedOperationException("ChaCha20-Poly1305 is not supported on this platform")
             }
-            val ccKey = ChaChaPolyKey.of(viewRemaining(key), secureScratch)
             require(ciphertextAndTag.remaining() >= AEAD_TAG_BYTES) {
                 "ciphertext too short: need at least $AEAD_TAG_BYTES bytes"
             }
             val dest = factory.allocate(ciphertextAndTag.remaining() - AEAD_TAG_BYTES)
-            chaChaPolyOpen(ccKey, nonce, aad, ciphertextAndTag, dest)
+            chaChaPolyOpen(key, nonce, aad, ciphertextAndTag, dest)
             dest.resetForRead()
             dest
         }

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HpkeContext.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HpkeContext.kt
@@ -5,6 +5,8 @@ import com.ditchoom.buffer.Default
 import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.WriteBuffer
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 /**
  * HPKE encryption contexts (RFC 9180 §5.2) and the setup functions that produce them.
@@ -15,7 +17,13 @@ import com.ditchoom.buffer.WriteBuffer
  * (key, nonce) pair is never reused. The [export] method derives independent secrets from the
  * context's `exporter_secret` (the HPKE secret-export interface, §5.3).
  *
- * The AEAD key, base nonce, and exporter secret live in wiped [SecureBuffer]s; [close] zeroes them.
+ * Concurrency: the per-message `seal`/`open` ops are serialized on an internal [Mutex], so
+ * concurrent callers on one context are safe — each op claims its sequence number exactly once
+ * (and a failed open still leaves the counter unchanged). [close] is not synchronized with
+ * in-flight ops; close a context only after its last op has returned.
+ *
+ * The AEAD key, base nonce, and exporter secret live in wiped [SecureBuffer]s; [close] zeroes them
+ * (idempotent) along with the wrapped [aeadKey]'s material. Ops on a closed context throw.
  */
 sealed class HpkeContext protected constructor(
     internal val suite: HpkeSuite,
@@ -24,6 +32,13 @@ sealed class HpkeContext protected constructor(
     internal val exporterSecret: PlatformBuffer,
 ) : AutoCloseable {
     private var seq: Long = 0L
+    private var closed = false
+
+    /** Serializes the nonce-compute → AEAD op → counter-advance sequence (see class KDoc). */
+    internal val seqLock = Mutex()
+
+    /** The derived AEAD key, wrapped once for the context's lifetime and wiped by [close]. */
+    internal val aeadKey: AeadKey = hpkeAeadKeyOf(suite.aead, key)
 
     /** RFC 9180 §5.3 secret export: `LabeledExpand(exporter_secret, "sec", context, L)`. */
     fun export(
@@ -31,6 +46,7 @@ sealed class HpkeContext protected constructor(
         length: Int,
         factory: BufferFactory = BufferFactory.Default,
     ): ReadBuffer {
+        requireOpen()
         require(length >= 0) { "export length must be non-negative, was $length" }
         val out = factory.allocate(length)
         labeledExpand(suite.kdf, suite.suiteId(), exporterSecret, LABEL_SEC, exporterContext.bytesOrNull, length, out)
@@ -76,7 +92,15 @@ sealed class HpkeContext protected constructor(
         seq = value
     }
 
+    /** Guards every op against use after [close]. */
+    internal fun requireOpen() {
+        check(!closed) { "HpkeContext already closed" }
+    }
+
     override fun close() {
+        if (closed) return
+        closed = true
+        aeadKey.closeMaterial()
         key.freeNativeMemory()
         baseNonce.freeNativeMemory()
         exporterSecret.freeNativeMemory()
@@ -91,20 +115,24 @@ sealed class HpkeContext protected constructor(
     ) : HpkeContext(suite, key, baseNonce, exporterSecret) {
         /**
          * Seals [plaintext] with [aad] under the next per-message nonce, returning `ct || tag`
-         * (read-ready, from [factory]). Advances the sequence number only on success.
+         * (read-ready, from [factory]). Advances the sequence number only on success; serialized
+         * against concurrent seals so a sequence number (and thus a nonce) is never reused.
          */
         suspend fun seal(
             plaintext: ReadBuffer,
             aad: Aad = Aad.None,
             factory: BufferFactory = BufferFactory.Default,
         ): PlatformBuffer {
-            val nonce = computeNonce()
-            return try {
-                val ct = hpkeAeadSeal(suite.aead, key, nonce, aad.bytesOrNull, plaintext, factory)
-                incrementSeq()
-                ct
-            } finally {
-                nonce.freeNativeMemory()
+            requireOpen()
+            return seqLock.withLock {
+                val nonce = computeNonce()
+                try {
+                    val ct = hpkeAeadSeal(aeadKey, nonce, aad.bytesOrNull, plaintext, factory)
+                    incrementSeq()
+                    ct
+                } finally {
+                    nonce.freeNativeMemory()
+                }
             }
         }
     }
@@ -129,13 +157,16 @@ sealed class HpkeContext protected constructor(
             aad: Aad = Aad.None,
             factory: BufferFactory = BufferFactory.Default,
         ): PlatformBuffer {
-            val nonce = computeNonce()
-            return try {
-                val pt = hpkeAeadOpen(suite.aead, key, nonce, aad.bytesOrNull, ciphertext, factory)
-                incrementSeq()
-                pt
-            } finally {
-                nonce.freeNativeMemory()
+            requireOpen()
+            return seqLock.withLock {
+                val nonce = computeNonce()
+                try {
+                    val pt = hpkeAeadOpen(aeadKey, nonce, aad.bytesOrNull, ciphertext, factory)
+                    incrementSeq()
+                    pt
+                } finally {
+                    nonce.freeNativeMemory()
+                }
             }
         }
     }
@@ -463,7 +494,7 @@ private fun keySchedule(
     val suiteId = suite.suiteId()
     val nh = kdf.nh
 
-    val pskValue: ReadBuffer? = psk?.psk
+    val pskValue: ReadBuffer? = psk?.requireOpen()
     val pskIdValue: ReadBuffer = psk?.pskId ?: EMPTY
 
     // psk_id_hash = LabeledExtract("", "psk_id_hash", psk_id)

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/Sha256.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/Sha256.kt
@@ -26,7 +26,8 @@ const val SHA256_BLOCK_BYTES = 64
  * of the input, leaving the source buffer's position untouched.
  *
  * Not thread-safe — use one instance per digest. [digestInto] wipes the instance's
- * scratch before returning and finalizes the digest; the instance must not be reused.
+ * scratch before returning and finalizes the digest; the instance is one-shot on every
+ * platform, so [update] or [digestInto] after finalization throws [IllegalStateException].
  */
 expect class Sha256Digest() {
     /** Absorbs the remaining bytes of [input] (non-destructive). Returns `this` for chaining. */

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/Sha384.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/Sha384.kt
@@ -21,7 +21,8 @@ const val SHA384_BLOCK_BYTES = 128
  *
  * Feed bytes with [update] (call repeatedly to hash `a ‖ b` without first concatenating),
  * then [digestInto] to write the 48-byte result into a caller-owned destination. Reading is
- * non-destructive. Not thread-safe — one instance per digest, not reusable after [digestInto].
+ * non-destructive. Not thread-safe — one instance per digest; [update] or [digestInto]
+ * after finalization throws [IllegalStateException] on every platform.
  */
 expect class Sha384Digest() {
     /** Absorbs the remaining bytes of [input] (non-destructive). Returns `this` for chaining. */

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/Sha512.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/Sha512.kt
@@ -24,8 +24,8 @@ const val SHA512_BLOCK_BYTES = 128
  * then [digestInto] to write the 64-byte result into a caller-owned destination. Reading is
  * non-destructive: [update] consumes a `slice()` of the input, leaving the source untouched.
  *
- * Not thread-safe — use one instance per digest. The instance must not be reused after
- * [digestInto].
+ * Not thread-safe — use one instance per digest. The instance is one-shot on every platform:
+ * [update] or [digestInto] after finalization throws [IllegalStateException].
  */
 expect class Sha512Digest() {
     /** Absorbs the remaining bytes of [input] (non-destructive). Returns `this` for chaining. */

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/AeadKeyCloseTest.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/AeadKeyCloseTest.kt
@@ -3,16 +3,21 @@ package com.ditchoom.buffer.crypto
 import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.crypto.CryptoTestVectors.hexBuffer
 import com.ditchoom.buffer.managed
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 /**
  * The AEAD key wrappers are [AutoCloseable] for parity with [SigningKey] and
- * [KeyAgreementPrivateKey]. Closing must zero the backing key material and be idempotent.
+ * [KeyAgreementPrivateKey]. Closing must zero the backing key material, be idempotent, and make
+ * every later material access (and therefore any seal/open) throw instead of silently operating
+ * on wiped or freed bytes.
  *
  * A managed (heap) secure factory is used so the backing buffer stays readable AFTER close()
  * (managed free is a GC no-op), letting the test observe the wipe in isolation — the same
- * technique [SecureBufferTest] uses.
+ * technique [SecureBufferTest] uses. The backing is captured *before* close, since the accessor
+ * itself rejects a closed key.
  */
 class AeadKeyCloseTest {
     private val secureManaged = BufferFactory.managed().secure()
@@ -24,47 +29,93 @@ class AeadKeyCloseTest {
     @Test
     fun aesGcmKeyCloseWipesMaterial() {
         val key = AesGcmKey.of(hexBuffer(aes128Key), secureManaged)
-        val len = key.requireInMemoryMaterial().limit()
+        val material = key.requireInMemoryMaterial()
+        val len = material.limit()
         assertEquals(AES_128_KEY_BYTES, len)
         // Material is non-zero before close (it is the key bytes).
         var anyNonZero = false
-        for (i in 0 until len) if (key.requireInMemoryMaterial().get(i).toInt() != 0) anyNonZero = true
+        for (i in 0 until len) if (material.get(i).toInt() != 0) anyNonZero = true
         assertEquals(true, anyNonZero, "key material should be non-zero before close")
         key.close()
-        for (i in 0 until len) assertEquals(0, key.requireInMemoryMaterial().get(i).toInt(), "byte $i not wiped")
+        for (i in 0 until len) assertEquals(0, material.get(i).toInt(), "byte $i not wiped")
     }
 
     @Test
     fun aesGcm256KeyCloseWipesMaterial() {
         val key = AesGcmKey.of(hexBuffer(aes256Key), secureManaged)
-        val len = key.requireInMemoryMaterial().limit()
+        val material = key.requireInMemoryMaterial()
+        val len = material.limit()
         assertEquals(AES_256_KEY_BYTES, len)
         key.close()
-        for (i in 0 until len) assertEquals(0, key.requireInMemoryMaterial().get(i).toInt(), "byte $i not wiped")
+        for (i in 0 until len) assertEquals(0, material.get(i).toInt(), "byte $i not wiped")
     }
 
     @Test
     fun chaChaPolyKeyCloseWipesMaterial() {
         val key = ChaChaPolyKey.of(hexBuffer(chachaKey), secureManaged)
-        val len = key.requireInMemoryMaterial().limit()
+        val material = key.requireInMemoryMaterial()
+        val len = material.limit()
         assertEquals(CHACHA_KEY_BYTES, len)
         key.close()
-        for (i in 0 until len) assertEquals(0, key.requireInMemoryMaterial().get(i).toInt(), "byte $i not wiped")
+        for (i in 0 until len) assertEquals(0, material.get(i).toInt(), "byte $i not wiped")
     }
 
     @Test
     fun aesGcmKeyCloseIsIdempotent() {
         val key = AesGcmKey.of(hexBuffer(aes128Key), secureManaged)
+        val material = key.requireInMemoryMaterial()
         key.close()
         key.close() // second close must not throw
-        for (i in 0 until key.requireInMemoryMaterial().limit()) assertEquals(0, key.requireInMemoryMaterial().get(i).toInt())
+        for (i in 0 until material.limit()) assertEquals(0, material.get(i).toInt())
     }
 
     @Test
     fun chaChaPolyKeyCloseIsIdempotent() {
         val key = ChaChaPolyKey.of(hexBuffer(chachaKey), secureManaged)
+        val material = key.requireInMemoryMaterial()
         key.close()
         key.close()
-        for (i in 0 until key.requireInMemoryMaterial().limit()) assertEquals(0, key.requireInMemoryMaterial().get(i).toInt())
+        for (i in 0 until material.limit()) assertEquals(0, material.get(i).toInt())
     }
+
+    @Test
+    fun aesGcmMaterialAccessAfterCloseThrows() {
+        val key = AesGcmKey.of(hexBuffer(aes128Key), secureManaged)
+        key.close()
+        assertFailsWith<IllegalStateException> { key.requireInMemoryMaterial() }
+    }
+
+    @Test
+    fun chaChaPolyMaterialAccessAfterCloseThrows() {
+        val key = ChaChaPolyKey.of(hexBuffer(chachaKey), secureManaged)
+        key.close()
+        assertFailsWith<IllegalStateException> { key.requireInMemoryMaterial() }
+    }
+
+    @Test
+    fun aesGcmSealWithClosedKeyThrows() =
+        runTest {
+            val key = AesGcmKey.of(hexBuffer(aes128Key), secureManaged)
+            key.close()
+            val ops =
+                when (val witness = CryptoCapabilities.aesGcm) {
+                    is Aead.Blocking -> witness.ops
+                    is Aead.AsyncOnly -> witness.ops
+                }
+            assertFailsWith<IllegalStateException> { ops.seal(key, hexBuffer("00112233")) }
+        }
+
+    @Test
+    fun chaChaPolySealWithClosedKeyThrows() =
+        runTest {
+            val key = ChaChaPolyKey.of(hexBuffer(chachaKey), secureManaged)
+            key.close()
+            val ops =
+                when (val witness = CryptoCapabilities.chaChaPoly) {
+                    is OptionalAead.Unavailable -> return@runTest
+                    is OptionalAead.Blocking -> witness.ops
+                    is OptionalAead.AsyncOnly -> witness.ops
+                }
+            assertFailsWith<IllegalStateException> { ops.seal(key, hexBuffer("00112233")) }
+        }
 }

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/DigestFinalizeContractTest.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/DigestFinalizeContractTest.kt
@@ -1,0 +1,105 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.crypto.CryptoTestVectors.ascii
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+/**
+ * The incremental digest/MAC classes are one-shot on every platform: after `digestInto` /
+ * `doFinalInto`, both a second finalize and a further `update` throw [IllegalStateException].
+ * The contract matters for uniformity (JCA would silently reset for reuse) and for safety on
+ * the native backends, where finalize releases the underlying context — reuse there would
+ * otherwise touch freed memory.
+ */
+class DigestFinalizeContractTest {
+    private val key = ascii("contract test key")
+
+    private fun out(bytes: Int): WriteBuffer = BufferFactory.Default.allocate(bytes)
+
+    @Test
+    fun sha256DoubleFinalizeThrows() {
+        val digest = Sha256Digest().update(ascii("abc"))
+        digest.digestInto(out(SHA256_DIGEST_BYTES))
+        assertFailsWith<IllegalStateException> { digest.digestInto(out(SHA256_DIGEST_BYTES)) }
+    }
+
+    @Test
+    fun sha256UpdateAfterFinalizeThrows() {
+        val digest = Sha256Digest().update(ascii("abc"))
+        digest.digestInto(out(SHA256_DIGEST_BYTES))
+        assertFailsWith<IllegalStateException> { digest.update(ascii("more")) }
+    }
+
+    @Test
+    fun sha384DoubleFinalizeThrows() {
+        val digest = Sha384Digest().update(ascii("abc"))
+        digest.digestInto(out(SHA384_DIGEST_BYTES))
+        assertFailsWith<IllegalStateException> { digest.digestInto(out(SHA384_DIGEST_BYTES)) }
+    }
+
+    @Test
+    fun sha384UpdateAfterFinalizeThrows() {
+        val digest = Sha384Digest().update(ascii("abc"))
+        digest.digestInto(out(SHA384_DIGEST_BYTES))
+        assertFailsWith<IllegalStateException> { digest.update(ascii("more")) }
+    }
+
+    @Test
+    fun sha512DoubleFinalizeThrows() {
+        val digest = Sha512Digest().update(ascii("abc"))
+        digest.digestInto(out(SHA512_DIGEST_BYTES))
+        assertFailsWith<IllegalStateException> { digest.digestInto(out(SHA512_DIGEST_BYTES)) }
+    }
+
+    @Test
+    fun sha512UpdateAfterFinalizeThrows() {
+        val digest = Sha512Digest().update(ascii("abc"))
+        digest.digestInto(out(SHA512_DIGEST_BYTES))
+        assertFailsWith<IllegalStateException> { digest.update(ascii("more")) }
+    }
+
+    @Test
+    fun hmacSha256DoubleFinalizeThrows() {
+        val mac = HmacSha256Mac(key).update(ascii("abc"))
+        mac.doFinalInto(out(HMAC_SHA256_BYTES))
+        assertFailsWith<IllegalStateException> { mac.doFinalInto(out(HMAC_SHA256_BYTES)) }
+    }
+
+    @Test
+    fun hmacSha256UpdateAfterFinalizeThrows() {
+        val mac = HmacSha256Mac(key).update(ascii("abc"))
+        mac.doFinalInto(out(HMAC_SHA256_BYTES))
+        assertFailsWith<IllegalStateException> { mac.update(ascii("more")) }
+    }
+
+    @Test
+    fun hmacSha384DoubleFinalizeThrows() {
+        val mac = HmacSha384Mac(key).update(ascii("abc"))
+        mac.doFinalInto(out(HMAC_SHA384_BYTES))
+        assertFailsWith<IllegalStateException> { mac.doFinalInto(out(HMAC_SHA384_BYTES)) }
+    }
+
+    @Test
+    fun hmacSha384UpdateAfterFinalizeThrows() {
+        val mac = HmacSha384Mac(key).update(ascii("abc"))
+        mac.doFinalInto(out(HMAC_SHA384_BYTES))
+        assertFailsWith<IllegalStateException> { mac.update(ascii("more")) }
+    }
+
+    @Test
+    fun hmacSha512DoubleFinalizeThrows() {
+        val mac = HmacSha512Mac(key).update(ascii("abc"))
+        mac.doFinalInto(out(HMAC_SHA512_BYTES))
+        assertFailsWith<IllegalStateException> { mac.doFinalInto(out(HMAC_SHA512_BYTES)) }
+    }
+
+    @Test
+    fun hmacSha512UpdateAfterFinalizeThrows() {
+        val mac = HmacSha512Mac(key).update(ascii("abc"))
+        mac.doFinalInto(out(HMAC_SHA512_BYTES))
+        assertFailsWith<IllegalStateException> { mac.update(ascii("more")) }
+    }
+}

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/HpkeRoundTripTest.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/HpkeRoundTripTest.kt
@@ -8,6 +8,7 @@ import com.ditchoom.buffer.crypto.CryptoTestVectors.toHex
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import kotlin.test.fail
 
@@ -206,6 +207,28 @@ class HpkeRoundTripTest {
             recipient.close()
             sender.context.close()
             receiver.close()
+        }
+
+    @Test
+    fun closedContextRejectsEveryOp() =
+        runTest {
+            val suite = firstSupported() ?: return@runTest
+            val recipient = hpkeGenerateKeyPair(suite.kem)
+            val info = ascii("closed context")
+            val pt = ascii("payload")
+
+            val sender = hpkeSetupBaseSender(suite, recipient.publicKey, info)
+            val receiver = hpkeSetupBaseReceiver(suite, recipient.privateKey, sender.enc, info)
+            val ct = sender.context.seal(pt, null, BufferFactory.Default)
+
+            sender.context.close()
+            sender.context.close() // second close must not throw
+            receiver.close()
+
+            assertFailsWith<IllegalStateException> { sender.context.seal(pt, null, BufferFactory.Default) }
+            assertFailsWith<IllegalStateException> { receiver.open(ct, null, BufferFactory.Default) }
+            assertFailsWith<IllegalStateException> { sender.context.export(ascii("ctx"), 32, BufferFactory.Default) }
+            recipient.close()
         }
 
     private fun firstSupported(): HpkeSuite? = allSuites.firstOrNull { HpkeTestSupport.suiteSupported(it) }

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256Mac.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256Mac.jsAndWasmJs.kt
@@ -15,6 +15,7 @@ actual class HmacSha256Mac actual constructor(
     // inner accumulates H(ipad ‖ message); opad (a managed buffer) is held for the outer hash.
     private val inner = Sha256Core()
     private val opad: PlatformBuffer = BufferFactory.managed().allocate(SHA256_BLOCK_BYTES)
+    private var finalized = false
 
     init {
         // Normalize the key to a single block (managed buffer, zero-initialized): hash it if
@@ -39,11 +40,14 @@ actual class HmacSha256Mac actual constructor(
     }
 
     actual fun update(input: ReadBuffer): HmacSha256Mac {
+        check(!finalized) { "mac already finalized" }
         inner.update(input)
         return this
     }
 
     actual fun doFinalInto(dest: WriteBuffer) {
+        check(!finalized) { "mac already finalized" }
+        finalized = true
         inner.finish() // inner = H(ipad ‖ message)
         val outer = Sha256Core()
         for (i in 0 until SHA256_BLOCK_BYTES) outer.absorbByte(opad.get(i))

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/HmacSha384Mac.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/HmacSha384Mac.jsAndWasmJs.kt
@@ -10,13 +10,17 @@ actual class HmacSha384Mac actual constructor(
     key: ReadBuffer,
 ) {
     private val core = Sha512FamilyHmac(key, mode384 = true, outBytes = SHA384_DIGEST_BYTES)
+    private var finalized = false
 
     actual fun update(input: ReadBuffer): HmacSha384Mac {
+        check(!finalized) { "mac already finalized" }
         core.update(input)
         return this
     }
 
     actual fun doFinalInto(dest: WriteBuffer) {
+        check(!finalized) { "mac already finalized" }
+        finalized = true
         core.doFinalInto(dest)
     }
 }

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/HmacSha512Mac.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/HmacSha512Mac.jsAndWasmJs.kt
@@ -10,13 +10,17 @@ actual class HmacSha512Mac actual constructor(
     key: ReadBuffer,
 ) {
     private val core = Sha512FamilyHmac(key, mode384 = false, outBytes = SHA512_DIGEST_BYTES)
+    private var finalized = false
 
     actual fun update(input: ReadBuffer): HmacSha512Mac {
+        check(!finalized) { "mac already finalized" }
         core.update(input)
         return this
     }
 
     actual fun doFinalInto(dest: WriteBuffer) {
+        check(!finalized) { "mac already finalized" }
+        finalized = true
         core.doFinalInto(dest)
     }
 }

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Sha256Digest.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Sha256Digest.jsAndWasmJs.kt
@@ -8,13 +8,17 @@ import com.ditchoom.buffer.WriteBuffer
 /** js/wasmJs SHA-256 backed by the synchronous pure-Kotlin [Sha256Core]. */
 actual class Sha256Digest actual constructor() {
     private val core = Sha256Core()
+    private var finalized = false
 
     actual fun update(input: ReadBuffer): Sha256Digest {
+        check(!finalized) { "digest already finalized" }
         core.update(input)
         return this
     }
 
     actual fun digestInto(dest: WriteBuffer) {
+        check(!finalized) { "digest already finalized" }
+        finalized = true
         core.finish()
         for (i in 0 until SHA256_DIGEST_BYTES) dest.writeByte(core.digestByte(i))
     }

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Sha384Digest.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Sha384Digest.jsAndWasmJs.kt
@@ -8,13 +8,17 @@ import com.ditchoom.buffer.WriteBuffer
 /** js/wasmJs SHA-384 backed by the synchronous pure-Kotlin [Sha512Core] (SHA-384 IV). */
 actual class Sha384Digest actual constructor() {
     private val core = Sha512Core(sha384 = true)
+    private var finalized = false
 
     actual fun update(input: ReadBuffer): Sha384Digest {
+        check(!finalized) { "digest already finalized" }
         core.update(input)
         return this
     }
 
     actual fun digestInto(dest: WriteBuffer) {
+        check(!finalized) { "digest already finalized" }
+        finalized = true
         core.finish()
         for (i in 0 until SHA384_DIGEST_BYTES) dest.writeByte(core.digestByte(i))
     }

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Sha512Digest.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Sha512Digest.jsAndWasmJs.kt
@@ -8,13 +8,17 @@ import com.ditchoom.buffer.WriteBuffer
 /** js/wasmJs SHA-512 backed by the synchronous pure-Kotlin [Sha512Core]. */
 actual class Sha512Digest actual constructor() {
     private val core = Sha512Core(sha384 = false)
+    private var finalized = false
 
     actual fun update(input: ReadBuffer): Sha512Digest {
+        check(!finalized) { "digest already finalized" }
         core.update(input)
         return this
     }
 
     actual fun digestInto(dest: WriteBuffer) {
+        check(!finalized) { "digest already finalized" }
+        finalized = true
         core.finish()
         for (i in 0 until SHA512_DIGEST_BYTES) dest.writeByte(core.digestByte(i))
     }

--- a/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/Aead.jvmCommon.kt
+++ b/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/Aead.jvmCommon.kt
@@ -58,7 +58,7 @@ internal actual fun aesGcmSeal(
     val cipher = Cipher.getInstance("AES/GCM/NoPadding")
     cipher.init(
         Cipher.ENCRYPT_MODE,
-        SecretKeySpec(materialBytes(key.requireInMemoryMaterial()), "AES"),
+        keySpec(key.requireInMemoryMaterial(), "AES"),
         GCMParameterSpec(GCM_TAG_BITS, nonceBytes(nonce)),
     )
     aad?.let { cipher.updateAADRemaining(it) }
@@ -77,7 +77,7 @@ internal actual fun aesGcmOpen(
     val cipher = Cipher.getInstance("AES/GCM/NoPadding")
     cipher.init(
         Cipher.DECRYPT_MODE,
-        SecretKeySpec(materialBytes(key.requireInMemoryMaterial()), "AES"),
+        keySpec(key.requireInMemoryMaterial(), "AES"),
         GCMParameterSpec(GCM_TAG_BITS, nonceBytes(nonce)),
     )
     aad?.let { cipher.updateAADRemaining(it) }
@@ -98,7 +98,7 @@ internal actual fun chaChaPolySeal(
     val cipher = Cipher.getInstance("ChaCha20-Poly1305")
     cipher.init(
         Cipher.ENCRYPT_MODE,
-        SecretKeySpec(materialBytes(key.requireInMemoryMaterial()), "ChaCha20"),
+        keySpec(key.requireInMemoryMaterial(), "ChaCha20"),
         IvParameterSpec(nonceBytes(nonce)),
     )
     aad?.let { cipher.updateAADRemaining(it) }
@@ -120,7 +120,7 @@ internal actual fun chaChaPolyOpen(
     val cipher = Cipher.getInstance("ChaCha20-Poly1305")
     cipher.init(
         Cipher.DECRYPT_MODE,
-        SecretKeySpec(materialBytes(key.requireInMemoryMaterial()), "ChaCha20"),
+        keySpec(key.requireInMemoryMaterial(), "ChaCha20"),
         IvParameterSpec(nonceBytes(nonce)),
     )
     aad?.let { cipher.updateAADRemaining(it) }
@@ -171,8 +171,20 @@ internal fun requireTagged(ciphertextAndTag: ReadBuffer) {
     }
 }
 
-/** Copies a key/nonce buffer's remaining bytes into a JCA-consumable array (non-destructive). */
-private fun materialBytes(buffer: ReadBuffer): ByteArray = remainingBytes(buffer)
+/**
+ * Builds a [SecretKeySpec] from the key buffer's remaining bytes (non-destructive). The staging
+ * array is zeroed as soon as the spec is constructed — [SecretKeySpec] copies the bytes internally,
+ * so the wipe cannot affect the spec and the raw key does not linger on the heap.
+ */
+private fun keySpec(
+    key: ReadBuffer,
+    algorithm: String,
+): SecretKeySpec {
+    val staged = remainingBytes(key)
+    val spec = SecretKeySpec(staged, algorithm)
+    staged.fill(0)
+    return spec
+}
 
 internal fun nonceBytes(nonce: ReadBuffer): ByteArray = remainingBytes(nonce)
 

--- a/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256Mac.jvmCommon.kt
+++ b/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256Mac.jvmCommon.kt
@@ -30,13 +30,18 @@ actual class HmacSha256Mac actual constructor(
                 }
             init(spec)
         }
+    private var finalized = false
 
     actual fun update(input: ReadBuffer): HmacSha256Mac {
+        check(!finalized) { "mac already finalized" }
         mac.updateRemaining(input)
         return this
     }
 
     actual fun doFinalInto(dest: WriteBuffer) {
+        // JCA resets the mac for reuse; the cross-platform contract is one-shot, so reject reuse.
+        check(!finalized) { "mac already finalized" }
+        finalized = true
         mac.doFinalInto(dest)
     }
 }

--- a/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha384Mac.jvmCommon.kt
+++ b/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha384Mac.jvmCommon.kt
@@ -30,13 +30,18 @@ actual class HmacSha384Mac actual constructor(
                 }
             init(spec)
         }
+    private var finalized = false
 
     actual fun update(input: ReadBuffer): HmacSha384Mac {
+        check(!finalized) { "mac already finalized" }
         mac.updateRemaining(input)
         return this
     }
 
     actual fun doFinalInto(dest: WriteBuffer) {
+        // JCA resets the mac for reuse; the cross-platform contract is one-shot, so reject reuse.
+        check(!finalized) { "mac already finalized" }
+        finalized = true
         mac.doFinalInto(dest)
     }
 }

--- a/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha512Mac.jvmCommon.kt
+++ b/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha512Mac.jvmCommon.kt
@@ -30,13 +30,18 @@ actual class HmacSha512Mac actual constructor(
                 }
             init(spec)
         }
+    private var finalized = false
 
     actual fun update(input: ReadBuffer): HmacSha512Mac {
+        check(!finalized) { "mac already finalized" }
         mac.updateRemaining(input)
         return this
     }
 
     actual fun doFinalInto(dest: WriteBuffer) {
+        // JCA resets the mac for reuse; the cross-platform contract is one-shot, so reject reuse.
+        check(!finalized) { "mac already finalized" }
+        finalized = true
         mac.doFinalInto(dest)
     }
 }

--- a/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/Sha256Digest.jvmCommon.kt
+++ b/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/Sha256Digest.jvmCommon.kt
@@ -9,13 +9,18 @@ import java.security.MessageDigest
 /** JVM/Android SHA-256 backed by the JCA [MessageDigest]. */
 actual class Sha256Digest actual constructor() {
     private val md = MessageDigest.getInstance("SHA-256")
+    private var finalized = false
 
     actual fun update(input: ReadBuffer): Sha256Digest {
+        check(!finalized) { "digest already finalized" }
         md.updateRemaining(input)
         return this
     }
 
     actual fun digestInto(dest: WriteBuffer) {
+        // JCA resets the digest for reuse; the cross-platform contract is one-shot, so reject reuse.
+        check(!finalized) { "digest already finalized" }
+        finalized = true
         md.digestInto(dest)
     }
 }

--- a/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/Sha384Digest.jvmCommon.kt
+++ b/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/Sha384Digest.jvmCommon.kt
@@ -9,13 +9,18 @@ import java.security.MessageDigest
 /** JVM/Android SHA-384 backed by the JCA [MessageDigest]. */
 actual class Sha384Digest actual constructor() {
     private val md = MessageDigest.getInstance("SHA-384")
+    private var finalized = false
 
     actual fun update(input: ReadBuffer): Sha384Digest {
+        check(!finalized) { "digest already finalized" }
         md.updateRemaining(input)
         return this
     }
 
     actual fun digestInto(dest: WriteBuffer) {
+        // JCA resets the digest for reuse; the cross-platform contract is one-shot, so reject reuse.
+        check(!finalized) { "digest already finalized" }
+        finalized = true
         md.digestInto(dest)
     }
 }

--- a/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/Sha512Digest.jvmCommon.kt
+++ b/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/Sha512Digest.jvmCommon.kt
@@ -9,13 +9,18 @@ import java.security.MessageDigest
 /** JVM/Android SHA-512 backed by the JCA [MessageDigest]. */
 actual class Sha512Digest actual constructor() {
     private val md = MessageDigest.getInstance("SHA-512")
+    private var finalized = false
 
     actual fun update(input: ReadBuffer): Sha512Digest {
+        check(!finalized) { "digest already finalized" }
         md.updateRemaining(input)
         return this
     }
 
     actual fun digestInto(dest: WriteBuffer) {
+        // JCA resets the digest for reuse; the cross-platform contract is one-shot, so reject reuse.
+        check(!finalized) { "digest already finalized" }
+        finalized = true
         md.digestInto(dest)
     }
 }

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256Mac.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256Mac.linux.kt
@@ -25,6 +25,7 @@ actual class HmacSha256Mac actual constructor(
     private var finalized = false
 
     actual fun update(input: ReadBuffer): HmacSha256Mac {
+        check(!finalized) { "mac already finalized" }
         input.withRemainingBytes { ptr, len -> bcl_hmac_update(ctx, ptr.reinterpret(), len.convert()) }
         return this
     }

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/HmacSha384Mac.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/HmacSha384Mac.linux.kt
@@ -25,6 +25,7 @@ actual class HmacSha384Mac actual constructor(
     private var finalized = false
 
     actual fun update(input: ReadBuffer): HmacSha384Mac {
+        check(!finalized) { "mac already finalized" }
         input.withRemainingBytes { ptr, len -> bcl_hmac_update(ctx, ptr.reinterpret(), len.convert()) }
         return this
     }

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/HmacSha512Mac.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/HmacSha512Mac.linux.kt
@@ -25,6 +25,7 @@ actual class HmacSha512Mac actual constructor(
     private var finalized = false
 
     actual fun update(input: ReadBuffer): HmacSha512Mac {
+        check(!finalized) { "mac already finalized" }
         input.withRemainingBytes { ptr, len -> bcl_hmac_update(ctx, ptr.reinterpret(), len.convert()) }
         return this
     }

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Sha256Digest.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Sha256Digest.linux.kt
@@ -18,6 +18,7 @@ actual class Sha256Digest actual constructor() {
     private var finalized = false
 
     actual fun update(input: ReadBuffer): Sha256Digest {
+        check(!finalized) { "digest already finalized" }
         input.withRemainingBytes { ptr, len -> bcl_sha256_update(ctx, ptr.reinterpret(), len.convert()) }
         return this
     }

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Sha384Digest.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Sha384Digest.linux.kt
@@ -18,6 +18,7 @@ actual class Sha384Digest actual constructor() {
     private var finalized = false
 
     actual fun update(input: ReadBuffer): Sha384Digest {
+        check(!finalized) { "digest already finalized" }
         input.withRemainingBytes { ptr, len -> bcl_sha384_update(ctx, ptr.reinterpret(), len.convert()) }
         return this
     }

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Sha512Digest.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Sha512Digest.linux.kt
@@ -18,6 +18,7 @@ actual class Sha512Digest actual constructor() {
     private var finalized = false
 
     actual fun update(input: ReadBuffer): Sha512Digest {
+        check(!finalized) { "digest already finalized" }
         input.withRemainingBytes { ptr, len -> bcl_sha512_update(ctx, ptr.reinterpret(), len.convert()) }
         return this
     }


### PR DESCRIPTION
Security fixes from the full-module review (verified findings; ranked by severity):

- **H1 — HPKE single-shot zeroization**: `hpkeSealBase`/`hpkeOpenBase` never closed their `HpkeContext` — the derived AEAD key, base nonce, and exporter secret were never wiped and native memory leaked per call. Now closed via try/finally; outputs verified independent of context memory.
- **H2 — per-message AEAD key-wrapper leak**: every HPKE seal/open minted an `AesGcmKey`/`ChaChaPolyKey` copy from secure scratch and never closed it. The typed wrapper is now hoisted into `HpkeContext` (created once, wiped in `close()`), which also removes a per-message key copy on streaming contexts. RFC 9180 KATs unchanged.
- **M1 — use-after-close**: `InMemoryAesGcmKey`/`InMemoryChaChaPolyKey` gained the same `requireOpen()` guard as the KeyAgreement/Signatures siblings (sealing with a closed key previously proceeded silently — under an all-zero key on secure backings). Same guards on `HpkeContext` ops and `HpkePsk`; `close()` is idempotent.
- **M2 — HPKE nonce-reuse race**: the per-message sequence counter was a plain `var`; concurrent `seal()` on one context could reuse a GCM nonce. Compute-nonce → op → increment now serialize under a Mutex; receiver no-advance-on-failure semantics preserved; concurrency contract documented.
- **M3 — digest/MAC double-finalize UAF (Apple + Linux)**: Apple actuals ran CommonCrypto over an already-freed ctx on double-finalize; Linux `update()`-after-finalize was also a UAF (the shim frees the ctx in `_final`). All guarded; Apple HMAC ctx (key-derived ipad/opad state) is zeroed before free; the reuse contract is now **uniform** across platforms (JVM/js/wasm now throw instead of silently resetting) and documented on the six commonMain expects.
- **L1**: JVM AEAD key staging arrays are zeroed after `SecretKeySpec` construction.

New tests: post-close ops throw (AEAD keys + HPKE context), double-finalize/update-after-finalize contract for all six digest/MAC classes (commonTest, all platforms), closed-context HPKE rejection.

Verified: jvm / jsNode / wasmJsNode / macosArm64 suites, ktlint, detekt, apiCheck (**no public ABI change** — new members internal/private). Linux compile-verified in CI (not registered on macOS hosts).