### PR TITLE
fix(crypto): security-hardening backlog — HPKE close/wipe race, PKCS#8 parse, secure AEAD key defaults

### DIFF
--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/Aead.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/Aead.kt
@@ -73,9 +73,9 @@ sealed interface AeadKey
  * implementations, it cannot write an exhaustive `when` over them — which is what lets a
  * hardware-backed variant be added later as a non-breaking minor.
  *
- * In-memory key material is **not** auto-wiped — callers that need erase-on-free should allocate
- * the backing buffer from a secure factory and pass it through [of]; the copy taken there
- * preserves that secure backing.
+ * In-memory key material is copied into a buffer from the factory passed to [of] — by default a
+ * secure deterministic one (matching [SigningKey] and [KeyAgreementPrivateKey]), so the copy is
+ * zeroed and freed by [close]. Pass a non-secure factory explicitly to opt out.
  */
 sealed interface AesGcmKey :
     AeadKey,
@@ -93,11 +93,12 @@ sealed interface AesGcmKey :
         /**
          * Wraps [key]'s remaining bytes as an in-memory AES-GCM key. The length must be exactly 16
          * (AES-128) or 32 (AES-256) bytes; any other length is rejected. The bytes are copied into
-         * a buffer from [factory] (use a secure factory for erase-on-free).
+         * a buffer from [factory] — secure and deterministic by default, so the copy is wiped and
+         * freed by [close] (align with [SigningKey]; pass a non-secure factory to opt out).
          */
         fun of(
             key: ReadBuffer,
-            factory: BufferFactory = BufferFactory.Default,
+            factory: BufferFactory = BufferFactory.deterministicSecure(),
         ): SyncCapableAesGcmKey {
             val n = key.remaining()
             require(n == AES_128_KEY_BYTES || n == AES_256_KEY_BYTES) {
@@ -154,11 +155,12 @@ sealed interface ChaChaPolyKey :
         /**
          * Wraps [key]'s remaining bytes as an in-memory ChaCha20-Poly1305 key. The length must be
          * exactly 32 bytes; any other length is rejected. The bytes are copied into a buffer from
-         * [factory] (use a secure factory for erase-on-free).
+         * [factory] — secure and deterministic by default, so the copy is wiped and freed by
+         * [close] (align with [SigningKey]; pass a non-secure factory to opt out).
          */
         fun of(
             key: ReadBuffer,
-            factory: BufferFactory = BufferFactory.Default,
+            factory: BufferFactory = BufferFactory.deterministicSecure(),
         ): ChaChaPolyKey {
             val n = key.remaining()
             require(n == CHACHA_KEY_BYTES) {

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/CryptoException.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/CryptoException.kt
@@ -30,6 +30,12 @@ expect open class NativeCryptoException : Exception {
  *    values ([InvalidPublicKey.curve]).
  *  - [VerificationFailed] is **deliberately opaque** — it carries no reason and no [cause], so a
  *    verification path can never become an oracle.
+ *  - **Capability gating is outside this hierarchy**: "this platform/engine does not provide the
+ *    algorithm" throws a plain [UnsupportedOperationException], not a [CryptoException] — it is an
+ *    environment/programming condition, not a crypto-operation failure, and the capability
+ *    witnesses ([CryptoCapabilities]) exist precisely so callers probe support instead of catching
+ *    it. The cost is that it is not part of the exhaustive sealed `when`; branch on the witness,
+ *    not the exception.
  *
  * Invariant for every subtype: **no secret material** (keys, plaintext, shared secrets, derived key
  * material) ever appears in any message, property, or cause.

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HkdfCore.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HkdfCore.kt
@@ -8,6 +8,12 @@ import com.ditchoom.buffer.deterministic
 import com.ditchoom.buffer.use
 
 /**
+ * HKDF-Expand's block-counter ceiling (RFC 5869 §2.3): output is at most 255 hash blocks, so the
+ * maximum length is `255 * Nh`. Shared with the pre-allocation length checks (e.g. HPKE export).
+ */
+internal const val HKDF_MAX_BLOCKS = 255
+
+/**
  * The minimal streaming-MAC surface [HkdfEngine] needs. Adapts any of the platform-native
  * `Hmac*Mac` classes without forcing them to share a supertype (keeps the landed expect
  * classes untouched).
@@ -32,7 +38,7 @@ internal class HkdfEngine(
     private val hashLen: Int,
     private val newMac: (key: ReadBuffer) -> HkdfMac,
 ) {
-    private val maxOutput = MAX_BLOCKS * hashLen
+    private val maxOutput = HKDF_MAX_BLOCKS * hashLen
 
     /**
      * Scratch factory for key-derived intermediates: deterministic so it can be `use {}`-freed,
@@ -73,7 +79,7 @@ internal class HkdfEngine(
     ) {
         require(length >= 0) { "length must be non-negative, was $length" }
         val blocks = (length + hashLen - 1) / hashLen
-        require(blocks <= MAX_BLOCKS) { "HKDF cannot expand to $length bytes (max $maxOutput)" }
+        require(blocks <= HKDF_MAX_BLOCKS) { "HKDF cannot expand to $length bytes (max $maxOutput)" }
         require(dest.remaining() >= length) { "dest needs $length bytes remaining, has ${dest.remaining()}" }
 
         // Two ping-pong T blocks plus a one-byte counter, all wiped on close.
@@ -139,9 +145,5 @@ internal class HkdfEngine(
         deriveInto(salt, ikm, info, length, out)
         out.resetForRead()
         return out
-    }
-
-    private companion object {
-        const val MAX_BLOCKS = 255
     }
 }

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HpkeContext.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HpkeContext.kt
@@ -7,6 +7,7 @@ import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.WriteBuffer
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlin.concurrent.Volatile
 
 /**
  * HPKE encryption contexts (RFC 9180 §5.2) and the setup functions that produce them.
@@ -19,8 +20,11 @@ import kotlinx.coroutines.sync.withLock
  *
  * Concurrency: the per-message `seal`/`open` ops are serialized on an internal [Mutex], so
  * concurrent callers on one context are safe — each op claims its sequence number exactly once
- * (and a failed open still leaves the counter unchanged). [close] is not synchronized with
- * in-flight ops; close a context only after its last op has returned.
+ * (and a failed open still leaves the counter unchanged). [close] marks the context closed
+ * immediately (later ops throw) and wipes under the same lock: inline when no op is in flight,
+ * otherwise deferred to the in-flight op's completion — so a seal/open never reads wiped or freed
+ * key material. [export] is *not* serialized on the lock (it cannot suspend); do not race it with
+ * [close].
  *
  * The AEAD key, base nonce, and exporter secret live in wiped [SecureBuffer]s; [close] zeroes them
  * (idempotent) along with the wrapped [aeadKey]'s material. Ops on a closed context throw.
@@ -32,7 +36,14 @@ sealed class HpkeContext protected constructor(
     internal val exporterSecret: PlatformBuffer,
 ) : AutoCloseable {
     private var seq: Long = 0L
+
+    // Volatile: close() may run on a different thread than the op holding seqLock; the op's
+    // completion path must observe the closed flag to perform the deferred wipe.
+    @Volatile
     private var closed = false
+
+    @Volatile
+    private var wiped = false
 
     /** Serializes the nonce-compute → AEAD op → counter-advance sequence (see class KDoc). */
     internal val seqLock = Mutex()
@@ -48,6 +59,11 @@ sealed class HpkeContext protected constructor(
     ): ReadBuffer {
         requireOpen()
         require(length >= 0) { "export length must be non-negative, was $length" }
+        // RFC 9180 §5.3: L must be at most 255*Nh (the HKDF-Expand block limit). Checked here,
+        // before the output allocation, so an oversized request cannot allocate first and only
+        // fail inside the KDF.
+        val maxLength = HKDF_MAX_BLOCKS * suite.kdf.nh
+        require(length <= maxLength) { "export length must be <= $maxLength bytes for this KDF, was $length" }
         val out = factory.allocate(length)
         labeledExpand(suite.kdf, suite.suiteId(), exporterSecret, LABEL_SEC, exporterContext.bytesOrNull, length, out)
         out.resetForRead()
@@ -92,19 +108,53 @@ sealed class HpkeContext protected constructor(
         seq = value
     }
 
-    /** Guards every op against use after [close]. */
+    /** Guards every op against use after [close]. `seal`/`open` re-check under [seqLock]. */
     internal fun requireOpen() {
         check(!closed) { "HpkeContext already closed" }
     }
 
+    /**
+     * Marks the context closed (later ops throw) and wipes the secrets under [seqLock]: inline if
+     * the lock is free, otherwise deferred to the in-flight op's completion path (a [Mutex] cannot
+     * be awaited from a non-suspend close). Either way a seal/open never observes wiped or freed
+     * material. Idempotent. [export] does not hold the lock — do not race it with close.
+     */
     override fun close() {
-        if (closed) return
         closed = true
+        if (wiped) return
+        if (seqLock.tryLock()) {
+            try {
+                wipeLocked()
+            } finally {
+                seqLock.unlock()
+            }
+        }
+    }
+
+    /** Zeroes/frees the derived secrets. Call only while holding [seqLock]; idempotent. */
+    private fun wipeLocked() {
+        if (wiped) return
+        wiped = true
         aeadKey.closeMaterial()
         key.freeNativeMemory()
         baseNonce.freeNativeMemory()
         exporterSecret.freeNativeMemory()
     }
+
+    /**
+     * Runs one serialized seal/open [op] under [seqLock]: re-checks [closed] once the lock is
+     * held (a close that won the lock first has already wiped — fail before touching freed
+     * memory), and performs the wipe a concurrent [close] deferred to us.
+     */
+    internal suspend fun <R> withOpLock(op: suspend () -> R): R =
+        seqLock.withLock {
+            try {
+                requireOpen()
+                op()
+            } finally {
+                if (closed) wipeLocked()
+            }
+        }
 
     /** A sender context: encrypts successive messages to the recipient. */
     class Sender internal constructor(
@@ -122,9 +172,8 @@ sealed class HpkeContext protected constructor(
             plaintext: ReadBuffer,
             aad: Aad = Aad.None,
             factory: BufferFactory = BufferFactory.Default,
-        ): PlatformBuffer {
-            requireOpen()
-            return seqLock.withLock {
+        ): PlatformBuffer =
+            withOpLock {
                 val nonce = computeNonce()
                 try {
                     val ct = hpkeAeadSeal(aeadKey, nonce, aad.bytesOrNull, plaintext, factory)
@@ -134,7 +183,6 @@ sealed class HpkeContext protected constructor(
                     nonce.freeNativeMemory()
                 }
             }
-        }
     }
 
     /** A receiver context: decrypts successive messages from the sender. */
@@ -156,9 +204,8 @@ sealed class HpkeContext protected constructor(
             ciphertext: ReadBuffer,
             aad: Aad = Aad.None,
             factory: BufferFactory = BufferFactory.Default,
-        ): PlatformBuffer {
-            requireOpen()
-            return seqLock.withLock {
+        ): PlatformBuffer =
+            withOpLock {
                 val nonce = computeNonce()
                 try {
                     val pt = hpkeAeadOpen(aeadKey, nonce, aad.bytesOrNull, ciphertext, factory)
@@ -168,7 +215,6 @@ sealed class HpkeContext protected constructor(
                     nonce.freeNativeMemory()
                 }
             }
-        }
     }
 }
 
@@ -464,7 +510,7 @@ private suspend fun keyScheduleReceiver(
     return HpkeContext.Receiver(suite, key, baseNonce, exporterSecret)
 }
 
-private class ScheduleOutput(
+internal class ScheduleOutput(
     val key: PlatformBuffer,
     val baseNonce: PlatformBuffer,
     val exporterSecret: PlatformBuffer,
@@ -480,15 +526,18 @@ private class ScheduleOutput(
  * The HPKE key schedule (RFC 9180 §5.1, `KeySchedule`). Computes `key`, `base_nonce`, and
  * `exporter_secret` from the KEM `shared_secret`, the [mode], `info`, and the optional [psk].
  * All intermediates (`psk_id_hash`, `info_hash`, `key_schedule_context`, `secret`) live in wiped
- * scratch and are freed before returning. The three returned buffers are secure (wiped on context
- * close).
+ * scratch and are freed before returning. The three returned buffers come from [outputFactory] —
+ * [secureScratch] in production, so they are wiped on context close. The parameter is a test seam:
+ * a `managed().secure()` factory keeps the wiped bytes readable after close (managed free is a GC
+ * no-op), letting a test byte-assert the zeroization — the [AeadKeyCloseTest] technique.
  */
-private fun keySchedule(
+internal fun keySchedule(
     suite: HpkeSuite,
     mode: HpkeMode,
     sharedSecret: PlatformBuffer,
     info: ReadBuffer,
     psk: HpkePsk?,
+    outputFactory: BufferFactory = secureScratch,
 ): ScheduleOutput {
     val kdf = suite.kdf
     val suiteId = suite.suiteId()
@@ -522,15 +571,15 @@ private fun keySchedule(
 
         // `secret` is read non-destructively by the HMAC (absolute position+remaining), so the same
         // read-ready buffer is reused for all three expands without re-resetting.
-        val key = secureScratch.allocate(suite.aead.nk)
+        val key = outputFactory.allocate(suite.aead.nk)
         labeledExpand(kdf, suiteId, secret, LABEL_KEY, ksc, suite.aead.nk, key)
         key.resetForRead()
 
-        val baseNonce = secureScratch.allocate(suite.aead.nn)
+        val baseNonce = outputFactory.allocate(suite.aead.nn)
         labeledExpand(kdf, suiteId, secret, LABEL_BASE_NONCE, ksc, suite.aead.nn, baseNonce)
         baseNonce.resetForRead()
 
-        val exporterSecret = secureScratch.allocate(nh)
+        val exporterSecret = outputFactory.allocate(nh)
         labeledExpand(kdf, suiteId, secret, LABEL_EXP, ksc, nh, exporterSecret)
         exporterSecret.resetForRead()
 

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HpkeContext.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HpkeContext.kt
@@ -144,7 +144,7 @@ sealed class HpkeContext protected constructor(
     /**
      * Runs one serialized seal/open [op] under [seqLock]: re-checks [closed] once the lock is
      * held (a close that won the lock first has already wiped — fail before touching freed
-     * memory), and performs the wipe a concurrent [close] deferred to us.
+     * memory), and performs the wipe that a concurrent [close] deferred to this op.
      */
     internal suspend fun <R> withOpLock(op: suspend () -> R): R =
         seqLock.withLock {

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/HpkeContextCloseWipeTest.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/HpkeContextCloseWipeTest.kt
@@ -1,0 +1,70 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.managed
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Byte-asserts [HpkeContext.close]'s zeroization contract: the derived AEAD `key`, `base_nonce`,
+ * and `exporter_secret` must all be wiped by close. In production these come from [secureScratch]
+ * (deterministic backing — freed memory is unreadable), so the wipe cannot be observed directly;
+ * the [keySchedule] output-factory seam injects a managed secure factory instead, whose free is a
+ * GC no-op after the wipe, keeping the zeroed bytes readable — the [AeadKeyCloseTest] technique.
+ */
+class HpkeContextCloseWipeTest {
+    private val secureManaged = BufferFactory.managed().secure()
+
+    private val suite = HpkeSuite(HpkeKem.DhkemX25519HkdfSha256, HpkeKdf.HkdfSha256, HpkeAead.Aes128Gcm)
+
+    /** Runs the key schedule on a fixed 32-byte shared secret with managed-secure outputs. */
+    private fun scheduleWithReadableOutputs(): ScheduleOutput {
+        val sharedSecretBytes = 32
+        val shared = secureManaged.allocate(sharedSecretBytes)
+        repeat(sharedSecretBytes) { shared.writeByte(0x42) }
+        shared.resetForRead()
+        return keySchedule(suite, HpkeMode.Base, shared, EMPTY, psk = null, outputFactory = secureManaged)
+    }
+
+    private fun assertAllZero(
+        buffer: ReadBuffer,
+        name: String,
+    ) {
+        for (i in 0 until buffer.limit()) {
+            assertEquals(0, buffer.get(i).toInt(), "$name byte $i not wiped after close")
+        }
+    }
+
+    private fun anyNonZero(buffer: ReadBuffer): Boolean {
+        for (i in 0 until buffer.limit()) if (buffer.get(i).toInt() != 0) return true
+        return false
+    }
+
+    @Test
+    fun closeWipesKeyBaseNonceAndExporterSecret() {
+        val out = scheduleWithReadableOutputs()
+        val captured: List<Pair<String, PlatformBuffer>> =
+            listOf("key" to out.key, "baseNonce" to out.baseNonce, "exporterSecret" to out.exporterSecret)
+        val ctx = HpkeContext.Sender(suite, out.key, out.baseNonce, out.exporterSecret)
+        // The schedule outputs are real KDF output — non-zero before close.
+        for ((name, buffer) in captured) {
+            assertTrue(anyNonZero(buffer), "$name should be non-zero before close")
+        }
+        ctx.close()
+        for ((name, buffer) in captured) assertAllZero(buffer, name)
+    }
+
+    @Test
+    fun closeIsIdempotentAndKeepsSecretsWiped() {
+        val out = scheduleWithReadableOutputs()
+        val ctx = HpkeContext.Receiver(suite, out.key, out.baseNonce, out.exporterSecret)
+        ctx.close()
+        ctx.close() // second close must not throw (and must not double-free)
+        assertAllZero(out.key, "key")
+        assertAllZero(out.baseNonce, "baseNonce")
+        assertAllZero(out.exporterSecret, "exporterSecret")
+    }
+}

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Aead.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Aead.jsAndWasmJs.kt
@@ -22,6 +22,14 @@ import com.ditchoom.buffer.WriteBuffer
  * and the Wasm backend without typed-array interop differences leaking in. No ByteArray crosses
  * the boundary, and the tag stays attached to the ciphertext (WebCrypto appends it), so
  * plaintext is only produced after WebCrypto verifies it.
+ *
+ * ZEROIZATION LIMITATION (documented, accepted): the hex marshalling means key material (and
+ * plaintext) transits the boundary as immutable JS Strings, which cannot be wiped — the copies
+ * live on the GC heap until collected. WebCrypto additionally copies the bytes into
+ * engine-internal key state that Kotlin also cannot wipe, so switching the bridge to Int8Array
+ * would narrow but not close the exposure. In-memory secrecy on the web targets is therefore
+ * best-effort only; the wipe-on-close contract of SecureBuffer applies to the Kotlin-side
+ * buffers, not to these boundary copies.
  */
 
 private const val NO_CHACHA_POLY = "ChaCha20-Poly1305 is not part of WebCrypto and is not polyfilled"

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/KeyAgreement.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/KeyAgreement.jsAndWasmJs.kt
@@ -23,6 +23,13 @@ import com.ditchoom.buffer.ReadBuffer
  * private keys as PKCS#8, so the stored scalar is wrapped via [scalarToPkcs8Hex] just before the
  * derive call. Off-curve / low-order peer points are rejected by `importKey` / `deriveBits`,
  * surfaced as [InvalidPublicKey].
+ *
+ * ZEROIZATION LIMITATION (documented, accepted): private scalars and derived shared secrets cross
+ * the Kotlin↔WebCrypto boundary as immutable hex Strings ([scalarToPkcs8Hex], the `privateHex` /
+ * shared-secret results), which cannot be wiped — the copies live on the GC heap until collected.
+ * WebCrypto also copies imported key bytes into engine-internal state Kotlin cannot reach, so
+ * Int8Array marshalling would narrow but not close the exposure. In-memory secrecy on the web
+ * targets is best-effort; SecureBuffer wiping covers only the Kotlin-side buffers.
  */
 
 private const val HEX_RADIX = 16

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Signatures.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Signatures.jsAndWasmJs.kt
@@ -20,6 +20,13 @@ import com.ditchoom.buffer.WriteBuffer
  * Ed25519 is only present on newer engines (Chrome 137+/Firefox 129+/Safari 17+, Node stable). We
  * **feature-detect** it (see [webCryptoEd25519Available]); when absent every Ed25519 op throws
  * [UnsupportedOperationException], matching the capability contract.
+ *
+ * ZEROIZATION LIMITATION (documented, accepted): private key material crosses the
+ * Kotlin↔WebCrypto boundary as immutable hex Strings (the PKCS#8 wrappers below), which cannot
+ * be wiped — the copies live on the GC heap until collected. WebCrypto also copies imported key
+ * bytes into engine-internal state Kotlin cannot reach, so Int8Array marshalling would narrow but
+ * not close the exposure. In-memory secrecy on the web targets is best-effort; SecureBuffer
+ * wiping covers only the Kotlin-side buffers.
  */
 
 actual val ecdsaSignatureEncoding: EcdsaSignatureEncoding get() = EcdsaSignatureEncoding.P1363

--- a/buffer-crypto/src/jsMain/kotlin/com/ditchoom/buffer/crypto/Signatures.js.kt
+++ b/buffer-crypto/src/jsMain/kotlin/com/ditchoom/buffer/crypto/Signatures.js.kt
@@ -6,8 +6,9 @@ import kotlin.coroutines.suspendCoroutine
 import kotlin.js.Promise
 
 /**
- * Awaits a [Promise] from a suspend function using only the stdlib coroutine intrinsics — the
- * crypto module deliberately does not depend on kotlinx-coroutines, so we bridge `then` ourselves.
+ * Awaits a [Promise] from a suspend function by bridging `then` with the stdlib coroutine
+ * intrinsics — equivalent to kotlinx-coroutines' `await`. (Predates the module's
+ * kotlinx-coroutines dependency; kept because it needs nothing beyond the stdlib.)
  */
 private suspend fun <T> Promise<T>.awaitResult(): T =
     suspendCoroutine { cont ->

--- a/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/Aead.jvmCommon.kt
+++ b/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/Aead.jvmCommon.kt
@@ -174,16 +174,19 @@ internal fun requireTagged(ciphertextAndTag: ReadBuffer) {
 /**
  * Builds a [SecretKeySpec] from the key buffer's remaining bytes (non-destructive). The staging
  * array is zeroed as soon as the spec is constructed — [SecretKeySpec] copies the bytes internally,
- * so the wipe cannot affect the spec and the raw key does not linger on the heap.
+ * so the wipe cannot affect the spec and the raw key does not linger on the heap. The wipe runs in
+ * a `finally` so the staged key is erased even when the spec constructor rejects the material.
  */
 private fun keySpec(
     key: ReadBuffer,
     algorithm: String,
 ): SecretKeySpec {
     val staged = remainingBytes(key)
-    val spec = SecretKeySpec(staged, algorithm)
-    staged.fill(0)
-    return spec
+    try {
+        return SecretKeySpec(staged, algorithm)
+    } finally {
+        staged.fill(0)
+    }
 }
 
 internal fun nonceBytes(nonce: ReadBuffer): ByteArray = remainingBytes(nonce)

--- a/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/KeyAgreement.jvmCommon.kt
+++ b/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/KeyAgreement.jvmCommon.kt
@@ -238,8 +238,15 @@ internal actual fun generateKeyPairPlatform(curve: KeyAgreementCurve): KeyAgreem
             val rawPub = rawX25519(kp.public)
             // Private scalar lives in a wiped SecureBuffer. JCA does not expose the raw XDH scalar
             // via a stable API, so we re-import the PKCS#8 octet string we'll need for agreement;
-            // store the PKCS#8-extracted 32-byte scalar.
-            val scalar = extractX25519Scalar(kp.private.encoded)
+            // store the PKCS#8-extracted 32-byte scalar. Both staging copies (the PKCS#8 encoding
+            // and the extracted scalar) are wiped once the scalar reaches the SecureBuffer.
+            val pkcs8 = kp.private.encoded
+            val scalar =
+                try {
+                    extractX25519Scalar(pkcs8)
+                } finally {
+                    pkcs8.fill(0)
+                }
             val priv = secureBufferOf(curve.privateKeyBytes) { it.writeBytes(scalar) }
             scalar.fill(0)
             keyAgreementKeyPairOf(curve, keyAgreementPrivateKeyOf(curve, priv), publicKeyOf(curve, rawPub))
@@ -259,12 +266,62 @@ internal actual fun generateKeyPairPlatform(curve: KeyAgreementCurve): KeyAgreem
     }
 }
 
-/** Extracts the 32-byte X25519 scalar from a PKCS#8 PrivateKeyInfo encoding. */
+// DER tags/length constants for the minimal PKCS#8 walk below.
+private const val DER_SEQUENCE = 0x30
+private const val DER_INTEGER = 0x02
+private const val DER_OCTET_STRING = 0x04
+private const val DER_LONG_FORM = 0x80
+private const val DER_LEN_MASK = 0x7F
+private const val UBYTE_MASK = 0xFF
+
+/**
+ * Extracts the 32-byte X25519 scalar from a PKCS#8 `PrivateKeyInfo` encoding by walking the DER
+ * structure (RFC 5958 / RFC 8410): `SEQUENCE { version INTEGER, privateKeyAlgorithm SEQUENCE,
+ * privateKey OCTET STRING { CurvePrivateKey ::= OCTET STRING (the raw scalar) } }`. Locating the
+ * nested OCTET STRING — rather than assuming the scalar is the trailing 32 bytes — stays correct
+ * for providers that append optional `attributes` or `publicKey` fields to the encoding.
+ */
 private fun extractX25519Scalar(pkcs8: ByteArray): ByteArray {
-    // The scalar is the last 32 bytes of the standard X25519 PKCS#8 encoding (inner OCTET STRING).
-    val out = ByteArray(X25519_RAW_BYTES)
-    System.arraycopy(pkcs8, pkcs8.size - X25519_RAW_BYTES, out, 0, X25519_RAW_BYTES)
-    return out
+    var pos = 0
+
+    fun u8(): Int {
+        check(pos < pkcs8.size) { "truncated PKCS#8 PrivateKeyInfo" }
+        return pkcs8[pos++].toInt() and UBYTE_MASK
+    }
+
+    // DER length: short form, or long form with 1..2 length octets (a PrivateKeyInfo is tiny).
+    fun length(): Int {
+        val first = u8()
+        if (first < DER_LONG_FORM) return first
+        val numBytes = first and DER_LEN_MASK
+        check(numBytes in 1..2) { "unsupported DER length form in PKCS#8 PrivateKeyInfo" }
+        var len = 0
+        repeat(numBytes) { len = (len shl Byte.SIZE_BITS) or u8() }
+        return len
+    }
+
+    // Reads a TLV header, checks the tag and that the value fits, and returns the value length
+    // with [pos] left at the value's first byte.
+    fun expectTag(tag: Int): Int {
+        check(u8() == tag) { "unexpected DER tag in PKCS#8 PrivateKeyInfo" }
+        val len = length()
+        check(len <= pkcs8.size - pos) { "truncated PKCS#8 PrivateKeyInfo" }
+        return len
+    }
+
+    // Skips a whole TLV: reads the header, then jumps over the value.
+    fun skipTag(tag: Int) {
+        val len = expectTag(tag)
+        pos += len
+    }
+
+    expectTag(DER_SEQUENCE) // PrivateKeyInfo — descend
+    skipTag(DER_INTEGER) // version
+    skipTag(DER_SEQUENCE) // privateKeyAlgorithm (id-X25519)
+    expectTag(DER_OCTET_STRING) // privateKey — descend
+    val scalarLen = expectTag(DER_OCTET_STRING) // CurvePrivateKey ::= OCTET STRING (RFC 8410 §7)
+    check(scalarLen == X25519_RAW_BYTES) { "X25519 scalar must be $X25519_RAW_BYTES bytes, was $scalarLen" }
+    return pkcs8.copyOfRange(pos, pos + X25519_RAW_BYTES)
 }
 
 private fun publicKeyOf(

--- a/buffer-crypto/src/nativeInterop/swift/CryptoKitShim.swift
+++ b/buffer-crypto/src/nativeInterop/swift/CryptoKitShim.swift
@@ -40,7 +40,9 @@ private func emit(_ data: Data, _ out: UnsafeMutablePointer<UInt8>?, _ outCap: I
     return BCKS_OK
 }
 
-// Build a Data view over a (pointer, length) pair without copying (valid only for the call).
+// Build a Data over a (pointer, length) pair. Data(bytes:count:) COPIES the bytes — this is a
+// staging copy, not a zero-copy view. The copy is released (not zeroed) when the Data goes out of
+// scope; Kotlin-side wiping covers only the caller's buffer, not this transient.
 private func bytes(_ ptr: UnsafePointer<UInt8>?, _ len: Int) -> Data {
     guard let ptr = ptr, len > 0 else { return Data() }
     return Data(bytes: ptr, count: len)


### PR DESCRIPTION
## Summary

Works through the deferred security-review backlog items not owned by #241/#243.

- **S1 — HPKE close-vs-op race**: `HpkeContext.close()` now wipes under the op `Mutex` — inline when the lock is free, otherwise deferred to the in-flight `seal`/`open`'s completion path (a `Mutex` cannot be awaited from a non-suspend `close`). `seal`/`open` re-check the closed flag *under* the lock, so an op can never read wiped or freed key material. `export` remains unsynchronized (non-suspend) and its contract is documented.
- **S1 — zeroization now test-pinned**: the HPKE key schedule gained an injectable output-factory seam; `HpkeContextCloseWipeTest` injects `managed().secure()` and byte-asserts that `key`, `base_nonce`, and `exporter_secret` are all zeroed by `close()` (the `AeadKeyCloseTest` technique).
- **L2**: `HpkeContext.export` validates `length ≤ 255*Nh` (RFC 9180 §5.3) *before* allocating the output buffer.
- **M5**: `AesGcmKey.of()` / `ChaChaPolyKey.of()` now default to a secure deterministic factory, matching `SigningKey` / `KeyAgreementPrivateKey` — AEAD key copies are wiped on `close()` by default. *(Public behavior change → minor.)*
- **C3**: JVM AEAD key staging array is zeroed in `try/finally`, so it is wiped even when the `SecretKeySpec` constructor throws.
- **L4**: JVM X25519 scalar extraction walks the PKCS#8 DER structure (RFC 5958/8410 nested OCTET STRING) instead of assuming the scalar is the trailing 32 bytes; the PKCS#8 staging copy is now wiped as well.
- **M4 (documented limitation)**: js/wasm WebCrypto marshalling passes private material as immutable hex `String`s that cannot be wiped; documented in all three web bridge files rather than converting to `Int8Array` — WebCrypto's engine-internal key copies mean typed-array marshalling would narrow but not close the exposure, and it would be a cross-source-set interop refactor.
- **L6 + code health (text-only)**: corrected the CryptoKit shim `bytes()` comment (`Data(bytes:count:)` copies — not a zero-copy view), refreshed the stale "no coroutines dep" comment in `Signatures.js.kt`, and documented in `CryptoException` why capability gating throws `UnsupportedOperationException` outside the sealed hierarchy.

Explicitly excluded per backlog: digest/MAC lifecycle (#243), L3 (BoringSSL stack-protector flags), C5 (intended behavior).

## Test plan

- [x] `:buffer-crypto:jvmTest` (includes new `HpkeContextCloseWipeTest`)
- [x] `:buffer-crypto:jsNodeTest`, `:buffer-crypto:wasmJsNodeTest`
- [x] `:buffer-crypto:macosArm64Test`
- [x] `:buffer-crypto:linuxX64Test` (alien)
- [x] `ktlintCheck`, `detekt`, `apiCheck` (no ABI change)