### PR TITLE
feat(crypto): OS-bound user authentication (biometrics) for hardware keys

### DIFF
--- a/buffer-crypto/api/android/buffer-crypto.api
+++ b/buffer-crypto/api/android/buffer-crypto.api
@@ -106,6 +106,10 @@ public final class com/ditchoom/buffer/crypto/AesGcmKey$DefaultImpls {
 public final class com/ditchoom/buffer/crypto/AuthorizationFailed : com/ditchoom/buffer/crypto/CryptoMisuseException {
 }
 
+public final class com/ditchoom/buffer/crypto/BiometricAuth_androidKt {
+	public static final fun userAuthenticated (Lcom/ditchoom/buffer/crypto/HardwareKeyProvider;Lcom/ditchoom/buffer/crypto/BiometricAuthorization;)Lcom/ditchoom/buffer/crypto/UserAuthenticatedKeyProvider;
+}
+
 public abstract interface class com/ditchoom/buffer/crypto/BiometricAuthorization : com/ditchoom/buffer/crypto/HardwareAuthorization {
 	public abstract fun authenticate (Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;Landroidx/biometric/BiometricPrompt$CryptoObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
@@ -254,9 +258,6 @@ public final class com/ditchoom/buffer/crypto/HardwareKeyException$UnsupportedHa
 public final class com/ditchoom/buffer/crypto/HardwareKeyException$UserAuthenticationRequired : com/ditchoom/buffer/crypto/HardwareKeyException {
 }
 
-public final class com/ditchoom/buffer/crypto/HardwareKeyException$UserAuthenticatorRequired : com/ditchoom/buffer/crypto/HardwareKeyException {
-}
-
 public abstract interface class com/ditchoom/buffer/crypto/HardwareKeyProvider {
 	public abstract fun eligible (Lcom/ditchoom/buffer/crypto/HardwareAlgorithm;)Z
 	public abstract fun generateAesGcm (Lcom/ditchoom/buffer/crypto/HardwareKeySpec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -266,11 +267,10 @@ public abstract interface class com/ditchoom/buffer/crypto/HardwareKeyProvider {
 
 public final class com/ditchoom/buffer/crypto/HardwareKeySpec {
 	public fun <init> ()V
-	public fun <init> (Lcom/ditchoom/buffer/crypto/HardwareAuthorization;ILcom/ditchoom/buffer/crypto/UserAuthenticationRequirement;)V
-	public synthetic fun <init> (Lcom/ditchoom/buffer/crypto/HardwareAuthorization;ILcom/ditchoom/buffer/crypto/UserAuthenticationRequirement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/ditchoom/buffer/crypto/HardwareAuthorization;I)V
+	public synthetic fun <init> (Lcom/ditchoom/buffer/crypto/HardwareAuthorization;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAesKeySizeBits ()I
 	public final fun getAuthorization ()Lcom/ditchoom/buffer/crypto/HardwareAuthorization;
-	public final fun getUserAuthentication ()Lcom/ditchoom/buffer/crypto/UserAuthenticationRequirement;
 }
 
 public final class com/ditchoom/buffer/crypto/HardwareKeysKt {
@@ -1275,6 +1275,17 @@ public final class com/ditchoom/buffer/crypto/SyncCapableAesGcmKey$DefaultImpls 
 public abstract interface class com/ditchoom/buffer/crypto/SyncCapableSigningKey : com/ditchoom/buffer/crypto/SigningKey {
 }
 
+public abstract interface class com/ditchoom/buffer/crypto/UserAuthenticatedKeyProvider {
+	public abstract fun eligible (Lcom/ditchoom/buffer/crypto/HardwareAlgorithm;)Z
+	public abstract fun generateAesGcm (Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun generateAesGcm$default (Lcom/ditchoom/buffer/crypto/UserAuthenticatedKeyProvider;Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun generateSigning (Lcom/ditchoom/buffer/crypto/SignatureScheme;Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/ditchoom/buffer/crypto/UserAuthenticatedKeyProvider$DefaultImpls {
+	public static synthetic fun generateAesGcm$default (Lcom/ditchoom/buffer/crypto/UserAuthenticatedKeyProvider;Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
 public final class com/ditchoom/buffer/crypto/UserAuthenticationMethod : java/lang/Enum {
 	public static final field BiometricOnly Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;
 	public static final field BiometricOrCredential Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;
@@ -1283,36 +1294,29 @@ public final class com/ditchoom/buffer/crypto/UserAuthenticationMethod : java/la
 	public static fun values ()[Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;
 }
 
-public abstract interface class com/ditchoom/buffer/crypto/UserAuthenticationRequirement {
+public abstract interface class com/ditchoom/buffer/crypto/UserAuthenticationPolicy {
 }
 
-public final class com/ditchoom/buffer/crypto/UserAuthenticationRequirement$None : com/ditchoom/buffer/crypto/UserAuthenticationRequirement {
-	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/UserAuthenticationRequirement$None;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/ditchoom/buffer/crypto/UserAuthenticationRequirement$PerUse : com/ditchoom/buffer/crypto/UserAuthenticationRequirement {
+public final class com/ditchoom/buffer/crypto/UserAuthenticationPolicy$PerUse : com/ditchoom/buffer/crypto/UserAuthenticationPolicy {
 	public fun <init> ()V
 	public fun <init> (Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;)V
 	public synthetic fun <init> (Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;
-	public final fun copy (Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;)Lcom/ditchoom/buffer/crypto/UserAuthenticationRequirement$PerUse;
-	public static synthetic fun copy$default (Lcom/ditchoom/buffer/crypto/UserAuthenticationRequirement$PerUse;Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/UserAuthenticationRequirement$PerUse;
+	public final fun copy (Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;)Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy$PerUse;
+	public static synthetic fun copy$default (Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy$PerUse;Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy$PerUse;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getMethod ()Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/ditchoom/buffer/crypto/UserAuthenticationRequirement$Session : com/ditchoom/buffer/crypto/UserAuthenticationRequirement {
+public final class com/ditchoom/buffer/crypto/UserAuthenticationPolicy$Session : com/ditchoom/buffer/crypto/UserAuthenticationPolicy {
 	public synthetic fun <init> (JLcom/ditchoom/buffer/crypto/UserAuthenticationMethod;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (JLcom/ditchoom/buffer/crypto/UserAuthenticationMethod;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-UwyO8pc ()J
 	public final fun component2 ()Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;
-	public final fun copy-VtjQ1oo (JLcom/ditchoom/buffer/crypto/UserAuthenticationMethod;)Lcom/ditchoom/buffer/crypto/UserAuthenticationRequirement$Session;
-	public static synthetic fun copy-VtjQ1oo$default (Lcom/ditchoom/buffer/crypto/UserAuthenticationRequirement$Session;JLcom/ditchoom/buffer/crypto/UserAuthenticationMethod;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/UserAuthenticationRequirement$Session;
+	public final fun copy-VtjQ1oo (JLcom/ditchoom/buffer/crypto/UserAuthenticationMethod;)Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy$Session;
+	public static synthetic fun copy-VtjQ1oo$default (Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy$Session;JLcom/ditchoom/buffer/crypto/UserAuthenticationMethod;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy$Session;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getMethod ()Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;
 	public final fun getValidity-UwyO8pc ()J

--- a/buffer-crypto/api/android/buffer-crypto.api
+++ b/buffer-crypto/api/android/buffer-crypto.api
@@ -106,6 +106,17 @@ public final class com/ditchoom/buffer/crypto/AesGcmKey$DefaultImpls {
 public final class com/ditchoom/buffer/crypto/AuthorizationFailed : com/ditchoom/buffer/crypto/CryptoMisuseException {
 }
 
+public abstract interface class com/ditchoom/buffer/crypto/BiometricAuthorization : com/ditchoom/buffer/crypto/HardwareAuthorization {
+	public abstract fun authenticate (Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;Landroidx/biometric/BiometricPrompt$CryptoObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/ditchoom/buffer/crypto/BiometricPromptAuthenticator : com/ditchoom/buffer/crypto/BiometricAuthorization {
+	public fun <init> (Landroidx/fragment/app/FragmentActivity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Landroidx/fragment/app/FragmentActivity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun authenticate (Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;Landroidx/biometric/BiometricPrompt$CryptoObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun authorize (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public abstract interface class com/ditchoom/buffer/crypto/ChaChaPolyKey : com/ditchoom/buffer/crypto/AeadKey, java/lang/AutoCloseable {
 	public static final field Companion Lcom/ditchoom/buffer/crypto/ChaChaPolyKey$Companion;
 	public abstract fun getProvenance ()Lcom/ditchoom/buffer/crypto/KeyProvenance;
@@ -224,6 +235,9 @@ public abstract class com/ditchoom/buffer/crypto/HardwareKeyException : com/ditc
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
+public final class com/ditchoom/buffer/crypto/HardwareKeyException$AlgorithmNotEligible : com/ditchoom/buffer/crypto/HardwareKeyException {
+}
+
 public final class com/ditchoom/buffer/crypto/HardwareKeyException$KeyInvalidated : com/ditchoom/buffer/crypto/HardwareKeyException {
 }
 
@@ -240,6 +254,9 @@ public final class com/ditchoom/buffer/crypto/HardwareKeyException$UnsupportedHa
 public final class com/ditchoom/buffer/crypto/HardwareKeyException$UserAuthenticationRequired : com/ditchoom/buffer/crypto/HardwareKeyException {
 }
 
+public final class com/ditchoom/buffer/crypto/HardwareKeyException$UserAuthenticatorRequired : com/ditchoom/buffer/crypto/HardwareKeyException {
+}
+
 public abstract interface class com/ditchoom/buffer/crypto/HardwareKeyProvider {
 	public abstract fun eligible (Lcom/ditchoom/buffer/crypto/HardwareAlgorithm;)Z
 	public abstract fun generateAesGcm (Lcom/ditchoom/buffer/crypto/HardwareKeySpec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -249,10 +266,11 @@ public abstract interface class com/ditchoom/buffer/crypto/HardwareKeyProvider {
 
 public final class com/ditchoom/buffer/crypto/HardwareKeySpec {
 	public fun <init> ()V
-	public fun <init> (Lcom/ditchoom/buffer/crypto/HardwareAuthorization;I)V
-	public synthetic fun <init> (Lcom/ditchoom/buffer/crypto/HardwareAuthorization;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/ditchoom/buffer/crypto/HardwareAuthorization;ILcom/ditchoom/buffer/crypto/UserAuthenticationRequirement;)V
+	public synthetic fun <init> (Lcom/ditchoom/buffer/crypto/HardwareAuthorization;ILcom/ditchoom/buffer/crypto/UserAuthenticationRequirement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAesKeySizeBits ()I
 	public final fun getAuthorization ()Lcom/ditchoom/buffer/crypto/HardwareAuthorization;
+	public final fun getUserAuthentication ()Lcom/ditchoom/buffer/crypto/UserAuthenticationRequirement;
 }
 
 public final class com/ditchoom/buffer/crypto/HardwareKeysKt {
@@ -1255,6 +1273,51 @@ public final class com/ditchoom/buffer/crypto/SyncCapableAesGcmKey$DefaultImpls 
 }
 
 public abstract interface class com/ditchoom/buffer/crypto/SyncCapableSigningKey : com/ditchoom/buffer/crypto/SigningKey {
+}
+
+public final class com/ditchoom/buffer/crypto/UserAuthenticationMethod : java/lang/Enum {
+	public static final field BiometricOnly Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;
+	public static final field BiometricOrCredential Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;
+	public static fun values ()[Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/UserAuthenticationRequirement {
+}
+
+public final class com/ditchoom/buffer/crypto/UserAuthenticationRequirement$None : com/ditchoom/buffer/crypto/UserAuthenticationRequirement {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/UserAuthenticationRequirement$None;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/UserAuthenticationRequirement$PerUse : com/ditchoom/buffer/crypto/UserAuthenticationRequirement {
+	public fun <init> ()V
+	public fun <init> (Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;)V
+	public synthetic fun <init> (Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;
+	public final fun copy (Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;)Lcom/ditchoom/buffer/crypto/UserAuthenticationRequirement$PerUse;
+	public static synthetic fun copy$default (Lcom/ditchoom/buffer/crypto/UserAuthenticationRequirement$PerUse;Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/UserAuthenticationRequirement$PerUse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMethod ()Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/UserAuthenticationRequirement$Session : com/ditchoom/buffer/crypto/UserAuthenticationRequirement {
+	public synthetic fun <init> (JLcom/ditchoom/buffer/crypto/UserAuthenticationMethod;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLcom/ditchoom/buffer/crypto/UserAuthenticationMethod;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-UwyO8pc ()J
+	public final fun component2 ()Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;
+	public final fun copy-VtjQ1oo (JLcom/ditchoom/buffer/crypto/UserAuthenticationMethod;)Lcom/ditchoom/buffer/crypto/UserAuthenticationRequirement$Session;
+	public static synthetic fun copy-VtjQ1oo$default (Lcom/ditchoom/buffer/crypto/UserAuthenticationRequirement$Session;JLcom/ditchoom/buffer/crypto/UserAuthenticationMethod;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/UserAuthenticationRequirement$Session;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMethod ()Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;
+	public final fun getValidity-UwyO8pc ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/ditchoom/buffer/crypto/VerificationFailed : com/ditchoom/buffer/crypto/CryptoException {

--- a/buffer-crypto/api/jvm/buffer-crypto.api
+++ b/buffer-crypto/api/jvm/buffer-crypto.api
@@ -243,9 +243,6 @@ public final class com/ditchoom/buffer/crypto/HardwareKeyException$UnsupportedHa
 public final class com/ditchoom/buffer/crypto/HardwareKeyException$UserAuthenticationRequired : com/ditchoom/buffer/crypto/HardwareKeyException {
 }
 
-public final class com/ditchoom/buffer/crypto/HardwareKeyException$UserAuthenticatorRequired : com/ditchoom/buffer/crypto/HardwareKeyException {
-}
-
 public abstract interface class com/ditchoom/buffer/crypto/HardwareKeyProvider {
 	public abstract fun eligible (Lcom/ditchoom/buffer/crypto/HardwareAlgorithm;)Z
 	public abstract fun generateAesGcm (Lcom/ditchoom/buffer/crypto/HardwareKeySpec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -255,11 +252,10 @@ public abstract interface class com/ditchoom/buffer/crypto/HardwareKeyProvider {
 
 public final class com/ditchoom/buffer/crypto/HardwareKeySpec {
 	public fun <init> ()V
-	public fun <init> (Lcom/ditchoom/buffer/crypto/HardwareAuthorization;ILcom/ditchoom/buffer/crypto/UserAuthenticationRequirement;)V
-	public synthetic fun <init> (Lcom/ditchoom/buffer/crypto/HardwareAuthorization;ILcom/ditchoom/buffer/crypto/UserAuthenticationRequirement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/ditchoom/buffer/crypto/HardwareAuthorization;I)V
+	public synthetic fun <init> (Lcom/ditchoom/buffer/crypto/HardwareAuthorization;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAesKeySizeBits ()I
 	public final fun getAuthorization ()Lcom/ditchoom/buffer/crypto/HardwareAuthorization;
-	public final fun getUserAuthentication ()Lcom/ditchoom/buffer/crypto/UserAuthenticationRequirement;
 }
 
 public final class com/ditchoom/buffer/crypto/HardwareKeysKt {
@@ -1262,6 +1258,17 @@ public final class com/ditchoom/buffer/crypto/SyncCapableAesGcmKey$DefaultImpls 
 public abstract interface class com/ditchoom/buffer/crypto/SyncCapableSigningKey : com/ditchoom/buffer/crypto/SigningKey {
 }
 
+public abstract interface class com/ditchoom/buffer/crypto/UserAuthenticatedKeyProvider {
+	public abstract fun eligible (Lcom/ditchoom/buffer/crypto/HardwareAlgorithm;)Z
+	public abstract fun generateAesGcm (Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun generateAesGcm$default (Lcom/ditchoom/buffer/crypto/UserAuthenticatedKeyProvider;Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun generateSigning (Lcom/ditchoom/buffer/crypto/SignatureScheme;Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/ditchoom/buffer/crypto/UserAuthenticatedKeyProvider$DefaultImpls {
+	public static synthetic fun generateAesGcm$default (Lcom/ditchoom/buffer/crypto/UserAuthenticatedKeyProvider;Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
 public final class com/ditchoom/buffer/crypto/UserAuthenticationMethod : java/lang/Enum {
 	public static final field BiometricOnly Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;
 	public static final field BiometricOrCredential Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;
@@ -1270,36 +1277,29 @@ public final class com/ditchoom/buffer/crypto/UserAuthenticationMethod : java/la
 	public static fun values ()[Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;
 }
 
-public abstract interface class com/ditchoom/buffer/crypto/UserAuthenticationRequirement {
+public abstract interface class com/ditchoom/buffer/crypto/UserAuthenticationPolicy {
 }
 
-public final class com/ditchoom/buffer/crypto/UserAuthenticationRequirement$None : com/ditchoom/buffer/crypto/UserAuthenticationRequirement {
-	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/UserAuthenticationRequirement$None;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/ditchoom/buffer/crypto/UserAuthenticationRequirement$PerUse : com/ditchoom/buffer/crypto/UserAuthenticationRequirement {
+public final class com/ditchoom/buffer/crypto/UserAuthenticationPolicy$PerUse : com/ditchoom/buffer/crypto/UserAuthenticationPolicy {
 	public fun <init> ()V
 	public fun <init> (Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;)V
 	public synthetic fun <init> (Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;
-	public final fun copy (Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;)Lcom/ditchoom/buffer/crypto/UserAuthenticationRequirement$PerUse;
-	public static synthetic fun copy$default (Lcom/ditchoom/buffer/crypto/UserAuthenticationRequirement$PerUse;Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/UserAuthenticationRequirement$PerUse;
+	public final fun copy (Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;)Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy$PerUse;
+	public static synthetic fun copy$default (Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy$PerUse;Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy$PerUse;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getMethod ()Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/ditchoom/buffer/crypto/UserAuthenticationRequirement$Session : com/ditchoom/buffer/crypto/UserAuthenticationRequirement {
+public final class com/ditchoom/buffer/crypto/UserAuthenticationPolicy$Session : com/ditchoom/buffer/crypto/UserAuthenticationPolicy {
 	public synthetic fun <init> (JLcom/ditchoom/buffer/crypto/UserAuthenticationMethod;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (JLcom/ditchoom/buffer/crypto/UserAuthenticationMethod;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-UwyO8pc ()J
 	public final fun component2 ()Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;
-	public final fun copy-VtjQ1oo (JLcom/ditchoom/buffer/crypto/UserAuthenticationMethod;)Lcom/ditchoom/buffer/crypto/UserAuthenticationRequirement$Session;
-	public static synthetic fun copy-VtjQ1oo$default (Lcom/ditchoom/buffer/crypto/UserAuthenticationRequirement$Session;JLcom/ditchoom/buffer/crypto/UserAuthenticationMethod;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/UserAuthenticationRequirement$Session;
+	public final fun copy-VtjQ1oo (JLcom/ditchoom/buffer/crypto/UserAuthenticationMethod;)Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy$Session;
+	public static synthetic fun copy-VtjQ1oo$default (Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy$Session;JLcom/ditchoom/buffer/crypto/UserAuthenticationMethod;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy$Session;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getMethod ()Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;
 	public final fun getValidity-UwyO8pc ()J

--- a/buffer-crypto/api/jvm/buffer-crypto.api
+++ b/buffer-crypto/api/jvm/buffer-crypto.api
@@ -224,6 +224,9 @@ public abstract class com/ditchoom/buffer/crypto/HardwareKeyException : com/ditc
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
+public final class com/ditchoom/buffer/crypto/HardwareKeyException$AlgorithmNotEligible : com/ditchoom/buffer/crypto/HardwareKeyException {
+}
+
 public final class com/ditchoom/buffer/crypto/HardwareKeyException$KeyInvalidated : com/ditchoom/buffer/crypto/HardwareKeyException {
 }
 
@@ -240,6 +243,9 @@ public final class com/ditchoom/buffer/crypto/HardwareKeyException$UnsupportedHa
 public final class com/ditchoom/buffer/crypto/HardwareKeyException$UserAuthenticationRequired : com/ditchoom/buffer/crypto/HardwareKeyException {
 }
 
+public final class com/ditchoom/buffer/crypto/HardwareKeyException$UserAuthenticatorRequired : com/ditchoom/buffer/crypto/HardwareKeyException {
+}
+
 public abstract interface class com/ditchoom/buffer/crypto/HardwareKeyProvider {
 	public abstract fun eligible (Lcom/ditchoom/buffer/crypto/HardwareAlgorithm;)Z
 	public abstract fun generateAesGcm (Lcom/ditchoom/buffer/crypto/HardwareKeySpec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -249,10 +255,11 @@ public abstract interface class com/ditchoom/buffer/crypto/HardwareKeyProvider {
 
 public final class com/ditchoom/buffer/crypto/HardwareKeySpec {
 	public fun <init> ()V
-	public fun <init> (Lcom/ditchoom/buffer/crypto/HardwareAuthorization;I)V
-	public synthetic fun <init> (Lcom/ditchoom/buffer/crypto/HardwareAuthorization;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/ditchoom/buffer/crypto/HardwareAuthorization;ILcom/ditchoom/buffer/crypto/UserAuthenticationRequirement;)V
+	public synthetic fun <init> (Lcom/ditchoom/buffer/crypto/HardwareAuthorization;ILcom/ditchoom/buffer/crypto/UserAuthenticationRequirement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAesKeySizeBits ()I
 	public final fun getAuthorization ()Lcom/ditchoom/buffer/crypto/HardwareAuthorization;
+	public final fun getUserAuthentication ()Lcom/ditchoom/buffer/crypto/UserAuthenticationRequirement;
 }
 
 public final class com/ditchoom/buffer/crypto/HardwareKeysKt {
@@ -1253,6 +1260,51 @@ public final class com/ditchoom/buffer/crypto/SyncCapableAesGcmKey$DefaultImpls 
 }
 
 public abstract interface class com/ditchoom/buffer/crypto/SyncCapableSigningKey : com/ditchoom/buffer/crypto/SigningKey {
+}
+
+public final class com/ditchoom/buffer/crypto/UserAuthenticationMethod : java/lang/Enum {
+	public static final field BiometricOnly Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;
+	public static final field BiometricOrCredential Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;
+	public static fun values ()[Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/UserAuthenticationRequirement {
+}
+
+public final class com/ditchoom/buffer/crypto/UserAuthenticationRequirement$None : com/ditchoom/buffer/crypto/UserAuthenticationRequirement {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/UserAuthenticationRequirement$None;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/UserAuthenticationRequirement$PerUse : com/ditchoom/buffer/crypto/UserAuthenticationRequirement {
+	public fun <init> ()V
+	public fun <init> (Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;)V
+	public synthetic fun <init> (Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;
+	public final fun copy (Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;)Lcom/ditchoom/buffer/crypto/UserAuthenticationRequirement$PerUse;
+	public static synthetic fun copy$default (Lcom/ditchoom/buffer/crypto/UserAuthenticationRequirement$PerUse;Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/UserAuthenticationRequirement$PerUse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMethod ()Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/UserAuthenticationRequirement$Session : com/ditchoom/buffer/crypto/UserAuthenticationRequirement {
+	public synthetic fun <init> (JLcom/ditchoom/buffer/crypto/UserAuthenticationMethod;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLcom/ditchoom/buffer/crypto/UserAuthenticationMethod;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-UwyO8pc ()J
+	public final fun component2 ()Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;
+	public final fun copy-VtjQ1oo (JLcom/ditchoom/buffer/crypto/UserAuthenticationMethod;)Lcom/ditchoom/buffer/crypto/UserAuthenticationRequirement$Session;
+	public static synthetic fun copy-VtjQ1oo$default (Lcom/ditchoom/buffer/crypto/UserAuthenticationRequirement$Session;JLcom/ditchoom/buffer/crypto/UserAuthenticationMethod;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/UserAuthenticationRequirement$Session;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMethod ()Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;
+	public final fun getValidity-UwyO8pc ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/ditchoom/buffer/crypto/VerificationFailed : com/ditchoom/buffer/crypto/CryptoException {

--- a/buffer-crypto/build.gradle.kts
+++ b/buffer-crypto/build.gradle.kts
@@ -483,6 +483,11 @@ kotlin {
         }
         androidMain {
             dependsOn(jvmCommonMain)
+            dependencies {
+                // `api`: BiometricPromptAuthenticator's constructor exposes FragmentActivity and
+                // BiometricPrompt types, so consumers must see them on their compile classpath.
+                api(libs.androidx.biometric)
+            }
         }
         jvmTest {
             dependsOn(jvmCommonTest)

--- a/buffer-crypto/secure-enclave-harness/Tests/SecureEnclaveHarnessTests/SecureEnclaveTests.swift
+++ b/buffer-crypto/secure-enclave-harness/Tests/SecureEnclaveHarnessTests/SecureEnclaveTests.swift
@@ -37,6 +37,47 @@ final class SecureEnclaveTests: XCTestCase {
         XCTAssertNotEqual(point1, point2, "each Enclave key generation must produce a fresh key")
     }
 
+    /// Tier-2 binding negative test (no human, no prompt): a key generated with a user-presence
+    /// `SecAccessControl` must be REFUSED when signing through an LAContext that is forbidden from
+    /// prompting (`interactionNotAllowed`). If this sign succeeds, the access control was never
+    /// applied at generation and the biometric gate is advisory-only again.
+    func testAccessControlledKeyRefusesSigningWithoutInteraction() throws {
+        try skipUnlessEnclaveUsable()
+
+        // authReq 1 = userPresence (biometric or device credential).
+        var blob = [UInt8](repeating: 0, count: blobCap)
+        var blobLen = 0
+        var point = [UInt8](repeating: 0, count: pointLen)
+        var pLen = 0
+        let genStatus = bcks_secure_enclave_p256_generate_ac(1, &blob, blobCap, &blobLen, &point, pointLen, &pLen)
+        guard genStatus == 0 else {
+            // A passcode-less host cannot mint user-presence keys — that is itself the binding
+            // working; nothing further to assert headlessly.
+            throw XCTSkip("access-controlled generate unavailable here (status \(genStatus)) — likely no passcode/biometry enrolled")
+        }
+        let keyBlob = Array(blob.prefix(blobLen))
+
+        let ctx = bcks_la_context_create("harness binding test")
+        XCTAssertGreaterThan(ctx, 0, "LocalAuthentication must be available on this platform")
+        defer { bcks_la_context_release(ctx) }
+
+        // Forbid interaction, then evaluate: must fail rather than prompt.
+        XCTAssertNotEqual(bcks_la_evaluate(ctx, 1, 0), 0, "evaluate with interactionNotAllowed must fail, not prompt")
+
+        // Signing through the never-evaluated, interaction-forbidden context must be refused by
+        // the Enclave's access control (BCKS_ERR_AUTH = -2), never emit a signature.
+        let message = Array("must not sign".utf8)
+        var sig = [UInt8](repeating: 0, count: sigCap)
+        var sigLen = 0
+        let signStatus = keyBlob.withUnsafeBufferPointer { blobPtr in
+            message.withUnsafeBufferPointer { msgPtr in
+                bcks_secure_enclave_p256_sign_ctx(blobPtr.baseAddress, keyBlob.count, ctx, msgPtr.baseAddress, message.count, &sig, sigCap, &sigLen)
+            }
+        }
+        XCTAssertEqual(signStatus, -2, "an access-controlled key must refuse an unauthenticated sign (got status \(signStatus))")
+        XCTAssertEqual(sigLen, 0, "no signature bytes may be emitted on refusal")
+    }
+
     // MARK: - shim drivers
 
     private func skipUnlessEnclaveUsable() throws {

--- a/buffer-crypto/src/androidInstrumentedTest/kotlin/com/ditchoom/buffer/crypto/UserAuthBindingInstrumentedTest.kt
+++ b/buffer-crypto/src/androidInstrumentedTest/kotlin/com/ditchoom/buffer/crypto/UserAuthBindingInstrumentedTest.kt
@@ -2,6 +2,7 @@ package com.ditchoom.buffer.crypto
 
 import android.app.KeyguardManager
 import android.content.Context
+import androidx.biometric.BiometricPrompt
 import androidx.test.platform.app.InstrumentationRegistry
 import com.ditchoom.buffer.crypto.CryptoTestVectors.ascii
 import kotlinx.coroutines.test.runTest
@@ -9,6 +10,7 @@ import org.junit.Assume.assumeTrue
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
+import kotlin.test.assertNotNull
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -16,18 +18,18 @@ import kotlin.time.Duration.Companion.seconds
  * binding is *real*, not advisory, without any human interaction (no prompt is ever shown, so
  * these run headless under `connectedCheck`).
  *
- *  - A [UserAuthenticationRequirement.Session]-bound key used without any recent device unlock
- *    must be refused **by the keystore** (`UserNotAuthenticatedException` →
- *    [HardwareKeyException.UserAuthenticationRequired]) — even though the SPI gate said yes. If
- *    this test fails, the key was generated without `setUserAuthenticationRequired` and the gate
- *    is advisory again.
- *  - A [UserAuthenticationRequirement.PerUse] key with a plain closure gate must be refused at
- *    *generation* ([HardwareKeyException.UserAuthenticatorRequired]): Android only honors
- *    auth-per-use through a `BiometricPrompt.CryptoObject`, which a closure cannot drive.
+ *  - A [UserAuthenticationPolicy.Session]-bound key used without any recent device unlock must be
+ *    refused **by the keystore** (`UserNotAuthenticatedException` →
+ *    [HardwareKeyException.UserAuthenticationRequired]) — even though the prompt host grants
+ *    unconditionally. If this test fails, the key was generated without
+ *    `setUserAuthenticationRequired` and the binding is advisory again.
+ *  - A [UserAuthenticationPolicy.PerUse] key must be refused **by the keystore** when the prompt
+ *    host claims success without actually authorizing the `CryptoObject` through a real
+ *    BiometricPrompt — the element only honors an authorization it saw itself.
  *
- * The session test needs a secure lock screen (the keystore rejects auth-bound generation
- * outright without one) — skipped via `assumeTrue` on unconfigured emulators. Tier-3
- * (prompt-and-match with a real finger) stays device/human-gated outside CI.
+ * Both tests need a secure lock screen (the keystore rejects auth-bound generation outright
+ * without one) — skipped via `assumeTrue` on unconfigured emulators. Tier-3 (prompt-and-match
+ * with a real finger) stays device/human-gated outside CI.
  */
 class UserAuthBindingInstrumentedTest {
     private val keyguard =
@@ -36,25 +38,32 @@ class UserAuthBindingInstrumentedTest {
             .targetContext
             .getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
 
-    private fun provider(): HardwareKeyProvider {
+    /** Grants everything but never shows a prompt — the keystore must still refuse on its own. */
+    private class LyingPrompt : BiometricAuthorization {
+        override suspend fun authorize(): Boolean = true
+
+        override suspend fun authenticate(
+            method: UserAuthenticationMethod,
+            cryptoObject: BiometricPrompt.CryptoObject?,
+        ): Boolean = true
+    }
+
+    private fun authenticatedProvider(): UserAuthenticatedKeyProvider {
         val hw = CryptoCapabilities.hardware
         assertIs<HardwareSupport.Available>(hw, "a device wires the Android Keystore provider")
-        return hw.provider
+        return assertNotNull(
+            hw.provider.userAuthenticated(LyingPrompt()),
+            "the platform provider must accept a BiometricAuthorization prompt host",
+        )
     }
 
     @Test
     fun sessionBoundKeyIsRefusedByTheKeystoreWithoutAuthentication() =
         runTest {
             assumeTrue("requires a secure lock screen", keyguard.isDeviceSecure)
-            val provider = provider()
-            // The gate grants unconditionally — if the op still fails, the *keystore* enforced the
-            // binding, which is exactly what this tier pins.
             val key =
-                provider.generateAesGcm(
-                    HardwareKeySpec(
-                        userAuthentication = UserAuthenticationRequirement.Session(5.seconds),
-                    ),
-                )
+                authenticatedProvider()
+                    .generateAesGcm(UserAuthenticationPolicy.Session(5.seconds))
             try {
                 assertFailsWith<HardwareKeyException.UserAuthenticationRequired>(
                     "an auth-bound key must be unusable without a recent device unlock",
@@ -67,22 +76,23 @@ class UserAuthBindingInstrumentedTest {
         }
 
     @Test
-    fun perUseGenerationRequiresACryptoObjectCapableAuthenticator() =
+    fun perUseKeyIsRefusedWhenTheCryptoObjectWasNeverAuthorized() =
         runTest {
-            val provider = provider()
-            // Thrown by policy resolution before the keystore is touched, so no lock screen needed.
-            assertFailsWith<HardwareKeyException.UserAuthenticatorRequired> {
-                provider.generateAesGcm(
-                    HardwareKeySpec(
-                        userAuthentication = UserAuthenticationRequirement.PerUse(),
-                    ),
-                )
-            }
-            assertFailsWith<HardwareKeyException.UserAuthenticatorRequired> {
-                provider.generateSigning(
-                    SignatureScheme.EcdsaP256,
-                    HardwareKeySpec(userAuthentication = UserAuthenticationRequirement.PerUse()),
-                )
+            assumeTrue("requires a secure lock screen", keyguard.isDeviceSecure)
+            val key =
+                authenticatedProvider()
+                    .generateAesGcm(UserAuthenticationPolicy.PerUse())
+            try {
+                // LyingPrompt said yes without driving BiometricPrompt over the CryptoObject, so
+                // the keystore itself must refuse the un-authorized cipher — any sealed
+                // HardwareKeyException state is a pass; a successful seal means the binding is fake.
+                assertFailsWith<HardwareKeyException>(
+                    "a per-use key must be unusable without a real CryptoObject authorization",
+                ) {
+                    aesGcmAsyncOps().seal(key, ascii("must not encrypt"))
+                }
+            } finally {
+                key.close()
             }
         }
 }

--- a/buffer-crypto/src/androidInstrumentedTest/kotlin/com/ditchoom/buffer/crypto/UserAuthBindingInstrumentedTest.kt
+++ b/buffer-crypto/src/androidInstrumentedTest/kotlin/com/ditchoom/buffer/crypto/UserAuthBindingInstrumentedTest.kt
@@ -1,0 +1,88 @@
+package com.ditchoom.buffer.crypto
+
+import android.app.KeyguardManager
+import android.content.Context
+import androidx.test.platform.app.InstrumentationRegistry
+import com.ditchoom.buffer.crypto.CryptoTestVectors.ascii
+import kotlinx.coroutines.test.runTest
+import org.junit.Assume.assumeTrue
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Tier-2 security-binding negative tests for user-authenticated keystore keys — proving the OS
+ * binding is *real*, not advisory, without any human interaction (no prompt is ever shown, so
+ * these run headless under `connectedCheck`).
+ *
+ *  - A [UserAuthenticationRequirement.Session]-bound key used without any recent device unlock
+ *    must be refused **by the keystore** (`UserNotAuthenticatedException` →
+ *    [HardwareKeyException.UserAuthenticationRequired]) — even though the SPI gate said yes. If
+ *    this test fails, the key was generated without `setUserAuthenticationRequired` and the gate
+ *    is advisory again.
+ *  - A [UserAuthenticationRequirement.PerUse] key with a plain closure gate must be refused at
+ *    *generation* ([HardwareKeyException.UserAuthenticatorRequired]): Android only honors
+ *    auth-per-use through a `BiometricPrompt.CryptoObject`, which a closure cannot drive.
+ *
+ * The session test needs a secure lock screen (the keystore rejects auth-bound generation
+ * outright without one) — skipped via `assumeTrue` on unconfigured emulators. Tier-3
+ * (prompt-and-match with a real finger) stays device/human-gated outside CI.
+ */
+class UserAuthBindingInstrumentedTest {
+    private val keyguard =
+        InstrumentationRegistry
+            .getInstrumentation()
+            .targetContext
+            .getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
+
+    private fun provider(): HardwareKeyProvider {
+        val hw = CryptoCapabilities.hardware
+        assertIs<HardwareSupport.Available>(hw, "a device wires the Android Keystore provider")
+        return hw.provider
+    }
+
+    @Test
+    fun sessionBoundKeyIsRefusedByTheKeystoreWithoutAuthentication() =
+        runTest {
+            assumeTrue("requires a secure lock screen", keyguard.isDeviceSecure)
+            val provider = provider()
+            // The gate grants unconditionally — if the op still fails, the *keystore* enforced the
+            // binding, which is exactly what this tier pins.
+            val key =
+                provider.generateAesGcm(
+                    HardwareKeySpec(
+                        userAuthentication = UserAuthenticationRequirement.Session(5.seconds),
+                    ),
+                )
+            try {
+                assertFailsWith<HardwareKeyException.UserAuthenticationRequired>(
+                    "an auth-bound key must be unusable without a recent device unlock",
+                ) {
+                    aesGcmAsyncOps().seal(key, ascii("must not encrypt"))
+                }
+            } finally {
+                key.close()
+            }
+        }
+
+    @Test
+    fun perUseGenerationRequiresACryptoObjectCapableAuthenticator() =
+        runTest {
+            val provider = provider()
+            // Thrown by policy resolution before the keystore is touched, so no lock screen needed.
+            assertFailsWith<HardwareKeyException.UserAuthenticatorRequired> {
+                provider.generateAesGcm(
+                    HardwareKeySpec(
+                        userAuthentication = UserAuthenticationRequirement.PerUse(),
+                    ),
+                )
+            }
+            assertFailsWith<HardwareKeyException.UserAuthenticatorRequired> {
+                provider.generateSigning(
+                    SignatureScheme.EcdsaP256,
+                    HardwareKeySpec(userAuthentication = UserAuthenticationRequirement.PerUse()),
+                )
+            }
+        }
+}

--- a/buffer-crypto/src/androidMain/kotlin/com/ditchoom/buffer/crypto/BiometricAuth.android.kt
+++ b/buffer-crypto/src/androidMain/kotlin/com/ditchoom/buffer/crypto/BiometricAuth.android.kt
@@ -1,0 +1,136 @@
+package com.ditchoom.buffer.crypto
+
+import android.os.Build
+import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricPrompt
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.FragmentActivity
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+
+/*
+ * Android biometric authenticator for hardware-backed keys.
+ *
+ * [HardwareAuthorization] is the common gate; this file is the Android refinement that can put a
+ * real prompt on screen. Two layers:
+ *
+ *  - [BiometricAuthorization] — the *capability* interface the Android keystore provider dispatches
+ *    to. It exists because Android's auth-per-use keys ([UserAuthenticationRequirement.PerUse])
+ *    require the OS to see the exact `Cipher` / `Signature` being authorized
+ *    ([BiometricPrompt.CryptoObject]); a plain `suspend () -> Boolean` closure cannot express that.
+ *    Generation of a PerUse key with a non-[BiometricAuthorization] gate throws
+ *    [HardwareKeyException.UserAuthenticatorRequired] — at generation, so a misconfigured key never
+ *    exists.
+ *
+ *  - [BiometricPromptAuthenticator] — the library-shipped implementation over androidx.biometric.
+ *    The UI host (a [FragmentActivity]) and the prompt strings cannot be expressed in common code,
+ *    so the app constructs this and injects it as [HardwareKeySpec.authorization] — the same
+ *    inversion-of-control pattern as `BufferFactory`.
+ */
+
+/**
+ * An [HardwareAuthorization] that can bind an authentication to the exact keystore operation via
+ * [BiometricPrompt.CryptoObject]. Required for [UserAuthenticationRequirement.PerUse] keys on
+ * Android; also used (without a crypto object) to unlock a
+ * [UserAuthenticationRequirement.Session] window.
+ */
+interface BiometricAuthorization : HardwareAuthorization {
+    /**
+     * Prompts the user with authenticator classes matching [method]. A non-null [cryptoObject]
+     * binds the authentication to that exact keystore `Cipher` / `Signature` (auth-per-use);
+     * `null` performs a plain session-unlock authentication. Returns `true` on success, `false`
+     * on denial / cancellation / lockout — the provider surfaces `false` as [AuthorizationFailed].
+     */
+    suspend fun authenticate(
+        method: UserAuthenticationMethod,
+        cryptoObject: BiometricPrompt.CryptoObject?,
+    ): Boolean
+}
+
+/**
+ * The library-shipped [BiometricAuthorization] over androidx.biometric's [BiometricPrompt].
+ *
+ * ```kotlin
+ * val spec = HardwareKeySpec(
+ *     authorization = BiometricPromptAuthenticator(activity, title = "Unlock signing key"),
+ *     userAuthentication = UserAuthenticationRequirement.PerUse(),
+ * )
+ * val key = provider.generateSigning(SignatureScheme.EcdsaP256, spec)
+ * ```
+ *
+ * The prompt always runs on the main executor; [authenticate] suspends until the user completes
+ * or dismisses it and never throws for a user-driven outcome (denial is `false`, not an
+ * exception). Cancelling the calling coroutine dismisses the prompt.
+ */
+class BiometricPromptAuthenticator(
+    private val activity: FragmentActivity,
+    private val title: String,
+    private val subtitle: String? = null,
+    /** Shown only when the device credential is not an allowed fallback (biometric-only prompts). */
+    private val negativeButtonText: String = "Cancel",
+) : BiometricAuthorization {
+    /** Plain gate use (advisory / session unlock): biometric or device credential. */
+    override suspend fun authorize(): Boolean = authenticate(UserAuthenticationMethod.BiometricOrCredential, null)
+
+    override suspend fun authenticate(
+        method: UserAuthenticationMethod,
+        cryptoObject: BiometricPrompt.CryptoObject?,
+    ): Boolean =
+        suspendCancellableCoroutine { cont ->
+            val executor = ContextCompat.getMainExecutor(activity)
+            executor.execute {
+                val callback =
+                    object : BiometricPrompt.AuthenticationCallback() {
+                        override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+                            if (cont.isActive) cont.resume(true)
+                        }
+
+                        override fun onAuthenticationError(
+                            errorCode: Int,
+                            errString: CharSequence,
+                        ) {
+                            // Cancel / lockout / no-enrollment: a definitive non-success.
+                            if (cont.isActive) cont.resume(false)
+                        }
+                        // onAuthenticationFailed (a non-matching attempt) keeps the prompt up;
+                        // the flow is still pending, so it neither resumes nor fails here.
+                    }
+                val prompt = BiometricPrompt(activity, executor, callback)
+                val info = promptInfo(method, forCryptoObject = cryptoObject != null)
+                cont.invokeOnCancellation { executor.execute { prompt.cancelAuthentication() } }
+                if (cryptoObject != null) {
+                    prompt.authenticate(info, cryptoObject)
+                } else {
+                    prompt.authenticate(info)
+                }
+            }
+        }
+
+    private fun promptInfo(
+        method: UserAuthenticationMethod,
+        forCryptoObject: Boolean,
+    ): BiometricPrompt.PromptInfo {
+        // Crypto-object prompts may only offer the device-credential fallback on API 30+ (the
+        // keystore cannot bind a credential confirmation to a Cipher before that), so older
+        // devices degrade to a biometric-only prompt for per-use keys.
+        val credentialAllowed =
+            method == UserAuthenticationMethod.BiometricOrCredential &&
+                (!forCryptoObject || Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)
+        val allowed =
+            if (credentialAllowed) {
+                BiometricManager.Authenticators.BIOMETRIC_STRONG or
+                    BiometricManager.Authenticators.DEVICE_CREDENTIAL
+            } else {
+                BiometricManager.Authenticators.BIOMETRIC_STRONG
+            }
+        return BiometricPrompt.PromptInfo
+            .Builder()
+            .setTitle(title)
+            .apply { subtitle?.let { setSubtitle(it) } }
+            .setAllowedAuthenticators(allowed)
+            .apply {
+                // A negative button is required exactly when the credential fallback is absent.
+                if (!credentialAllowed) setNegativeButtonText(negativeButtonText)
+            }.build()
+    }
+}

--- a/buffer-crypto/src/androidMain/kotlin/com/ditchoom/buffer/crypto/BiometricAuth.android.kt
+++ b/buffer-crypto/src/androidMain/kotlin/com/ditchoom/buffer/crypto/BiometricAuth.android.kt
@@ -1,38 +1,39 @@
 package com.ditchoom.buffer.crypto
 
 import android.os.Build
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
 import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricPrompt
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.resume
+import kotlin.time.Duration
 
 /*
  * Android biometric authenticator for hardware-backed keys.
  *
- * [HardwareAuthorization] is the common gate; this file is the Android refinement that can put a
- * real prompt on screen. Two layers:
+ * Two layers:
  *
- *  - [BiometricAuthorization] — the *capability* interface the Android keystore provider dispatches
- *    to. It exists because Android's auth-per-use keys ([UserAuthenticationRequirement.PerUse])
- *    require the OS to see the exact `Cipher` / `Signature` being authorized
- *    ([BiometricPrompt.CryptoObject]); a plain `suspend () -> Boolean` closure cannot express that.
- *    Generation of a PerUse key with a non-[BiometricAuthorization] gate throws
- *    [HardwareKeyException.UserAuthenticatorRequired] — at generation, so a misconfigured key never
- *    exists.
+ *  - [BiometricAuthorization] — the prompt-host capability [userAuthenticated] demands at the type
+ *    level to mint OS-bound keys. It exists because Android's auth-per-use keys
+ *    ([UserAuthenticationPolicy.PerUse]) require the OS to see the exact `Cipher` / `Signature`
+ *    being authorized ([BiometricPrompt.CryptoObject]); a plain `suspend () -> Boolean` closure
+ *    cannot express that — so the requirement lives in the signature of [userAuthenticated], not
+ *    in a runtime check.
  *
  *  - [BiometricPromptAuthenticator] — the library-shipped implementation over androidx.biometric.
  *    The UI host (a [FragmentActivity]) and the prompt strings cannot be expressed in common code,
- *    so the app constructs this and injects it as [HardwareKeySpec.authorization] — the same
- *    inversion-of-control pattern as `BufferFactory`.
+ *    so the app constructs this at the platform boundary and hands it to [userAuthenticated].
  */
 
 /**
- * An [HardwareAuthorization] that can bind an authentication to the exact keystore operation via
- * [BiometricPrompt.CryptoObject]. Required for [UserAuthenticationRequirement.PerUse] keys on
- * Android; also used (without a crypto object) to unlock a
- * [UserAuthenticationRequirement.Session] window.
+ * A prompt host that can bind an authentication to the exact keystore operation via
+ * [BiometricPrompt.CryptoObject]. Handed to [userAuthenticated] to obtain a
+ * [UserAuthenticatedKeyProvider]; drives [UserAuthenticationPolicy.PerUse] ops and unlocks stale
+ * [UserAuthenticationPolicy.Session] windows. Also usable as a plain advisory
+ * [HardwareAuthorization] gate.
  */
 interface BiometricAuthorization : HardwareAuthorization {
     /**
@@ -51,11 +52,8 @@ interface BiometricAuthorization : HardwareAuthorization {
  * The library-shipped [BiometricAuthorization] over androidx.biometric's [BiometricPrompt].
  *
  * ```kotlin
- * val spec = HardwareKeySpec(
- *     authorization = BiometricPromptAuthenticator(activity, title = "Unlock signing key"),
- *     userAuthentication = UserAuthenticationRequirement.PerUse(),
- * )
- * val key = provider.generateSigning(SignatureScheme.EcdsaP256, spec)
+ * val authed = provider.userAuthenticated(BiometricPromptAuthenticator(activity, title = "Unlock signing key"))
+ * val key = authed?.generateSigning(SignatureScheme.EcdsaP256, UserAuthenticationPolicy.PerUse())
  * ```
  *
  * The prompt always runs on the main executor; [authenticate] suspends until the user completes
@@ -134,3 +132,112 @@ class BiometricPromptAuthenticator(
             }.build()
     }
 }
+
+/**
+ * The key's auth behavior, fixed at generation. Each variant carries exactly what its op path
+ * needs — [Session]/[PerUse] hold the [BiometricAuthorization] the [UserAuthenticatedKeyProvider]
+ * captured at construction, so "OS-bound key without a prompt host" is unrepresentable (no cast,
+ * no nullable downstream, no runtime validation state).
+ */
+internal sealed interface ResolvedAndroidPolicy {
+    /** No OS binding; [gate] is the advisory [HardwareKeySpec.authorization]. */
+    class Advisory(
+        val gate: HardwareAuthorization,
+    ) : ResolvedAndroidPolicy
+
+    class Session(
+        val validity: Duration,
+        val method: UserAuthenticationMethod,
+        val prompt: BiometricAuthorization,
+    ) : ResolvedAndroidPolicy {
+        suspend fun unlock(): Boolean = prompt.authenticate(method, cryptoObject = null)
+    }
+
+    class PerUse(
+        val method: UserAuthenticationMethod,
+        val prompt: BiometricAuthorization,
+    ) : ResolvedAndroidPolicy
+}
+
+/**
+ * The Android [UserAuthenticatedKeyProvider]: pairs the keystore provider with the
+ * [BiometricAuthorization] prompt host captured at construction, and maps each pure-data
+ * [UserAuthenticationPolicy] onto a [ResolvedAndroidPolicy] that carries it.
+ */
+internal class AndroidUserAuthenticatedKeyProvider(
+    private val base: AndroidKeystoreHardwareKeyProvider,
+    private val prompt: BiometricAuthorization,
+) : UserAuthenticatedKeyProvider {
+    override fun eligible(alg: HardwareAlgorithm): Boolean = base.eligible(alg)
+
+    override suspend fun generateAesGcm(
+        policy: UserAuthenticationPolicy,
+        aesKeySizeBits: Int,
+    ): AesGcmKey = base.generateAesGcmBound(policy.resolve(), aesKeySizeBits)
+
+    override suspend fun generateSigning(
+        scheme: SignatureScheme,
+        policy: UserAuthenticationPolicy,
+    ): SigningKey = base.generateSigningBound(policy.resolve(), scheme)
+
+    private fun UserAuthenticationPolicy.resolve(): ResolvedAndroidPolicy =
+        when (this) {
+            is UserAuthenticationPolicy.Session -> ResolvedAndroidPolicy.Session(validity, method, prompt)
+            is UserAuthenticationPolicy.PerUse -> ResolvedAndroidPolicy.PerUse(method, prompt)
+        }
+}
+
+/**
+ * Binds this provider to a [BiometricAuthorization] prompt host, unlocking generation of keys the
+ * *keystore itself* refuses without user authentication ([UserAuthenticationPolicy.Session] /
+ * [UserAuthenticationPolicy.PerUse]). The prompt host is captured here — at the platform boundary,
+ * where it already had to be constructed — so the policy values stay pure data and a bound key
+ * without a prompt is a compile error, not a runtime state.
+ *
+ * Returns `null` for a provider this platform did not mint (e.g. a test fake): only the Android
+ * Keystore provider can honor OS-level binding.
+ */
+fun HardwareKeyProvider.userAuthenticated(prompt: BiometricAuthorization): UserAuthenticatedKeyProvider? =
+    (this as? AndroidKeystoreHardwareKeyProvider)?.let { AndroidUserAuthenticatedKeyProvider(it, prompt) }
+
+/**
+ * Applies OS-level user-authentication binding to a keystore key at generation. On API 30+ the
+ * typed `setUserAuthenticationParameters` expresses both the window and the allowed authenticator
+ * classes; 28/29 only have the deprecated validity-duration seconds, where `-1` means
+ * auth-per-use (biometric + `CryptoObject` only) and the authenticator classes cannot be narrowed.
+ */
+internal fun KeyGenParameterSpec.Builder.applyUserAuth(policy: ResolvedAndroidPolicy) {
+    when (policy) {
+        is ResolvedAndroidPolicy.Advisory -> return
+        is ResolvedAndroidPolicy.Session -> {
+            setUserAuthenticationRequired(true)
+            val seconds =
+                policy.validity.inWholeSeconds
+                    .coerceIn(1L, Int.MAX_VALUE.toLong())
+                    .toInt()
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                setUserAuthenticationParameters(seconds, keystoreAuthTypes(policy.method))
+            } else {
+                @Suppress("DEPRECATION")
+                setUserAuthenticationValidityDurationSeconds(seconds)
+            }
+        }
+        is ResolvedAndroidPolicy.PerUse -> {
+            setUserAuthenticationRequired(true)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                setUserAuthenticationParameters(0, keystoreAuthTypes(policy.method))
+            } else {
+                @Suppress("DEPRECATION")
+                setUserAuthenticationValidityDurationSeconds(-1)
+            }
+        }
+    }
+}
+
+/** [UserAuthenticationMethod] → the API 30+ keystore authenticator-class bitmask. */
+internal fun keystoreAuthTypes(method: UserAuthenticationMethod): Int =
+    when (method) {
+        UserAuthenticationMethod.BiometricOnly -> KeyProperties.AUTH_BIOMETRIC_STRONG
+        UserAuthenticationMethod.BiometricOrCredential ->
+            KeyProperties.AUTH_BIOMETRIC_STRONG or KeyProperties.AUTH_DEVICE_CREDENTIAL
+    }

--- a/buffer-crypto/src/androidMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.android.kt
+++ b/buffer-crypto/src/androidMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.android.kt
@@ -68,21 +68,19 @@ import javax.crypto.spec.GCMParameterSpec
  *    under a [Mutex] on [Dispatchers.Default]. The auth gate ([HardwareAuthorization.authorize]) is
  *    evaluated *outside* the lock — a biometric prompt must not hold the keystore mutex.
  *
- * **User authentication** follows [HardwareKeySpec.userAuthentication]:
- *  - [UserAuthenticationRequirement.None] — no OS binding; the [HardwareAuthorization] gate is
- *    advisory, evaluated before every op (the pre-biometrics behavior, and the default — this is
- *    what keeps unattended conformance runs green).
- *  - [UserAuthenticationRequirement.Session] — the key is generated with
+ * **User authentication** is a [ResolvedAndroidPolicy], fixed at generation:
+ *  - [ResolvedAndroidPolicy.Advisory] — the base provider's keys: no OS binding, the
+ *    [HardwareAuthorization] gate is evaluated before every op (the pre-biometrics behavior).
+ *  - [ResolvedAndroidPolicy.Session] — via [userAuthenticated]: the key is generated with
  *    `setUserAuthenticationRequired(true)` + a validity window (`setUserAuthenticationParameters`
  *    on API 30+, the deprecated validity-duration seconds on 28/29), so the *keystore* refuses a
- *    stale op with `UserNotAuthenticatedException`. The provider then prompts via the gate
- *    (a [BiometricAuthorization] shows a real prompt; a plain closure just decides) and retries
- *    exactly once — an already-authenticated user is never re-prompted.
- *  - [UserAuthenticationRequirement.PerUse] — auth-per-use binding (timeout 0 /
- *    validity -1), which Android only honors through a `BiometricPrompt.CryptoObject`
- *    wrapping the exact `Cipher`/`Signature`. Generation therefore requires a
- *    [BiometricAuthorization] (the library ships [BiometricPromptAuthenticator]); anything else
- *    throws [HardwareKeyException.UserAuthenticatorRequired] at generation.
+ *    stale op with `UserNotAuthenticatedException`. The provider then prompts through the
+ *    captured [BiometricAuthorization] and retries exactly once — an already-authenticated user
+ *    is never re-prompted.
+ *  - [ResolvedAndroidPolicy.PerUse] — via [userAuthenticated]: auth-per-use binding (timeout 0 /
+ *    validity -1), which Android only honors through a `BiometricPrompt.CryptoObject` wrapping
+ *    the exact `Cipher`/`Signature` — which is exactly why [userAuthenticated] demands a
+ *    [BiometricAuthorization] at the type level (the library ships [BiometricPromptAuthenticator]).
  */
 internal class AndroidKeystoreHardwareKeyProvider : HardwareKeyProvider {
     private val keyStore: KeyStore = KeyStore.getInstance(ANDROID_KEY_STORE).apply { load(null) }
@@ -113,16 +111,27 @@ internal class AndroidKeystoreHardwareKeyProvider : HardwareKeyProvider {
             else -> false
         }
 
-    override suspend fun generateAesGcm(spec: HardwareKeySpec): AesGcmKey {
-        val keyBits = spec.aesKeySizeBits
-        if (keyBits != AES_128_KEY_BYTES * Byte.SIZE_BITS && keyBits != AES_256_KEY_BYTES * Byte.SIZE_BITS) {
-            throw HardwareKeyException.UnsupportedHardwareKey()
-        }
-        val policy = resolvePolicy(spec)
+    override suspend fun generateAesGcm(spec: HardwareKeySpec): AesGcmKey =
+        generateAesGcmBound(ResolvedAndroidPolicy.Advisory(spec.authorization), spec.aesKeySizeBits)
+
+    override suspend fun generateSigning(
+        scheme: SignatureScheme,
+        spec: HardwareKeySpec,
+    ): SigningKey = generateSigningBound(ResolvedAndroidPolicy.Advisory(spec.authorization), scheme)
+
+    /** Generates an AES-GCM keystore key under [policy] — the shared path for unbound and OS-bound keys. */
+    internal suspend fun generateAesGcmBound(
+        policy: ResolvedAndroidPolicy,
+        aesKeySizeBits: Int,
+    ): AesGcmKey {
+        val validSize =
+            aesKeySizeBits == AES_128_KEY_BYTES * Byte.SIZE_BITS ||
+                aesKeySizeBits == AES_256_KEY_BYTES * Byte.SIZE_BITS
+        if (!validSize) throw HardwareKeyException.UnsupportedHardwareKey()
         val alias = newAlias("aes")
-        val key = keystoreOp { generateAesKey(alias, spec.aesKeySizeBits, spec.userAuthentication) }
+        val key = keystoreOp { generateAesKey(alias, aesKeySizeBits, policy) }
         return HardwareAesGcmKey(
-            sizeBits = spec.aesKeySizeBits,
+            sizeBits = aesKeySizeBits,
             gatedSeal = { aad, plaintext, factory ->
                 gatedOp(
                     policy = policy,
@@ -172,14 +181,14 @@ internal class AndroidKeystoreHardwareKeyProvider : HardwareKeyProvider {
         )
     }
 
-    override suspend fun generateSigning(
+    /** Generates an ECDSA-P256 keystore key under [policy] — the shared path for unbound and OS-bound keys. */
+    internal suspend fun generateSigningBound(
+        policy: ResolvedAndroidPolicy,
         scheme: SignatureScheme,
-        spec: HardwareKeySpec,
     ): SigningKey {
         if (!eligible(scheme.toHardwareAlgorithm())) throw HardwareKeyException.AlgorithmNotEligible()
-        val policy = resolvePolicy(spec)
         val alias = newAlias("ec")
-        val keyPair = keystoreOp { generateEcKeyPair(alias, spec.userAuthentication) }
+        val keyPair = keystoreOp { generateEcKeyPair(alias, policy) }
         val privateKey = keyPair.private
         val verifyKey = VerifyKey.ecdsaP256(uncompressedPoint(keyPair.public as ECPublicKey))
         return HardwareSigningKey(
@@ -269,60 +278,27 @@ internal class AndroidKeystoreHardwareKeyProvider : HardwareKeyProvider {
     private fun generateAesKey(
         alias: String,
         sizeBits: Int,
-        req: UserAuthenticationRequirement,
+        policy: ResolvedAndroidPolicy,
     ): SecretKey =
         generateWithStrongBoxFallback { strongBox ->
             KeyGenerator
                 .getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEY_STORE)
                 .apply {
-                    init(aesSpec(alias, sizeBits, strongBox, req))
+                    init(aesSpec(alias, sizeBits, strongBox, policy))
                 }.generateKey()
         }
 
-    private fun aesSpec(
-        alias: String,
-        sizeBits: Int,
-        strongBox: Boolean,
-        req: UserAuthenticationRequirement,
-    ): KeyGenParameterSpec =
-        KeyGenParameterSpec
-            .Builder(
-                alias,
-                KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
-            ).setKeySize(sizeBits)
-            .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
-            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
-            // Randomized encryption stays *required* (the default): the keystore picks a fresh GCM IV
-            // per seal, which the witness reads back and frames (see HardwareAesGcmKey.gatedSeal). The
-            // library never supplies a seal nonce — one reused GCM (key, nonce) pair is catastrophic.
-            .setIsStrongBoxBacked(strongBox)
-            .apply { applyUserAuth(req) }
-            .build()
-
     private fun generateEcKeyPair(
         alias: String,
-        req: UserAuthenticationRequirement,
+        policy: ResolvedAndroidPolicy,
     ): java.security.KeyPair =
         generateWithStrongBoxFallback { strongBox ->
             KeyPairGenerator
                 .getInstance(KeyProperties.KEY_ALGORITHM_EC, ANDROID_KEY_STORE)
                 .apply {
-                    initialize(ecSpec(alias, strongBox, req))
+                    initialize(ecSpec(alias, strongBox, policy))
                 }.generateKeyPair()
         }
-
-    private fun ecSpec(
-        alias: String,
-        strongBox: Boolean,
-        req: UserAuthenticationRequirement,
-    ): KeyGenParameterSpec =
-        KeyGenParameterSpec
-            .Builder(alias, KeyProperties.PURPOSE_SIGN)
-            .setAlgorithmParameterSpec(ECGenParameterSpec(SECP256R1))
-            .setDigests(KeyProperties.DIGEST_SHA256)
-            .setIsStrongBoxBacked(strongBox)
-            .apply { applyUserAuth(req) }
-            .build()
 
     /**
      * Builds a key with `setIsStrongBoxBacked(true)`, falling back to the TEE on *any* StrongBox
@@ -356,8 +332,11 @@ internal class AndroidKeystoreHardwareKeyProvider : HardwareKeyProvider {
                 val keyPair =
                     KeyPairGenerator
                         .getInstance(KeyProperties.KEY_ALGORITHM_EC, ANDROID_KEY_STORE)
-                        .apply { initialize(ecSpec(alias, strongBox = true, req = UserAuthenticationRequirement.None)) }
-                        .generateKeyPair()
+                        .apply {
+                            initialize(
+                                ecSpec(alias, strongBox = true, policy = probeAdvisoryPolicy),
+                            )
+                        }.generateKeyPair()
                 // A device may honor a StrongBox request silently in the TEE, so confirm the level
                 // where the OS exposes it (API 31+); pre-31 keep the best-effort "no throw ⇒ assume".
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
@@ -385,101 +364,43 @@ private const val ALIAS_PREFIX = "com.ditchoom.buffer.crypto.hw."
 private const val P256_FIELD_BYTES = 32
 private const val SEC1_UNCOMPRESSED = 0x04
 
-/**
- * The key's user-auth policy resolved once at generation. Each variant carries exactly what its
- * op path needs — [PerUse] holds its [BiometricAuthorization] by construction, so "per-use key
- * without a CryptoObject-capable prompt" is unrepresentable (no cast, no nullable downstream).
- */
-private sealed interface ResolvedAndroidPolicy {
-    class Advisory(
-        val gate: HardwareAuthorization,
-    ) : ResolvedAndroidPolicy
-
-    /**
-     * [gate] may or may not be a real prompt: a [BiometricAuthorization] shows the OS prompt on a
-     * stale window ([unlock]); a plain closure just decides — the keystore still enforces the
-     * binding either way.
-     */
-    class Session(
-        val method: UserAuthenticationMethod,
-        val gate: HardwareAuthorization,
-    ) : ResolvedAndroidPolicy {
-        suspend fun unlock(): Boolean =
-            when (gate) {
-                is BiometricAuthorization -> gate.authenticate(method, cryptoObject = null)
-                else -> gate.authorize()
-            }
-    }
-
-    class PerUse(
-        val method: UserAuthenticationMethod,
-        val prompt: BiometricAuthorization,
-    ) : ResolvedAndroidPolicy
-}
-
-/**
- * Resolves [HardwareKeySpec.userAuthentication] + [HardwareKeySpec.authorization] into a
- * [ResolvedAndroidPolicy], failing generation with the typed
- * [HardwareKeyException.UserAuthenticatorRequired] when per-use binding is requested without a
- * [BiometricAuthorization] (Android only honors auth-per-use through a
- * `BiometricPrompt.CryptoObject`; a plain closure cannot put the OS prompt on screen, so the key
- * would be permanently unusable).
- */
-private fun resolvePolicy(spec: HardwareKeySpec): ResolvedAndroidPolicy =
-    when (val req = spec.userAuthentication) {
-        UserAuthenticationRequirement.None -> ResolvedAndroidPolicy.Advisory(spec.authorization)
-        is UserAuthenticationRequirement.Session -> ResolvedAndroidPolicy.Session(req.method, spec.authorization)
-        is UserAuthenticationRequirement.PerUse ->
-            ResolvedAndroidPolicy.PerUse(
-                req.method,
-                spec.authorization as? BiometricAuthorization
-                    ?: throw HardwareKeyException.UserAuthenticatorRequired(),
-            )
-    }
-
 // --- stateless keystore helpers (file-level: no provider state, kept off the class) --------------
 
-/**
- * Applies OS-level user-authentication binding to a keystore key at generation. On API 30+ the
- * typed `setUserAuthenticationParameters` expresses both the window and the allowed authenticator
- * classes; 28/29 only have the deprecated validity-duration seconds, where `-1` means
- * auth-per-use (biometric + `CryptoObject` only) and the authenticator classes cannot be narrowed.
- */
-private fun KeyGenParameterSpec.Builder.applyUserAuth(req: UserAuthenticationRequirement) {
-    when (req) {
-        UserAuthenticationRequirement.None -> return
-        is UserAuthenticationRequirement.Session -> {
-            setUserAuthenticationRequired(true)
-            val seconds =
-                req.validity.inWholeSeconds
-                    .coerceIn(1L, Int.MAX_VALUE.toLong())
-                    .toInt()
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                setUserAuthenticationParameters(seconds, keystoreAuthTypes(req.method))
-            } else {
-                @Suppress("DEPRECATION")
-                setUserAuthenticationValidityDurationSeconds(seconds)
-            }
-        }
-        is UserAuthenticationRequirement.PerUse -> {
-            setUserAuthenticationRequired(true)
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                setUserAuthenticationParameters(0, keystoreAuthTypes(req.method))
-            } else {
-                @Suppress("DEPRECATION")
-                setUserAuthenticationValidityDurationSeconds(-1)
-            }
-        }
-    }
-}
+/** Unbound throwaway-key policy for the StrongBox probe. */
+private val probeAdvisoryPolicy = ResolvedAndroidPolicy.Advisory(HardwareAuthorization { true })
 
-/** [UserAuthenticationMethod] → the API 30+ keystore authenticator-class bitmask. */
-private fun keystoreAuthTypes(method: UserAuthenticationMethod): Int =
-    when (method) {
-        UserAuthenticationMethod.BiometricOnly -> KeyProperties.AUTH_BIOMETRIC_STRONG
-        UserAuthenticationMethod.BiometricOrCredential ->
-            KeyProperties.AUTH_BIOMETRIC_STRONG or KeyProperties.AUTH_DEVICE_CREDENTIAL
-    }
+private fun aesSpec(
+    alias: String,
+    sizeBits: Int,
+    strongBox: Boolean,
+    policy: ResolvedAndroidPolicy,
+): KeyGenParameterSpec =
+    KeyGenParameterSpec
+        .Builder(
+            alias,
+            KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
+        ).setKeySize(sizeBits)
+        .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+        .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+        // Randomized encryption stays *required* (the default): the keystore picks a fresh GCM IV
+        // per seal, which the witness reads back and frames (see HardwareAesGcmKey.gatedSeal). The
+        // library never supplies a seal nonce — one reused GCM (key, nonce) pair is catastrophic.
+        .setIsStrongBoxBacked(strongBox)
+        .apply { applyUserAuth(policy) }
+        .build()
+
+private fun ecSpec(
+    alias: String,
+    strongBox: Boolean,
+    policy: ResolvedAndroidPolicy,
+): KeyGenParameterSpec =
+    KeyGenParameterSpec
+        .Builder(alias, KeyProperties.PURPOSE_SIGN)
+        .setAlgorithmParameterSpec(ECGenParameterSpec(SECP256R1))
+        .setDigests(KeyProperties.DIGEST_SHA256)
+        .setIsStrongBoxBacked(strongBox)
+        .apply { applyUserAuth(policy) }
+        .build()
 
 /**
  * Runs [block], normalizing any keystore-originated failure to a [HardwareKeyException]. A

--- a/buffer-crypto/src/androidMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.android.kt
+++ b/buffer-crypto/src/androidMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.android.kt
@@ -10,6 +10,7 @@ import android.security.keystore.KeyPermanentlyInvalidatedException
 import android.security.keystore.KeyProperties
 import android.security.keystore.StrongBoxUnavailableException
 import android.security.keystore.UserNotAuthenticatedException
+import androidx.biometric.BiometricPrompt
 import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.Default
 import com.ditchoom.buffer.PlatformBuffer
@@ -67,11 +68,21 @@ import javax.crypto.spec.GCMParameterSpec
  *    under a [Mutex] on [Dispatchers.Default]. The auth gate ([HardwareAuthorization.authorize]) is
  *    evaluated *outside* the lock — a biometric prompt must not hold the keystore mutex.
  *
- * The per-use gate is [HardwareKeySpec.authorization], evaluated in Kotlin before every op. OS-level
- * user-authentication binding (`setUserAuthenticationRequired`) is intentionally NOT set: it would
- * make a key unusable without a fresh device unlock / biometric, which the [HardwareAuthorization]
- * gate already models at the SPI level and which would break unattended conformance runs. Binding the
- * keystore to a biometric prompt is a future enhancement layered on top of the gate.
+ * **User authentication** follows [HardwareKeySpec.userAuthentication]:
+ *  - [UserAuthenticationRequirement.None] — no OS binding; the [HardwareAuthorization] gate is
+ *    advisory, evaluated before every op (the pre-biometrics behavior, and the default — this is
+ *    what keeps unattended conformance runs green).
+ *  - [UserAuthenticationRequirement.Session] — the key is generated with
+ *    `setUserAuthenticationRequired(true)` + a validity window (`setUserAuthenticationParameters`
+ *    on API 30+, the deprecated validity-duration seconds on 28/29), so the *keystore* refuses a
+ *    stale op with `UserNotAuthenticatedException`. The provider then prompts via the gate
+ *    (a [BiometricAuthorization] shows a real prompt; a plain closure just decides) and retries
+ *    exactly once — an already-authenticated user is never re-prompted.
+ *  - [UserAuthenticationRequirement.PerUse] — auth-per-use binding (timeout 0 /
+ *    validity -1), which Android only honors through a `BiometricPrompt.CryptoObject`
+ *    wrapping the exact `Cipher`/`Signature`. Generation therefore requires a
+ *    [BiometricAuthorization] (the library ships [BiometricPromptAuthenticator]); anything else
+ *    throws [HardwareKeyException.UserAuthenticatorRequired] at generation.
  */
 internal class AndroidKeystoreHardwareKeyProvider : HardwareKeyProvider {
     private val keyStore: KeyStore = KeyStore.getInstance(ANDROID_KEY_STORE).apply { load(null) }
@@ -104,43 +115,58 @@ internal class AndroidKeystoreHardwareKeyProvider : HardwareKeyProvider {
 
     override suspend fun generateAesGcm(spec: HardwareKeySpec): AesGcmKey {
         val keyBits = spec.aesKeySizeBits
-        require(keyBits == AES_128_KEY_BYTES * Byte.SIZE_BITS || keyBits == AES_256_KEY_BYTES * Byte.SIZE_BITS) {
-            "AES key size must be 128 or 256 bits, was $keyBits"
+        if (keyBits != AES_128_KEY_BYTES * Byte.SIZE_BITS && keyBits != AES_256_KEY_BYTES * Byte.SIZE_BITS) {
+            throw HardwareKeyException.UnsupportedHardwareKey()
         }
+        val policy = resolvePolicy(spec)
         val alias = newAlias("aes")
-        val key = keystoreOp { generateAesKey(alias, spec.aesKeySizeBits) }
-        val auth = spec.authorization
+        val key = keystoreOp { generateAesKey(alias, spec.aesKeySizeBits, spec.userAuthentication) }
         return HardwareAesGcmKey(
             sizeBits = spec.aesKeySizeBits,
             gatedSeal = { aad, plaintext, factory ->
-                if (!auth.authorize()) throw AuthorizationFailed()
-                keystoreOp {
-                    val cipher = Cipher.getInstance(AES_GCM_TRANSFORM)
-                    // Randomized-encryption-required (the JCA default) ⇒ the keystore generates a
-                    // fresh 12-byte GCM IV at init; read it back and frame it ahead of the ciphertext.
-                    cipher.init(Cipher.ENCRYPT_MODE, key)
-                    val nonce = cipher.iv
-                    aad?.let { cipher.updateAADRemaining(it) }
-                    val out = factory.allocate(nonce.size + plaintext.remaining() + AEAD_TAG_BYTES)
-                    out.writeBytes(nonce)
-                    finalInto(cipher, plaintext, out)
-                    out.resetForRead()
-                    out
-                }
+                gatedOp(
+                    policy = policy,
+                    create = {
+                        val cipher = Cipher.getInstance(AES_GCM_TRANSFORM)
+                        // Randomized-encryption-required (the JCA default) ⇒ the keystore generates
+                        // a fresh 12-byte GCM IV at init; read it back and frame it ahead of the
+                        // ciphertext.
+                        cipher.init(Cipher.ENCRYPT_MODE, key)
+                        cipher
+                    },
+                    wrap = { BiometricPrompt.CryptoObject(it) },
+                    use = { cipher ->
+                        val nonce = cipher.iv
+                        aad?.let { cipher.updateAADRemaining(it.slice()) }
+                        val plaintextView = plaintext.slice()
+                        val out = factory.allocate(nonce.size + plaintextView.remaining() + AEAD_TAG_BYTES)
+                        out.writeBytes(nonce)
+                        finalInto(cipher, plaintextView, out)
+                        out.resetForRead()
+                        out
+                    },
+                )
             },
             gatedOpen = { nonce, aad, ciphertextAndTag, factory ->
-                if (!auth.authorize()) throw AuthorizationFailed()
                 requireNonce(nonce)
                 requireTagged(ciphertextAndTag)
-                keystoreOp {
-                    val cipher = Cipher.getInstance(AES_GCM_TRANSFORM)
-                    cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(gcmTagBits, nonceBytes(nonce)))
-                    aad?.let { cipher.updateAADRemaining(it) }
-                    val out = factory.allocate(maxOf(0, ciphertextAndTag.remaining() - AEAD_TAG_BYTES))
-                    openInto(cipher, ciphertextAndTag, out)
-                    out.resetForRead()
-                    out
-                }
+                gatedOp(
+                    policy = policy,
+                    create = {
+                        val cipher = Cipher.getInstance(AES_GCM_TRANSFORM)
+                        cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(gcmTagBits, nonceBytes(nonce.slice())))
+                        cipher
+                    },
+                    wrap = { BiometricPrompt.CryptoObject(it) },
+                    use = { cipher ->
+                        aad?.let { cipher.updateAADRemaining(it.slice()) }
+                        val ctView = ciphertextAndTag.slice()
+                        val out = factory.allocate(maxOf(0, ctView.remaining() - AEAD_TAG_BYTES))
+                        openInto(cipher, ctView, out)
+                        out.resetForRead()
+                        out
+                    },
+                )
             },
             onClose = { runCatching { keyStore.deleteEntry(alias) } },
         )
@@ -150,33 +176,78 @@ internal class AndroidKeystoreHardwareKeyProvider : HardwareKeyProvider {
         scheme: SignatureScheme,
         spec: HardwareKeySpec,
     ): SigningKey {
-        require(eligible(scheme.toHardwareAlgorithm())) {
-            "${scheme.schemeName} is not eligible for hardware backing"
-        }
+        if (!eligible(scheme.toHardwareAlgorithm())) throw HardwareKeyException.AlgorithmNotEligible()
+        val policy = resolvePolicy(spec)
         val alias = newAlias("ec")
-        val keyPair = keystoreOp { generateEcKeyPair(alias) }
+        val keyPair = keystoreOp { generateEcKeyPair(alias, spec.userAuthentication) }
         val privateKey = keyPair.private
         val verifyKey = VerifyKey.ecdsaP256(uncompressedPoint(keyPair.public as ECPublicKey))
-        val auth = spec.authorization
         return HardwareSigningKey(
             scheme = SignatureScheme.EcdsaP256,
             gatedSign = { message, factory ->
-                if (!auth.authorize()) throw AuthorizationFailed()
-                keystoreOp {
-                    val signer = Signature.getInstance(ECDSA_SHA256)
-                    signer.initSign(privateKey)
-                    signer.update(message.remainingBytes())
-                    val der = signer.sign()
-                    val out: PlatformBuffer = factory.allocate(der.size)
-                    out.writeBytes(der)
-                    out.resetForRead()
-                    out
-                }
+                gatedOp(
+                    policy = policy,
+                    create = {
+                        Signature.getInstance(ECDSA_SHA256).apply { initSign(privateKey) }
+                    },
+                    wrap = { BiometricPrompt.CryptoObject(it) },
+                    use = { signer ->
+                        signer.update(message.slice().remainingBytes())
+                        val der = signer.sign()
+                        val out: PlatformBuffer = factory.allocate(der.size)
+                        out.writeBytes(der)
+                        out.resetForRead()
+                        out
+                    },
+                )
             },
             verifyKey = verifyKey,
             onClose = { runCatching { keyStore.deleteEntry(alias) } },
         )
     }
+
+    // --- user-authentication policy dispatch -------------------------------------------------------
+
+    /**
+     * Runs one keystore op under the key's resolved user-auth [policy]. [create] initializes the
+     * JCA handle (`Cipher`/`Signature`) and [use] drives it to completion — both inside
+     * [keystoreOp]; the prompt (when any) happens strictly *outside* the keystore lock.
+     *
+     *  - [ResolvedAndroidPolicy.Advisory]: gate first, then one shot.
+     *  - [ResolvedAndroidPolicy.Session]: one shot; when the keystore reports the auth window
+     *    stale ([HardwareKeyException.UserAuthenticationRequired], mapped from
+     *    `UserNotAuthenticatedException`), prompt once and retry once — a fresh handle, because
+     *    the stale one is unusable.
+     *  - [ResolvedAndroidPolicy.PerUse]: initialize the handle, authorize *that exact handle* via
+     *    `CryptoObject`, then drive it. The variant carries its [BiometricAuthorization] by
+     *    construction — resolved at generation, so no cast and no nullable state here.
+     */
+    private suspend fun <C : Any, T> gatedOp(
+        policy: ResolvedAndroidPolicy,
+        create: () -> C,
+        wrap: (C) -> BiometricPrompt.CryptoObject,
+        use: (C) -> T,
+    ): T =
+        when (policy) {
+            is ResolvedAndroidPolicy.Advisory -> {
+                if (!policy.gate.authorize()) throw AuthorizationFailed()
+                keystoreOp { use(create()) }
+            }
+
+            is ResolvedAndroidPolicy.Session ->
+                try {
+                    keystoreOp { use(create()) }
+                } catch (_: HardwareKeyException.UserAuthenticationRequired) {
+                    if (!policy.unlock()) throw AuthorizationFailed()
+                    keystoreOp { use(create()) }
+                }
+
+            is ResolvedAndroidPolicy.PerUse -> {
+                val crypto = keystoreOp { create() }
+                if (!policy.prompt.authenticate(policy.method, wrap(crypto))) throw AuthorizationFailed()
+                keystoreOp { use(crypto) }
+            }
+        }
 
     // --- keystore serialization ------------------------------------------------------------------
 
@@ -198,12 +269,13 @@ internal class AndroidKeystoreHardwareKeyProvider : HardwareKeyProvider {
     private fun generateAesKey(
         alias: String,
         sizeBits: Int,
+        req: UserAuthenticationRequirement,
     ): SecretKey =
         generateWithStrongBoxFallback { strongBox ->
             KeyGenerator
                 .getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEY_STORE)
                 .apply {
-                    init(aesSpec(alias, sizeBits, strongBox))
+                    init(aesSpec(alias, sizeBits, strongBox, req))
                 }.generateKey()
         }
 
@@ -211,6 +283,7 @@ internal class AndroidKeystoreHardwareKeyProvider : HardwareKeyProvider {
         alias: String,
         sizeBits: Int,
         strongBox: Boolean,
+        req: UserAuthenticationRequirement,
     ): KeyGenParameterSpec =
         KeyGenParameterSpec
             .Builder(
@@ -223,26 +296,32 @@ internal class AndroidKeystoreHardwareKeyProvider : HardwareKeyProvider {
             // per seal, which the witness reads back and frames (see HardwareAesGcmKey.gatedSeal). The
             // library never supplies a seal nonce — one reused GCM (key, nonce) pair is catastrophic.
             .setIsStrongBoxBacked(strongBox)
+            .apply { applyUserAuth(req) }
             .build()
 
-    private fun generateEcKeyPair(alias: String): java.security.KeyPair =
+    private fun generateEcKeyPair(
+        alias: String,
+        req: UserAuthenticationRequirement,
+    ): java.security.KeyPair =
         generateWithStrongBoxFallback { strongBox ->
             KeyPairGenerator
                 .getInstance(KeyProperties.KEY_ALGORITHM_EC, ANDROID_KEY_STORE)
                 .apply {
-                    initialize(ecSpec(alias, strongBox))
+                    initialize(ecSpec(alias, strongBox, req))
                 }.generateKeyPair()
         }
 
     private fun ecSpec(
         alias: String,
         strongBox: Boolean,
+        req: UserAuthenticationRequirement,
     ): KeyGenParameterSpec =
         KeyGenParameterSpec
             .Builder(alias, KeyProperties.PURPOSE_SIGN)
             .setAlgorithmParameterSpec(ECGenParameterSpec(SECP256R1))
             .setDigests(KeyProperties.DIGEST_SHA256)
             .setIsStrongBoxBacked(strongBox)
+            .apply { applyUserAuth(req) }
             .build()
 
     /**
@@ -277,7 +356,7 @@ internal class AndroidKeystoreHardwareKeyProvider : HardwareKeyProvider {
                 val keyPair =
                     KeyPairGenerator
                         .getInstance(KeyProperties.KEY_ALGORITHM_EC, ANDROID_KEY_STORE)
-                        .apply { initialize(ecSpec(alias, strongBox = true)) }
+                        .apply { initialize(ecSpec(alias, strongBox = true, req = UserAuthenticationRequirement.None)) }
                         .generateKeyPair()
                 // A device may honor a StrongBox request silently in the TEE, so confirm the level
                 // where the OS exposes it (API 31+); pre-31 keep the best-effort "no throw ⇒ assume".
@@ -294,9 +373,9 @@ internal class AndroidKeystoreHardwareKeyProvider : HardwareKeyProvider {
                 runCatching { keyStore.deleteEntry(alias) }
             }
         }
-
-    private fun newAlias(kind: String): String = "$ALIAS_PREFIX$kind-${UUID.randomUUID()}"
 }
+
+private fun newAlias(kind: String): String = "$ALIAS_PREFIX$kind-${UUID.randomUUID()}"
 
 private const val ANDROID_KEY_STORE = "AndroidKeyStore"
 private const val AES_GCM_TRANSFORM = "AES/GCM/NoPadding"
@@ -306,7 +385,101 @@ private const val ALIAS_PREFIX = "com.ditchoom.buffer.crypto.hw."
 private const val P256_FIELD_BYTES = 32
 private const val SEC1_UNCOMPRESSED = 0x04
 
+/**
+ * The key's user-auth policy resolved once at generation. Each variant carries exactly what its
+ * op path needs — [PerUse] holds its [BiometricAuthorization] by construction, so "per-use key
+ * without a CryptoObject-capable prompt" is unrepresentable (no cast, no nullable downstream).
+ */
+private sealed interface ResolvedAndroidPolicy {
+    class Advisory(
+        val gate: HardwareAuthorization,
+    ) : ResolvedAndroidPolicy
+
+    /**
+     * [gate] may or may not be a real prompt: a [BiometricAuthorization] shows the OS prompt on a
+     * stale window ([unlock]); a plain closure just decides — the keystore still enforces the
+     * binding either way.
+     */
+    class Session(
+        val method: UserAuthenticationMethod,
+        val gate: HardwareAuthorization,
+    ) : ResolvedAndroidPolicy {
+        suspend fun unlock(): Boolean =
+            when (gate) {
+                is BiometricAuthorization -> gate.authenticate(method, cryptoObject = null)
+                else -> gate.authorize()
+            }
+    }
+
+    class PerUse(
+        val method: UserAuthenticationMethod,
+        val prompt: BiometricAuthorization,
+    ) : ResolvedAndroidPolicy
+}
+
+/**
+ * Resolves [HardwareKeySpec.userAuthentication] + [HardwareKeySpec.authorization] into a
+ * [ResolvedAndroidPolicy], failing generation with the typed
+ * [HardwareKeyException.UserAuthenticatorRequired] when per-use binding is requested without a
+ * [BiometricAuthorization] (Android only honors auth-per-use through a
+ * `BiometricPrompt.CryptoObject`; a plain closure cannot put the OS prompt on screen, so the key
+ * would be permanently unusable).
+ */
+private fun resolvePolicy(spec: HardwareKeySpec): ResolvedAndroidPolicy =
+    when (val req = spec.userAuthentication) {
+        UserAuthenticationRequirement.None -> ResolvedAndroidPolicy.Advisory(spec.authorization)
+        is UserAuthenticationRequirement.Session -> ResolvedAndroidPolicy.Session(req.method, spec.authorization)
+        is UserAuthenticationRequirement.PerUse ->
+            ResolvedAndroidPolicy.PerUse(
+                req.method,
+                spec.authorization as? BiometricAuthorization
+                    ?: throw HardwareKeyException.UserAuthenticatorRequired(),
+            )
+    }
+
 // --- stateless keystore helpers (file-level: no provider state, kept off the class) --------------
+
+/**
+ * Applies OS-level user-authentication binding to a keystore key at generation. On API 30+ the
+ * typed `setUserAuthenticationParameters` expresses both the window and the allowed authenticator
+ * classes; 28/29 only have the deprecated validity-duration seconds, where `-1` means
+ * auth-per-use (biometric + `CryptoObject` only) and the authenticator classes cannot be narrowed.
+ */
+private fun KeyGenParameterSpec.Builder.applyUserAuth(req: UserAuthenticationRequirement) {
+    when (req) {
+        UserAuthenticationRequirement.None -> return
+        is UserAuthenticationRequirement.Session -> {
+            setUserAuthenticationRequired(true)
+            val seconds =
+                req.validity.inWholeSeconds
+                    .coerceIn(1L, Int.MAX_VALUE.toLong())
+                    .toInt()
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                setUserAuthenticationParameters(seconds, keystoreAuthTypes(req.method))
+            } else {
+                @Suppress("DEPRECATION")
+                setUserAuthenticationValidityDurationSeconds(seconds)
+            }
+        }
+        is UserAuthenticationRequirement.PerUse -> {
+            setUserAuthenticationRequired(true)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                setUserAuthenticationParameters(0, keystoreAuthTypes(req.method))
+            } else {
+                @Suppress("DEPRECATION")
+                setUserAuthenticationValidityDurationSeconds(-1)
+            }
+        }
+    }
+}
+
+/** [UserAuthenticationMethod] → the API 30+ keystore authenticator-class bitmask. */
+private fun keystoreAuthTypes(method: UserAuthenticationMethod): Int =
+    when (method) {
+        UserAuthenticationMethod.BiometricOnly -> KeyProperties.AUTH_BIOMETRIC_STRONG
+        UserAuthenticationMethod.BiometricOrCredential ->
+            KeyProperties.AUTH_BIOMETRIC_STRONG or KeyProperties.AUTH_DEVICE_CREDENTIAL
+    }
 
 /**
  * Runs [block], normalizing any keystore-originated failure to a [HardwareKeyException]. A

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.apple.kt
@@ -7,23 +7,28 @@ import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.Default
 import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.BCKS_ERR_AUTH
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.BCKS_ERR_INPUT
 import com.ditchoom.buffer.crypto.cinterop.cryptokit.BCKS_OK
 import com.ditchoom.buffer.crypto.cinterop.cryptokit.bcks_secure_enclave_available
 import com.ditchoom.buffer.crypto.cinterop.cryptokit.bcks_secure_enclave_p256_generate
-import com.ditchoom.buffer.crypto.cinterop.cryptokit.bcks_secure_enclave_p256_sign
-import kotlinx.cinterop.ByteVar
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.bcks_secure_enclave_p256_generate_ac
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.bcks_secure_enclave_p256_sign_ctx
 import kotlinx.cinterop.ExperimentalForeignApi
-import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.alloc
-import kotlinx.cinterop.allocArray
 import kotlinx.cinterop.convert
-import kotlinx.cinterop.get
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.ptr
 import kotlinx.cinterop.reinterpret
-import kotlinx.cinterop.usePinned
 import kotlinx.cinterop.value
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import platform.posix.size_tVar
+import kotlin.time.Duration
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource
 
 /*
  * Apple Secure Enclave hardware-backed key provider (CryptoKit `SecureEnclave.P256.Signing`, via the
@@ -33,7 +38,8 @@ import platform.posix.size_tVar
  * through the shim, which reconstructs the key from its opaque encrypted blob and signs *inside* the
  * Enclave (DER output, matching [ecdsaSignatureEncoding] == Der and the JVM/Android contract). The
  * public key the Enclave produced is captured into the returned [SigningKey] so the verifier can be
- * published.
+ * published. All byte transport is buffer-native: the shim reads from / writes into buffer memory
+ * directly ([withRemainingBytes] / [withWritablePointer]); no ByteArray round-trips.
  *
  * **Only ECDSA P-256 is backed.** AES-GCM is not eligible: CryptoKit exposes no symmetric Secure
  * Enclave key, and the only "Enclave-tied" AES one could build (ECDH a P-256 Enclave key → derive a
@@ -41,8 +47,25 @@ import platform.posix.size_tVar
  * non-exportable hardware-key contract. (The Enclave *does* contain an AES engine, but Apple exposes
  * no developer API to drive it as an app-controlled non-exportable AEAD key.)
  *
- * The per-use gate is [HardwareKeySpec.authorization], evaluated in Kotlin before each op. Binding
- * the Enclave key to a biometric `SecAccessControl` is a future enhancement layered on the gate.
+ * **User authentication** is resolved at generation into a [ResolvedApplePolicy] — each variant
+ * carries exactly the authenticator its sign path needs, so a policy without its authenticator is
+ * unrepresentable (no nullable state downstream):
+ *  - [ResolvedApplePolicy.Advisory] ([UserAuthenticationRequirement.None]) — no `SecAccessControl`;
+ *    the [HardwareAuthorization] gate is advisory, evaluated before every sign (the pre-biometrics
+ *    behavior and default).
+ *  - [ResolvedApplePolicy.Session] — the key is generated with
+ *    `SecAccessControl(privateKeyUsage + userPresence/biometryCurrentSet)`, so the *Enclave*
+ *    refuses an unauthenticated sign. Signs go through the [LocalAuthAuthenticator]'s long-lived
+ *    LAContext; the provider prompts (evaluates the context) lazily when the library-tracked
+ *    validity window is stale — the Enclave has no timed window of its own, so the *window* is
+ *    library-enforced while the *authentication itself* stays OS-enforced.
+ *  - [ResolvedApplePolicy.PerUse] — same `SecAccessControl` binding, but every sign uses a fresh,
+ *    un-evaluated LAContext, so the OS prompts for that exact operation.
+ *
+ * Session/PerUse generation requires a [LocalAuthAuthenticator] (it carries the prompt reason and
+ * owns the LAContext); any other gate throws [HardwareKeyException.UserAuthenticatorRequired] at
+ * generation. On platforms without LocalAuthentication (tvOS) the authenticator reports
+ * unavailable and generation fails the same way.
  */
 internal class SecureEnclaveHardwareKeyProvider : HardwareKeyProvider {
     override val dedicatedSecureElement: Boolean get() = true
@@ -50,41 +73,147 @@ internal class SecureEnclaveHardwareKeyProvider : HardwareKeyProvider {
     override fun eligible(alg: HardwareAlgorithm): Boolean = alg == HardwareAlgorithm.EcdsaP256
 
     override suspend fun generateAesGcm(spec: HardwareKeySpec): AesGcmKey =
-        throw IllegalArgumentException(
-            "AES-GCM is not eligible for Secure Enclave backing (no app-controlled non-exportable " +
-                "symmetric Enclave key exists on Apple)",
-        )
+        // No app-controlled non-exportable symmetric Enclave key exists on Apple.
+        throw HardwareKeyException.AlgorithmNotEligible()
 
     override suspend fun generateSigning(
         scheme: SignatureScheme,
         spec: HardwareKeySpec,
     ): SigningKey {
-        require(eligible(scheme.toHardwareAlgorithm())) {
-            "${scheme.schemeName} is not eligible for hardware backing"
-        }
-        val generated = enclaveGenerateP256()
-        val verifyKey = VerifyKey.ecdsaP256(BufferFactory.Default.wrap(generated.point))
-        val blob = generated.blob
-        val auth = spec.authorization
+        if (!eligible(scheme.toHardwareAlgorithm())) throw HardwareKeyException.AlgorithmNotEligible()
+        val policy = resolvePolicy(spec)
+        val generated =
+            when (val req = spec.userAuthentication) {
+                UserAuthenticationRequirement.None -> enclaveGenerateP256()
+                is UserAuthenticationRequirement.Session -> enclaveGenerateP256AccessControlled(req.method)
+                is UserAuthenticationRequirement.PerUse -> enclaveGenerateP256AccessControlled(req.method)
+            }
         return HardwareSigningKey(
             scheme = SignatureScheme.EcdsaP256,
-            gatedSign = { message, factory ->
-                if (!auth.authorize()) throw AuthorizationFailed()
-                val der = enclaveSignP256(blob, message)
-                val out: PlatformBuffer = factory.allocate(der.size)
-                out.writeBytes(der)
-                out.resetForRead()
-                out
-            },
-            verifyKey = verifyKey,
+            gatedSign = gatedSign(policy, generated.blob),
+            verifyKey = VerifyKey.ecdsaP256(generated.point),
         )
+    }
+
+    private fun gatedSign(
+        policy: ResolvedApplePolicy,
+        blob: PlatformBuffer,
+    ): HardwareSign =
+        when (policy) {
+            is ResolvedApplePolicy.Advisory -> advisorySign(policy.gate, blob)
+            is ResolvedApplePolicy.Session -> sessionSign(policy, blob)
+            is ResolvedApplePolicy.PerUse -> perUseSign(policy.authenticator, blob)
+        }
+
+    private fun advisorySign(
+        gate: HardwareAuthorization,
+        blob: PlatformBuffer,
+    ): HardwareSign =
+        { message, factory ->
+            if (!gate.authorize()) throw AuthorizationFailed()
+            // No SecAccessControl on this key, so an auth-denied status is unreachable; surface
+            // the impossible as the closest structured outcome rather than a silent success.
+            enclaveSignP256Into(blob, laHandle = 0L, message, factory)
+                ?: throw AuthorizationFailed()
+        }
+
+    private fun sessionSign(
+        policy: ResolvedApplePolicy.Session,
+        blob: PlatformBuffer,
+    ): HardwareSign {
+        val window = SessionWindow(policy.validity, policy.method, policy.authenticator)
+        return { message, factory ->
+            window.ensureAuthenticated()
+            // The evaluated LAContext authorizes the Enclave sign without a prompt; a stale/
+            // invalidated context surfaces as the keystore-style "authenticate and retry" state.
+            withContext(Dispatchers.Default) {
+                enclaveSignP256Into(blob, policy.authenticator.contextHandle, message, factory)
+            } ?: throw HardwareKeyException.UserAuthenticationRequired()
+        }
+    }
+
+    private fun perUseSign(
+        authenticator: LocalAuthAuthenticator,
+        blob: PlatformBuffer,
+    ): HardwareSign =
+        { message, factory ->
+            // A fresh, un-evaluated context per op: the OS prompts during the sign itself,
+            // binding the authentication to exactly this operation. Blocking prompt ⇒ off the
+            // calling thread.
+            val fresh = authenticator.newContextHandle()
+            try {
+                withContext(Dispatchers.Default) {
+                    enclaveSignP256Into(blob, fresh, message, factory)
+                } ?: throw AuthorizationFailed()
+            } finally {
+                releaseContextHandle(fresh)
+            }
+        }
+}
+
+/**
+ * The key's user-auth policy resolved once at generation. Each variant carries exactly what its
+ * sign path needs — [Session]/[PerUse] hold their (non-null, available) [LocalAuthAuthenticator]
+ * by construction, so "auth-bound key without an authenticator" is unrepresentable.
+ */
+private sealed interface ResolvedApplePolicy {
+    class Advisory(
+        val gate: HardwareAuthorization,
+    ) : ResolvedApplePolicy
+
+    class Session(
+        val validity: Duration,
+        val method: UserAuthenticationMethod,
+        val authenticator: LocalAuthAuthenticator,
+    ) : ResolvedApplePolicy
+
+    class PerUse(
+        val authenticator: LocalAuthAuthenticator,
+    ) : ResolvedApplePolicy
+}
+
+private fun resolvePolicy(spec: HardwareKeySpec): ResolvedApplePolicy =
+    when (val req = spec.userAuthentication) {
+        UserAuthenticationRequirement.None -> ResolvedApplePolicy.Advisory(spec.authorization)
+        is UserAuthenticationRequirement.Session ->
+            ResolvedApplePolicy.Session(req.validity, req.method, spec.authorization.requireLocalAuth())
+        is UserAuthenticationRequirement.PerUse ->
+            ResolvedApplePolicy.PerUse(spec.authorization.requireLocalAuth())
+    }
+
+/** An OS-auth-bound key needs the library's LocalAuthentication authenticator, usable on this platform. */
+private fun HardwareAuthorization.requireLocalAuth(): LocalAuthAuthenticator =
+    (this as? LocalAuthAuthenticator)?.takeIf { it.available }
+        ?: throw HardwareKeyException.UserAuthenticatorRequired()
+
+/**
+ * Library-enforced session validity window (the Enclave has no timed window of its own). Within
+ * the window the already-evaluated LAContext signs silently; past it, the authenticator
+ * re-prompts. The lock serializes only the window check + prompt, never the sign.
+ */
+private class SessionWindow(
+    private val validity: Duration,
+    private val method: UserAuthenticationMethod,
+    private val authenticator: LocalAuthAuthenticator,
+) {
+    private val lock = Mutex()
+    private var lastAuth: TimeMark? = null
+
+    suspend fun ensureAuthenticated() {
+        lock.withLock {
+            val withinWindow = lastAuth?.let { it.elapsedNow() < validity } == true
+            if (!withinWindow) {
+                if (!authenticator.evaluate(method)) throw AuthorizationFailed()
+                lastAuth = TimeSource.Monotonic.markNow()
+            }
+        }
     }
 }
 
 /** A freshly generated Enclave key: the opaque restore [blob] and its uncompressed SEC1 [point]. */
 private class EnclaveP256Key(
-    val blob: ByteArray,
-    val point: ByteArray,
+    val blob: PlatformBuffer,
+    val point: PlatformBuffer,
 )
 
 // A Secure Enclave P-256 signing key's `dataRepresentation` is ~284 bytes (observed); 1024 gives
@@ -94,52 +223,115 @@ private const val ENCLAVE_BLOB_CAP = 1024
 private const val P256_POINT_BYTES = 65
 
 private fun enclaveGenerateP256(): EnclaveP256Key =
-    memScoped {
-        val blobOut = allocArray<ByteVar>(ENCLAVE_BLOB_CAP)
-        val blobLen = alloc<size_tVar>()
-        val pointOut = allocArray<ByteVar>(P256_POINT_BYTES)
-        val pointLen = alloc<size_tVar>()
-        val status =
-            bcks_secure_enclave_p256_generate(
-                blobOut.reinterpret(),
-                ENCLAVE_BLOB_CAP.convert(),
-                blobLen.ptr,
-                pointOut.reinterpret(),
-                P256_POINT_BYTES.convert(),
-                pointLen.ptr,
-            )
-        check(status == BCKS_OK) { "Secure Enclave P-256 key generation failed (status $status)" }
-        val blob = ByteArray(blobLen.value.toInt()) { blobOut[it] }
-        val point = ByteArray(pointLen.value.toInt()) { pointOut[it] }
-        EnclaveP256Key(blob, point)
+    enclaveGenerate { blobPtr, blobCap, blobLen, pointPtr, pointCap, pointLen ->
+        bcks_secure_enclave_p256_generate(blobPtr, blobCap, blobLen, pointPtr, pointCap, pointLen)
     }
 
-private fun enclaveSignP256(
-    blob: ByteArray,
-    message: ReadBuffer,
-): ByteArray {
-    val cap = maxSignatureBytes(SignatureScheme.EcdsaP256)
-    return memScoped {
-        val sigOut = allocArray<ByteVar>(cap)
-        val sigLen = alloc<size_tVar>()
-        var status = -1
-        val msgLen = message.remaining()
-        blob.usePinned { blobPin ->
-            message.withRemainingBytes2(msgLen) { msgPtr ->
+private fun enclaveGenerateP256AccessControlled(method: UserAuthenticationMethod): EnclaveP256Key =
+    enclaveGenerate { blobPtr, blobCap, blobLen, pointPtr, pointCap, pointLen ->
+        // The shim's authReq selector matches laMethod(): 1 = userPresence, 2 = biometryCurrentSet.
+        bcks_secure_enclave_p256_generate_ac(method.laMethod(), blobPtr, blobCap, blobLen, pointPtr, pointCap, pointLen)
+    }
+
+/**
+ * Runs an Enclave generate call with the shim writing straight into two freshly allocated native
+ * buffers (blob + public point) — no intermediate arrays. A non-OK status is a typed
+ * [HardwareKeyException.SecureElementUnavailable]: the element would not mint the key (absent,
+ * unentitled, or — for the access-controlled variant — no passcode/biometric enrolled).
+ */
+private inline fun enclaveGenerate(
+    call: (
+        blobPtr: kotlinx.cinterop.CPointer<kotlinx.cinterop.UByteVar>,
+        blobCap: platform.posix.size_t,
+        blobLen: kotlinx.cinterop.CPointer<size_tVar>,
+        pointPtr: kotlinx.cinterop.CPointer<kotlinx.cinterop.UByteVar>,
+        pointCap: platform.posix.size_t,
+        pointLen: kotlinx.cinterop.CPointer<size_tVar>,
+    ) -> Int,
+): EnclaveP256Key {
+    val blob = BufferFactory.Default.allocate(ENCLAVE_BLOB_CAP)
+    val point = BufferFactory.Default.allocate(P256_POINT_BYTES)
+    var status = -1
+    var blobWritten = 0
+    var pointWritten = 0
+    memScoped {
+        val blobLen = alloc<size_tVar>()
+        val pointLen = alloc<size_tVar>()
+        blob.withWritablePointer(ENCLAVE_BLOB_CAP) { blobPtr ->
+            point.withWritablePointer(P256_POINT_BYTES) { pointPtr ->
                 status =
-                    bcks_secure_enclave_p256_sign(
-                        blobPin.addressOf(0).reinterpret(),
-                        blob.size.convert(),
-                        msgPtr.reinterpret(),
-                        msgLen.convert(),
-                        sigOut.reinterpret(),
-                        cap.convert(),
-                        sigLen.ptr,
+                    call(
+                        blobPtr.reinterpret(),
+                        ENCLAVE_BLOB_CAP.convert(),
+                        blobLen.ptr,
+                        pointPtr.reinterpret(),
+                        P256_POINT_BYTES.convert(),
+                        pointLen.ptr,
                     )
             }
         }
-        require(status == BCKS_OK) { "Secure Enclave signing failed (status $status)" }
-        ByteArray(sigLen.value.toInt()) { sigOut[it] }
+        blobWritten = blobLen.value.toInt()
+        pointWritten = pointLen.value.toInt()
+    }
+    if (status != BCKS_OK) throw HardwareKeyException.SecureElementUnavailable()
+    blob.position(blobWritten)
+    blob.resetForRead()
+    point.position(pointWritten)
+    point.resetForRead()
+    return EnclaveP256Key(blob, point)
+}
+
+/**
+ * Signs [message] with the Enclave key restored from [blob], authorized through the LAContext
+ * behind [laHandle] (`0` = none), with the DER signature written by the shim straight into a
+ * buffer from the caller's [factory].
+ *
+ * Returns `null` when the OS denied user authentication (the caller maps it to the
+ * policy-appropriate typed exception); throws [HardwareKeyException.KeyInvalidated] when the blob
+ * is no longer restorable (e.g. biometric re-enrollment invalidated an access-controlled key) and
+ * [HardwareKeyException.TransientHardwareFailure] for anything else.
+ */
+private fun enclaveSignP256Into(
+    blob: ReadBuffer,
+    laHandle: Long,
+    message: ReadBuffer,
+    factory: BufferFactory,
+): PlatformBuffer? {
+    val cap = maxSignatureBytes(SignatureScheme.EcdsaP256)
+    val out = factory.allocate(cap)
+    var status = -1
+    var sigWritten = 0
+    memScoped {
+        val sigLen = alloc<size_tVar>()
+        val msgLen = message.remaining()
+        blob.withRemainingBytes { blobPtr, blobLen ->
+            message.withRemainingBytes2(msgLen) { msgPtr ->
+                out.withWritablePointer(cap) { sigPtr ->
+                    status =
+                        bcks_secure_enclave_p256_sign_ctx(
+                            blobPtr.reinterpret(),
+                            blobLen.convert(),
+                            laHandle,
+                            msgPtr.reinterpret(),
+                            msgLen.convert(),
+                            sigPtr.reinterpret(),
+                            cap.convert(),
+                            sigLen.ptr,
+                        )
+                }
+            }
+        }
+        sigWritten = sigLen.value.toInt()
+    }
+    return when (status) {
+        BCKS_OK -> {
+            out.position(sigWritten)
+            out.resetForRead()
+            out
+        }
+        BCKS_ERR_AUTH -> null
+        BCKS_ERR_INPUT -> throw HardwareKeyException.KeyInvalidated()
+        else -> throw HardwareKeyException.TransientHardwareFailure(retryable = false)
     }
 }
 

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.apple.kt
@@ -47,25 +47,24 @@ import kotlin.time.TimeSource
  * non-exportable hardware-key contract. (The Enclave *does* contain an AES engine, but Apple exposes
  * no developer API to drive it as an app-controlled non-exportable AEAD key.)
  *
- * **User authentication** is resolved at generation into a [ResolvedApplePolicy] — each variant
- * carries exactly the authenticator its sign path needs, so a policy without its authenticator is
+ * **User authentication** is a [ResolvedApplePolicy], fixed at generation — each variant carries
+ * exactly the authenticator its sign path needs, so a policy without its authenticator is
  * unrepresentable (no nullable state downstream):
- *  - [ResolvedApplePolicy.Advisory] ([UserAuthenticationRequirement.None]) — no `SecAccessControl`;
- *    the [HardwareAuthorization] gate is advisory, evaluated before every sign (the pre-biometrics
- *    behavior and default).
- *  - [ResolvedApplePolicy.Session] — the key is generated with
+ *  - [ResolvedApplePolicy.Advisory] — the base provider's keys: no `SecAccessControl`; the
+ *    [HardwareAuthorization] gate is advisory, evaluated before every sign (the pre-biometrics
+ *    behavior).
+ *  - [ResolvedApplePolicy.Session] — via [userAuthenticated]: the key is generated with
  *    `SecAccessControl(privateKeyUsage + userPresence/biometryCurrentSet)`, so the *Enclave*
  *    refuses an unauthenticated sign. Signs go through the [LocalAuthAuthenticator]'s long-lived
  *    LAContext; the provider prompts (evaluates the context) lazily when the library-tracked
  *    validity window is stale — the Enclave has no timed window of its own, so the *window* is
  *    library-enforced while the *authentication itself* stays OS-enforced.
- *  - [ResolvedApplePolicy.PerUse] — same `SecAccessControl` binding, but every sign uses a fresh,
- *    un-evaluated LAContext, so the OS prompts for that exact operation.
+ *  - [ResolvedApplePolicy.PerUse] — via [userAuthenticated]: same `SecAccessControl` binding, but
+ *    every sign uses a fresh, un-evaluated LAContext, so the OS prompts for that exact operation.
  *
- * Session/PerUse generation requires a [LocalAuthAuthenticator] (it carries the prompt reason and
- * owns the LAContext); any other gate throws [HardwareKeyException.UserAuthenticatorRequired] at
- * generation. On platforms without LocalAuthentication (tvOS) the authenticator reports
- * unavailable and generation fails the same way.
+ * [userAuthenticated] captures the [LocalAuthAuthenticator] (prompt reason + LAContext owner) at
+ * the platform boundary and returns `null` where LocalAuthentication cannot be driven (tvOS), so
+ * no bound-key request ever reaches this provider without a usable prompt host.
  */
 internal class SecureEnclaveHardwareKeyProvider : HardwareKeyProvider {
     override val dedicatedSecureElement: Boolean get() = true
@@ -79,14 +78,19 @@ internal class SecureEnclaveHardwareKeyProvider : HardwareKeyProvider {
     override suspend fun generateSigning(
         scheme: SignatureScheme,
         spec: HardwareKeySpec,
+    ): SigningKey = generateSigningBound(ResolvedApplePolicy.Advisory(spec.authorization), scheme)
+
+    /** Generates an Enclave P-256 key under [policy] — the shared path for unbound and OS-bound keys. */
+    internal suspend fun generateSigningBound(
+        policy: ResolvedApplePolicy,
+        scheme: SignatureScheme,
     ): SigningKey {
         if (!eligible(scheme.toHardwareAlgorithm())) throw HardwareKeyException.AlgorithmNotEligible()
-        val policy = resolvePolicy(spec)
         val generated =
-            when (val req = spec.userAuthentication) {
-                UserAuthenticationRequirement.None -> enclaveGenerateP256()
-                is UserAuthenticationRequirement.Session -> enclaveGenerateP256AccessControlled(req.method)
-                is UserAuthenticationRequirement.PerUse -> enclaveGenerateP256AccessControlled(req.method)
+            when (policy) {
+                is ResolvedApplePolicy.Advisory -> enclaveGenerateP256()
+                is ResolvedApplePolicy.Session -> enclaveGenerateP256AccessControlled(policy.method)
+                is ResolvedApplePolicy.PerUse -> enclaveGenerateP256AccessControlled(policy.method)
             }
         return HardwareSigningKey(
             scheme = SignatureScheme.EcdsaP256,
@@ -152,11 +156,13 @@ internal class SecureEnclaveHardwareKeyProvider : HardwareKeyProvider {
 }
 
 /**
- * The key's user-auth policy resolved once at generation. Each variant carries exactly what its
- * sign path needs — [Session]/[PerUse] hold their (non-null, available) [LocalAuthAuthenticator]
- * by construction, so "auth-bound key without an authenticator" is unrepresentable.
+ * The key's auth behavior, fixed at generation. Each variant carries exactly what its sign path
+ * needs — [Session]/[PerUse] hold the (available) [LocalAuthAuthenticator] the
+ * [UserAuthenticatedKeyProvider] captured at construction, so "OS-bound key without an
+ * authenticator" is unrepresentable.
  */
-private sealed interface ResolvedApplePolicy {
+internal sealed interface ResolvedApplePolicy {
+    /** No `SecAccessControl`; [gate] is the advisory [HardwareKeySpec.authorization]. */
     class Advisory(
         val gate: HardwareAuthorization,
     ) : ResolvedApplePolicy
@@ -168,23 +174,54 @@ private sealed interface ResolvedApplePolicy {
     ) : ResolvedApplePolicy
 
     class PerUse(
+        val method: UserAuthenticationMethod,
         val authenticator: LocalAuthAuthenticator,
     ) : ResolvedApplePolicy
 }
 
-private fun resolvePolicy(spec: HardwareKeySpec): ResolvedApplePolicy =
-    when (val req = spec.userAuthentication) {
-        UserAuthenticationRequirement.None -> ResolvedApplePolicy.Advisory(spec.authorization)
-        is UserAuthenticationRequirement.Session ->
-            ResolvedApplePolicy.Session(req.validity, req.method, spec.authorization.requireLocalAuth())
-        is UserAuthenticationRequirement.PerUse ->
-            ResolvedApplePolicy.PerUse(spec.authorization.requireLocalAuth())
-    }
+/**
+ * The Apple [UserAuthenticatedKeyProvider]: pairs the Enclave provider with the
+ * [LocalAuthAuthenticator] captured at construction, and maps each pure-data
+ * [UserAuthenticationPolicy] onto a [ResolvedApplePolicy] that carries it.
+ */
+internal class AppleUserAuthenticatedKeyProvider(
+    private val base: SecureEnclaveHardwareKeyProvider,
+    private val authenticator: LocalAuthAuthenticator,
+) : UserAuthenticatedKeyProvider {
+    override fun eligible(alg: HardwareAlgorithm): Boolean = base.eligible(alg)
 
-/** An OS-auth-bound key needs the library's LocalAuthentication authenticator, usable on this platform. */
-private fun HardwareAuthorization.requireLocalAuth(): LocalAuthAuthenticator =
-    (this as? LocalAuthAuthenticator)?.takeIf { it.available }
-        ?: throw HardwareKeyException.UserAuthenticatorRequired()
+    override suspend fun generateAesGcm(
+        policy: UserAuthenticationPolicy,
+        aesKeySizeBits: Int,
+    ): AesGcmKey = throw HardwareKeyException.AlgorithmNotEligible()
+
+    override suspend fun generateSigning(
+        scheme: SignatureScheme,
+        policy: UserAuthenticationPolicy,
+    ): SigningKey = base.generateSigningBound(policy.resolve(), scheme)
+
+    private fun UserAuthenticationPolicy.resolve(): ResolvedApplePolicy =
+        when (this) {
+            is UserAuthenticationPolicy.Session -> ResolvedApplePolicy.Session(validity, method, authenticator)
+            is UserAuthenticationPolicy.PerUse -> ResolvedApplePolicy.PerUse(method, authenticator)
+        }
+}
+
+/**
+ * Binds this provider to a [LocalAuthAuthenticator], unlocking generation of Enclave keys the
+ * *element itself* refuses without user authentication (`SecAccessControl`;
+ * [UserAuthenticationPolicy.Session] / [UserAuthenticationPolicy.PerUse]). The authenticator is
+ * captured here — at the platform boundary, where its prompt reason already had to be written —
+ * so the policy values stay pure data and a bound key without a prompt host is a compile error,
+ * not a runtime state.
+ *
+ * Returns `null` for a provider this platform did not mint (e.g. a test fake) and on platforms
+ * where LocalAuthentication cannot be driven (tvOS, or a closed authenticator).
+ */
+fun HardwareKeyProvider.userAuthenticated(prompt: LocalAuthAuthenticator): UserAuthenticatedKeyProvider? =
+    (this as? SecureEnclaveHardwareKeyProvider)
+        ?.takeIf { prompt.available }
+        ?.let { AppleUserAuthenticatedKeyProvider(it, prompt) }
 
 /**
  * Library-enforced session validity window (the Enclave has no timed window of its own). Within

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.apple.kt
@@ -58,7 +58,9 @@ import kotlin.time.TimeSource
  *    refuses an unauthenticated sign. Signs go through the [LocalAuthAuthenticator]'s long-lived
  *    LAContext; the provider prompts (evaluates the context) lazily when the library-tracked
  *    validity window is stale — the Enclave has no timed window of its own, so the *window* is
- *    library-enforced while the *authentication itself* stays OS-enforced.
+ *    library-enforced while the *authentication itself* stays OS-enforced. If the OS invalidates
+ *    the context mid-window, the sign re-prompts once (see [sessionSign]) rather than failing for
+ *    the rest of the window; a closed authenticator is refused with [AuthorizationFailed].
  *  - [ResolvedApplePolicy.PerUse] — via [userAuthenticated]: same `SecAccessControl` binding, but
  *    every sign uses a fresh, un-evaluated LAContext, so the OS prompts for that exact operation.
  *
@@ -125,14 +127,33 @@ internal class SecureEnclaveHardwareKeyProvider : HardwareKeyProvider {
         policy: ResolvedApplePolicy.Session,
         blob: PlatformBuffer,
     ): HardwareSign {
-        val window = SessionWindow(policy.validity, policy.method, policy.authenticator)
+        val authenticator = policy.authenticator
+        val window = SessionWindow(policy.validity, policy.method, authenticator)
         return { message, factory ->
+            // A closed authenticator has released its LAContext; refuse before handing the shim a
+            // stale handle (which would otherwise misreport as KeyInvalidated).
+            if (!authenticator.available) throw AuthorizationFailed()
+
             window.ensureAuthenticated()
-            // The evaluated LAContext authorizes the Enclave sign without a prompt; a stale/
-            // invalidated context surfaces as the keystore-style "authenticate and retry" state.
-            withContext(Dispatchers.Default) {
-                enclaveSignP256Into(blob, policy.authenticator.contextHandle, message, factory)
-            } ?: throw HardwareKeyException.UserAuthenticationRequired()
+            val first =
+                withContext(Dispatchers.Default) {
+                    enclaveSignP256Into(blob, authenticator.contextHandle, message, factory)
+                }
+            if (first != null) {
+                first
+            } else {
+                // The OS refused the sign on a window we believed fresh — the LAContext was
+                // invalidated out from under us (backgrounding, device lock, biometry change,
+                // reuse-duration expiry). Reset the window, re-prompt exactly once, and retry;
+                // only a second refusal is the terminal "authenticate and retry" state. Without
+                // this the fresh window would suppress every re-prompt for the whole validity
+                // period — a self-inflicted lockout.
+                window.invalidate()
+                window.ensureAuthenticated()
+                withContext(Dispatchers.Default) {
+                    enclaveSignP256Into(blob, authenticator.contextHandle, message, factory)
+                } ?: throw HardwareKeyException.UserAuthenticationRequired()
+            }
         }
     }
 
@@ -244,6 +265,15 @@ private class SessionWindow(
                 lastAuth = TimeSource.Monotonic.markNow()
             }
         }
+    }
+
+    /**
+     * Drops the current window so the next [ensureAuthenticated] re-prompts. Called after the OS
+     * refuses a sign the window believed authorized — concurrent stale signs coalesce, since the
+     * next [ensureAuthenticated] to win the lock re-authenticates and the rest see the new window.
+     */
+    suspend fun invalidate() {
+        lock.withLock { lastAuth = null }
     }
 }
 

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/LocalAuth.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/LocalAuth.apple.kt
@@ -1,0 +1,80 @@
+@file:OptIn(ExperimentalForeignApi::class)
+@file:Suppress("MatchingDeclarationName") // MPP platform-suffixed file; also holds file-level helpers
+
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.BCKS_OK
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.bcks_la_context_create
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.bcks_la_context_release
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.bcks_la_evaluate
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/*
+ * Apple LocalAuthentication authenticator for hardware-backed keys.
+ *
+ * [HardwareAuthorization] is the common gate; this is the Apple refinement that puts a real OS
+ * prompt on screen (Touch ID / Face ID / device passcode via LocalAuthentication). The UI-facing
+ * pieces — the localized reason string, the long-lived LAContext whose successful evaluation
+ * authorizes Secure Enclave signs without re-prompting — cannot be expressed in common code, so
+ * the app constructs this and injects it as [HardwareKeySpec.authorization], the same
+ * inversion-of-control pattern as `BufferFactory`.
+ *
+ * The LAContext lives behind the CryptoKit shim as an opaque handle (LocalAuthentication does not
+ * exist on every Apple platform — no tvOS — and routing through the shim keeps this file compiling
+ * for every apple target; on an unsupported platform [available] is `false` and generation of an
+ * auth-bound key fails with a typed [HardwareKeyException.UserAuthenticatorRequired]).
+ *
+ * Lifecycle: the authenticator owns one native LAContext; [close] invalidates it. A closed (or
+ * never-usable) authenticator denies everything.
+ */
+class LocalAuthAuthenticator(
+    /** User-facing reason shown in the OS authentication prompt. */
+    private val reason: String,
+) : HardwareAuthorization,
+    AutoCloseable {
+    /**
+     * Opaque shim handle for the long-lived LAContext (session use); `0` when LocalAuthentication
+     * is unavailable on this platform.
+     */
+    internal val contextHandle: Long = newContextHandle()
+
+    /** `true` when LocalAuthentication exists on this platform and [close] has not been called. */
+    internal val available: Boolean get() = contextHandle != 0L
+
+    /** Plain gate use (advisory / session unlock): biometric or device credential. */
+    override suspend fun authorize(): Boolean = evaluate(UserAuthenticationMethod.BiometricOrCredential)
+
+    /**
+     * Prompts the user via LocalAuthentication (off the calling thread — the shim call blocks
+     * until the user responds). On success the underlying LAContext is *evaluated* and will
+     * authorize Enclave signs without re-prompting until [close].
+     */
+    internal suspend fun evaluate(method: UserAuthenticationMethod): Boolean {
+        if (!available) return false
+        return withContext(Dispatchers.Default) {
+            bcks_la_evaluate(contextHandle, method.laMethod(), interactionAllowed = 1) == BCKS_OK
+        }
+    }
+
+    /**
+     * A fresh, *un-evaluated* context carrying [reason], for per-use signs (the Enclave prompts
+     * during the sign itself). Caller must release it with [releaseContextHandle].
+     */
+    internal fun newContextHandle(): Long = bcks_la_context_create(reason)
+
+    override fun close() = releaseContextHandle(contextHandle)
+}
+
+/** [UserAuthenticationMethod] → the shim's LAPolicy selector (1 = with credential, 2 = biometric only). */
+internal fun UserAuthenticationMethod.laMethod(): Int =
+    when (this) {
+        UserAuthenticationMethod.BiometricOrCredential -> 1
+        UserAuthenticationMethod.BiometricOnly -> 2
+    }
+
+/** Releases a shim LAContext handle (idempotent; `0` is a no-op). */
+internal fun releaseContextHandle(handle: Long) {
+    if (handle != 0L) bcks_la_context_release(handle)
+}

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/LocalAuth.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/LocalAuth.apple.kt
@@ -14,17 +14,17 @@ import kotlinx.coroutines.withContext
 /*
  * Apple LocalAuthentication authenticator for hardware-backed keys.
  *
- * [HardwareAuthorization] is the common gate; this is the Apple refinement that puts a real OS
- * prompt on screen (Touch ID / Face ID / device passcode via LocalAuthentication). The UI-facing
- * pieces — the localized reason string, the long-lived LAContext whose successful evaluation
- * authorizes Secure Enclave signs without re-prompting — cannot be expressed in common code, so
- * the app constructs this and injects it as [HardwareKeySpec.authorization], the same
- * inversion-of-control pattern as `BufferFactory`.
+ * The prompt host that puts a real OS prompt on screen (Touch ID / Face ID / device passcode via
+ * LocalAuthentication). The UI-facing pieces — the localized reason string, the long-lived
+ * LAContext whose successful evaluation authorizes Secure Enclave signs without re-prompting —
+ * cannot be expressed in common code, so the app constructs this at the platform boundary and
+ * hands it to [userAuthenticated] to obtain a [UserAuthenticatedKeyProvider]. Also usable as a
+ * plain advisory [HardwareAuthorization] gate.
  *
  * The LAContext lives behind the CryptoKit shim as an opaque handle (LocalAuthentication does not
  * exist on every Apple platform — no tvOS — and routing through the shim keeps this file compiling
- * for every apple target; on an unsupported platform [available] is `false` and generation of an
- * auth-bound key fails with a typed [HardwareKeyException.UserAuthenticatorRequired]).
+ * for every apple target; on an unsupported platform [available] is `false`, so
+ * [userAuthenticated] returns `null` and no bound key can be requested at all).
  *
  * Lifecycle: the authenticator owns one native LAContext; [close] invalidates it. A closed (or
  * never-usable) authenticator denies everything.

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/LocalAuth.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/LocalAuth.apple.kt
@@ -10,6 +10,7 @@ import com.ditchoom.buffer.crypto.cinterop.cryptokit.bcks_la_evaluate
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlin.concurrent.Volatile
 
 /*
  * Apple LocalAuthentication authenticator for hardware-backed keys.
@@ -26,8 +27,10 @@ import kotlinx.coroutines.withContext
  * for every apple target; on an unsupported platform [available] is `false`, so
  * [userAuthenticated] returns `null` and no bound key can be requested at all).
  *
- * Lifecycle: the authenticator owns one native LAContext; [close] invalidates it. A closed (or
- * never-usable) authenticator denies everything.
+ * Lifecycle: the authenticator owns one native LAContext; [close] releases it and flips
+ * [available] to `false`. A closed (or never-usable) authenticator denies everything — a session
+ * sign on a closed authenticator fails cleanly ([AuthorizationFailed]) rather than passing a
+ * released handle to the shim.
  */
 class LocalAuthAuthenticator(
     /** User-facing reason shown in the OS authentication prompt. */
@@ -40,8 +43,16 @@ class LocalAuthAuthenticator(
      */
     internal val contextHandle: Long = newContextHandle()
 
-    /** `true` when LocalAuthentication exists on this platform and [close] has not been called. */
-    internal val available: Boolean get() = contextHandle != 0L
+    /** Flipped by [close]; `@Volatile` so a session sign on another thread observes the release. */
+    @Volatile
+    private var closed: Boolean = false
+
+    /**
+     * `true` when LocalAuthentication exists on this platform and [close] has not been called.
+     * Reports `false` once closed, so [userAuthenticated] refuses a closed authenticator and an
+     * in-flight session sign fails cleanly instead of signing through a released handle.
+     */
+    internal val available: Boolean get() = contextHandle != 0L && !closed
 
     /** Plain gate use (advisory / session unlock): biometric or device credential. */
     override suspend fun authorize(): Boolean = evaluate(UserAuthenticationMethod.BiometricOrCredential)
@@ -64,7 +75,10 @@ class LocalAuthAuthenticator(
      */
     internal fun newContextHandle(): Long = bcks_la_context_create(reason)
 
-    override fun close() = releaseContextHandle(contextHandle)
+    override fun close() {
+        closed = true
+        releaseContextHandle(contextHandle)
+    }
 }
 
 /** [UserAuthenticationMethod] → the shim's LAPolicy selector (1 = with credential, 2 = biometric only). */

--- a/buffer-crypto/src/appleTest/kotlin/com/ditchoom/buffer/crypto/LocalAuthAuthenticatorTest.kt
+++ b/buffer-crypto/src/appleTest/kotlin/com/ditchoom/buffer/crypto/LocalAuthAuthenticatorTest.kt
@@ -1,0 +1,51 @@
+package com.ditchoom.buffer.crypto
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Runtime guard for the [LocalAuthAuthenticator] lifecycle contract — the half of the Apple
+ * user-auth path that needs only LocalAuthentication (no entitled Secure Enclave), so it runs on
+ * the macOS CI test binary rather than being device-gated like the Enclave sign path.
+ *
+ * Pins the fix for the "closed authenticator still reports available" defect: [close] must flip
+ * [LocalAuthAuthenticator.available] to `false` so [userAuthenticated] refuses it and a session
+ * sign fails cleanly with [AuthorizationFailed] instead of handing the shim a released LAContext
+ * handle (which the sign path would otherwise misreport as [HardwareKeyException.KeyInvalidated]).
+ */
+class LocalAuthAuthenticatorTest {
+    @Test
+    fun closeFlipsAvailableToFalse() {
+        val auth = LocalAuthAuthenticator(reason = "unit test")
+        // Skip only where LocalAuthentication itself is absent (no context handle minted); on any
+        // real macOS runner the context is created and this exercises the close transition.
+        if (!auth.available) return
+        assertTrue(auth.available, "a freshly constructed authenticator with LA present is available")
+        auth.close()
+        assertFalse(auth.available, "a closed authenticator must report unavailable")
+    }
+
+    @Test
+    fun closeIsIdempotent() {
+        val auth = LocalAuthAuthenticator(reason = "unit test")
+        if (!auth.available) return
+        auth.close()
+        // A second close must not double-release the native handle or crash.
+        auth.close()
+        assertFalse(auth.available)
+    }
+
+    @Test
+    fun userAuthenticatedRefusesAClosedAuthenticator() {
+        val provider = platformHardwareKeyProvider() ?: return // no Enclave provider on this runner
+        val auth = LocalAuthAuthenticator(reason = "unit test")
+        if (!auth.available) return
+        auth.close()
+        // A closed prompt host cannot drive OS auth, so the witness-style extension must decline it.
+        assertTrue(
+            provider.userAuthenticated(auth) == null,
+            "userAuthenticated must return null for a closed authenticator",
+        )
+    }
+}

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/CryptoException.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/CryptoException.kt
@@ -112,4 +112,20 @@ sealed class HardwareKeyException protected constructor(
 
     /** The secure element does not support the requested algorithm / key size / parameters. */
     class UnsupportedHardwareKey internal constructor() : HardwareKeyException("unsupported hardware key parameters")
+
+    /**
+     * Generation was requested for a [HardwareAlgorithm] where [HardwareKeyProvider.eligible] is
+     * `false` (e.g. AES-GCM on the Apple Secure Enclave). Typed — not an
+     * `IllegalArgumentException` with a message — so a caller can branch on it exhaustively; the
+     * fix is to consult [HardwareKeyProvider.eligible] before generating.
+     */
+    class AlgorithmNotEligible internal constructor() : HardwareKeyException("algorithm not hardware-eligible")
+
+    /**
+     * The requested `HardwareKeySpec.userAuthentication` needs a platform prompt authenticator the
+     * supplied `HardwareKeySpec.authorization` cannot provide (e.g. Android `PerUse` binding
+     * requires a `CryptoObject`-capable `BiometricPromptAuthenticator`, not a plain closure).
+     * Raised at *generation*, so a misconfigured key can never exist.
+     */
+    class UserAuthenticatorRequired internal constructor() : HardwareKeyException("user authenticator required")
 }

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/CryptoException.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/CryptoException.kt
@@ -120,12 +120,4 @@ sealed class HardwareKeyException protected constructor(
      * fix is to consult [HardwareKeyProvider.eligible] before generating.
      */
     class AlgorithmNotEligible internal constructor() : HardwareKeyException("algorithm not hardware-eligible")
-
-    /**
-     * The requested `HardwareKeySpec.userAuthentication` needs a platform prompt authenticator the
-     * supplied `HardwareKeySpec.authorization` cannot provide (e.g. Android `PerUse` binding
-     * requires a `CryptoObject`-capable `BiometricPromptAuthenticator`, not a plain closure).
-     * Raised at *generation*, so a misconfigured key can never exist.
-     */
-    class UserAuthenticatorRequired internal constructor() : HardwareKeyException("user authenticator required")
 }

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.kt
@@ -70,13 +70,10 @@ internal fun SignatureScheme.toHardwareAlgorithm(): HardwareAlgorithm =
  * [AuthorizationFailed]. `suspend` because a real gate (a biometric prompt, a TEE round-trip) is
  * inherently asynchronous.
  *
- * The library ships a real prompt-backed implementation per platform that has OS user
- * authentication — `BiometricPromptAuthenticator` (androidMain, androidx.biometric) and
- * `LocalAuthAuthenticator` (appleMain, LocalAuthentication) — which is how
- * [UserAuthenticationRequirement.Session] / [UserAuthenticationRequirement.PerUse] keys actually
- * put a prompt on screen. The UI host (an Activity, a localized reason) cannot be expressed in
- * common code, so the app constructs the platform authenticator and injects it here — the same
- * inversion-of-control pattern as `BufferFactory`.
+ * This gate is **advisory** — library code deciding whether to proceed. Keys the secure element
+ * itself refuses without user authentication come from [UserAuthenticatedKeyProvider] instead,
+ * whose platform `userAuthenticated(...)` constructor captures a real prompt authenticator
+ * (`BiometricPromptAuthenticator` on Android, `LocalAuthAuthenticator` on Apple).
  */
 fun interface HardwareAuthorization {
     /** Returns `true` to authorize the pending hardware key operation, `false` to deny it. */
@@ -84,7 +81,7 @@ fun interface HardwareAuthorization {
 }
 
 /**
- * Which kinds of user authentication satisfy a [UserAuthenticationRequirement] binding. Fixed at
+ * Which kinds of user authentication satisfy a [UserAuthenticationPolicy] binding. Fixed at
  * generation and enforced by the OS, not by library code.
  */
 enum class UserAuthenticationMethod {
@@ -104,25 +101,16 @@ enum class UserAuthenticationMethod {
 }
 
 /**
- * OS-level user-authentication binding for a hardware-backed key, fixed at generation. Unlike the
- * advisory [HardwareAuthorization] gate (library code deciding whether to proceed), this binds the
- * key *inside the secure element*: an op on an unauthenticated key fails in hardware no matter what
- * the process does.
- *
- * Platform reality: OS binding exists on Android (Keystore `setUserAuthenticationRequired`) and
- * Apple (Secure Enclave `SecAccessControl`). Platforms without a hardware provider (JVM, JS, WASM,
- * Linux) never see these values — [CryptoCapabilities.hardware] is already
- * [HardwareSupport.Unavailable] there.
+ * How an OS-bound key requires user authentication, fixed at generation. Pure data — no platform
+ * handles, identical shape on every target. A policy only ever reaches a provider through
+ * [UserAuthenticatedKeyProvider], whose platform constructor already captured the prompt
+ * authenticator — so "policy without an authenticator" is unrepresentable, not a runtime error.
  */
-sealed interface UserAuthenticationRequirement {
-    /** No OS binding (the default). The key is usable whenever the process runs. */
-    data object None : UserAuthenticationRequirement
-
+sealed interface UserAuthenticationPolicy {
     /**
      * One successful user authentication unlocks the key for [validity]; ops inside the window do
-     * not re-prompt. The provider prompts lazily — it attempts the op and only invokes the
-     * [HardwareKeySpec.authorization] gate when the OS reports the window stale — so an
-     * already-authenticated user is never re-prompted.
+     * not re-prompt. The provider prompts lazily — it attempts the op and only prompts when the
+     * OS reports the window stale — so an already-authenticated user is never re-prompted.
      *
      * Window enforcement is by the OS on Android (keystore auth timeout); on Apple the Enclave has
      * no timed window, so the provider enforces [validity] by re-prompting when it expires — the
@@ -131,7 +119,7 @@ sealed interface UserAuthenticationRequirement {
     data class Session(
         val validity: Duration,
         val method: UserAuthenticationMethod = UserAuthenticationMethod.BiometricOrCredential,
-    ) : UserAuthenticationRequirement {
+    ) : UserAuthenticationPolicy {
         init {
             require(validity >= 1.seconds) { "session validity must be at least 1 second, was $validity" }
         }
@@ -141,14 +129,50 @@ sealed interface UserAuthenticationRequirement {
      * Every operation requires a fresh user authentication bound to that exact operation (Android:
      * auth-per-use key + `BiometricPrompt.CryptoObject` wrapping the exact `Cipher`/`Signature`;
      * Apple: a fresh, un-evaluated `LAContext` per sign, so the Enclave prompts each time).
-     *
-     * On Android this requires a `CryptoObject`-capable authenticator
-     * (`BiometricPromptAuthenticator`); generation with a plain [HardwareAuthorization] closure
-     * throws [HardwareKeyException.UserAuthenticatorRequired].
      */
     data class PerUse(
         val method: UserAuthenticationMethod = UserAuthenticationMethod.BiometricOnly,
-    ) : UserAuthenticationRequirement
+    ) : UserAuthenticationPolicy
+}
+
+/**
+ * Mints hardware keys that are **bound to user authentication inside the secure element** — an op
+ * on an unauthenticated key fails in hardware no matter what the process does, unlike the advisory
+ * [HardwareKeySpec.authorization] gate on [HardwareKeyProvider]'s unbound keys.
+ *
+ * Obtained from a [HardwareKeyProvider] through a **platform** `userAuthenticated(...)` extension
+ * (androidMain takes a `BiometricAuthorization` prompt host, appleMain a `LocalAuthAuthenticator`),
+ * which returns `null` where OS user authentication cannot be driven (a non-platform provider, or
+ * a platform without the auth framework — e.g. tvOS). Because the prompt authenticator is captured
+ * at construction, the policy values stay pure data and a misconfigured request is a compile
+ * error, not a [CryptoException].
+ *
+ * Keys returned here are ordinary [AesGcmKey]/[SigningKey] values with [KeyProvenance.Hardware]:
+ * they flow through the same async witness ops as every other hardware key. What changes is only
+ * the reachable failure states: a denied/cancelled prompt is [AuthorizationFailed]; a stale
+ * session the user must re-authenticate is [HardwareKeyException.UserAuthenticationRequired]; a
+ * biometric re-enrollment invalidating a [UserAuthenticationMethod.BiometricOnly] key is
+ * [HardwareKeyException.KeyInvalidated].
+ */
+interface UserAuthenticatedKeyProvider {
+    /** Whether the underlying secure element can generate a key for [alg] (same subset as the base provider). */
+    fun eligible(alg: HardwareAlgorithm): Boolean
+
+    /**
+     * Generates a fresh AES-GCM key inside the secure element, OS-bound to [policy].
+     * [aesKeySizeBits] is 128 or 256; an unsupported size throws
+     * [HardwareKeyException.UnsupportedHardwareKey].
+     */
+    suspend fun generateAesGcm(
+        policy: UserAuthenticationPolicy,
+        aesKeySizeBits: Int = AES_256_KEY_BYTES * Byte.SIZE_BITS,
+    ): AesGcmKey
+
+    /** Generates a fresh signing key for [scheme] inside the secure element, OS-bound to [policy]. */
+    suspend fun generateSigning(
+        scheme: SignatureScheme,
+        policy: UserAuthenticationPolicy,
+    ): SigningKey
 }
 
 /**
@@ -157,15 +181,10 @@ sealed interface UserAuthenticationRequirement {
  */
 class HardwareKeySpec(
     /**
-     * The gate evaluated before each use of the generated key. The default authorizes
-     * unconditionally; a real caller supplies a biometric / device-credential prompt
-     * (`BiometricPromptAuthenticator` on Android, `LocalAuthAuthenticator` on Apple).
-     *
-     * With [userAuthentication] = [UserAuthenticationRequirement.None] this is a purely advisory
-     * gate evaluated before every op. With [UserAuthenticationRequirement.Session] it is invoked
-     * lazily — only when the OS reports the auth window stale. With
-     * [UserAuthenticationRequirement.PerUse] it is invoked for every op, bound to the exact
-     * crypto operation where the platform supports that (Android `CryptoObject`).
+     * The advisory gate evaluated before each use of the generated key. The default authorizes
+     * unconditionally. Library code deciding whether to proceed — *not* an OS binding; for keys
+     * the secure element itself refuses without user authentication, use the platform's
+     * `userAuthenticated(...)` extension to obtain a [UserAuthenticatedKeyProvider].
      */
     val authorization: HardwareAuthorization = HardwareAuthorization { true },
     /**
@@ -173,12 +192,6 @@ class HardwareKeySpec(
      * generating a signing key (the curve fixes the size).
      */
     val aesKeySizeBits: Int = AES_256_KEY_BYTES * Byte.SIZE_BITS,
-    /**
-     * OS-level user-authentication binding, fixed at generation. The default
-     * ([UserAuthenticationRequirement.None]) preserves the pre-existing behavior: no OS binding,
-     * [authorization] is advisory-only.
-     */
-    val userAuthentication: UserAuthenticationRequirement = UserAuthenticationRequirement.None,
 )
 
 /**
@@ -193,22 +206,20 @@ class HardwareKeySpec(
  * closures a provider builds into each key, but the *gate itself is the provider's responsibility* —
  * the common code holds no authorization to evaluate. Therefore an implementation **MUST**, for every
  * key it generates:
- *  1. evaluate [HardwareKeySpec.authorization] (`authorize()`) per the key's
- *     [HardwareKeySpec.userAuthentication] policy — [UserAuthenticationRequirement.None]: before
- *     every op; [UserAuthenticationRequirement.Session]: lazily, when the OS reports the auth
- *     window stale, then retry the op exactly once; [UserAuthenticationRequirement.PerUse]: for
- *     every op, bound to the exact crypto operation where the platform supports binding — and
- *     throw [AuthorizationFailed] when the gate returns `false` or throws: never proceed with the
- *     crypto op;
- *  2. honor [HardwareKeySpec.userAuthentication] *inside the secure element* where the platform
- *     supports it (Android `setUserAuthenticationRequired`, Apple `SecAccessControl`), so the
- *     binding is not bypassable by code that skips the gate;
- *  3. keep secret key material inside the secure element — never expose it through any returned type
+ *  1. evaluate [HardwareKeySpec.authorization] (`authorize()`) before each use of the key, and throw
+ *     [AuthorizationFailed] when it returns `false` or throws — never proceed with the crypto op;
+ *  2. keep secret key material inside the secure element — never expose it through any returned type
  *     (the [KeyProvenance.Hardware] key types carry no exportable material by construction);
- *  4. refuse generation for an [alg] where [eligible] is `false`, and throw
- *     [HardwareKeyException.UserAuthenticatorRequired] when the requested
- *     [HardwareKeySpec.userAuthentication] needs a platform prompt the supplied
- *     [HardwareKeySpec.authorization] cannot provide.
+ *  3. refuse generation for an [alg] where [eligible] is `false` with
+ *     [HardwareKeyException.AlgorithmNotEligible].
+ *
+ * A [UserAuthenticatedKeyProvider] obtained from this provider additionally **MUST** bind its
+ * keys' [UserAuthenticationPolicy] *inside the secure element* (Android
+ * `setUserAuthenticationRequired`, Apple `SecAccessControl`), so the binding is not bypassable by
+ * code that skips any library gate; it drives its captured platform authenticator per policy —
+ * [UserAuthenticationPolicy.Session]: lazily, when the OS reports the window stale, then retry
+ * the op exactly once; [UserAuthenticationPolicy.PerUse]: for every op, bound to the exact crypto
+ * operation where the platform supports binding.
  */
 interface HardwareKeyProvider {
     /**

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.kt
@@ -3,6 +3,8 @@ package com.ditchoom.buffer.crypto
 import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.ReadBuffer
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 /*
  * Hardware-backed key support — the *shape* of the API, frozen in 6.0 so a real secure-element /
@@ -67,10 +69,86 @@ internal fun SignatureScheme.toHardwareAlgorithm(): HardwareAlgorithm =
  * Returning `false` (or throwing) denies the operation, which the witness ops surface as
  * [AuthorizationFailed]. `suspend` because a real gate (a biometric prompt, a TEE round-trip) is
  * inherently asynchronous.
+ *
+ * The library ships a real prompt-backed implementation per platform that has OS user
+ * authentication — `BiometricPromptAuthenticator` (androidMain, androidx.biometric) and
+ * `LocalAuthAuthenticator` (appleMain, LocalAuthentication) — which is how
+ * [UserAuthenticationRequirement.Session] / [UserAuthenticationRequirement.PerUse] keys actually
+ * put a prompt on screen. The UI host (an Activity, a localized reason) cannot be expressed in
+ * common code, so the app constructs the platform authenticator and injects it here — the same
+ * inversion-of-control pattern as `BufferFactory`.
  */
 fun interface HardwareAuthorization {
     /** Returns `true` to authorize the pending hardware key operation, `false` to deny it. */
     suspend fun authorize(): Boolean
+}
+
+/**
+ * Which kinds of user authentication satisfy a [UserAuthenticationRequirement] binding. Fixed at
+ * generation and enforced by the OS, not by library code.
+ */
+enum class UserAuthenticationMethod {
+    /**
+     * A strong biometric only (fingerprint / face). The OS invalidates the key when biometric
+     * enrollment changes (Android `AUTH_BIOMETRIC_STRONG` + invalidate-on-enrollment, Apple
+     * `SecAccessControl.biometryCurrentSet`) — surfacing as [HardwareKeyException.KeyInvalidated].
+     */
+    BiometricOnly,
+
+    /**
+     * A biometric or the device credential (PIN / pattern / passcode). Survives biometric
+     * re-enrollment (Android `AUTH_BIOMETRIC_STRONG or AUTH_DEVICE_CREDENTIAL`, Apple
+     * `SecAccessControl.userPresence`).
+     */
+    BiometricOrCredential,
+}
+
+/**
+ * OS-level user-authentication binding for a hardware-backed key, fixed at generation. Unlike the
+ * advisory [HardwareAuthorization] gate (library code deciding whether to proceed), this binds the
+ * key *inside the secure element*: an op on an unauthenticated key fails in hardware no matter what
+ * the process does.
+ *
+ * Platform reality: OS binding exists on Android (Keystore `setUserAuthenticationRequired`) and
+ * Apple (Secure Enclave `SecAccessControl`). Platforms without a hardware provider (JVM, JS, WASM,
+ * Linux) never see these values — [CryptoCapabilities.hardware] is already
+ * [HardwareSupport.Unavailable] there.
+ */
+sealed interface UserAuthenticationRequirement {
+    /** No OS binding (the default). The key is usable whenever the process runs. */
+    data object None : UserAuthenticationRequirement
+
+    /**
+     * One successful user authentication unlocks the key for [validity]; ops inside the window do
+     * not re-prompt. The provider prompts lazily — it attempts the op and only invokes the
+     * [HardwareKeySpec.authorization] gate when the OS reports the window stale — so an
+     * already-authenticated user is never re-prompted.
+     *
+     * Window enforcement is by the OS on Android (keystore auth timeout); on Apple the Enclave has
+     * no timed window, so the provider enforces [validity] by re-prompting when it expires — the
+     * OS still enforces *that a successful authentication happened* via `SecAccessControl`.
+     */
+    data class Session(
+        val validity: Duration,
+        val method: UserAuthenticationMethod = UserAuthenticationMethod.BiometricOrCredential,
+    ) : UserAuthenticationRequirement {
+        init {
+            require(validity >= 1.seconds) { "session validity must be at least 1 second, was $validity" }
+        }
+    }
+
+    /**
+     * Every operation requires a fresh user authentication bound to that exact operation (Android:
+     * auth-per-use key + `BiometricPrompt.CryptoObject` wrapping the exact `Cipher`/`Signature`;
+     * Apple: a fresh, un-evaluated `LAContext` per sign, so the Enclave prompts each time).
+     *
+     * On Android this requires a `CryptoObject`-capable authenticator
+     * (`BiometricPromptAuthenticator`); generation with a plain [HardwareAuthorization] closure
+     * throws [HardwareKeyException.UserAuthenticatorRequired].
+     */
+    data class PerUse(
+        val method: UserAuthenticationMethod = UserAuthenticationMethod.BiometricOnly,
+    ) : UserAuthenticationRequirement
 }
 
 /**
@@ -80,7 +158,14 @@ fun interface HardwareAuthorization {
 class HardwareKeySpec(
     /**
      * The gate evaluated before each use of the generated key. The default authorizes
-     * unconditionally; a real caller supplies a biometric / device-credential prompt.
+     * unconditionally; a real caller supplies a biometric / device-credential prompt
+     * (`BiometricPromptAuthenticator` on Android, `LocalAuthAuthenticator` on Apple).
+     *
+     * With [userAuthentication] = [UserAuthenticationRequirement.None] this is a purely advisory
+     * gate evaluated before every op. With [UserAuthenticationRequirement.Session] it is invoked
+     * lazily — only when the OS reports the auth window stale. With
+     * [UserAuthenticationRequirement.PerUse] it is invoked for every op, bound to the exact
+     * crypto operation where the platform supports that (Android `CryptoObject`).
      */
     val authorization: HardwareAuthorization = HardwareAuthorization { true },
     /**
@@ -88,6 +173,12 @@ class HardwareKeySpec(
      * generating a signing key (the curve fixes the size).
      */
     val aesKeySizeBits: Int = AES_256_KEY_BYTES * Byte.SIZE_BITS,
+    /**
+     * OS-level user-authentication binding, fixed at generation. The default
+     * ([UserAuthenticationRequirement.None]) preserves the pre-existing behavior: no OS binding,
+     * [authorization] is advisory-only.
+     */
+    val userAuthentication: UserAuthenticationRequirement = UserAuthenticationRequirement.None,
 )
 
 /**
@@ -102,11 +193,22 @@ class HardwareKeySpec(
  * closures a provider builds into each key, but the *gate itself is the provider's responsibility* —
  * the common code holds no authorization to evaluate. Therefore an implementation **MUST**, for every
  * key it generates:
- *  1. evaluate [HardwareKeySpec.authorization] (`authorize()`) before each use of the key, and throw
- *     [AuthorizationFailed] when it returns `false` or throws — never proceed with the crypto op;
- *  2. keep secret key material inside the secure element — never expose it through any returned type
+ *  1. evaluate [HardwareKeySpec.authorization] (`authorize()`) per the key's
+ *     [HardwareKeySpec.userAuthentication] policy — [UserAuthenticationRequirement.None]: before
+ *     every op; [UserAuthenticationRequirement.Session]: lazily, when the OS reports the auth
+ *     window stale, then retry the op exactly once; [UserAuthenticationRequirement.PerUse]: for
+ *     every op, bound to the exact crypto operation where the platform supports binding — and
+ *     throw [AuthorizationFailed] when the gate returns `false` or throws: never proceed with the
+ *     crypto op;
+ *  2. honor [HardwareKeySpec.userAuthentication] *inside the secure element* where the platform
+ *     supports it (Android `setUserAuthenticationRequired`, Apple `SecAccessControl`), so the
+ *     binding is not bypassable by code that skips the gate;
+ *  3. keep secret key material inside the secure element — never expose it through any returned type
  *     (the [KeyProvenance.Hardware] key types carry no exportable material by construction);
- *  3. refuse generation for an [alg] where [eligible] is `false`.
+ *  4. refuse generation for an [alg] where [eligible] is `false`, and throw
+ *     [HardwareKeyException.UserAuthenticatorRequired] when the requested
+ *     [HardwareKeySpec.userAuthentication] needs a platform prompt the supplied
+ *     [HardwareKeySpec.authorization] cannot provide.
  */
 interface HardwareKeyProvider {
     /**

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/FakeHardware.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/FakeHardware.kt
@@ -1,6 +1,8 @@
 package com.ditchoom.buffer.crypto
 
 import com.ditchoom.buffer.crypto.CryptoTestVectors.hexBuffer
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource
 
 /*
  * A test fake for [HardwareKeyProvider]. No platform ships a real secure-element backend in 6.0, so
@@ -23,7 +25,41 @@ import com.ditchoom.buffer.crypto.CryptoTestVectors.hexBuffer
  */
 internal class FakeHardware(
     override val dedicatedSecureElement: Boolean = true,
+    /** Injectable clock so tests can advance a [UserAuthenticationRequirement.Session] window. */
+    private val timeSource: TimeSource = TimeSource.Monotonic,
 ) : HardwareKeyProvider {
+    /**
+     * Models the per-key auth behavior a real provider implements for
+     * [HardwareKeySpec.userAuthentication]:
+     * [UserAuthenticationRequirement.None] and [UserAuthenticationRequirement.PerUse] evaluate the
+     * gate before *every* op (advisory / bound-per-op respectively — observably identical here,
+     * where no OS prompt exists); [UserAuthenticationRequirement.Session] evaluates it only when
+     * the validity window is stale, then remembers the successful authentication.
+     */
+    private inner class FakeAuthPolicy(
+        spec: HardwareKeySpec,
+    ) {
+        private val req = spec.userAuthentication
+        private val gate = spec.authorization
+        private var windowStart: TimeMark? = null
+
+        suspend fun beforeOp() {
+            when (val r = req) {
+                UserAuthenticationRequirement.None,
+                is UserAuthenticationRequirement.PerUse,
+                -> if (!gate.authorize()) throw AuthorizationFailed()
+
+                is UserAuthenticationRequirement.Session -> {
+                    val withinWindow = windowStart?.let { it.elapsedNow() < r.validity } == true
+                    if (!withinWindow) {
+                        if (!gate.authorize()) throw AuthorizationFailed()
+                        windowStart = timeSource.markNow()
+                    }
+                }
+            }
+        }
+    }
+
     /** A hardware AES-GCM key plus the software twin (same material) the test opens with to cross-check. */
     class AesGcmPair(
         val hardware: AesGcmKey,
@@ -44,16 +80,16 @@ internal class FakeHardware(
         scheme: SignatureScheme,
         spec: HardwareKeySpec,
     ): SigningKey {
-        require(eligible(scheme.toHardwareAlgorithm())) {
-            "${scheme.schemeName} is not eligible for hardware backing"
-        }
+        if (!eligible(scheme.toHardwareAlgorithm())) throw HardwareKeyException.AlgorithmNotEligible()
         return signingPair(spec).hardware
     }
 
     /** Richer result for the conformance test: the hardware key and a software twin with the same key. */
     fun aesGcmPair(spec: HardwareKeySpec): AesGcmPair {
-        require(spec.aesKeySizeBits == AES_128_KEY_BYTES * Byte.SIZE_BITS || spec.aesKeySizeBits == AES_256_KEY_BYTES * Byte.SIZE_BITS) {
-            "AES key size must be 128 or 256 bits, was ${spec.aesKeySizeBits}"
+        if (spec.aesKeySizeBits != AES_128_KEY_BYTES * Byte.SIZE_BITS &&
+            spec.aesKeySizeBits != AES_256_KEY_BYTES * Byte.SIZE_BITS
+        ) {
+            throw HardwareKeyException.UnsupportedHardwareKey()
         }
         val material = cryptoRandom(spec.aesKeySizeBits / Byte.SIZE_BITS)
         // Two independent in-memory keys over the SAME bytes: one drives the gated closures (the
@@ -62,12 +98,12 @@ internal class FakeHardware(
         // so the test can prove the hardware seal produced standard, openable AES-GCM.
         val inner = AesGcmKey.of(material)
         val twin = AesGcmKey.of(material)
-        val auth = spec.authorization
+        val policy = FakeAuthPolicy(spec)
         val hardware =
             HardwareAesGcmKey(
                 sizeBits = spec.aesKeySizeBits,
                 gatedSeal = { aad, plaintext, factory ->
-                    if (!auth.authorize()) throw AuthorizationFailed()
+                    policy.beforeOp()
                     // A real secure element generates the nonce itself, so the seam hands the closure
                     // none: the fake mints a fresh CSPRNG nonce and frames nonce ‖ ciphertext ‖ tag,
                     // exactly as the Android keystore path frames its keystore-chosen IV.
@@ -80,7 +116,7 @@ internal class FakeHardware(
                     out
                 },
                 gatedOpen = { nonce, aad, ciphertextAndTag, factory ->
-                    if (!auth.authorize()) throw AuthorizationFailed()
+                    policy.beforeOp()
                     aesGcmOpenWithNonceAsync(inner, nonce, aad, ciphertextAndTag, factory)
                 },
             )
@@ -91,12 +127,12 @@ internal class FakeHardware(
     fun signingPair(spec: HardwareKeySpec): SigningPair {
         val verifyKey = VerifyKey.ecdsaP256(hexBuffer(P256_POINT_HEX))
         val inner = SigningKey.ecdsaP256(hexBuffer(P256_SCALAR_HEX), verifyKey)
-        val auth = spec.authorization
+        val policy = FakeAuthPolicy(spec)
         val hardware =
             HardwareSigningKey(
                 scheme = SignatureScheme.EcdsaP256,
                 gatedSign = { message, factory ->
-                    if (!auth.authorize()) throw AuthorizationFailed()
+                    policy.beforeOp()
                     signAsyncPlatform(inner, message, factory)
                 },
                 verifyKey = verifyKey,

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/FakeHardware.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/FakeHardware.kt
@@ -25,32 +25,30 @@ import kotlin.time.TimeSource
  */
 internal class FakeHardware(
     override val dedicatedSecureElement: Boolean = true,
-    /** Injectable clock so tests can advance a [UserAuthenticationRequirement.Session] window. */
+    /** Injectable clock so tests can advance a [UserAuthenticationPolicy.Session] window. */
     private val timeSource: TimeSource = TimeSource.Monotonic,
 ) : HardwareKeyProvider {
     /**
-     * Models the per-key auth behavior a real provider implements for
-     * [HardwareKeySpec.userAuthentication]:
-     * [UserAuthenticationRequirement.None] and [UserAuthenticationRequirement.PerUse] evaluate the
-     * gate before *every* op (advisory / bound-per-op respectively — observably identical here,
-     * where no OS prompt exists); [UserAuthenticationRequirement.Session] evaluates it only when
-     * the validity window is stale, then remembers the successful authentication.
+     * Models the per-key auth behavior a real provider implements: an advisory gate (`policy` ==
+     * null) and [UserAuthenticationPolicy.PerUse] evaluate the gate before *every* op (advisory /
+     * bound-per-op respectively — observably identical here, where no OS prompt exists);
+     * [UserAuthenticationPolicy.Session] evaluates it only when the validity window is stale, then
+     * remembers the successful authentication.
      */
     private inner class FakeAuthPolicy(
-        spec: HardwareKeySpec,
+        private val gate: HardwareAuthorization,
+        private val policy: UserAuthenticationPolicy?,
     ) {
-        private val req = spec.userAuthentication
-        private val gate = spec.authorization
         private var windowStart: TimeMark? = null
 
         suspend fun beforeOp() {
-            when (val r = req) {
-                UserAuthenticationRequirement.None,
-                is UserAuthenticationRequirement.PerUse,
+            when (val p = policy) {
+                null,
+                is UserAuthenticationPolicy.PerUse,
                 -> if (!gate.authorize()) throw AuthorizationFailed()
 
-                is UserAuthenticationRequirement.Session -> {
-                    val withinWindow = windowStart?.let { it.elapsedNow() < r.validity } == true
+                is UserAuthenticationPolicy.Session -> {
+                    val withinWindow = windowStart?.let { it.elapsedNow() < p.validity } == true
                     if (!withinWindow) {
                         if (!gate.authorize()) throw AuthorizationFailed()
                         windowStart = timeSource.markNow()
@@ -59,6 +57,30 @@ internal class FakeHardware(
             }
         }
     }
+
+    /**
+     * The fake counterpart of the platform `userAuthenticated(...)` extensions: captures the
+     * prompt [gate] at construction (as the real ones capture their platform authenticator), so
+     * the policy values handed to generate stay pure data — mirroring the production shape where
+     * a bound key without a prompt host is unrepresentable.
+     */
+    fun userAuthenticated(gate: HardwareAuthorization): UserAuthenticatedKeyProvider =
+        object : UserAuthenticatedKeyProvider {
+            override fun eligible(alg: HardwareAlgorithm): Boolean = this@FakeHardware.eligible(alg)
+
+            override suspend fun generateAesGcm(
+                policy: UserAuthenticationPolicy,
+                aesKeySizeBits: Int,
+            ): AesGcmKey = aesGcmPair(HardwareKeySpec(gate, aesKeySizeBits), policy).hardware
+
+            override suspend fun generateSigning(
+                scheme: SignatureScheme,
+                policy: UserAuthenticationPolicy,
+            ): SigningKey {
+                if (!eligible(scheme.toHardwareAlgorithm())) throw HardwareKeyException.AlgorithmNotEligible()
+                return signingPair(HardwareKeySpec(gate), policy).hardware
+            }
+        }
 
     /** A hardware AES-GCM key plus the software twin (same material) the test opens with to cross-check. */
     class AesGcmPair(
@@ -85,7 +107,10 @@ internal class FakeHardware(
     }
 
     /** Richer result for the conformance test: the hardware key and a software twin with the same key. */
-    fun aesGcmPair(spec: HardwareKeySpec): AesGcmPair {
+    fun aesGcmPair(
+        spec: HardwareKeySpec,
+        policy: UserAuthenticationPolicy? = null,
+    ): AesGcmPair {
         if (spec.aesKeySizeBits != AES_128_KEY_BYTES * Byte.SIZE_BITS &&
             spec.aesKeySizeBits != AES_256_KEY_BYTES * Byte.SIZE_BITS
         ) {
@@ -98,12 +123,12 @@ internal class FakeHardware(
         // so the test can prove the hardware seal produced standard, openable AES-GCM.
         val inner = AesGcmKey.of(material)
         val twin = AesGcmKey.of(material)
-        val policy = FakeAuthPolicy(spec)
+        val auth = FakeAuthPolicy(spec.authorization, policy)
         val hardware =
             HardwareAesGcmKey(
                 sizeBits = spec.aesKeySizeBits,
                 gatedSeal = { aad, plaintext, factory ->
-                    policy.beforeOp()
+                    auth.beforeOp()
                     // A real secure element generates the nonce itself, so the seam hands the closure
                     // none: the fake mints a fresh CSPRNG nonce and frames nonce ‖ ciphertext ‖ tag,
                     // exactly as the Android keystore path frames its keystore-chosen IV.
@@ -116,7 +141,7 @@ internal class FakeHardware(
                     out
                 },
                 gatedOpen = { nonce, aad, ciphertextAndTag, factory ->
-                    policy.beforeOp()
+                    auth.beforeOp()
                     aesGcmOpenWithNonceAsync(inner, nonce, aad, ciphertextAndTag, factory)
                 },
             )
@@ -124,15 +149,18 @@ internal class FakeHardware(
     }
 
     /** Richer result for the conformance test: the hardware signing key and its public verify key. */
-    fun signingPair(spec: HardwareKeySpec): SigningPair {
+    fun signingPair(
+        spec: HardwareKeySpec,
+        policy: UserAuthenticationPolicy? = null,
+    ): SigningPair {
         val verifyKey = VerifyKey.ecdsaP256(hexBuffer(P256_POINT_HEX))
         val inner = SigningKey.ecdsaP256(hexBuffer(P256_SCALAR_HEX), verifyKey)
-        val policy = FakeAuthPolicy(spec)
+        val auth = FakeAuthPolicy(spec.authorization, policy)
         val hardware =
             HardwareSigningKey(
                 scheme = SignatureScheme.EcdsaP256,
                 gatedSign = { message, factory ->
-                    policy.beforeOp()
+                    auth.beforeOp()
                     signAsyncPlatform(inner, message, factory)
                 },
                 verifyKey = verifyKey,

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/HardwareKeyConformanceTest.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/HardwareKeyConformanceTest.kt
@@ -118,11 +118,13 @@ class HardwareKeyConformanceTest {
             }
         }
 
-    // ---- User-authentication policies (Session / PerUse / None) ----
-    // The observable contract every real provider must honor, driven through the fake: when the
-    // gate fires, how the session window behaves, and how denial surfaces. The OS-binding halves
-    // (keystore UserNotAuthenticatedException, Enclave SecAccessControl) are covered by the
-    // device-gated Tier-2 tests.
+    // ---- User-authentication policies (Session / PerUse) ----
+    // The observable contract every UserAuthenticatedKeyProvider must honor, driven through the
+    // fake's userAuthenticated() (which captures the prompt gate at construction, exactly like the
+    // platform extensions capture their authenticator): when the gate fires, how the session
+    // window behaves, and how denial surfaces. The OS-binding halves (keystore
+    // UserNotAuthenticatedException, Enclave SecAccessControl) are covered by the device-gated
+    // Tier-2 tests.
 
     /** A gate that counts invocations and answers from [answers] (last answer repeats). */
     private class CountingGate(
@@ -143,43 +145,30 @@ class HardwareKeyConformanceTest {
         runTest {
             val clock = TestTimeSource()
             val gate = CountingGate(true)
-            val provider = FakeHardware(timeSource = clock)
-            val keys =
-                provider.aesGcmPair(
-                    HardwareKeySpec(
-                        authorization = gate,
-                        userAuthentication = UserAuthenticationRequirement.Session(5.minutes),
-                    ),
-                )
+            val authed = FakeHardware(timeSource = clock).userAuthenticated(gate)
+            val key = authed.generateAesGcm(UserAuthenticationPolicy.Session(5.minutes))
             val ops = aesGcmAsyncOps()
 
-            ops.seal(keys.hardware, ascii("first"))
-            ops.seal(keys.hardware, ascii("second"))
+            ops.seal(key, ascii("first"))
+            ops.seal(key, ascii("second"))
             assertEquals(1, gate.calls, "ops inside the window must not re-prompt")
 
             clock += 6.minutes
-            ops.seal(keys.hardware, ascii("third"))
+            ops.seal(key, ascii("third"))
             assertEquals(2, gate.calls, "a stale window must re-prompt exactly once")
         }
 
     @Test
     fun sessionDenialSurfacesAsAuthorizationFailedAndDoesNotOpenAWindow() =
         runTest {
-            val clock = TestTimeSource()
             val gate = CountingGate(false, true)
-            val provider = FakeHardware(timeSource = clock)
-            val keys =
-                provider.aesGcmPair(
-                    HardwareKeySpec(
-                        authorization = gate,
-                        userAuthentication = UserAuthenticationRequirement.Session(5.minutes),
-                    ),
-                )
+            val authed = FakeHardware(timeSource = TestTimeSource()).userAuthenticated(gate)
+            val key = authed.generateAesGcm(UserAuthenticationPolicy.Session(5.minutes))
             val ops = aesGcmAsyncOps()
 
-            assertFailsWith<AuthorizationFailed> { ops.seal(keys.hardware, ascii("denied")) }
+            assertFailsWith<AuthorizationFailed> { ops.seal(key, ascii("denied")) }
             // The denial must not have started a validity window: the next op prompts again.
-            ops.seal(keys.hardware, ascii("granted"))
+            ops.seal(key, ascii("granted"))
             assertEquals(2, gate.calls, "a denied prompt must not open the session window")
         }
 
@@ -187,26 +176,34 @@ class HardwareKeyConformanceTest {
     fun perUseAuthenticatesEveryOperation() =
         runTest {
             val gate = CountingGate(true)
-            val keys =
-                provider.aesGcmPair(
-                    HardwareKeySpec(
-                        authorization = gate,
-                        userAuthentication = UserAuthenticationRequirement.PerUse(),
-                    ),
-                )
+            val key = provider.userAuthenticated(gate).generateAesGcm(UserAuthenticationPolicy.PerUse())
             val ops = aesGcmAsyncOps()
 
-            val sealed = ops.seal(keys.hardware, ascii("payload"), Aad.Of(ascii("ctx")))
-            ops.open(sealed, keys.hardware, Aad.Of(ascii("ctx")))
+            val sealed = ops.seal(key, ascii("payload"), Aad.Of(ascii("ctx")))
+            ops.open(sealed, key, Aad.Of(ascii("ctx")))
             assertEquals(2, gate.calls, "per-use must authenticate each op, including opens")
         }
 
     @Test
     fun sessionValidityRejectsSubSecondWindows() {
         assertFailsWith<IllegalArgumentException> {
-            UserAuthenticationRequirement.Session(500.milliseconds)
+            UserAuthenticationPolicy.Session(500.milliseconds)
         }
     }
+
+    @Test
+    fun authenticatedSigningVerifiesAndPromptsPerPolicy() =
+        runTest {
+            if (!supportsEcdsaSigningFromScalar) return@runTest
+            val gate = CountingGate(true)
+            val authed = provider.userAuthenticated(gate)
+            val key = authed.generateSigning(SignatureScheme.EcdsaP256, UserAuthenticationPolicy.PerUse())
+            val ops = signatureAsyncOrNull(SignatureScheme.EcdsaP256) ?: return@runTest
+            val message = ascii("authenticated signature")
+            val signature = ops.sign(key, message)
+            assertTrue(ops.verify(key.verifyKey, message, signature), "bound hw-sign verifies under its public key")
+            assertEquals(1, gate.calls, "per-use signing prompts for the op")
+        }
 
     // ---- AES-GCM ----
 

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/HardwareKeyConformanceTest.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/HardwareKeyConformanceTest.kt
@@ -8,6 +8,9 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.TestTimeSource
 
 /**
  * Conformance contract for the hardware-backed key machinery (the shape frozen in 6.0). No platform
@@ -100,10 +103,110 @@ class HardwareKeyConformanceTest {
     @Test
     fun generateSigningRejectsIneligibleScheme() =
         runTest {
-            assertFailsWith<IllegalArgumentException> {
+            // Typed, not an IllegalArgumentException with a message: callers branch on the sealed
+            // state and consult eligible() before generating.
+            assertFailsWith<HardwareKeyException.AlgorithmNotEligible> {
                 provider.generateSigning(SignatureScheme.Ed25519, grant)
             }
         }
+
+    @Test
+    fun generateAesGcmRejectsUnsupportedKeySizeTyped() =
+        runTest {
+            assertFailsWith<HardwareKeyException.UnsupportedHardwareKey> {
+                provider.generateAesGcm(HardwareKeySpec(aesKeySizeBits = 192))
+            }
+        }
+
+    // ---- User-authentication policies (Session / PerUse / None) ----
+    // The observable contract every real provider must honor, driven through the fake: when the
+    // gate fires, how the session window behaves, and how denial surfaces. The OS-binding halves
+    // (keystore UserNotAuthenticatedException, Enclave SecAccessControl) are covered by the
+    // device-gated Tier-2 tests.
+
+    /** A gate that counts invocations and answers from [answers] (last answer repeats). */
+    private class CountingGate(
+        private vararg val answers: Boolean,
+    ) : HardwareAuthorization {
+        var calls = 0
+            private set
+
+        override suspend fun authorize(): Boolean {
+            val answer = answers.getOrElse(calls) { answers.last() }
+            calls++
+            return answer
+        }
+    }
+
+    @Test
+    fun sessionAuthenticatesOncePerValidityWindow() =
+        runTest {
+            val clock = TestTimeSource()
+            val gate = CountingGate(true)
+            val provider = FakeHardware(timeSource = clock)
+            val keys =
+                provider.aesGcmPair(
+                    HardwareKeySpec(
+                        authorization = gate,
+                        userAuthentication = UserAuthenticationRequirement.Session(5.minutes),
+                    ),
+                )
+            val ops = aesGcmAsyncOps()
+
+            ops.seal(keys.hardware, ascii("first"))
+            ops.seal(keys.hardware, ascii("second"))
+            assertEquals(1, gate.calls, "ops inside the window must not re-prompt")
+
+            clock += 6.minutes
+            ops.seal(keys.hardware, ascii("third"))
+            assertEquals(2, gate.calls, "a stale window must re-prompt exactly once")
+        }
+
+    @Test
+    fun sessionDenialSurfacesAsAuthorizationFailedAndDoesNotOpenAWindow() =
+        runTest {
+            val clock = TestTimeSource()
+            val gate = CountingGate(false, true)
+            val provider = FakeHardware(timeSource = clock)
+            val keys =
+                provider.aesGcmPair(
+                    HardwareKeySpec(
+                        authorization = gate,
+                        userAuthentication = UserAuthenticationRequirement.Session(5.minutes),
+                    ),
+                )
+            val ops = aesGcmAsyncOps()
+
+            assertFailsWith<AuthorizationFailed> { ops.seal(keys.hardware, ascii("denied")) }
+            // The denial must not have started a validity window: the next op prompts again.
+            ops.seal(keys.hardware, ascii("granted"))
+            assertEquals(2, gate.calls, "a denied prompt must not open the session window")
+        }
+
+    @Test
+    fun perUseAuthenticatesEveryOperation() =
+        runTest {
+            val gate = CountingGate(true)
+            val keys =
+                provider.aesGcmPair(
+                    HardwareKeySpec(
+                        authorization = gate,
+                        userAuthentication = UserAuthenticationRequirement.PerUse(),
+                    ),
+                )
+            val ops = aesGcmAsyncOps()
+
+            val sealed = ops.seal(keys.hardware, ascii("payload"), Aad.Of(ascii("ctx")))
+            ops.open(sealed, keys.hardware, Aad.Of(ascii("ctx")))
+            assertEquals(2, gate.calls, "per-use must authenticate each op, including opens")
+        }
+
+    @Test
+    fun sessionValidityRejectsSubSecondWindows() {
+        assertFailsWith<IllegalArgumentException> {
+            UserAuthenticationRequirement.Session(500.milliseconds)
+        }
+    }
 
     // ---- AES-GCM ----
 

--- a/buffer-crypto/src/nativeInterop/swift/CryptoKitShim.h
+++ b/buffer-crypto/src/nativeInterop/swift/CryptoKitShim.h
@@ -112,4 +112,37 @@ int32_t bcks_secure_enclave_p256_sign(
     uint8_t *sigOut, size_t sigCap,
     size_t *sigLenOut);
 
+// User-authentication binding (LocalAuthentication + SecAccessControl). LocalAuthentication does
+// not exist on every Apple platform (no tvOS): bcks_la_context_create returns 0 there and the
+// Kotlin side surfaces a typed unsupported/authenticator-required error instead.
+
+// Creates a LocalAuthentication context carrying the user-facing prompt reason (UTF-8).
+// Returns an opaque handle (> 0), or 0 when LocalAuthentication is unavailable.
+int64_t bcks_la_context_create(const char *reasonUtf8);
+
+// Invalidates and releases a context created by bcks_la_context_create. Idempotent.
+void bcks_la_context_release(int64_t handle);
+
+// Evaluates the context's auth policy, prompting the user (method: 1 = biometric or device
+// credential, 2 = biometric only). interactionAllowed == 0 fails instead of prompting. BLOCKING —
+// call off the main thread. BCKS_OK on success, BCKS_ERR_AUTH on denial.
+int32_t bcks_la_evaluate(int64_t handle, int32_t method, int32_t interactionAllowed);
+
+// Generates a Secure Enclave P-256 signing key bound to user authentication via SecAccessControl
+// (authReq: 1 = userPresence, 2 = biometryCurrentSet). Outputs match
+// bcks_secure_enclave_p256_generate.
+int32_t bcks_secure_enclave_p256_generate_ac(
+    int32_t authReq,
+    uint8_t *blobOut, size_t blobCap, size_t *blobLenOut,
+    uint8_t *pointOut, size_t pointCap, size_t *pointLenOut);
+
+// Signs with the Enclave key reconstructed from its blob, authorized through the LAContext behind
+// laHandle (0 = no context). BCKS_ERR_AUTH when user authentication was denied.
+int32_t bcks_secure_enclave_p256_sign_ctx(
+    const uint8_t *blobPtr, size_t blobLen,
+    int64_t laHandle,
+    const uint8_t *msgPtr, size_t msgLen,
+    uint8_t *sigOut, size_t sigCap,
+    size_t *sigLenOut);
+
 #endif // BUFFER_CRYPTO_CRYPTOKIT_SHIM_H

--- a/buffer-crypto/src/nativeInterop/swift/CryptoKitShim.swift
+++ b/buffer-crypto/src/nativeInterop/swift/CryptoKitShim.swift
@@ -17,6 +17,11 @@
 
 import CryptoKit
 import Foundation
+#if canImport(LocalAuthentication) && !os(tvOS)
+// tvOS ships the framework for canImport purposes but marks LAContext itself unavailable,
+// so the os() clause is load-bearing.
+import LocalAuthentication
+#endif
 
 // Status codes — kept in sync with CryptoKitShim.h.
 private let BCKS_OK: Int32 = 0
@@ -361,4 +366,179 @@ public func bcks_secure_enclave_p256_sign(
     }
     guard let sig = try? key.signature(for: bytes(msgPtr, msgLen)) else { return BCKS_ERR_INTERNAL }
     return emit(sig.derRepresentation, sigOut, sigCap, sigLenOut)
+}
+
+// =============================================================================
+// User-authentication binding — LocalAuthentication contexts + Secure Enclave
+// access control. LocalAuthentication does not exist on every Apple platform
+// (no tvOS), so the whole surface is canImport-guarded and degrades to typed
+// "unsupported" statuses instead of failing to compile the Kotlin actuals.
+// =============================================================================
+
+#if canImport(LocalAuthentication) && !os(tvOS)
+// Live LAContexts handed to Kotlin as opaque Int64 handles. Kotlin owns the
+// lifecycle (create/release); the registry just keeps ARC references alive and
+// remembers the localized reason to show in the OS prompt.
+private final class LAContextRegistry {
+    static let shared = LAContextRegistry()
+    private var next: Int64 = 1
+    private var entries: [Int64: (LAContext, String)] = [:]
+    private let lock = NSLock()
+
+    func create(reason: String) -> Int64 {
+        lock.lock(); defer { lock.unlock() }
+        let handle = next
+        next += 1
+        entries[handle] = (LAContext(), reason)
+        return handle
+    }
+
+    func get(_ handle: Int64) -> (LAContext, String)? {
+        lock.lock(); defer { lock.unlock() }
+        return entries[handle]
+    }
+
+    func release(_ handle: Int64) {
+        lock.lock(); defer { lock.unlock() }
+        if let (ctx, _) = entries.removeValue(forKey: handle) { ctx.invalidate() }
+    }
+}
+#endif
+
+// Create a LocalAuthentication context with the user-facing reason string shown in the OS prompt.
+// Returns an opaque handle (> 0), or 0 when LocalAuthentication is unavailable on this platform.
+@_cdecl("bcks_la_context_create")
+public func bcks_la_context_create(_ reasonPtr: UnsafePointer<CChar>?) -> Int64 {
+    #if canImport(LocalAuthentication) && !os(tvOS)
+    let reason = reasonPtr.map { String(cString: $0) } ?? ""
+    return LAContextRegistry.shared.create(reason: reason)
+    #else
+    return 0
+    #endif
+}
+
+// Invalidate and release a context created by bcks_la_context_create. Idempotent.
+@_cdecl("bcks_la_context_release")
+public func bcks_la_context_release(_ handle: Int64) {
+    #if canImport(LocalAuthentication) && !os(tvOS)
+    LAContextRegistry.shared.release(handle)
+    #endif
+}
+
+// Evaluate the context's auth policy, prompting the user. method: 1 = biometric or device
+// credential, 2 = biometric only. interactionAllowed == 0 sets interactionNotAllowed so a
+// headless caller fails (BCKS_ERR_AUTH) instead of hanging on an invisible prompt. BLOCKING —
+// call off the main thread. A successfully evaluated context can then authorize Enclave signs
+// (bcks_secure_enclave_p256_sign_ctx) without re-prompting until released.
+@_cdecl("bcks_la_evaluate")
+public func bcks_la_evaluate(_ handle: Int64, _ method: Int32, _ interactionAllowed: Int32) -> Int32 {
+    #if canImport(LocalAuthentication) && !os(tvOS)
+    guard let (ctx, reason) = LAContextRegistry.shared.get(handle) else { return BCKS_ERR_INPUT }
+    #if os(watchOS)
+    // watchOS exposes no discrete biometric policy (wrist detection stands in for biometrics);
+    // deviceOwnerAuthentication is the strongest policy the platform offers for either method.
+    let policy: LAPolicy = .deviceOwnerAuthentication
+    #else
+    let policy: LAPolicy = method == 2 ? .deviceOwnerAuthenticationWithBiometrics : .deviceOwnerAuthentication
+    #endif
+    ctx.interactionNotAllowed = interactionAllowed == 0
+    let sem = DispatchSemaphore(value: 0)
+    var ok = false
+    ctx.evaluatePolicy(policy, localizedReason: reason.isEmpty ? "authorize hardware key use" : reason) { success, _ in
+        ok = success
+        sem.signal()
+    }
+    sem.wait()
+    return ok ? BCKS_OK : BCKS_ERR_AUTH
+    #else
+    return BCKS_ERR_INTERNAL
+    #endif
+}
+
+// Generate a Secure Enclave P-256 signing key bound to user authentication via SecAccessControl.
+// authReq: 1 = userPresence (biometric or device credential), 2 = biometryCurrentSet (biometric
+// only; the OS invalidates the key when biometric enrollment changes). Same outputs as
+// bcks_secure_enclave_p256_generate.
+@_cdecl("bcks_secure_enclave_p256_generate_ac")
+public func bcks_secure_enclave_p256_generate_ac(
+    _ authReq: Int32,
+    _ blobOut: UnsafeMutablePointer<UInt8>?, _ blobCap: Int,
+    _ blobLenOut: UnsafeMutablePointer<Int>?,
+    _ pointOut: UnsafeMutablePointer<UInt8>?, _ pointCap: Int,
+    _ pointLenOut: UnsafeMutablePointer<Int>?
+) -> Int32 {
+    guard SecureEnclave.isAvailable else { return BCKS_ERR_INTERNAL }
+    var flags: SecAccessControlCreateFlags = [.privateKeyUsage]
+    switch authReq {
+    case 1: flags.insert(.userPresence)
+    case 2: flags.insert(.biometryCurrentSet)
+    default: return BCKS_ERR_INPUT
+    }
+    var acError: Unmanaged<CFError>?
+    guard let ac = SecAccessControlCreateWithFlags(
+        kCFAllocatorDefault, kSecAttrAccessibleWhenUnlockedThisDeviceOnly, flags, &acError
+    ) else { return BCKS_ERR_INTERNAL }
+    guard let key = try? SecureEnclave.P256.Signing.PrivateKey(accessControl: ac) else { return BCKS_ERR_INTERNAL }
+    let s = emit(key.dataRepresentation, blobOut, blobCap, blobLenOut)
+    if s != BCKS_OK { return s }
+    return emit(key.publicKey.x963Representation, pointOut, pointCap, pointLenOut)
+}
+
+// Classify a signing failure on an access-controlled key: user-auth denials (cancel, no match,
+// interaction not allowed, auth failed) map to BCKS_ERR_AUTH; everything else is internal.
+private func classifySignFailure(_ error: Error) -> Int32 {
+    let ns = error as NSError
+    #if canImport(LocalAuthentication) && !os(tvOS)
+    if ns.domain == LAError.errorDomain { return BCKS_ERR_AUTH }
+    #endif
+    if ns.domain == NSOSStatusErrorDomain {
+        switch OSStatus(ns.code) {
+        case errSecAuthFailed, errSecUserCanceled, errSecInteractionNotAllowed: return BCKS_ERR_AUTH
+        default: return BCKS_ERR_INTERNAL
+        }
+    }
+    return BCKS_ERR_INTERNAL
+}
+
+// Sign with the Enclave key reconstructed from its blob, authorizing through the LAContext
+// behind laHandle (0 = no context: the OS drives any required prompt itself, or refuses when it
+// cannot). Emits a DER signature; BCKS_ERR_AUTH when user authentication was denied.
+@_cdecl("bcks_secure_enclave_p256_sign_ctx")
+public func bcks_secure_enclave_p256_sign_ctx(
+    _ blobPtr: UnsafePointer<UInt8>?, _ blobLen: Int,
+    _ laHandle: Int64,
+    _ msgPtr: UnsafePointer<UInt8>?, _ msgLen: Int,
+    _ sigOut: UnsafeMutablePointer<UInt8>?, _ sigCap: Int,
+    _ sigLenOut: UnsafeMutablePointer<Int>?
+) -> Int32 {
+    #if canImport(LocalAuthentication) && !os(tvOS)
+    let ctx: LAContext? = laHandle == 0 ? nil : LAContextRegistry.shared.get(laHandle)?.0
+    if laHandle != 0 && ctx == nil { return BCKS_ERR_INPUT }
+    // The context-carrying init needs watchOS 9; below that (floor: 7) sign without one — the
+    // access control still holds, the OS just drives any prompt itself.
+    guard #available(watchOS 9.0, iOS 13.0, macOS 10.15, *) else {
+        guard let key = try? SecureEnclave.P256.Signing.PrivateKey(
+            dataRepresentation: bytes(blobPtr, blobLen)
+        ) else { return BCKS_ERR_INPUT }
+        do {
+            let sig = try key.signature(for: bytes(msgPtr, msgLen))
+            return emit(sig.derRepresentation, sigOut, sigCap, sigLenOut)
+        } catch {
+            return classifySignFailure(error)
+        }
+    }
+    guard let key = try? SecureEnclave.P256.Signing.PrivateKey(
+        dataRepresentation: bytes(blobPtr, blobLen), authenticationContext: ctx
+    ) else { return BCKS_ERR_INPUT }
+    #else
+    guard let key = try? SecureEnclave.P256.Signing.PrivateKey(
+        dataRepresentation: bytes(blobPtr, blobLen)
+    ) else { return BCKS_ERR_INPUT }
+    #endif
+    do {
+        let sig = try key.signature(for: bytes(msgPtr, msgLen))
+        return emit(sig.derRepresentation, sigOut, sigCap, sigLenOut)
+    } catch {
+        return classifySignFailure(error)
+    }
 }

--- a/docs/docs/recipes/cryptography.md
+++ b/docs/docs/recipes/cryptography.md
@@ -443,6 +443,69 @@ when (val hw = CryptoCapabilities.hardware) {
 
 The per-platform results of these checks are the [capability matrix](#per-platform-capability-matrix) below.
 
+## Biometric / user-authenticated hardware keys
+
+A hardware-backed key can be **bound to user authentication inside the secure element** at
+generation — the OS refuses an unauthenticated operation no matter what the process does. The
+binding is a value on `HardwareKeySpec`:
+
+```kotlin
+sealed interface UserAuthenticationRequirement {
+    data object None                    // default: no OS binding, the gate is advisory
+    data class Session(val validity: Duration,
+                       val method: UserAuthenticationMethod = BiometricOrCredential)
+    data class PerUse(val method: UserAuthenticationMethod = BiometricOnly)
+}
+```
+
+- **`Session(validity)`** — one successful authentication unlocks the key for the window; ops
+  inside it never re-prompt (the provider prompts *lazily*, only when the OS reports the window
+  stale). Android enforces the window in the keystore; the Apple Enclave has no timed window, so
+  the window is library-tracked there while the authentication itself stays OS-enforced.
+- **`PerUse()`** — every operation requires a fresh authentication bound to that exact operation
+  (Android `BiometricPrompt.CryptoObject` wrapping the exact `Cipher`/`Signature`; Apple a fresh,
+  un-evaluated `LAContext`, so the Enclave prompts during the sign itself).
+- **`method`** — `BiometricOnly` (strong biometric; the OS invalidates the key when enrollment
+  changes → `HardwareKeyException.KeyInvalidated`) or `BiometricOrCredential` (biometric or the
+  device PIN/passcode).
+
+The prompt needs UI context that common code cannot express, so each platform ships an
+authenticator the app constructs and injects as `HardwareKeySpec.authorization` (the same
+inversion-of-control pattern as `BufferFactory`):
+
+```kotlin
+// Android (androidMain) — androidx.biometric prompt host
+val spec = HardwareKeySpec(
+    authorization = BiometricPromptAuthenticator(activity, title = "Unlock signing key"),
+    userAuthentication = UserAuthenticationRequirement.Session(5.minutes),
+)
+
+// Apple (appleMain) — LocalAuthentication
+val spec = HardwareKeySpec(
+    authorization = LocalAuthAuthenticator(reason = "Sign the audit record"),
+    userAuthentication = UserAuthenticationRequirement.Session(5.minutes),
+)
+
+// Common code from here on — the key is an ordinary SigningKey / AesGcmKey:
+val hw = CryptoCapabilities.hardware
+if (hw is HardwareSupport.Available) {
+    val key = hw.provider.generateSigning(SignatureScheme.EcdsaP256, spec)
+    // first op in the window prompts; later ops are silent; expiry re-prompts
+}
+```
+
+Typed outcomes to branch on: a denied/cancelled prompt is `AuthorizationFailed`; a stale session
+the user must re-authenticate is `HardwareKeyException.UserAuthenticationRequired`; biometric
+re-enrollment invalidating a `BiometricOnly` key is `HardwareKeyException.KeyInvalidated`;
+requesting `PerUse` without a platform authenticator fails **at generation** with
+`HardwareKeyException.UserAuthenticatorRequired` (a misconfigured key can never exist).
+
+Platform notes: Android requires a secure lock screen to generate auth-bound keys (API 30+ uses
+`setUserAuthenticationParameters`; 28/29 the legacy validity-duration API, where `method` cannot
+be narrowed). On Apple, tvOS has no LocalAuthentication and watchOS has no discrete biometric
+policy (wrist detection / passcode stands in), so `BiometricOnly` degrades accordingly. Platforms
+without a secure element (`HardwareSupport.Unavailable`) never reach these values.
+
 ## Using buffer-crypto with buffer-codec
 
 `buffer-crypto` and `buffer-codec` are deliberately **independent siblings over `:buffer`** — neither module depends on the other, and no `Codec` ever calls a crypto op. You compose them in application code: the codec owns the wire envelope, crypto owns the payload.

--- a/docs/docs/recipes/cryptography.md
+++ b/docs/docs/recipes/cryptography.md
@@ -446,17 +446,21 @@ The per-platform results of these checks are the [capability matrix](#per-platfo
 ## Biometric / user-authenticated hardware keys
 
 A hardware-backed key can be **bound to user authentication inside the secure element** at
-generation — the OS refuses an unauthenticated operation no matter what the process does. The
-binding is a value on `HardwareKeySpec`:
+generation — the OS refuses an unauthenticated operation no matter what the process does. Bound
+keys come from a `UserAuthenticatedKeyProvider`, obtained by handing the platform's prompt host to
+the `userAuthenticated(...)` extension; the policies themselves are pure data:
 
 ```kotlin
-sealed interface UserAuthenticationRequirement {
-    data object None                    // default: no OS binding, the gate is advisory
+sealed interface UserAuthenticationPolicy {
     data class Session(val validity: Duration,
                        val method: UserAuthenticationMethod = BiometricOrCredential)
     data class PerUse(val method: UserAuthenticationMethod = BiometricOnly)
 }
 ```
+
+Because the prompt host is captured when the provider is constructed, "a bound key without a
+prompt" is a compile error, not a runtime exception — the base `HardwareKeyProvider` keeps only
+the advisory `HardwareKeySpec.authorization` gate and mints unbound keys, exactly as before.
 
 - **`Session(validity)`** — one successful authentication unlocks the key for the window; ops
   inside it never re-prompt (the provider prompts *lazily*, only when the OS reports the window
@@ -469,36 +473,36 @@ sealed interface UserAuthenticationRequirement {
   changes → `HardwareKeyException.KeyInvalidated`) or `BiometricOrCredential` (biometric or the
   device PIN/passcode).
 
-The prompt needs UI context that common code cannot express, so each platform ships an
-authenticator the app constructs and injects as `HardwareKeySpec.authorization` (the same
-inversion-of-control pattern as `BufferFactory`):
+The prompt needs UI context that common code cannot express, so `userAuthenticated(...)` is a
+**platform** extension — its parameter type is the platform's prompt host, which is exactly the
+one line of platform code the app had to write anyway:
 
 ```kotlin
 // Android (androidMain) — androidx.biometric prompt host
-val spec = HardwareKeySpec(
-    authorization = BiometricPromptAuthenticator(activity, title = "Unlock signing key"),
-    userAuthentication = UserAuthenticationRequirement.Session(5.minutes),
+val authed = hw.provider.userAuthenticated(
+    BiometricPromptAuthenticator(activity, title = "Unlock signing key"),
 )
 
 // Apple (appleMain) — LocalAuthentication
-val spec = HardwareKeySpec(
-    authorization = LocalAuthAuthenticator(reason = "Sign the audit record"),
-    userAuthentication = UserAuthenticationRequirement.Session(5.minutes),
+val authed = hw.provider.userAuthenticated(
+    LocalAuthAuthenticator(reason = "Sign the audit record"),
 )
 
-// Common code from here on — the key is an ordinary SigningKey / AesGcmKey:
-val hw = CryptoCapabilities.hardware
-if (hw is HardwareSupport.Available) {
-    val key = hw.provider.generateSigning(SignatureScheme.EcdsaP256, spec)
-    // first op in the window prompts; later ops are silent; expiry re-prompts
-}
+// Common code from here on — policies are pure data, keys are ordinary SigningKey / AesGcmKey:
+val key = authed?.generateSigning(
+    SignatureScheme.EcdsaP256,
+    UserAuthenticationPolicy.Session(5.minutes),
+)
+// first op in the window prompts; later ops are silent; expiry re-prompts
 ```
+
+`userAuthenticated` returns `null` where OS user authentication cannot be driven (a non-platform
+provider, tvOS, a closed authenticator) — witness-style honesty, like
+`CryptoCapabilities.hardware` itself.
 
 Typed outcomes to branch on: a denied/cancelled prompt is `AuthorizationFailed`; a stale session
 the user must re-authenticate is `HardwareKeyException.UserAuthenticationRequired`; biometric
-re-enrollment invalidating a `BiometricOnly` key is `HardwareKeyException.KeyInvalidated`;
-requesting `PerUse` without a platform authenticator fails **at generation** with
-`HardwareKeyException.UserAuthenticatorRequired` (a misconfigured key can never exist).
+re-enrollment invalidating a `BiometricOnly` key is `HardwareKeyException.KeyInvalidated`.
 
 Platform notes: Android requires a secure lock screen to generate auth-bound keys (API 30+ uses
 `setUserAuthenticationParameters`; 28/29 the legacy validity-duration API, where `method` cannot

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,8 @@ androidxTestRunner = "1.7.0"
 androidxTestRules = "1.7.0"
 androidxTestCore = "1.7.0"
 androidxTestJunit = "1.3.0"
+# androidx.biometric — BiometricPrompt host for buffer-crypto's BiometricPromptAuthenticator
+androidxBiometric = "1.1.0"
 kotlinWrappers = "2026.6.0"
 ksp = "2.3.9"
 # kctfork 0.13.0-alpha01 requires Kotlin 2.4.0-Beta1; hold at 0.12.0-alpha01 for Kotlin 2.3.x
@@ -46,6 +48,7 @@ androidx-test-runner = { module = "androidx.test:runner", version.ref = "android
 androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidxTestRules" }
 androidx-test-core-ktx = { module = "androidx.test:core-ktx", version.ref = "androidxTestCore" }
 androidx-test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidxTestJunit" }
+androidx-biometric = { module = "androidx.biometric:biometric", version.ref = "androidxBiometric" }
 kotlin-web = { module = "org.jetbrains.kotlin-wrappers:kotlin-web", version.ref = "kotlinWrappers" }
 kotlin-js = { module = "org.jetbrains.kotlin-wrappers:kotlin-js", version.ref = "kotlinWrappers" }
 


### PR DESCRIPTION
Hardware keys can now be **bound to user authentication inside the secure element** at generation, replacing the advisory-only `authorize()` gate for keys that need real protection: an op on an unauthenticated key fails in hardware no matter what the process does.

## API (witness-style sub-provider)

Policies are pure data; the platform prompt host is captured once, at the platform boundary:

```kotlin
// Android (androidMain)
val authed = hw.provider.userAuthenticated(BiometricPromptAuthenticator(activity, title = "Unlock signing key"))
// Apple (appleMain)
val authed = hw.provider.userAuthenticated(LocalAuthAuthenticator(reason = "Sign the audit record"))

// common from here on
val key = authed?.generateSigning(SignatureScheme.EcdsaP256, UserAuthenticationPolicy.Session(5.minutes))
```

- `UserAuthenticationPolicy.Session(validity, method)` — one auth unlocks a window (OS-enforced on Android; library-tracked window + OS-enforced auth on Apple, since the Enclave has no timed window). Lazy prompting: an already-authenticated user is never re-prompted.
- `UserAuthenticationPolicy.PerUse(method)` — every op re-authenticates, bound to that exact operation (Android `BiometricPrompt.CryptoObject` over the exact `Cipher`/`Signature`; Apple fresh un-evaluated `LAContext` per sign).
- `method`: `BiometricOnly` (key invalidated on re-enrollment → `KeyInvalidated`) or `BiometricOrCredential`.
- Because the authenticator is captured at construction, **a bound key without a prompt host is a compile error** — `userAuthenticated()` returns `null` where OS auth can't be driven (non-platform provider, tvOS). `HardwareKeySpec` stays a pure value; base-provider behavior is unchanged.

## Implementation

- **Android**: `setUserAuthenticationRequired` + `setUserAuthenticationParameters` (API 30+; legacy validity-duration on 28/29). Session retries once after a lazy prompt on `UserNotAuthenticatedException`; per-use drives the `CryptoObject` flow. Ships `BiometricPromptAuthenticator` (androidx.biometric, `api` dep).
- **Apple**: Enclave keys generated with `SecAccessControl(privateKeyUsage + userPresence/biometryCurrentSet)` via new shim entry points; `LocalAuthAuthenticator` owns a shim-registered `LAContext` so the same Kotlin compiles on every Apple target (tvOS has no LocalAuthentication; watchOS has no discrete biometric policy — both degrade with typed honesty). Enclave glue is now buffer-native end-to-end (shim reads/writes `PlatformBuffer` memory directly).
- Policies resolve at generation into internal sealed `Resolved*Policy` variants that carry their authenticator by construction — no nullable authenticator state anywhere downstream.
- Typed errors: new `HardwareKeyException.AlgorithmNotEligible`; remaining stringly `require`/`check` hardware paths converted to sealed states.

## Tests

- **Tier 1 (all platforms, CI)**: fake-provider conformance contract — session window (injectable `TestTimeSource`), per-use per-op prompts, denial → `AuthorizationFailed`, typed generation failures. Green on jvm / jsNode / wasmJsNode / macosArm64.
- **Tier 2 (device, headless)**: binding negative tests proving the OS enforcement is real — Android instrumented: a session-bound key with an always-granting gate is still refused by the *keystore*; a per-use key whose prompt host lies (grants without driving BiometricPrompt) is refused for the never-authorized `CryptoObject`. Apple: Enclave harness asserts an access-controlled key refuses an `interactionNotAllowed` sign. **222/0 instrumented tests on a real device (TEE-only, secure lock screen).**
- **Tier 3** (prompt-and-match) stays device/human-gated, deliberately not CI.

Also: Swift shim typechecked against all six Apple target triples; ktlint/detekt/apiCheck green; API dumps updated; biometrics section added to the cryptography recipe.