### PR TITLE
fix(crypto): releasable digest/MAC lifecycle — close() for never-finalized ctx, Linux SHA ctx cleanse

### DIFF
--- a/buffer-crypto/api/android/buffer-crypto.api
+++ b/buffer-crypto/api/android/buffer-crypto.api
@@ -311,8 +311,9 @@ public final class com/ditchoom/buffer/crypto/HmacSha256Kt {
 	public static synthetic fun hmacSha256$default (Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;ILjava/lang/Object;)Lcom/ditchoom/buffer/ReadBuffer;
 }
 
-public final class com/ditchoom/buffer/crypto/HmacSha256Mac {
+public final class com/ditchoom/buffer/crypto/HmacSha256Mac : java/lang/AutoCloseable {
 	public fun <init> (Lcom/ditchoom/buffer/ReadBuffer;)V
+	public fun close ()V
 	public final fun doFinalInto (Lcom/ditchoom/buffer/WriteBuffer;)V
 	public final fun update (Lcom/ditchoom/buffer/ReadBuffer;)Lcom/ditchoom/buffer/crypto/HmacSha256Mac;
 }
@@ -324,8 +325,9 @@ public final class com/ditchoom/buffer/crypto/HmacSha384Kt {
 	public static synthetic fun hmacSha384$default (Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;ILjava/lang/Object;)Lcom/ditchoom/buffer/ReadBuffer;
 }
 
-public final class com/ditchoom/buffer/crypto/HmacSha384Mac {
+public final class com/ditchoom/buffer/crypto/HmacSha384Mac : java/lang/AutoCloseable {
 	public fun <init> (Lcom/ditchoom/buffer/ReadBuffer;)V
+	public fun close ()V
 	public final fun doFinalInto (Lcom/ditchoom/buffer/WriteBuffer;)V
 	public final fun update (Lcom/ditchoom/buffer/ReadBuffer;)Lcom/ditchoom/buffer/crypto/HmacSha384Mac;
 }
@@ -337,8 +339,9 @@ public final class com/ditchoom/buffer/crypto/HmacSha512Kt {
 	public static synthetic fun hmacSha512$default (Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;ILjava/lang/Object;)Lcom/ditchoom/buffer/ReadBuffer;
 }
 
-public final class com/ditchoom/buffer/crypto/HmacSha512Mac {
+public final class com/ditchoom/buffer/crypto/HmacSha512Mac : java/lang/AutoCloseable {
 	public fun <init> (Lcom/ditchoom/buffer/ReadBuffer;)V
+	public fun close ()V
 	public final fun doFinalInto (Lcom/ditchoom/buffer/WriteBuffer;)V
 	public final fun update (Lcom/ditchoom/buffer/ReadBuffer;)Lcom/ditchoom/buffer/crypto/HmacSha512Mac;
 }
@@ -1080,8 +1083,9 @@ public final class com/ditchoom/buffer/crypto/SecurePoolKt {
 	public static synthetic fun withSecureBuffer$default (Lcom/ditchoom/buffer/pool/BufferPool;ILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
-public final class com/ditchoom/buffer/crypto/Sha256Digest {
+public final class com/ditchoom/buffer/crypto/Sha256Digest : java/lang/AutoCloseable {
 	public fun <init> ()V
+	public fun close ()V
 	public final fun digestInto (Lcom/ditchoom/buffer/WriteBuffer;)V
 	public final fun update (Lcom/ditchoom/buffer/ReadBuffer;)Lcom/ditchoom/buffer/crypto/Sha256Digest;
 }
@@ -1094,8 +1098,9 @@ public final class com/ditchoom/buffer/crypto/Sha256Kt {
 	public static synthetic fun sha256$default (Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;ILjava/lang/Object;)Lcom/ditchoom/buffer/ReadBuffer;
 }
 
-public final class com/ditchoom/buffer/crypto/Sha384Digest {
+public final class com/ditchoom/buffer/crypto/Sha384Digest : java/lang/AutoCloseable {
 	public fun <init> ()V
+	public fun close ()V
 	public final fun digestInto (Lcom/ditchoom/buffer/WriteBuffer;)V
 	public final fun update (Lcom/ditchoom/buffer/ReadBuffer;)Lcom/ditchoom/buffer/crypto/Sha384Digest;
 }
@@ -1108,8 +1113,9 @@ public final class com/ditchoom/buffer/crypto/Sha384Kt {
 	public static synthetic fun sha384$default (Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;ILjava/lang/Object;)Lcom/ditchoom/buffer/ReadBuffer;
 }
 
-public final class com/ditchoom/buffer/crypto/Sha512Digest {
+public final class com/ditchoom/buffer/crypto/Sha512Digest : java/lang/AutoCloseable {
 	public fun <init> ()V
+	public fun close ()V
 	public final fun digestInto (Lcom/ditchoom/buffer/WriteBuffer;)V
 	public final fun update (Lcom/ditchoom/buffer/ReadBuffer;)Lcom/ditchoom/buffer/crypto/Sha512Digest;
 }

--- a/buffer-crypto/api/jvm/buffer-crypto.api
+++ b/buffer-crypto/api/jvm/buffer-crypto.api
@@ -311,8 +311,9 @@ public final class com/ditchoom/buffer/crypto/HmacSha256Kt {
 	public static synthetic fun hmacSha256$default (Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;ILjava/lang/Object;)Lcom/ditchoom/buffer/ReadBuffer;
 }
 
-public final class com/ditchoom/buffer/crypto/HmacSha256Mac {
+public final class com/ditchoom/buffer/crypto/HmacSha256Mac : java/lang/AutoCloseable {
 	public fun <init> (Lcom/ditchoom/buffer/ReadBuffer;)V
+	public fun close ()V
 	public final fun doFinalInto (Lcom/ditchoom/buffer/WriteBuffer;)V
 	public final fun update (Lcom/ditchoom/buffer/ReadBuffer;)Lcom/ditchoom/buffer/crypto/HmacSha256Mac;
 }
@@ -324,8 +325,9 @@ public final class com/ditchoom/buffer/crypto/HmacSha384Kt {
 	public static synthetic fun hmacSha384$default (Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;ILjava/lang/Object;)Lcom/ditchoom/buffer/ReadBuffer;
 }
 
-public final class com/ditchoom/buffer/crypto/HmacSha384Mac {
+public final class com/ditchoom/buffer/crypto/HmacSha384Mac : java/lang/AutoCloseable {
 	public fun <init> (Lcom/ditchoom/buffer/ReadBuffer;)V
+	public fun close ()V
 	public final fun doFinalInto (Lcom/ditchoom/buffer/WriteBuffer;)V
 	public final fun update (Lcom/ditchoom/buffer/ReadBuffer;)Lcom/ditchoom/buffer/crypto/HmacSha384Mac;
 }
@@ -337,8 +339,9 @@ public final class com/ditchoom/buffer/crypto/HmacSha512Kt {
 	public static synthetic fun hmacSha512$default (Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;ILjava/lang/Object;)Lcom/ditchoom/buffer/ReadBuffer;
 }
 
-public final class com/ditchoom/buffer/crypto/HmacSha512Mac {
+public final class com/ditchoom/buffer/crypto/HmacSha512Mac : java/lang/AutoCloseable {
 	public fun <init> (Lcom/ditchoom/buffer/ReadBuffer;)V
+	public fun close ()V
 	public final fun doFinalInto (Lcom/ditchoom/buffer/WriteBuffer;)V
 	public final fun update (Lcom/ditchoom/buffer/ReadBuffer;)Lcom/ditchoom/buffer/crypto/HmacSha512Mac;
 }
@@ -1078,8 +1081,9 @@ public final class com/ditchoom/buffer/crypto/SecurePoolKt {
 	public static synthetic fun withSecureBuffer$default (Lcom/ditchoom/buffer/pool/BufferPool;ILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
-public final class com/ditchoom/buffer/crypto/Sha256Digest {
+public final class com/ditchoom/buffer/crypto/Sha256Digest : java/lang/AutoCloseable {
 	public fun <init> ()V
+	public fun close ()V
 	public final fun digestInto (Lcom/ditchoom/buffer/WriteBuffer;)V
 	public final fun update (Lcom/ditchoom/buffer/ReadBuffer;)Lcom/ditchoom/buffer/crypto/Sha256Digest;
 }
@@ -1092,8 +1096,9 @@ public final class com/ditchoom/buffer/crypto/Sha256Kt {
 	public static synthetic fun sha256$default (Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;ILjava/lang/Object;)Lcom/ditchoom/buffer/ReadBuffer;
 }
 
-public final class com/ditchoom/buffer/crypto/Sha384Digest {
+public final class com/ditchoom/buffer/crypto/Sha384Digest : java/lang/AutoCloseable {
 	public fun <init> ()V
+	public fun close ()V
 	public final fun digestInto (Lcom/ditchoom/buffer/WriteBuffer;)V
 	public final fun update (Lcom/ditchoom/buffer/ReadBuffer;)Lcom/ditchoom/buffer/crypto/Sha384Digest;
 }
@@ -1106,8 +1111,9 @@ public final class com/ditchoom/buffer/crypto/Sha384Kt {
 	public static synthetic fun sha384$default (Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;ILjava/lang/Object;)Lcom/ditchoom/buffer/ReadBuffer;
 }
 
-public final class com/ditchoom/buffer/crypto/Sha512Digest {
+public final class com/ditchoom/buffer/crypto/Sha512Digest : java/lang/AutoCloseable {
 	public fun <init> ()V
+	public fun close ()V
 	public final fun digestInto (Lcom/ditchoom/buffer/WriteBuffer;)V
 	public final fun update (Lcom/ditchoom/buffer/ReadBuffer;)Lcom/ditchoom/buffer/crypto/Sha512Digest;
 }

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256Mac.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256Mac.apple.kt
@@ -21,7 +21,7 @@ import platform.posix.memset
 /** Apple HMAC-SHA256 backed by CommonCrypto (`CCHmac`). Reads and writes via buffer pointers — no arrays. */
 actual class HmacSha256Mac actual constructor(
     key: ReadBuffer,
-) {
+) : AutoCloseable {
     private val ctx = nativeHeap.alloc<CCHmacContext>()
     private var finalized = false
 
@@ -44,7 +44,17 @@ actual class HmacSha256Mac actual constructor(
         finalized = true
         // CommonCrypto writes the 32-byte tag straight into the destination buffer's memory.
         dest.withWritablePointer(SHA256_DIGEST_BYTES) { ptr -> CCHmacFinal(ctx.ptr, ptr) }
-        // The context holds key-derived ipad/opad state; zero it before returning the allocation.
+        releaseCtx()
+    }
+
+    actual override fun close() {
+        if (finalized) return
+        finalized = true
+        releaseCtx()
+    }
+
+    // The context holds key-derived ipad/opad state; zero it before returning the allocation.
+    private fun releaseCtx() {
         memset(ctx.ptr, 0, sizeOf<CCHmacContext>().convert())
         nativeHeap.free(ctx.rawPtr)
     }

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256Mac.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256Mac.apple.kt
@@ -41,9 +41,11 @@ actual class HmacSha256Mac actual constructor(
 
     actual fun doFinalInto(dest: WriteBuffer) {
         check(!finalized) { "mac already finalized" }
-        finalized = true
         // CommonCrypto writes the 32-byte tag straight into the destination buffer's memory.
+        // withWritablePointer validates capacity BEFORE invoking the block, so a too-small
+        // dest throws here with the ctx untouched — the finalize stays retryable (C1).
         dest.withWritablePointer(SHA256_DIGEST_BYTES) { ptr -> CCHmacFinal(ctx.ptr, ptr) }
+        finalized = true
         releaseCtx()
     }
 

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HmacSha384Mac.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HmacSha384Mac.apple.kt
@@ -21,7 +21,7 @@ import platform.posix.memset
 /** Apple HMAC-SHA384 backed by CommonCrypto (`CCHmac`). Reads and writes via buffer pointers — no arrays. */
 actual class HmacSha384Mac actual constructor(
     key: ReadBuffer,
-) {
+) : AutoCloseable {
     private val ctx = nativeHeap.alloc<CCHmacContext>()
     private var finalized = false
 
@@ -44,7 +44,17 @@ actual class HmacSha384Mac actual constructor(
         finalized = true
         // CommonCrypto writes the 48-byte tag straight into the destination buffer's memory.
         dest.withWritablePointer(SHA384_DIGEST_BYTES) { ptr -> CCHmacFinal(ctx.ptr, ptr) }
-        // The context holds key-derived ipad/opad state; zero it before returning the allocation.
+        releaseCtx()
+    }
+
+    actual override fun close() {
+        if (finalized) return
+        finalized = true
+        releaseCtx()
+    }
+
+    // The context holds key-derived ipad/opad state; zero it before returning the allocation.
+    private fun releaseCtx() {
         memset(ctx.ptr, 0, sizeOf<CCHmacContext>().convert())
         nativeHeap.free(ctx.rawPtr)
     }

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HmacSha384Mac.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HmacSha384Mac.apple.kt
@@ -41,9 +41,11 @@ actual class HmacSha384Mac actual constructor(
 
     actual fun doFinalInto(dest: WriteBuffer) {
         check(!finalized) { "mac already finalized" }
-        finalized = true
         // CommonCrypto writes the 48-byte tag straight into the destination buffer's memory.
+        // withWritablePointer validates capacity BEFORE invoking the block, so a too-small
+        // dest throws here with the ctx untouched — the finalize stays retryable (C1).
         dest.withWritablePointer(SHA384_DIGEST_BYTES) { ptr -> CCHmacFinal(ctx.ptr, ptr) }
+        finalized = true
         releaseCtx()
     }
 

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HmacSha512Mac.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HmacSha512Mac.apple.kt
@@ -41,9 +41,11 @@ actual class HmacSha512Mac actual constructor(
 
     actual fun doFinalInto(dest: WriteBuffer) {
         check(!finalized) { "mac already finalized" }
-        finalized = true
         // CommonCrypto writes the 64-byte tag straight into the destination buffer's memory.
+        // withWritablePointer validates capacity BEFORE invoking the block, so a too-small
+        // dest throws here with the ctx untouched — the finalize stays retryable (C1).
         dest.withWritablePointer(SHA512_DIGEST_BYTES) { ptr -> CCHmacFinal(ctx.ptr, ptr) }
+        finalized = true
         releaseCtx()
     }
 

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HmacSha512Mac.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HmacSha512Mac.apple.kt
@@ -21,7 +21,7 @@ import platform.posix.memset
 /** Apple HMAC-SHA512 backed by CommonCrypto (`CCHmac`). Reads and writes via buffer pointers — no arrays. */
 actual class HmacSha512Mac actual constructor(
     key: ReadBuffer,
-) {
+) : AutoCloseable {
     private val ctx = nativeHeap.alloc<CCHmacContext>()
     private var finalized = false
 
@@ -44,7 +44,17 @@ actual class HmacSha512Mac actual constructor(
         finalized = true
         // CommonCrypto writes the 64-byte tag straight into the destination buffer's memory.
         dest.withWritablePointer(SHA512_DIGEST_BYTES) { ptr -> CCHmacFinal(ctx.ptr, ptr) }
-        // The context holds key-derived ipad/opad state; zero it before returning the allocation.
+        releaseCtx()
+    }
+
+    actual override fun close() {
+        if (finalized) return
+        finalized = true
+        releaseCtx()
+    }
+
+    // The context holds key-derived ipad/opad state; zero it before returning the allocation.
+    private fun releaseCtx() {
         memset(ctx.ptr, 0, sizeOf<CCHmacContext>().convert())
         nativeHeap.free(ctx.rawPtr)
     }

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/Sha256Digest.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/Sha256Digest.apple.kt
@@ -35,9 +35,11 @@ actual class Sha256Digest actual constructor() : AutoCloseable {
 
     actual fun digestInto(dest: WriteBuffer) {
         check(!finalized) { "digest already finalized" }
-        finalized = true
         // CommonCrypto writes the 32-byte digest straight into the destination buffer's memory.
+        // withWritablePointer validates capacity BEFORE invoking the block, so a too-small
+        // dest throws here with the ctx untouched — the finalize stays retryable (C1).
         dest.withWritablePointer(SHA256_DIGEST_BYTES) { ptr -> CC_SHA256_Final(ptr.reinterpret(), ctx.ptr) }
+        finalized = true
         releaseCtx()
     }
 

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/Sha256Digest.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/Sha256Digest.apple.kt
@@ -19,7 +19,7 @@ import platform.CoreCrypto.CC_SHA256_Update
 import platform.posix.memset
 
 /** Apple SHA-256 backed by CommonCrypto (`CC_SHA256`). Reads and writes via buffer pointers — no arrays. */
-actual class Sha256Digest actual constructor() {
+actual class Sha256Digest actual constructor() : AutoCloseable {
     private val ctx = nativeHeap.alloc<CC_SHA256_CTX>()
     private var finalized = false
 
@@ -38,7 +38,17 @@ actual class Sha256Digest actual constructor() {
         finalized = true
         // CommonCrypto writes the 32-byte digest straight into the destination buffer's memory.
         dest.withWritablePointer(SHA256_DIGEST_BYTES) { ptr -> CC_SHA256_Final(ptr.reinterpret(), ctx.ptr) }
-        // The context still holds absorbed state; zero it before returning the allocation.
+        releaseCtx()
+    }
+
+    actual override fun close() {
+        if (finalized) return
+        finalized = true
+        releaseCtx()
+    }
+
+    // The context still holds absorbed state; zero it before returning the allocation.
+    private fun releaseCtx() {
         memset(ctx.ptr, 0, sizeOf<CC_SHA256_CTX>().convert())
         nativeHeap.free(ctx.rawPtr)
     }

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/Sha384Digest.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/Sha384Digest.apple.kt
@@ -22,7 +22,7 @@ import platform.posix.memset
  * Apple SHA-384 backed by CommonCrypto (`CC_SHA384`). SHA-384 shares SHA-512's context type
  * ([CC_SHA512_CTX]) with a distinct init. Reads and writes via buffer pointers — no arrays.
  */
-actual class Sha384Digest actual constructor() {
+actual class Sha384Digest actual constructor() : AutoCloseable {
     private val ctx = nativeHeap.alloc<CC_SHA512_CTX>()
     private var finalized = false
 
@@ -41,7 +41,17 @@ actual class Sha384Digest actual constructor() {
         finalized = true
         // CommonCrypto writes the 48-byte digest straight into the destination buffer's memory.
         dest.withWritablePointer(SHA384_DIGEST_BYTES) { ptr -> CC_SHA384_Final(ptr.reinterpret(), ctx.ptr) }
-        // The context still holds absorbed state; zero it before returning the allocation.
+        releaseCtx()
+    }
+
+    actual override fun close() {
+        if (finalized) return
+        finalized = true
+        releaseCtx()
+    }
+
+    // The context still holds absorbed state; zero it before returning the allocation.
+    private fun releaseCtx() {
         memset(ctx.ptr, 0, sizeOf<CC_SHA512_CTX>().convert())
         nativeHeap.free(ctx.rawPtr)
     }

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/Sha384Digest.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/Sha384Digest.apple.kt
@@ -38,9 +38,11 @@ actual class Sha384Digest actual constructor() : AutoCloseable {
 
     actual fun digestInto(dest: WriteBuffer) {
         check(!finalized) { "digest already finalized" }
-        finalized = true
         // CommonCrypto writes the 48-byte digest straight into the destination buffer's memory.
+        // withWritablePointer validates capacity BEFORE invoking the block, so a too-small
+        // dest throws here with the ctx untouched — the finalize stays retryable (C1).
         dest.withWritablePointer(SHA384_DIGEST_BYTES) { ptr -> CC_SHA384_Final(ptr.reinterpret(), ctx.ptr) }
+        finalized = true
         releaseCtx()
     }
 

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/Sha512Digest.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/Sha512Digest.apple.kt
@@ -19,7 +19,7 @@ import platform.CoreCrypto.CC_SHA512_Update
 import platform.posix.memset
 
 /** Apple SHA-512 backed by CommonCrypto (`CC_SHA512`). Reads and writes via buffer pointers — no arrays. */
-actual class Sha512Digest actual constructor() {
+actual class Sha512Digest actual constructor() : AutoCloseable {
     private val ctx = nativeHeap.alloc<CC_SHA512_CTX>()
     private var finalized = false
 
@@ -38,7 +38,17 @@ actual class Sha512Digest actual constructor() {
         finalized = true
         // CommonCrypto writes the 64-byte digest straight into the destination buffer's memory.
         dest.withWritablePointer(SHA512_DIGEST_BYTES) { ptr -> CC_SHA512_Final(ptr.reinterpret(), ctx.ptr) }
-        // The context still holds absorbed state; zero it before returning the allocation.
+        releaseCtx()
+    }
+
+    actual override fun close() {
+        if (finalized) return
+        finalized = true
+        releaseCtx()
+    }
+
+    // The context still holds absorbed state; zero it before returning the allocation.
+    private fun releaseCtx() {
         memset(ctx.ptr, 0, sizeOf<CC_SHA512_CTX>().convert())
         nativeHeap.free(ctx.rawPtr)
     }

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/Sha512Digest.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/Sha512Digest.apple.kt
@@ -35,9 +35,11 @@ actual class Sha512Digest actual constructor() : AutoCloseable {
 
     actual fun digestInto(dest: WriteBuffer) {
         check(!finalized) { "digest already finalized" }
-        finalized = true
         // CommonCrypto writes the 64-byte digest straight into the destination buffer's memory.
+        // withWritablePointer validates capacity BEFORE invoking the block, so a too-small
+        // dest throws here with the ctx untouched — the finalize stays retryable (C1).
         dest.withWritablePointer(SHA512_DIGEST_BYTES) { ptr -> CC_SHA512_Final(ptr.reinterpret(), ctx.ptr) }
+        finalized = true
         releaseCtx()
     }
 

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256.kt
@@ -25,15 +25,22 @@ const val HMAC_SHA256_BYTES = SHA256_DIGEST_BYTES
  */
 expect class HmacSha256Mac(
     key: ReadBuffer,
-) {
+) : AutoCloseable {
     /** Absorbs the remaining bytes of [input] (non-destructive). Returns `this` for chaining. */
     fun update(input: ReadBuffer): HmacSha256Mac
 
     /**
      * Finalizes and writes [HMAC_SHA256_BYTES] bytes into [dest] at its current
      * position, advancing it. [dest] must have at least [HMAC_SHA256_BYTES] remaining.
+     * Releases the MAC state; any further [update]/[doFinalInto] throws [IllegalStateException].
      */
     fun doFinalInto(dest: WriteBuffer)
+
+    /**
+     * Releases the (key-derived) MAC state without producing a tag — for a MAC abandoned before
+     * [doFinalInto] (which releases the state itself). Idempotent; a no-op after [doFinalInto].
+     */
+    override fun close()
 }
 
 /**

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha384.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha384.kt
@@ -25,15 +25,22 @@ const val HMAC_SHA384_BYTES = SHA384_DIGEST_BYTES
  */
 expect class HmacSha384Mac(
     key: ReadBuffer,
-) {
+) : AutoCloseable {
     /** Absorbs the remaining bytes of [input] (non-destructive). Returns `this` for chaining. */
     fun update(input: ReadBuffer): HmacSha384Mac
 
     /**
      * Finalizes and writes [HMAC_SHA384_BYTES] bytes into [dest] at its current
      * position, advancing it. [dest] must have at least [HMAC_SHA384_BYTES] remaining.
+     * Releases the MAC state; any further [update]/[doFinalInto] throws [IllegalStateException].
      */
     fun doFinalInto(dest: WriteBuffer)
+
+    /**
+     * Releases the (key-derived) MAC state without producing a tag — for a MAC abandoned before
+     * [doFinalInto] (which releases the state itself). Idempotent; a no-op after [doFinalInto].
+     */
+    override fun close()
 }
 
 /**

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha512.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha512.kt
@@ -25,15 +25,22 @@ const val HMAC_SHA512_BYTES = SHA512_DIGEST_BYTES
  */
 expect class HmacSha512Mac(
     key: ReadBuffer,
-) {
+) : AutoCloseable {
     /** Absorbs the remaining bytes of [input] (non-destructive). Returns `this` for chaining. */
     fun update(input: ReadBuffer): HmacSha512Mac
 
     /**
      * Finalizes and writes [HMAC_SHA512_BYTES] bytes into [dest] at its current
      * position, advancing it. [dest] must have at least [HMAC_SHA512_BYTES] remaining.
+     * Releases the MAC state; any further [update]/[doFinalInto] throws [IllegalStateException].
      */
     fun doFinalInto(dest: WriteBuffer)
+
+    /**
+     * Releases the (key-derived) MAC state without producing a tag — for a MAC abandoned before
+     * [doFinalInto] (which releases the state itself). Idempotent; a no-op after [doFinalInto].
+     */
+    override fun close()
 }
 
 /**

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/Sha256.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/Sha256.kt
@@ -29,15 +29,22 @@ const val SHA256_BLOCK_BYTES = 64
  * scratch before returning and finalizes the digest; the instance is one-shot on every
  * platform, so [update] or [digestInto] after finalization throws [IllegalStateException].
  */
-expect class Sha256Digest() {
+expect class Sha256Digest() : AutoCloseable {
     /** Absorbs the remaining bytes of [input] (non-destructive). Returns `this` for chaining. */
     fun update(input: ReadBuffer): Sha256Digest
 
     /**
      * Finalizes and writes [SHA256_DIGEST_BYTES] bytes into [dest] at its current
      * position, advancing it. [dest] must have at least [SHA256_DIGEST_BYTES] remaining.
+     * Releases the digest state; any further [update]/[digestInto] throws [IllegalStateException].
      */
     fun digestInto(dest: WriteBuffer)
+
+    /**
+     * Releases the digest state without producing a result — for a digest abandoned before
+     * [digestInto] (which releases the state itself). Idempotent; a no-op after [digestInto].
+     */
+    override fun close()
 }
 
 /**

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/Sha384.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/Sha384.kt
@@ -24,15 +24,22 @@ const val SHA384_BLOCK_BYTES = 128
  * non-destructive. Not thread-safe — one instance per digest; [update] or [digestInto]
  * after finalization throws [IllegalStateException] on every platform.
  */
-expect class Sha384Digest() {
+expect class Sha384Digest() : AutoCloseable {
     /** Absorbs the remaining bytes of [input] (non-destructive). Returns `this` for chaining. */
     fun update(input: ReadBuffer): Sha384Digest
 
     /**
      * Finalizes and writes [SHA384_DIGEST_BYTES] bytes into [dest] at its current
      * position, advancing it. [dest] must have at least [SHA384_DIGEST_BYTES] remaining.
+     * Releases the digest state; any further [update]/[digestInto] throws [IllegalStateException].
      */
     fun digestInto(dest: WriteBuffer)
+
+    /**
+     * Releases the digest state without producing a result — for a digest abandoned before
+     * [digestInto] (which releases the state itself). Idempotent; a no-op after [digestInto].
+     */
+    override fun close()
 }
 
 /**

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/Sha512.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/Sha512.kt
@@ -27,15 +27,22 @@ const val SHA512_BLOCK_BYTES = 128
  * Not thread-safe — use one instance per digest. The instance is one-shot on every platform:
  * [update] or [digestInto] after finalization throws [IllegalStateException].
  */
-expect class Sha512Digest() {
+expect class Sha512Digest() : AutoCloseable {
     /** Absorbs the remaining bytes of [input] (non-destructive). Returns `this` for chaining. */
     fun update(input: ReadBuffer): Sha512Digest
 
     /**
      * Finalizes and writes [SHA512_DIGEST_BYTES] bytes into [dest] at its current
      * position, advancing it. [dest] must have at least [SHA512_DIGEST_BYTES] remaining.
+     * Releases the digest state; any further [update]/[digestInto] throws [IllegalStateException].
      */
     fun digestInto(dest: WriteBuffer)
+
+    /**
+     * Releases the digest state without producing a result — for a digest abandoned before
+     * [digestInto] (which releases the state itself). Idempotent; a no-op after [digestInto].
+     */
+    override fun close()
 }
 
 /**

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/DigestOneShotContractTest.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/DigestOneShotContractTest.kt
@@ -8,6 +8,7 @@ import com.ditchoom.buffer.crypto.CryptoTestVectors.ascii
 import com.ditchoom.buffer.crypto.CryptoTestVectors.repeatedByte
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 /**
  * The `close()` half of the streaming digest/MAC lifecycle: a never-finalized instance releases
@@ -31,6 +32,39 @@ class DigestOneShotContractTest {
         close() // idempotent — must not double-free the native ctx
         assertFailsWith<IllegalStateException> { update(ascii("x")) }
         assertFailsWith<IllegalStateException> { finalize(BufferFactory.Default.allocate(outBytes)) }
+    }
+
+    /** One instance's lifecycle ops, so helpers can create fresh instances themselves. */
+    private class Ops(
+        val update: (ReadBuffer) -> Unit,
+        val finalize: (WriteBuffer) -> Unit,
+        val close: () -> Unit,
+    )
+
+    /**
+     * C1 regression: a too-small dest must fail BEFORE the underlying state is consumed (every
+     * platform validates capacity first and throws [IllegalArgumentException]), leaving the
+     * finalize retryable — and the retry must produce the digest of the ORIGINAL message, not
+     * of a silently-reset engine. close() must still be a working no-op afterwards.
+     */
+    private fun tooSmallDestIsRetryable(
+        make: () -> Ops,
+        outBytes: Int,
+    ) {
+        val ops = make()
+        ops.update(ascii("abc"))
+        assertFailsWith<IllegalArgumentException> { ops.finalize(BufferFactory.Default.allocate(outBytes - 1)) }
+        val out = BufferFactory.Default.allocate(outBytes)
+        ops.finalize(out) // retry with a correctly-sized dest must succeed
+        out.resetForRead()
+        val reference = BufferFactory.Default.allocate(outBytes)
+        val fresh = make()
+        fresh.update(ascii("abc"))
+        fresh.finalize(reference)
+        reference.resetForRead()
+        assertTrue(out.contentEquals(reference), "retried finalize must digest the original message")
+        ops.close() // still a working no-op after the successful finalize
+        fresh.close()
     }
 
     /** After a successful finalize (which released the state itself), close is a no-op. */
@@ -117,4 +151,46 @@ class DigestOneShotContractTest {
         val m = HmacSha512Mac(hmacKey)
         closeAfterFinalizeIsNoOp({ m.update(it) }, { m.doFinalInto(it) }, { m.close() }, HMAC_SHA512_BYTES)
     }
+
+    @Test
+    fun sha256TooSmallDestIsRetryable() =
+        tooSmallDestIsRetryable({
+            val d = Sha256Digest()
+            Ops({ d.update(it) }, { d.digestInto(it) }, { d.close() })
+        }, SHA256_DIGEST_BYTES)
+
+    @Test
+    fun sha384TooSmallDestIsRetryable() =
+        tooSmallDestIsRetryable({
+            val d = Sha384Digest()
+            Ops({ d.update(it) }, { d.digestInto(it) }, { d.close() })
+        }, SHA384_DIGEST_BYTES)
+
+    @Test
+    fun sha512TooSmallDestIsRetryable() =
+        tooSmallDestIsRetryable({
+            val d = Sha512Digest()
+            Ops({ d.update(it) }, { d.digestInto(it) }, { d.close() })
+        }, SHA512_DIGEST_BYTES)
+
+    @Test
+    fun hmacSha256TooSmallDestIsRetryable() =
+        tooSmallDestIsRetryable({
+            val m = HmacSha256Mac(hmacKey)
+            Ops({ m.update(it) }, { m.doFinalInto(it) }, { m.close() })
+        }, HMAC_SHA256_BYTES)
+
+    @Test
+    fun hmacSha384TooSmallDestIsRetryable() =
+        tooSmallDestIsRetryable({
+            val m = HmacSha384Mac(hmacKey)
+            Ops({ m.update(it) }, { m.doFinalInto(it) }, { m.close() })
+        }, HMAC_SHA384_BYTES)
+
+    @Test
+    fun hmacSha512TooSmallDestIsRetryable() =
+        tooSmallDestIsRetryable({
+            val m = HmacSha512Mac(hmacKey)
+            Ops({ m.update(it) }, { m.doFinalInto(it) }, { m.close() })
+        }, HMAC_SHA512_BYTES)
 }

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/DigestOneShotContractTest.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/DigestOneShotContractTest.kt
@@ -1,0 +1,120 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.crypto.CryptoTestVectors.ascii
+import com.ditchoom.buffer.crypto.CryptoTestVectors.repeatedByte
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+/**
+ * The `close()` half of the streaming digest/MAC lifecycle: a never-finalized instance releases
+ * its state via [AutoCloseable.close] (on Apple/Linux that frees — and zeroes — the native ctx
+ * that would otherwise leak). This pins, on EVERY platform: close bars further use, close is
+ * idempotent, and close after finalize is a no-op. The finalize-bars-reuse half of the contract
+ * is pinned by [DigestFinalizeContractTest].
+ */
+class DigestOneShotContractTest {
+    private val hmacKey = repeatedByte(0x0B, 20)
+
+    /** After close: update and finalize throw; close stays idempotent. */
+    private fun closeBarsUse(
+        update: (ReadBuffer) -> Unit,
+        finalize: (WriteBuffer) -> Unit,
+        close: () -> Unit,
+        outBytes: Int,
+    ) {
+        update(ascii("abc"))
+        close()
+        close() // idempotent — must not double-free the native ctx
+        assertFailsWith<IllegalStateException> { update(ascii("x")) }
+        assertFailsWith<IllegalStateException> { finalize(BufferFactory.Default.allocate(outBytes)) }
+    }
+
+    /** After a successful finalize (which released the state itself), close is a no-op. */
+    private fun closeAfterFinalizeIsNoOp(
+        update: (ReadBuffer) -> Unit,
+        finalize: (WriteBuffer) -> Unit,
+        close: () -> Unit,
+        outBytes: Int,
+    ) {
+        update(ascii("abc"))
+        finalize(BufferFactory.Default.allocate(outBytes))
+        close() // no-op after finalize — must not free the already-freed ctx
+        close() // idempotent
+    }
+
+    @Test
+    fun sha256CloseBarsUse() {
+        val d = Sha256Digest()
+        closeBarsUse({ d.update(it) }, { d.digestInto(it) }, { d.close() }, SHA256_DIGEST_BYTES)
+    }
+
+    @Test
+    fun sha256CloseAfterFinalizeIsNoOp() {
+        val d = Sha256Digest()
+        closeAfterFinalizeIsNoOp({ d.update(it) }, { d.digestInto(it) }, { d.close() }, SHA256_DIGEST_BYTES)
+    }
+
+    @Test
+    fun sha384CloseBarsUse() {
+        val d = Sha384Digest()
+        closeBarsUse({ d.update(it) }, { d.digestInto(it) }, { d.close() }, SHA384_DIGEST_BYTES)
+    }
+
+    @Test
+    fun sha384CloseAfterFinalizeIsNoOp() {
+        val d = Sha384Digest()
+        closeAfterFinalizeIsNoOp({ d.update(it) }, { d.digestInto(it) }, { d.close() }, SHA384_DIGEST_BYTES)
+    }
+
+    @Test
+    fun sha512CloseBarsUse() {
+        val d = Sha512Digest()
+        closeBarsUse({ d.update(it) }, { d.digestInto(it) }, { d.close() }, SHA512_DIGEST_BYTES)
+    }
+
+    @Test
+    fun sha512CloseAfterFinalizeIsNoOp() {
+        val d = Sha512Digest()
+        closeAfterFinalizeIsNoOp({ d.update(it) }, { d.digestInto(it) }, { d.close() }, SHA512_DIGEST_BYTES)
+    }
+
+    @Test
+    fun hmacSha256CloseBarsUse() {
+        val m = HmacSha256Mac(hmacKey)
+        closeBarsUse({ m.update(it) }, { m.doFinalInto(it) }, { m.close() }, HMAC_SHA256_BYTES)
+    }
+
+    @Test
+    fun hmacSha256CloseAfterFinalizeIsNoOp() {
+        val m = HmacSha256Mac(hmacKey)
+        closeAfterFinalizeIsNoOp({ m.update(it) }, { m.doFinalInto(it) }, { m.close() }, HMAC_SHA256_BYTES)
+    }
+
+    @Test
+    fun hmacSha384CloseBarsUse() {
+        val m = HmacSha384Mac(hmacKey)
+        closeBarsUse({ m.update(it) }, { m.doFinalInto(it) }, { m.close() }, HMAC_SHA384_BYTES)
+    }
+
+    @Test
+    fun hmacSha384CloseAfterFinalizeIsNoOp() {
+        val m = HmacSha384Mac(hmacKey)
+        closeAfterFinalizeIsNoOp({ m.update(it) }, { m.doFinalInto(it) }, { m.close() }, HMAC_SHA384_BYTES)
+    }
+
+    @Test
+    fun hmacSha512CloseBarsUse() {
+        val m = HmacSha512Mac(hmacKey)
+        closeBarsUse({ m.update(it) }, { m.doFinalInto(it) }, { m.close() }, HMAC_SHA512_BYTES)
+    }
+
+    @Test
+    fun hmacSha512CloseAfterFinalizeIsNoOp() {
+        val m = HmacSha512Mac(hmacKey)
+        closeAfterFinalizeIsNoOp({ m.update(it) }, { m.doFinalInto(it) }, { m.close() }, HMAC_SHA512_BYTES)
+    }
+}

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/HpkeCloseGuardTest.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/HpkeCloseGuardTest.kt
@@ -1,0 +1,37 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.crypto.CryptoTestVectors.ascii
+import com.ditchoom.buffer.crypto.CryptoTestVectors.repeatedByte
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+/**
+ * Use-after-close guard on the HPKE PSK wrapper. A closed [HpkePsk]'s secret is already wiped
+ * (or, on deterministic backings, freed) — the key schedule must fail fast rather than derive a
+ * context from that memory. The context-level close guards (seal/open/export after close) are
+ * pinned by [HpkeRoundTripTest.closedContextRejectsEveryOp].
+ */
+class HpkeCloseGuardTest {
+    private val candidateSuites =
+        listOf(
+            HpkeSuite(HpkeKem.DhkemX25519HkdfSha256, HpkeKdf.HkdfSha256, HpkeAead.Aes128Gcm),
+            HpkeSuite(HpkeKem.DhkemP256HkdfSha256, HpkeKdf.HkdfSha256, HpkeAead.Aes128Gcm),
+        )
+
+    private fun firstSupported(): HpkeSuite? = candidateSuites.firstOrNull { HpkeTestSupport.suiteSupported(it) }
+
+    @Test
+    fun closedPskIsRejectedAtSetup() =
+        runTest {
+            val suite = firstSupported() ?: return@runTest
+            val recipient = hpkeGenerateKeyPair(suite.kem)
+            val psk = HpkePsk.of(repeatedByte(0x42, 32), ascii("psk-id"))
+            psk.close()
+            psk.close() // idempotent
+            assertFailsWith<IllegalStateException> {
+                hpkeSetupPskSender(suite, recipient.publicKey, ascii("info"), psk)
+            }
+            recipient.close()
+        }
+}

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256Mac.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256Mac.jsAndWasmJs.kt
@@ -47,7 +47,9 @@ actual class HmacSha256Mac actual constructor(
 
     actual fun doFinalInto(dest: WriteBuffer) {
         check(!finalized) { "mac already finalized" }
-        finalized = true
+        // Validate BEFORE finish(): the core's padding absorb is not re-runnable, so a
+        // short dest must fail while the state is still retryable (C1).
+        require(dest.remaining() >= HMAC_SHA256_BYTES) { "dest needs $HMAC_SHA256_BYTES bytes remaining, has ${dest.remaining()}" }
         inner.finish() // inner = H(ipad ‖ message)
         val outer = Sha256Core()
         for (i in 0 until SHA256_BLOCK_BYTES) outer.absorbByte(opad.get(i))
@@ -55,6 +57,7 @@ actual class HmacSha256Mac actual constructor(
         outer.finish()
         for (i in 0 until SHA256_DIGEST_BYTES) dest.writeByte(outer.digestByte(i))
         opad.fill(0)
+        finalized = true
     }
 
     actual override fun close() {

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256Mac.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256Mac.jsAndWasmJs.kt
@@ -49,7 +49,9 @@ actual class HmacSha256Mac actual constructor(
         check(!finalized) { "mac already finalized" }
         // Validate BEFORE finish(): the core's padding absorb is not re-runnable, so a
         // short dest must fail while the state is still retryable (C1).
-        require(dest.remaining() >= HMAC_SHA256_BYTES) { "dest needs $HMAC_SHA256_BYTES bytes remaining, has ${dest.remaining()}" }
+        require(dest.remaining() >= HMAC_SHA256_BYTES) {
+            "dest needs $HMAC_SHA256_BYTES bytes remaining, has ${dest.remaining()}"
+        }
         inner.finish() // inner = H(ipad ‖ message)
         val outer = Sha256Core()
         for (i in 0 until SHA256_BLOCK_BYTES) outer.absorbByte(opad.get(i))

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256Mac.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256Mac.jsAndWasmJs.kt
@@ -11,7 +11,7 @@ import com.ditchoom.buffer.managed
 /** js/wasmJs HMAC-SHA256 (RFC 2104) over the pure-Kotlin [Sha256Core]. Holds no primitive arrays. */
 actual class HmacSha256Mac actual constructor(
     key: ReadBuffer,
-) {
+) : AutoCloseable {
     // inner accumulates H(ipad ‖ message); opad (a managed buffer) is held for the outer hash.
     private val inner = Sha256Core()
     private val opad: PlatformBuffer = BufferFactory.managed().allocate(SHA256_BLOCK_BYTES)
@@ -55,5 +55,13 @@ actual class HmacSha256Mac actual constructor(
         outer.finish()
         for (i in 0 until SHA256_DIGEST_BYTES) dest.writeByte(outer.digestByte(i))
         opad.fill(0)
+    }
+
+    actual override fun close() {
+        // GC-managed state; nothing to free beyond wiping opad. The flag still bars further
+        // use, matching the other platforms' post-close behavior.
+        if (finalized) return
+        opad.fill(0)
+        finalized = true
     }
 }

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/HmacSha384Mac.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/HmacSha384Mac.jsAndWasmJs.kt
@@ -8,7 +8,7 @@ import com.ditchoom.buffer.WriteBuffer
 /** js/wasmJs HMAC-SHA384 (RFC 2104) over the pure-Kotlin [Sha512Core] (SHA-384 IV). No primitive arrays. */
 actual class HmacSha384Mac actual constructor(
     key: ReadBuffer,
-) {
+) : AutoCloseable {
     private val core = Sha512FamilyHmac(key, mode384 = true, outBytes = SHA384_DIGEST_BYTES)
     private var finalized = false
 
@@ -22,5 +22,12 @@ actual class HmacSha384Mac actual constructor(
         check(!finalized) { "mac already finalized" }
         finalized = true
         core.doFinalInto(dest)
+    }
+
+    actual override fun close() {
+        // GC-managed state; nothing to free. The flag still bars further use, matching the
+        // other platforms' post-close behavior.
+        if (finalized) return
+        finalized = true
     }
 }

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/HmacSha384Mac.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/HmacSha384Mac.jsAndWasmJs.kt
@@ -20,8 +20,11 @@ actual class HmacSha384Mac actual constructor(
 
     actual fun doFinalInto(dest: WriteBuffer) {
         check(!finalized) { "mac already finalized" }
-        finalized = true
+        // Validate BEFORE the core finalize: the core's padding absorb is not re-runnable, so a
+        // short dest must fail while the state is still retryable (C1).
+        require(dest.remaining() >= HMAC_SHA384_BYTES) { "dest needs $HMAC_SHA384_BYTES bytes remaining, has ${dest.remaining()}" }
         core.doFinalInto(dest)
+        finalized = true
     }
 
     actual override fun close() {

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/HmacSha384Mac.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/HmacSha384Mac.jsAndWasmJs.kt
@@ -22,7 +22,9 @@ actual class HmacSha384Mac actual constructor(
         check(!finalized) { "mac already finalized" }
         // Validate BEFORE the core finalize: the core's padding absorb is not re-runnable, so a
         // short dest must fail while the state is still retryable (C1).
-        require(dest.remaining() >= HMAC_SHA384_BYTES) { "dest needs $HMAC_SHA384_BYTES bytes remaining, has ${dest.remaining()}" }
+        require(dest.remaining() >= HMAC_SHA384_BYTES) {
+            "dest needs $HMAC_SHA384_BYTES bytes remaining, has ${dest.remaining()}"
+        }
         core.doFinalInto(dest)
         finalized = true
     }

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/HmacSha512Mac.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/HmacSha512Mac.jsAndWasmJs.kt
@@ -22,7 +22,9 @@ actual class HmacSha512Mac actual constructor(
         check(!finalized) { "mac already finalized" }
         // Validate BEFORE the core finalize: the core's padding absorb is not re-runnable, so a
         // short dest must fail while the state is still retryable (C1).
-        require(dest.remaining() >= HMAC_SHA512_BYTES) { "dest needs $HMAC_SHA512_BYTES bytes remaining, has ${dest.remaining()}" }
+        require(dest.remaining() >= HMAC_SHA512_BYTES) {
+            "dest needs $HMAC_SHA512_BYTES bytes remaining, has ${dest.remaining()}"
+        }
         core.doFinalInto(dest)
         finalized = true
     }

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/HmacSha512Mac.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/HmacSha512Mac.jsAndWasmJs.kt
@@ -20,8 +20,11 @@ actual class HmacSha512Mac actual constructor(
 
     actual fun doFinalInto(dest: WriteBuffer) {
         check(!finalized) { "mac already finalized" }
-        finalized = true
+        // Validate BEFORE the core finalize: the core's padding absorb is not re-runnable, so a
+        // short dest must fail while the state is still retryable (C1).
+        require(dest.remaining() >= HMAC_SHA512_BYTES) { "dest needs $HMAC_SHA512_BYTES bytes remaining, has ${dest.remaining()}" }
         core.doFinalInto(dest)
+        finalized = true
     }
 
     actual override fun close() {

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/HmacSha512Mac.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/HmacSha512Mac.jsAndWasmJs.kt
@@ -8,7 +8,7 @@ import com.ditchoom.buffer.WriteBuffer
 /** js/wasmJs HMAC-SHA512 (RFC 2104) over the pure-Kotlin [Sha512Core]. Holds no primitive arrays. */
 actual class HmacSha512Mac actual constructor(
     key: ReadBuffer,
-) {
+) : AutoCloseable {
     private val core = Sha512FamilyHmac(key, mode384 = false, outBytes = SHA512_DIGEST_BYTES)
     private var finalized = false
 
@@ -22,5 +22,12 @@ actual class HmacSha512Mac actual constructor(
         check(!finalized) { "mac already finalized" }
         finalized = true
         core.doFinalInto(dest)
+    }
+
+    actual override fun close() {
+        // GC-managed state; nothing to free. The flag still bars further use, matching the
+        // other platforms' post-close behavior.
+        if (finalized) return
+        finalized = true
     }
 }

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Sha256Digest.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Sha256Digest.jsAndWasmJs.kt
@@ -18,9 +18,12 @@ actual class Sha256Digest actual constructor() : AutoCloseable {
 
     actual fun digestInto(dest: WriteBuffer) {
         check(!finalized) { "digest already finalized" }
-        finalized = true
+        // Validate BEFORE finish(): the core's padding absorb is not re-runnable, so a
+        // short dest must fail while the state is still retryable (C1).
+        require(dest.remaining() >= SHA256_DIGEST_BYTES) { "dest needs $SHA256_DIGEST_BYTES bytes remaining, has ${dest.remaining()}" }
         core.finish()
         for (i in 0 until SHA256_DIGEST_BYTES) dest.writeByte(core.digestByte(i))
+        finalized = true
     }
 
     actual override fun close() {

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Sha256Digest.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Sha256Digest.jsAndWasmJs.kt
@@ -6,7 +6,7 @@ import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.WriteBuffer
 
 /** js/wasmJs SHA-256 backed by the synchronous pure-Kotlin [Sha256Core]. */
-actual class Sha256Digest actual constructor() {
+actual class Sha256Digest actual constructor() : AutoCloseable {
     private val core = Sha256Core()
     private var finalized = false
 
@@ -21,5 +21,12 @@ actual class Sha256Digest actual constructor() {
         finalized = true
         core.finish()
         for (i in 0 until SHA256_DIGEST_BYTES) dest.writeByte(core.digestByte(i))
+    }
+
+    actual override fun close() {
+        // GC-managed state; nothing to free. The flag still bars further use, matching the
+        // other platforms' post-close behavior.
+        if (finalized) return
+        finalized = true
     }
 }

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Sha256Digest.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Sha256Digest.jsAndWasmJs.kt
@@ -20,7 +20,9 @@ actual class Sha256Digest actual constructor() : AutoCloseable {
         check(!finalized) { "digest already finalized" }
         // Validate BEFORE finish(): the core's padding absorb is not re-runnable, so a
         // short dest must fail while the state is still retryable (C1).
-        require(dest.remaining() >= SHA256_DIGEST_BYTES) { "dest needs $SHA256_DIGEST_BYTES bytes remaining, has ${dest.remaining()}" }
+        require(dest.remaining() >= SHA256_DIGEST_BYTES) {
+            "dest needs $SHA256_DIGEST_BYTES bytes remaining, has ${dest.remaining()}"
+        }
         core.finish()
         for (i in 0 until SHA256_DIGEST_BYTES) dest.writeByte(core.digestByte(i))
         finalized = true

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Sha384Digest.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Sha384Digest.jsAndWasmJs.kt
@@ -20,7 +20,9 @@ actual class Sha384Digest actual constructor() : AutoCloseable {
         check(!finalized) { "digest already finalized" }
         // Validate BEFORE finish(): the core's padding absorb is not re-runnable, so a
         // short dest must fail while the state is still retryable (C1).
-        require(dest.remaining() >= SHA384_DIGEST_BYTES) { "dest needs $SHA384_DIGEST_BYTES bytes remaining, has ${dest.remaining()}" }
+        require(dest.remaining() >= SHA384_DIGEST_BYTES) {
+            "dest needs $SHA384_DIGEST_BYTES bytes remaining, has ${dest.remaining()}"
+        }
         core.finish()
         for (i in 0 until SHA384_DIGEST_BYTES) dest.writeByte(core.digestByte(i))
         finalized = true

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Sha384Digest.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Sha384Digest.jsAndWasmJs.kt
@@ -6,7 +6,7 @@ import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.WriteBuffer
 
 /** js/wasmJs SHA-384 backed by the synchronous pure-Kotlin [Sha512Core] (SHA-384 IV). */
-actual class Sha384Digest actual constructor() {
+actual class Sha384Digest actual constructor() : AutoCloseable {
     private val core = Sha512Core(sha384 = true)
     private var finalized = false
 
@@ -21,5 +21,12 @@ actual class Sha384Digest actual constructor() {
         finalized = true
         core.finish()
         for (i in 0 until SHA384_DIGEST_BYTES) dest.writeByte(core.digestByte(i))
+    }
+
+    actual override fun close() {
+        // GC-managed state; nothing to free. The flag still bars further use, matching the
+        // other platforms' post-close behavior.
+        if (finalized) return
+        finalized = true
     }
 }

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Sha384Digest.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Sha384Digest.jsAndWasmJs.kt
@@ -18,9 +18,12 @@ actual class Sha384Digest actual constructor() : AutoCloseable {
 
     actual fun digestInto(dest: WriteBuffer) {
         check(!finalized) { "digest already finalized" }
-        finalized = true
+        // Validate BEFORE finish(): the core's padding absorb is not re-runnable, so a
+        // short dest must fail while the state is still retryable (C1).
+        require(dest.remaining() >= SHA384_DIGEST_BYTES) { "dest needs $SHA384_DIGEST_BYTES bytes remaining, has ${dest.remaining()}" }
         core.finish()
         for (i in 0 until SHA384_DIGEST_BYTES) dest.writeByte(core.digestByte(i))
+        finalized = true
     }
 
     actual override fun close() {

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Sha512Digest.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Sha512Digest.jsAndWasmJs.kt
@@ -20,7 +20,9 @@ actual class Sha512Digest actual constructor() : AutoCloseable {
         check(!finalized) { "digest already finalized" }
         // Validate BEFORE finish(): the core's padding absorb is not re-runnable, so a
         // short dest must fail while the state is still retryable (C1).
-        require(dest.remaining() >= SHA512_DIGEST_BYTES) { "dest needs $SHA512_DIGEST_BYTES bytes remaining, has ${dest.remaining()}" }
+        require(dest.remaining() >= SHA512_DIGEST_BYTES) {
+            "dest needs $SHA512_DIGEST_BYTES bytes remaining, has ${dest.remaining()}"
+        }
         core.finish()
         for (i in 0 until SHA512_DIGEST_BYTES) dest.writeByte(core.digestByte(i))
         finalized = true

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Sha512Digest.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Sha512Digest.jsAndWasmJs.kt
@@ -6,7 +6,7 @@ import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.WriteBuffer
 
 /** js/wasmJs SHA-512 backed by the synchronous pure-Kotlin [Sha512Core]. */
-actual class Sha512Digest actual constructor() {
+actual class Sha512Digest actual constructor() : AutoCloseable {
     private val core = Sha512Core(sha384 = false)
     private var finalized = false
 
@@ -21,5 +21,12 @@ actual class Sha512Digest actual constructor() {
         finalized = true
         core.finish()
         for (i in 0 until SHA512_DIGEST_BYTES) dest.writeByte(core.digestByte(i))
+    }
+
+    actual override fun close() {
+        // GC-managed state; nothing to free. The flag still bars further use, matching the
+        // other platforms' post-close behavior.
+        if (finalized) return
+        finalized = true
     }
 }

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Sha512Digest.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Sha512Digest.jsAndWasmJs.kt
@@ -18,9 +18,12 @@ actual class Sha512Digest actual constructor() : AutoCloseable {
 
     actual fun digestInto(dest: WriteBuffer) {
         check(!finalized) { "digest already finalized" }
-        finalized = true
+        // Validate BEFORE finish(): the core's padding absorb is not re-runnable, so a
+        // short dest must fail while the state is still retryable (C1).
+        require(dest.remaining() >= SHA512_DIGEST_BYTES) { "dest needs $SHA512_DIGEST_BYTES bytes remaining, has ${dest.remaining()}" }
         core.finish()
         for (i in 0 until SHA512_DIGEST_BYTES) dest.writeByte(core.digestByte(i))
+        finalized = true
     }
 
     actual override fun close() {

--- a/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256Mac.jvmCommon.kt
+++ b/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256Mac.jvmCommon.kt
@@ -12,7 +12,7 @@ import javax.crypto.spec.SecretKeySpec
 /** JVM/Android HMAC-SHA256 backed by the JCA [Mac]. */
 actual class HmacSha256Mac actual constructor(
     key: ReadBuffer,
-) {
+) : AutoCloseable {
     private val mac =
         Mac.getInstance("HmacSHA256").apply {
             val managed = key.managedMemoryAccess
@@ -43,5 +43,11 @@ actual class HmacSha256Mac actual constructor(
         check(!finalized) { "mac already finalized" }
         finalized = true
         mac.doFinalInto(dest)
+    }
+
+    actual override fun close() {
+        if (finalized) return
+        finalized = true
+        mac.reset()
     }
 }

--- a/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256Mac.jvmCommon.kt
+++ b/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256Mac.jvmCommon.kt
@@ -41,8 +41,10 @@ actual class HmacSha256Mac actual constructor(
     actual fun doFinalInto(dest: WriteBuffer) {
         // JCA resets the mac for reuse; the cross-platform contract is one-shot, so reject reuse.
         check(!finalized) { "mac already finalized" }
-        finalized = true
+        // doFinalInto validates capacity BEFORE consuming the JCA state, so a too-small
+        // dest throws with the MAC still intact — the finalize stays retryable (C1).
         mac.doFinalInto(dest)
+        finalized = true
     }
 
     actual override fun close() {

--- a/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha384Mac.jvmCommon.kt
+++ b/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha384Mac.jvmCommon.kt
@@ -12,7 +12,7 @@ import javax.crypto.spec.SecretKeySpec
 /** JVM/Android HMAC-SHA384 backed by the JCA [Mac]. */
 actual class HmacSha384Mac actual constructor(
     key: ReadBuffer,
-) {
+) : AutoCloseable {
     private val mac =
         Mac.getInstance("HmacSHA384").apply {
             val managed = key.managedMemoryAccess
@@ -43,5 +43,11 @@ actual class HmacSha384Mac actual constructor(
         check(!finalized) { "mac already finalized" }
         finalized = true
         mac.doFinalInto(dest)
+    }
+
+    actual override fun close() {
+        if (finalized) return
+        finalized = true
+        mac.reset()
     }
 }

--- a/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha384Mac.jvmCommon.kt
+++ b/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha384Mac.jvmCommon.kt
@@ -41,8 +41,10 @@ actual class HmacSha384Mac actual constructor(
     actual fun doFinalInto(dest: WriteBuffer) {
         // JCA resets the mac for reuse; the cross-platform contract is one-shot, so reject reuse.
         check(!finalized) { "mac already finalized" }
-        finalized = true
+        // doFinalInto validates capacity BEFORE consuming the JCA state, so a too-small
+        // dest throws with the MAC still intact — the finalize stays retryable (C1).
         mac.doFinalInto(dest)
+        finalized = true
     }
 
     actual override fun close() {

--- a/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha512Mac.jvmCommon.kt
+++ b/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha512Mac.jvmCommon.kt
@@ -41,8 +41,10 @@ actual class HmacSha512Mac actual constructor(
     actual fun doFinalInto(dest: WriteBuffer) {
         // JCA resets the mac for reuse; the cross-platform contract is one-shot, so reject reuse.
         check(!finalized) { "mac already finalized" }
-        finalized = true
+        // doFinalInto validates capacity BEFORE consuming the JCA state, so a too-small
+        // dest throws with the MAC still intact — the finalize stays retryable (C1).
         mac.doFinalInto(dest)
+        finalized = true
     }
 
     actual override fun close() {

--- a/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha512Mac.jvmCommon.kt
+++ b/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha512Mac.jvmCommon.kt
@@ -12,7 +12,7 @@ import javax.crypto.spec.SecretKeySpec
 /** JVM/Android HMAC-SHA512 backed by the JCA [Mac]. */
 actual class HmacSha512Mac actual constructor(
     key: ReadBuffer,
-) {
+) : AutoCloseable {
     private val mac =
         Mac.getInstance("HmacSHA512").apply {
             val managed = key.managedMemoryAccess
@@ -43,5 +43,11 @@ actual class HmacSha512Mac actual constructor(
         check(!finalized) { "mac already finalized" }
         finalized = true
         mac.doFinalInto(dest)
+    }
+
+    actual override fun close() {
+        if (finalized) return
+        finalized = true
+        mac.reset()
     }
 }

--- a/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/JvmCryptoBridge.jvmCommon.kt
+++ b/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/JvmCryptoBridge.jvmCommon.kt
@@ -41,6 +41,11 @@ internal fun Mac.updateRemaining(buffer: ReadBuffer) {
  * buffer via `writeBytes` — the only `ByteArray` here is the one the system API produces.
  */
 internal fun MessageDigest.digestInto(dest: WriteBuffer) {
+    // Validate BEFORE digest(): JCA's digest()/doFinal() consume and auto-reset the engine,
+    // so letting a short dest fail inside writeBytes (direct path) — or silently write past
+    // the buffer's limit into a larger shared backing array (heap path) — would destroy
+    // state the caller could otherwise retry with a correctly-sized buffer.
+    require(dest.remaining() >= digestLength) { "dest needs $digestLength bytes remaining, has ${dest.remaining()}" }
     val managed = dest.managedMemoryAccess
     if (managed != null) {
         val pos = dest.position()
@@ -53,6 +58,8 @@ internal fun MessageDigest.digestInto(dest: WriteBuffer) {
 
 /** As [MessageDigest.digestInto], for an HMAC tag. */
 internal fun Mac.doFinalInto(dest: WriteBuffer) {
+    // See [MessageDigest.digestInto] — same validate-before-doFinal() rationale.
+    require(dest.remaining() >= macLength) { "dest needs $macLength bytes remaining, has ${dest.remaining()}" }
     val managed = dest.managedMemoryAccess
     if (managed != null) {
         val pos = dest.position()

--- a/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/Sha256Digest.jvmCommon.kt
+++ b/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/Sha256Digest.jvmCommon.kt
@@ -7,7 +7,7 @@ import com.ditchoom.buffer.WriteBuffer
 import java.security.MessageDigest
 
 /** JVM/Android SHA-256 backed by the JCA [MessageDigest]. */
-actual class Sha256Digest actual constructor() {
+actual class Sha256Digest actual constructor() : AutoCloseable {
     private val md = MessageDigest.getInstance("SHA-256")
     private var finalized = false
 
@@ -22,5 +22,11 @@ actual class Sha256Digest actual constructor() {
         check(!finalized) { "digest already finalized" }
         finalized = true
         md.digestInto(dest)
+    }
+
+    actual override fun close() {
+        if (finalized) return
+        finalized = true
+        md.reset()
     }
 }

--- a/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/Sha256Digest.jvmCommon.kt
+++ b/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/Sha256Digest.jvmCommon.kt
@@ -20,8 +20,10 @@ actual class Sha256Digest actual constructor() : AutoCloseable {
     actual fun digestInto(dest: WriteBuffer) {
         // JCA resets the digest for reuse; the cross-platform contract is one-shot, so reject reuse.
         check(!finalized) { "digest already finalized" }
-        finalized = true
+        // digestInto validates capacity BEFORE consuming the JCA state, so a too-small
+        // dest throws with the digest still intact — the finalize stays retryable (C1).
         md.digestInto(dest)
+        finalized = true
     }
 
     actual override fun close() {

--- a/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/Sha384Digest.jvmCommon.kt
+++ b/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/Sha384Digest.jvmCommon.kt
@@ -7,7 +7,7 @@ import com.ditchoom.buffer.WriteBuffer
 import java.security.MessageDigest
 
 /** JVM/Android SHA-384 backed by the JCA [MessageDigest]. */
-actual class Sha384Digest actual constructor() {
+actual class Sha384Digest actual constructor() : AutoCloseable {
     private val md = MessageDigest.getInstance("SHA-384")
     private var finalized = false
 
@@ -22,5 +22,11 @@ actual class Sha384Digest actual constructor() {
         check(!finalized) { "digest already finalized" }
         finalized = true
         md.digestInto(dest)
+    }
+
+    actual override fun close() {
+        if (finalized) return
+        finalized = true
+        md.reset()
     }
 }

--- a/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/Sha384Digest.jvmCommon.kt
+++ b/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/Sha384Digest.jvmCommon.kt
@@ -20,8 +20,10 @@ actual class Sha384Digest actual constructor() : AutoCloseable {
     actual fun digestInto(dest: WriteBuffer) {
         // JCA resets the digest for reuse; the cross-platform contract is one-shot, so reject reuse.
         check(!finalized) { "digest already finalized" }
-        finalized = true
+        // digestInto validates capacity BEFORE consuming the JCA state, so a too-small
+        // dest throws with the digest still intact — the finalize stays retryable (C1).
         md.digestInto(dest)
+        finalized = true
     }
 
     actual override fun close() {

--- a/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/Sha512Digest.jvmCommon.kt
+++ b/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/Sha512Digest.jvmCommon.kt
@@ -7,7 +7,7 @@ import com.ditchoom.buffer.WriteBuffer
 import java.security.MessageDigest
 
 /** JVM/Android SHA-512 backed by the JCA [MessageDigest]. */
-actual class Sha512Digest actual constructor() {
+actual class Sha512Digest actual constructor() : AutoCloseable {
     private val md = MessageDigest.getInstance("SHA-512")
     private var finalized = false
 
@@ -22,5 +22,11 @@ actual class Sha512Digest actual constructor() {
         check(!finalized) { "digest already finalized" }
         finalized = true
         md.digestInto(dest)
+    }
+
+    actual override fun close() {
+        if (finalized) return
+        finalized = true
+        md.reset()
     }
 }

--- a/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/Sha512Digest.jvmCommon.kt
+++ b/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/Sha512Digest.jvmCommon.kt
@@ -20,8 +20,10 @@ actual class Sha512Digest actual constructor() : AutoCloseable {
     actual fun digestInto(dest: WriteBuffer) {
         // JCA resets the digest for reuse; the cross-platform contract is one-shot, so reject reuse.
         check(!finalized) { "digest already finalized" }
-        finalized = true
+        // digestInto validates capacity BEFORE consuming the JCA state, so a too-small
+        // dest throws with the digest still intact — the finalize stays retryable (C1).
         md.digestInto(dest)
+        finalized = true
     }
 
     actual override fun close() {

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256Mac.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256Mac.linux.kt
@@ -35,8 +35,11 @@ actual class HmacSha256Mac actual constructor(
 
     actual fun doFinalInto(dest: WriteBuffer) {
         check(!finalized) { "mac already finalized" }
-        finalized = true
+        // withWritablePointer validates capacity BEFORE invoking the block, so a too-small
+        // dest throws with the ctx untouched (not yet freed by the shim) — the finalize
+        // stays retryable (C1). The flag is set only after the shim call succeeds.
         dest.withWritablePointer(HMAC_SHA256_BYTES) { ptr -> bcl_hmac_final(ctx, ptr.reinterpret()) }
+        finalized = true
     }
 
     actual override fun close() {

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256Mac.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/HmacSha256Mac.linux.kt
@@ -9,13 +9,16 @@ import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_hmac_final
 import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_hmac_sha256_new
 import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_hmac_update
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.UByteVar
+import kotlinx.cinterop.allocArray
 import kotlinx.cinterop.convert
+import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.reinterpret
 
 /** Linux HMAC-SHA256 backed by BoringSSL (`HMAC_*`). Reads and writes via buffer pointers — no arrays. */
 actual class HmacSha256Mac actual constructor(
     key: ReadBuffer,
-) {
+) : AutoCloseable {
     private val ctx =
         run {
             var c = if (key.remaining() == 0) bcl_hmac_sha256_new(null, 0.convert()) else null
@@ -34,5 +37,16 @@ actual class HmacSha256Mac actual constructor(
         check(!finalized) { "mac already finalized" }
         finalized = true
         dest.withWritablePointer(HMAC_SHA256_BYTES) { ptr -> bcl_hmac_final(ctx, ptr.reinterpret()) }
+    }
+
+    actual override fun close() {
+        if (finalized) return
+        finalized = true
+        // The shim has no free-without-final: finalize into discarded stack scratch, which
+        // cleanses and frees the ctx.
+        memScoped {
+            val scratch = allocArray<UByteVar>(HMAC_SHA256_BYTES)
+            bcl_hmac_final(ctx, scratch)
+        }
     }
 }

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/HmacSha384Mac.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/HmacSha384Mac.linux.kt
@@ -9,13 +9,16 @@ import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_hmac_final
 import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_hmac_sha384_new
 import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_hmac_update
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.UByteVar
+import kotlinx.cinterop.allocArray
 import kotlinx.cinterop.convert
+import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.reinterpret
 
 /** Linux HMAC-SHA384 backed by BoringSSL (`HMAC_*`). Reads and writes via buffer pointers — no arrays. */
 actual class HmacSha384Mac actual constructor(
     key: ReadBuffer,
-) {
+) : AutoCloseable {
     private val ctx =
         run {
             var c = if (key.remaining() == 0) bcl_hmac_sha384_new(null, 0.convert()) else null
@@ -34,5 +37,16 @@ actual class HmacSha384Mac actual constructor(
         check(!finalized) { "mac already finalized" }
         finalized = true
         dest.withWritablePointer(HMAC_SHA384_BYTES) { ptr -> bcl_hmac_final(ctx, ptr.reinterpret()) }
+    }
+
+    actual override fun close() {
+        if (finalized) return
+        finalized = true
+        // The shim has no free-without-final: finalize into discarded stack scratch, which
+        // cleanses and frees the ctx.
+        memScoped {
+            val scratch = allocArray<UByteVar>(HMAC_SHA384_BYTES)
+            bcl_hmac_final(ctx, scratch)
+        }
     }
 }

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/HmacSha384Mac.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/HmacSha384Mac.linux.kt
@@ -35,8 +35,11 @@ actual class HmacSha384Mac actual constructor(
 
     actual fun doFinalInto(dest: WriteBuffer) {
         check(!finalized) { "mac already finalized" }
-        finalized = true
+        // withWritablePointer validates capacity BEFORE invoking the block, so a too-small
+        // dest throws with the ctx untouched (not yet freed by the shim) — the finalize
+        // stays retryable (C1). The flag is set only after the shim call succeeds.
         dest.withWritablePointer(HMAC_SHA384_BYTES) { ptr -> bcl_hmac_final(ctx, ptr.reinterpret()) }
+        finalized = true
     }
 
     actual override fun close() {

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/HmacSha512Mac.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/HmacSha512Mac.linux.kt
@@ -9,13 +9,16 @@ import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_hmac_final
 import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_hmac_sha512_new
 import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_hmac_update
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.UByteVar
+import kotlinx.cinterop.allocArray
 import kotlinx.cinterop.convert
+import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.reinterpret
 
 /** Linux HMAC-SHA512 backed by BoringSSL (`HMAC_*`). Reads and writes via buffer pointers — no arrays. */
 actual class HmacSha512Mac actual constructor(
     key: ReadBuffer,
-) {
+) : AutoCloseable {
     private val ctx =
         run {
             var c = if (key.remaining() == 0) bcl_hmac_sha512_new(null, 0.convert()) else null
@@ -34,5 +37,16 @@ actual class HmacSha512Mac actual constructor(
         check(!finalized) { "mac already finalized" }
         finalized = true
         dest.withWritablePointer(HMAC_SHA512_BYTES) { ptr -> bcl_hmac_final(ctx, ptr.reinterpret()) }
+    }
+
+    actual override fun close() {
+        if (finalized) return
+        finalized = true
+        // The shim has no free-without-final: finalize into discarded stack scratch, which
+        // cleanses and frees the ctx.
+        memScoped {
+            val scratch = allocArray<UByteVar>(HMAC_SHA512_BYTES)
+            bcl_hmac_final(ctx, scratch)
+        }
     }
 }

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/HmacSha512Mac.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/HmacSha512Mac.linux.kt
@@ -35,8 +35,11 @@ actual class HmacSha512Mac actual constructor(
 
     actual fun doFinalInto(dest: WriteBuffer) {
         check(!finalized) { "mac already finalized" }
-        finalized = true
+        // withWritablePointer validates capacity BEFORE invoking the block, so a too-small
+        // dest throws with the ctx untouched (not yet freed by the shim) — the finalize
+        // stays retryable (C1). The flag is set only after the shim call succeeds.
         dest.withWritablePointer(HMAC_SHA512_BYTES) { ptr -> bcl_hmac_final(ctx, ptr.reinterpret()) }
+        finalized = true
     }
 
     actual override fun close() {

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Sha256Digest.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Sha256Digest.linux.kt
@@ -9,11 +9,14 @@ import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_sha256_final
 import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_sha256_new
 import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_sha256_update
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.UByteVar
+import kotlinx.cinterop.allocArray
 import kotlinx.cinterop.convert
+import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.reinterpret
 
 /** Linux SHA-256 backed by BoringSSL (`SHA256_*`). Reads and writes via buffer pointers — no arrays. */
-actual class Sha256Digest actual constructor() {
+actual class Sha256Digest actual constructor() : AutoCloseable {
     private val ctx = bcl_sha256_new() ?: error("SHA256_Init failed")
     private var finalized = false
 
@@ -27,5 +30,16 @@ actual class Sha256Digest actual constructor() {
         check(!finalized) { "digest already finalized" }
         finalized = true
         dest.withWritablePointer(SHA256_DIGEST_BYTES) { ptr -> bcl_sha256_final(ctx, ptr.reinterpret()) }
+    }
+
+    actual override fun close() {
+        if (finalized) return
+        finalized = true
+        // The shim has no free-without-final: finalize into discarded stack scratch, which
+        // cleanses and frees the ctx.
+        memScoped {
+            val scratch = allocArray<UByteVar>(SHA256_DIGEST_BYTES)
+            bcl_sha256_final(ctx, scratch)
+        }
     }
 }

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Sha256Digest.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Sha256Digest.linux.kt
@@ -28,8 +28,11 @@ actual class Sha256Digest actual constructor() : AutoCloseable {
 
     actual fun digestInto(dest: WriteBuffer) {
         check(!finalized) { "digest already finalized" }
-        finalized = true
+        // withWritablePointer validates capacity BEFORE invoking the block, so a too-small
+        // dest throws with the ctx untouched (not yet freed by the shim) — the finalize
+        // stays retryable (C1). The flag is set only after the shim call succeeds.
         dest.withWritablePointer(SHA256_DIGEST_BYTES) { ptr -> bcl_sha256_final(ctx, ptr.reinterpret()) }
+        finalized = true
     }
 
     actual override fun close() {

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Sha384Digest.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Sha384Digest.linux.kt
@@ -28,8 +28,11 @@ actual class Sha384Digest actual constructor() : AutoCloseable {
 
     actual fun digestInto(dest: WriteBuffer) {
         check(!finalized) { "digest already finalized" }
-        finalized = true
+        // withWritablePointer validates capacity BEFORE invoking the block, so a too-small
+        // dest throws with the ctx untouched (not yet freed by the shim) — the finalize
+        // stays retryable (C1). The flag is set only after the shim call succeeds.
         dest.withWritablePointer(SHA384_DIGEST_BYTES) { ptr -> bcl_sha384_final(ctx, ptr.reinterpret()) }
+        finalized = true
     }
 
     actual override fun close() {

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Sha384Digest.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Sha384Digest.linux.kt
@@ -9,11 +9,14 @@ import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_sha384_final
 import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_sha384_new
 import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_sha384_update
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.UByteVar
+import kotlinx.cinterop.allocArray
 import kotlinx.cinterop.convert
+import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.reinterpret
 
 /** Linux SHA-384 backed by BoringSSL (`SHA384_*`). Reads and writes via buffer pointers — no arrays. */
-actual class Sha384Digest actual constructor() {
+actual class Sha384Digest actual constructor() : AutoCloseable {
     private val ctx = bcl_sha384_new() ?: error("SHA384_Init failed")
     private var finalized = false
 
@@ -27,5 +30,16 @@ actual class Sha384Digest actual constructor() {
         check(!finalized) { "digest already finalized" }
         finalized = true
         dest.withWritablePointer(SHA384_DIGEST_BYTES) { ptr -> bcl_sha384_final(ctx, ptr.reinterpret()) }
+    }
+
+    actual override fun close() {
+        if (finalized) return
+        finalized = true
+        // The shim has no free-without-final: finalize into discarded stack scratch, which
+        // cleanses and frees the ctx.
+        memScoped {
+            val scratch = allocArray<UByteVar>(SHA384_DIGEST_BYTES)
+            bcl_sha384_final(ctx, scratch)
+        }
     }
 }

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Sha512Digest.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Sha512Digest.linux.kt
@@ -9,11 +9,14 @@ import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_sha512_final
 import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_sha512_new
 import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_sha512_update
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.UByteVar
+import kotlinx.cinterop.allocArray
 import kotlinx.cinterop.convert
+import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.reinterpret
 
 /** Linux SHA-512 backed by BoringSSL (`SHA512_*`). Reads and writes via buffer pointers — no arrays. */
-actual class Sha512Digest actual constructor() {
+actual class Sha512Digest actual constructor() : AutoCloseable {
     private val ctx = bcl_sha512_new() ?: error("SHA512_Init failed")
     private var finalized = false
 
@@ -27,5 +30,16 @@ actual class Sha512Digest actual constructor() {
         check(!finalized) { "digest already finalized" }
         finalized = true
         dest.withWritablePointer(SHA512_DIGEST_BYTES) { ptr -> bcl_sha512_final(ctx, ptr.reinterpret()) }
+    }
+
+    actual override fun close() {
+        if (finalized) return
+        finalized = true
+        // The shim has no free-without-final: finalize into discarded stack scratch, which
+        // cleanses and frees the ctx.
+        memScoped {
+            val scratch = allocArray<UByteVar>(SHA512_DIGEST_BYTES)
+            bcl_sha512_final(ctx, scratch)
+        }
     }
 }

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Sha512Digest.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Sha512Digest.linux.kt
@@ -28,8 +28,11 @@ actual class Sha512Digest actual constructor() : AutoCloseable {
 
     actual fun digestInto(dest: WriteBuffer) {
         check(!finalized) { "digest already finalized" }
-        finalized = true
+        // withWritablePointer validates capacity BEFORE invoking the block, so a too-small
+        // dest throws with the ctx untouched (not yet freed by the shim) — the finalize
+        // stays retryable (C1). The flag is set only after the shim call succeeds.
         dest.withWritablePointer(SHA512_DIGEST_BYTES) { ptr -> bcl_sha512_final(ctx, ptr.reinterpret()) }
+        finalized = true
     }
 
     actual override fun close() {

--- a/buffer-crypto/src/nativeInterop/cinterop/boringsslcrypto.def
+++ b/buffer-crypto/src/nativeInterop/cinterop/boringsslcrypto.def
@@ -44,6 +44,7 @@ static inline void bcl_sha256_update(SHA256_CTX *c, const uint8_t *data, size_t 
 }
 static inline void bcl_sha256_final(SHA256_CTX *c, uint8_t *out32) {
     SHA256_Final(out32, c);
+    OPENSSL_cleanse(c, sizeof(*c));
     OPENSSL_free(c);
 }
 
@@ -57,6 +58,7 @@ static inline void bcl_sha384_update(SHA512_CTX *c, const uint8_t *data, size_t 
 }
 static inline void bcl_sha384_final(SHA512_CTX *c, uint8_t *out48) {
     SHA384_Final(out48, c);
+    OPENSSL_cleanse(c, sizeof(*c));
     OPENSSL_free(c);
 }
 
@@ -70,6 +72,7 @@ static inline void bcl_sha512_update(SHA512_CTX *c, const uint8_t *data, size_t 
 }
 static inline void bcl_sha512_final(SHA512_CTX *c, uint8_t *out64) {
     SHA512_Final(out64, c);
+    OPENSSL_cleanse(c, sizeof(*c));
     OPENSSL_free(c);
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #241, which added `finalized` guards to the six streaming digest/MAC classes but deliberately made no API change — leaving two gaps this PR closes:

- **Never-finalized ctx leak**: a `Sha*Digest`/`HmacSha*Mac` that is abandoned before finalize leaks its native context on Apple (`nativeHeap` allocation) and Linux (shim `OPENSSL_malloc`). The six classes are now `AutoCloseable` with an idempotent `close()` — a no-op after finalize, releases (and on Apple zeroes) the ctx otherwise, and bars further use via the same `finalized` guard #241 added.
- **Linux SHA ctx freed unzeroed**: the BoringSSL shim's `bcl_sha{256,384,512}_final` now `OPENSSL_cleanse` the ctx (message-derived state) before `OPENSSL_free`. `bcl_hmac_final` unchanged — `HMAC_CTX_free` already cleanses.

Additive API only (`apiDump` updated: `AutoCloseable` + `close()V` on the six classes) → `minor`.

## Tests

- `DigestOneShotContractTest` (12): close-before-finalize bars use, close idempotent, close-after-finalize is a no-op — for all six classes on every platform. (Finalize-twice/update-after-finalize are already pinned by #241's `DigestFinalizeContractTest`.)
- `HpkeCloseGuardTest`: closed `HpkePsk` rejected at setup (#241 added `HpkePsk.requireOpen()` but had no test for it).

## Verification

- [x] jvm / jsNode / wasmJsNode / macosArm64 test suites green; ktlint, detekt, apiCheck green
- [x] linuxX64Test run natively (exercises the new cinterop cleanse + linuxMain close() paths): green