### PR TITLE
fix(buffer-crypto): break HKDF-Expand var-alias cycle that StackOverflows K/N CastsOptimization on iOS

### DIFF
--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HkdfCore.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HkdfCore.kt
@@ -1,7 +1,6 @@
 package com.ditchoom.buffer.crypto
 
 import com.ditchoom.buffer.BufferFactory
-import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.WriteBuffer
 import com.ditchoom.buffer.deterministic
@@ -88,18 +87,26 @@ internal class HkdfEngine(
         // per inlined `use {}`, and three nested here overflowed its stack on iOS
         // (StackOverflowError in body lowering). Same secure-erase guarantee — all three
         // scratch buffers are freed on every exit path, including exceptions.
-        val tA = scratch.allocate(hashLen)
-        val tB = scratch.allocate(hashLen)
+        //
+        // The two blocks ping-pong by array index — `t[(i-1) and 1]` is T(i), `t[i and 1]`
+        // is T(i-1). This deliberately avoids a `var prev/cur/spare` swap: reassigning locals
+        // to each other in a loop builds a cyclic variable-alias graph that Kotlin/Native's
+        // `CastsOptimization.buildNullablePredicate` walks WITHOUT a visited-set, so a nullable
+        // `prev` fed from that cycle recurses forever → StackOverflowError in body lowering on
+        // iOS (independent of -Xss). Indexed `val`s have no reassignment and no nullable, so
+        // the predicate builder terminates.
+        val t = arrayOf(scratch.allocate(hashLen), scratch.allocate(hashLen))
         val counter = scratch.allocate(1)
         try {
-            var prev: PlatformBuffer? = null // T(0) is empty
-            var cur = tA
-            var spare = tB
             var written = 0
             for (i in 1..blocks) {
                 // T(i) = HMAC(prk, T(i-1) ‖ info ‖ i) — streamed, never concatenated.
+                val cur = t[(i - 1) and 1]
                 val mac = newMac(prk)
-                prev?.let { mac.update(it) }
+                // T(i-1): the other buffer, still at position 0 with limit == hashLen from
+                // the previous round (a full block — only the final block is limit-clamped,
+                // and it is never replayed). T(0) is empty, so skip it on the first round.
+                if (i > 1) mac.update(t[i and 1])
                 info?.let { mac.update(it) }
                 counter.resetForWrite()
                 counter.writeByte(i.toByte())
@@ -111,25 +118,19 @@ internal class HkdfEngine(
 
                 // Bulk-copy this block's contribution into dest. `slice()` is a
                 // zero-copy view that does NOT advance `cur`'s position, so `cur`
-                // stays at position 0 and can still be replayed as `prev` (T(i-1))
-                // into the next round's MAC. `setLimit(take)` clamps the final,
-                // possibly-partial block; only the last block is partial and it is
-                // never reused as `prev`, so clamping the limit is safe.
+                // stays at position 0 and can still be replayed as T(i-1) into the
+                // next round's MAC. `setLimit(take)` clamps the final, possibly-partial
+                // block; only the last block is partial and it is never reused, so
+                // clamping the limit is safe.
                 val take = minOf(hashLen, length - written)
                 cur.setLimit(take)
                 dest.write(cur.slice())
                 written += take
-
-                // Swap: this block becomes T(i-1) for the next round.
-                prev = cur
-                val next = spare
-                spare = cur
-                cur = next
             }
         } finally {
             counter.freeNativeMemory()
-            tB.freeNativeMemory()
-            tA.freeNativeMemory()
+            t[1].freeNativeMemory()
+            t[0].freeNativeMemory()
         }
     }
 


### PR DESCRIPTION
## What

HKDF-Expand's ping-pong buffer swap crashes the **Kotlin/Native 2.4.0** backend when a consumer links `buffer-crypto` into an iOS binary (`Output kind: PROGRAM`):

```
Internal error in body lowering: java.lang.StackOverflowError
  at org.jetbrains.kotlin.backend.konan.optimizations.CastsOptimization$lower$visitor$1.buildNullablePredicate(CastsOptimization.kt:600)   ×∞
```

#246 (released as 6.3.1) flattened the nested `use {}` and fixed the lowering stack *depth*, but this is a **different, deeper trigger**: the swap itself. Sits on top of the bulk-copy path from #248.

## Root cause

`expandInto` ping-ponged two `T` blocks with reassignment:

```kotlin
var prev: PlatformBuffer? = null
var cur = tA; var spare = tB
...
prev = cur
val next = spare
spare = cur
cur = next
```

That builds a **cyclic variable-alias graph** — `cur → next → spare → cur` — feeding a nullable `prev`. `CastsOptimization.buildNullablePredicate` traces a value's nullability sources **without a visited-set**, so the cycle recurses forever. It overflows at *any* `-Xss` (which is why bumping the consumer's daemon stack never helped — and `-Xss` never reaches the K/N compiler process anyway).

## Fix

Ping-pong the two blocks **by array index** with `val` locals — no reassignment, no nullable, so the predicate builder terminates:

```kotlin
val t = arrayOf(scratch.allocate(hashLen), scratch.allocate(hashLen))
for (i in 1..blocks) {
    val cur = t[(i - 1) and 1]          // T(i)
    val mac = newMac(prk)
    if (i > 1) mac.update(t[i and 1])   // T(i-1)
    ...
}
```

HKDF output is **byte-identical** — same streaming, same secure-erase-on-every-path guarantee.

## Validation

- ✅ `:buffer-crypto:jvmTest` — Wycheproof HKDF KATs + the #248 prefix-consistency KAT, green with the fix.
- ✅ A downstream consumer on **Kotlin 2.4.0** whose `:linkDebugTestIosSimulatorArm64` **reproducibly** StackOverflowed on 6.3.1 (44s, every run) now **links clean** against this.
- ✅ With that consumer's K/N static cache **re-enabled**, HkdfCore lowers through the cache builder with no StackOverflow (a separate, unrelated cryptokitshim Swift-interop link issue remains — out of scope here).

## Regression coverage

This repo's Apple CI already links & runs `HkdfTest` on `iosSimulatorArm64` (`build-apple.yaml`: `./gradlew macosArm64Test iosSimulatorArm64Test`), so the crashing path **is** exercised in CI. It didn't catch this because **buffer builds with Kotlin 2.3.21, and the `CastsOptimization` StackOverflow is a Kotlin 2.4.0-only regression** — verified: the pre-fix code links clean on `iosSimulatorArm64` under 2.3.21. That existing test therefore becomes an active guard automatically once the Kotlin 2.4.0 bump (#230) lands; no new test is added here. The active guard today lives in the 2.4.0 consumer's iOS link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)