### PR TITLE
perf(buffer-crypto): bulk-copy HKDF-Expand block output instead of byte-by-byte

### DIFF
--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HkdfCore.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HkdfCore.kt
@@ -109,8 +109,15 @@ internal class HkdfEngine(
                 mac.doFinalInto(cur)
                 cur.resetForRead()
 
+                // Bulk-copy this block's contribution into dest. `slice()` is a
+                // zero-copy view that does NOT advance `cur`'s position, so `cur`
+                // stays at position 0 and can still be replayed as `prev` (T(i-1))
+                // into the next round's MAC. `setLimit(take)` clamps the final,
+                // possibly-partial block; only the last block is partial and it is
+                // never reused as `prev`, so clamping the limit is safe.
                 val take = minOf(hashLen, length - written)
-                for (j in 0 until take) dest.writeByte(cur.get(j))
+                cur.setLimit(take)
+                dest.write(cur.slice())
                 written += take
 
                 // Swap: this block becomes T(i-1) for the next round.

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/HkdfTest.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/HkdfTest.kt
@@ -53,4 +53,26 @@ class HkdfTest {
         assertEquals(12, Hkdf.derive(Salt.None, repeatedByte(1, 32), Info.None, 12, BufferFactory.Default).remaining())
         assertEquals(80, Hkdf.derive(Salt.None, repeatedByte(1, 32), Info.None, 80, BufferFactory.Default).remaining())
     }
+
+    /**
+     * HKDF-Expand emits a block stream: block T(i) is independent of the requested length, so the
+     * OKM for a shorter length must be a byte-exact prefix of the OKM for any longer length. This
+     * pins the per-block copy and the final-partial-block `setLimit` clamp across the block
+     * boundary (SHA-256 hashLen = 32) — an off-by-one in either would make a shorter derivation
+     * diverge from the prefix of the 80-byte (3-block) output.
+     */
+    @Test
+    fun expandOutputIsPrefixConsistentAcrossLengths() {
+        fun okm(length: Int): String =
+            derive(
+                salt = hexBuffer("000102030405060708090a0b0c"),
+                ikm = repeatedByte(0x0b, 22),
+                info = hexBuffer("f0f1f2f3f4f5f6f7f8f9"),
+                length = length,
+            )
+        val full = okm(80) // 3 blocks: 32 + 32 + 16
+        for (n in intArrayOf(1, 31, 32, 33, 42, 64, 79)) {
+            assertEquals(full.substring(0, n * 2), okm(n), "OKM($n) must be the $n-byte prefix of OKM(80)")
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Follow-up to #246 (which flattened the nested `use {}` to fix the Kotlin/Native body-lowering ICE). This replaces the per-byte copy of each HKDF-Expand `T`-block into `dest`:

```kotlin
// before
val take = minOf(hashLen, length - written)
for (j in 0 until take) dest.writeByte(cur.get(j))
written += take

// after
val take = minOf(hashLen, length - written)
cur.setLimit(take)
dest.write(cur.slice())     // bulk buffer-to-buffer copy
written += take
```

`WriteBuffer.write(ReadBuffer)` is the platform bulk copy primitive (memcpy / `ByteBuffer.put` / `Int8Array.set`), replacing up to `hashLen` interface-boundary `writeByte`/`get` calls per block with one bulk move.

## Why `slice()` and not `dest.write(cur)`

`dest.write(cur)` would advance `cur`'s **position**, but `cur` is reused as `prev` (T(i-1)) and replayed into the **next** block's `mac.update`, which reads from position. `slice()` is a zero-copy view that does **not** move `cur`'s position, so the ping-pong reuse stays intact. `setLimit(take)` clamps the final, possibly-partial block; only the last block is partial and it is never reused as `prev`, so clamping the limit is safe.

## Scope / correctness

Pure refactor of the copy path — **HKDF output is byte-identical**. This deliberately stayed out of #246 (an ICE fix) so it can be reviewed and re-KAT'd on its own.

## Tests

Added `expandOutputIsPrefixConsistentAcrossLengths`: HKDF-Expand emits a block stream, so OKM(N) must be the byte-exact prefix of OKM(80) for N ∈ {1, 31, 32, 33, 42, 64, 79}. This pins the per-block copy and the final-partial `setLimit` clamp across the SHA-256 block boundary — an off-by-one in either would make a shorter derivation diverge from the prefix of the longer one.

## Verified

- `:buffer-crypto:jvmTest --tests "*Hkdf*"` — RFC 5869 KATs unchanged + new prefix test, 0 failures (HkdfTest 5/5, HkdfSha384Sha512Test 4/4)
- `:buffer-crypto:ktlintCheck` — clean
- Rebased onto current `main` (on top of #246)

🤖 Generated with [Claude Code](https://claude.com/claude-code)