### PR TITLE
fix(buffer): writeString throw-on-overflow + grow the length-prefixed list scratch (#249, #250)

### DIFF
--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterConstants.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterConstants.kt
@@ -88,8 +88,6 @@ internal val PLATFORM_BUFFER_CN = ClassName("com.ditchoom.buffer", "PlatformBuff
 internal val BUFFER_FACTORY_CN = ClassName("com.ditchoom.buffer", "BufferFactory")
 internal val BUFFER_FACTORY_DEFAULT_MN =
     MemberName("com.ditchoom.buffer", "Default")
-internal val BUFFER_USE_MN =
-    MemberName("com.ditchoom.buffer", "use")
 internal val CODEC_CN = ClassName("com.ditchoom.buffer.codec", "Codec")
 internal val DECODER_CN = ClassName("com.ditchoom.buffer.codec", "Decoder")
 internal val DECODE_CONTEXT_CN = ClassName("com.ditchoom.buffer.codec", "DecodeContext")
@@ -100,6 +98,8 @@ internal val STREAM_PROCESSOR_CN = ClassName("com.ditchoom.buffer.stream", "Stre
 internal val DECODE_EXCEPTION_CN = ClassName("com.ditchoom.buffer.codec", "DecodeException")
 internal val ENCODE_EXCEPTION_CN = ClassName("com.ditchoom.buffer.codec", "EncodeException")
 internal val FRAMED_ENCODER_CN = ClassName("com.ditchoom.buffer.codec", "FramedEncoder")
+internal val LENGTH_PREFIXED_LIST_ENCODER_CN =
+    ClassName("com.ditchoom.buffer.codec", "LengthPrefixedListEncoder")
 internal val FORWARD_COMPATIBLE_FACTORY_KEY_CN =
     ClassName("com.ditchoom.buffer.codec", "ForwardCompatibleFactoryKey")
 internal val BUFFER_FACTORY_MANAGED_MN =

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterFields.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterFields.kt
@@ -1938,23 +1938,19 @@ internal fun appendEncodeLengthPrefixedUseCodecPayload(
  *
  * **Sealed elements** — variants commonly carry BackPatch-wireSize
  * fields (`@LengthPrefixed val: String`, `@When` trailers), so the
- * pre-measure `as WireSize.Exact` cast doesn't apply. Encode each
- * element into a scratch buffer first to capture the actual byte
- * count, then write the VBI prefix and bulk-copy:
+ * pre-measure `as WireSize.Exact` cast doesn't apply. Delegate to the
+ * runtime `LengthPrefixedListEncoder`, which stages the elements into a
+ * growable scratch to measure the exact body size, writes the VBI
+ * prefix, then bulk-copies the body:
  * ```
- * BufferFactory.Default.allocate(64, buffer.byteOrder).use { __<n>Scratch ->
- *     for (__elem in <accessor>) {
- *         ElementCodec.encode(__<n>Scratch, __elem, context)
- *     }
- *     val __<n>BodyBytes = __<n>Scratch.position()
- *     <codecType>.encode(buffer, __<n>BodyBytes.toUInt(), context)
- *     __<n>Scratch.resetForRead()
- *     buffer.write(__<n>Scratch)
- * }
+ * LengthPrefixedListEncoder.encode(
+ *     buffer, BufferFactory.Default, <codecType>, <accessor>, ElementCodec, context,
+ * )
  * ```
- * 64-byte starting allocation is a heuristic — `BufferFactory` grows
- * on demand for buffers that exceed it. Tunable per-field if a
- * measurable hot path emerges.
+ * The scratch grows on demand (via the codec module's
+ * `GrowableWriteBufferPool`), so a list section of any size encodes
+ * correctly. An earlier emit used a fixed 64-byte scratch that silently
+ * truncated sections over 64 bytes.
  *
  * **Data-class elements** — pre-measure body bytes via the element
  * codec's `wireSize as Exact`, write VBI prefix, iterate. BackPatch
@@ -1972,31 +1968,18 @@ internal fun appendEncodeLengthPrefixedListBody(
     namespacePrefix: String,
 ) {
     if (spec.elementIsBackPatch) {
-        val scratchVar = "__${namespacePrefix}Scratch"
-        val bodyBytesVar = "__${namespacePrefix}BodyBytes"
-        body.beginControlFlow(
-            "%T.%M.allocate(64, buffer.byteOrder).%M { %L ->",
+        // Elements are BackPatch-sized, so the body byte count isn't known until they're
+        // encoded. Stage into a growable scratch (via LengthPrefixedListEncoder) that grows
+        // to any size, measures the exact body, writes the length prefix, then bulk-copies.
+        body.addStatement(
+            "%T.encode(buffer, %T.%M, %T, %L, %T, context)",
+            LENGTH_PREFIXED_LIST_ENCODER_CN,
             BUFFER_FACTORY_CN,
             BUFFER_FACTORY_DEFAULT_MN,
-            BUFFER_USE_MN,
-            scratchVar,
-        )
-        body.beginControlFlow("for (__elem in %L)", accessor)
-        body.addStatement(
-            "%T.encode(%L, __elem, context)",
-            spec.elementCodecClassName,
-            scratchVar,
-        )
-        body.endControlFlow()
-        body.addStatement("val %L = %L.position()", bodyBytesVar, scratchVar)
-        body.addStatement(
-            "%T.encode(buffer, %L.toUInt(), context)",
             spec.codecType,
-            bodyBytesVar,
+            accessor,
+            spec.elementCodecClassName,
         )
-        body.addStatement("%L.resetForRead()", scratchVar)
-        body.addStatement("buffer.write(%L)", scratchVar)
-        body.endControlFlow()
     } else {
         val bodyBytesVar = "__${namespacePrefix}BodyBytes"
         body.addStatement(

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/StringTaggedPropertyBagCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/StringTaggedPropertyBagCodec.kt
@@ -8,11 +8,11 @@ import com.ditchoom.buffer.WriteBuffer
 import com.ditchoom.buffer.codec.Codec
 import com.ditchoom.buffer.codec.DecodeContext
 import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.LengthPrefixedListEncoder
 import com.ditchoom.buffer.codec.PeekResult
 import com.ditchoom.buffer.codec.WireSize
 import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttRemainingLengthCodec
 import com.ditchoom.buffer.stream.StreamProcessor
-import com.ditchoom.buffer.use
 import kotlin.Int
 import kotlin.Throwable
 
@@ -37,15 +37,7 @@ public object StringTaggedPropertyBagCodec : Codec<StringTaggedPropertyBag> {
     `value`: StringTaggedPropertyBag,
     context: EncodeContext,
   ) {
-    BufferFactory.Default.allocate(64, buffer.byteOrder).use { __propertiesScratch ->
-      for (__elem in value.properties) {
-        StringTaggedPropertyCodec.encode(__propertiesScratch, __elem, context)
-      }
-      val __propertiesBodyBytes = __propertiesScratch.position()
-      MqttRemainingLengthCodec.encode(buffer, __propertiesBodyBytes.toUInt(), context)
-      __propertiesScratch.resetForRead()
-      buffer.write(__propertiesScratch)
-    }
+    LengthPrefixedListEncoder.encode(buffer, BufferFactory.Default, MqttRemainingLengthCodec, value.properties, StringTaggedPropertyCodec, context)
   }
 
   override fun wireSize(`value`: StringTaggedPropertyBag, context: EncodeContext): WireSize = WireSize.BackPatch

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/LengthPrefixedUseCodecListCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/LengthPrefixedUseCodecListCodecTest.kt
@@ -304,6 +304,33 @@ class LengthPrefixedUseCodecListCodecTest {
     }
 
     @Test
+    fun stringTaggedPropertyBagOver64BytesRoundTrips() {
+        // Regression for the fixed-64-byte scratch bug (issue #249): a
+        // `@LengthPrefixed @UseCodec List<E>` section whose encoded body
+        // exceeds 64 bytes must round-trip. The old emit staged the body into
+        // a fixed 64-byte scratch, which silently truncated (JVM/JS) or overran
+        // native memory (Linux simdutf) once the section grew past 64 bytes.
+        // Now the body is staged through a growable scratch that grows to fit.
+        val original =
+            StringTaggedPropertyBag(
+                properties =
+                    (0 until 8).map {
+                        StringTaggedProperty(tag = "user-property-value-$it".repeat(2), value = it.toUByte())
+                    },
+            )
+        val buffer = BufferFactory.Default.allocate(1024)
+        StringTaggedPropertyBagCodec.encode(buffer, original, EncodeContext.Empty)
+        buffer.resetForRead()
+        // Body is well over 64 bytes (8 * ~45 = ~360), so the scratch must have grown.
+        assertTrue(
+            buffer.remaining() > 64,
+            "expected an encoded frame larger than the old 64-byte scratch, got ${buffer.remaining()}",
+        )
+        val decoded = StringTaggedPropertyBagCodec.decode(buffer, DecodeContext.Empty)
+        assertEquals(original, decoded)
+    }
+
+    @Test
     fun stringTaggedPropertyBagWireBytesMatchScratchPath() {
         // Independent computation of the expected wire layout: for each
         // element, [lpStringLen (2 BE) | tagBytes | value (1)]; sum lengths,

--- a/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/GrowableWriteBuffer.kt
+++ b/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/GrowableWriteBuffer.kt
@@ -51,6 +51,19 @@ internal class GrowableWriteBuffer : WriteBuffer {
         factory = null
     }
 
+    /**
+     * Frees the inner buffer (if attached) and clears state. Used by callers that
+     * own the scratch for its whole lifetime — e.g. [LengthPrefixedListEncoder],
+     * which copies the measured body into the target buffer and then discards the
+     * scratch, rather than transferring ownership to a returned slice the way
+     * [FramedEncoder] does.
+     */
+    fun freeAndDetach() {
+        inner?.freeNativeMemory()
+        inner = null
+        factory = null
+    }
+
     override val byteOrder: ByteOrder get() = requireInner().byteOrder
 
     override fun limit(): Int = requireInner().limit()

--- a/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/LengthPrefixedListEncoder.kt
+++ b/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/LengthPrefixedListEncoder.kt
@@ -1,0 +1,46 @@
+package com.ditchoom.buffer.codec
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.WriteBuffer
+
+/**
+ * Runtime entry point for the generated encode of a `@LengthPrefixed @UseCodec List<T>`
+ * section whose elements are [WireSize.BackPatch] — variable-length, so the body byte
+ * count isn't known until the elements are encoded.
+ *
+ * Encodes every element into a growable scratch buffer to measure the exact body size,
+ * writes the length prefix into [target] via [lengthPrefixCodec], then bulk-copies the
+ * measured body. The scratch grows on demand (via [GrowableWriteBufferPool]) so a list
+ * section of any size encodes correctly.
+ *
+ * This replaces an earlier emit that staged the body into a **fixed 64-byte** buffer:
+ * once the encoded section exceeded 64 bytes the scratch overflowed and — on platforms
+ * whose `writeString`/`write` silently truncated instead of throwing — produced a
+ * structurally-valid frame carrying truncated data (the truncated count is what got
+ * length-prefixed, so nothing downstream could detect the corruption).
+ */
+public object LengthPrefixedListEncoder {
+    public fun <T> encode(
+        target: WriteBuffer,
+        factory: BufferFactory,
+        lengthPrefixCodec: Encoder<UInt>,
+        elements: Iterable<T>,
+        elementCodec: Encoder<T>,
+        context: EncodeContext,
+        initialBodyEstimate: Int = 256,
+    ) {
+        val growable = GrowableWriteBufferPool.acquire()
+        try {
+            growable.attach(factory, initialSize = initialBodyEstimate, byteOrder = target.byteOrder)
+            for (element in elements) {
+                elementCodec.encode(growable, element, context)
+            }
+            val bodyBytes = growable.position()
+            lengthPrefixCodec.encode(target, bodyBytes.toUInt(), context)
+            target.write(growable.toReadBuffer())
+        } finally {
+            growable.freeAndDetach()
+            GrowableWriteBufferPool.release(growable)
+        }
+    }
+}

--- a/buffer/src/commonTest/kotlin/com/ditchoom/buffer/WriteStringOverflowTest.kt
+++ b/buffer/src/commonTest/kotlin/com/ditchoom/buffer/WriteStringOverflowTest.kt
@@ -1,0 +1,71 @@
+package com.ditchoom.buffer
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * Regression tests for `writeString` overflow handling (issue #250).
+ *
+ * `writeString` must throw [BufferOverflowException] when the encoded bytes
+ * exceed the write window, rather than:
+ *   - silently truncating the output (JVM `CharsetEncoder` OVERFLOW result was
+ *     discarded; JS `TextEncoder.encodeInto` truncates to the target size), or
+ *   - overrunning native memory (Linux `simdutf` wrote the full multi-byte
+ *     UTF-8 with no destination cap after a char-count-only bounds check).
+ *
+ * Runs on every platform so all `writeString` actuals are held to the contract.
+ */
+class WriteStringOverflowTest {
+    private fun factories(): List<Pair<String, BufferFactory>> =
+        listOf(
+            "Default" to BufferFactory.Default,
+            "managed" to BufferFactory.managed(),
+        )
+
+    @Test
+    fun writeStringThrowsWhenAsciiExceedsCapacity() {
+        for ((name, factory) in factories()) {
+            val buffer = factory.allocate(4)
+            assertFailsWith<BufferOverflowException>("[$name] ascii overflow must throw") {
+                buffer.writeString("abcdefgh") // 8 ASCII bytes into a 4-byte buffer
+            }
+        }
+    }
+
+    @Test
+    fun writeStringThrowsWhenMultiByteExceedsCapacity() {
+        // Each 'é' encodes to 2 UTF-8 bytes → 10 bytes needed, only 4 available.
+        // The pre-fix native path overran the buffer instead of throwing because
+        // it checked only the char count (5), not the encoded length (10).
+        for ((name, factory) in factories()) {
+            val buffer = factory.allocate(4)
+            assertFailsWith<BufferOverflowException>("[$name] multibyte overflow must throw") {
+                buffer.writeString("ééééé")
+            }
+        }
+    }
+
+    @Test
+    fun writeStringThrowsWhenAppendingPastRemaining() {
+        // Partially fill, then overflow the remaining window — the silent-truncation case.
+        for ((name, factory) in factories()) {
+            val buffer = factory.allocate(8)
+            buffer.writeString("123456") // 6 bytes, remaining = 2
+            assertFailsWith<BufferOverflowException>("[$name] short write past remaining must throw") {
+                buffer.writeString("789") // 3 bytes into 2 remaining
+            }
+        }
+    }
+
+    @Test
+    fun writeStringSucceedsWhenExactlyFits() {
+        for ((name, factory) in factories()) {
+            val buffer = factory.allocate(5)
+            buffer.writeString("hello") // exactly 5 UTF-8 bytes
+            buffer.resetForRead()
+            assertEquals(5, buffer.remaining(), "[$name] full string must be written")
+            assertEquals("hello", buffer.readString(5, Charset.UTF8).toString(), "[$name] round-trip")
+        }
+    }
+}

--- a/buffer/src/jsMain/kotlin/com/ditchoom/buffer/JsBuffer.kt
+++ b/buffer/src/jsMain/kotlin/com/ditchoom/buffer/JsBuffer.kt
@@ -217,9 +217,19 @@ class JsBuffer(
             Charset.UTF8 -> {
                 val str = text.toString()
                 if (str.isEmpty()) return this
-                // Zero-alloc: TextEncoder.encodeInto() writes UTF-8 directly into the buffer
-                val target = Uint8Array(buffer.buffer, buffer.byteOffset + positionValue, capacity - positionValue)
+                // Zero-alloc: TextEncoder.encodeInto() writes UTF-8 directly into the buffer.
+                // Bound the target to the write window (limit), not capacity, so we never write
+                // past the limit; encodeInto() silently truncates when the target is too small,
+                // so compare code units read against the input length and throw on a short write.
+                val available = limitValue - positionValue
+                val target = Uint8Array(buffer.buffer, buffer.byteOffset + positionValue, available)
                 val result = textEncoder.asDynamic().encodeInto(str, target)
+                if ((result.read as Int) < str.length) {
+                    throw BufferOverflowException(
+                        "Buffer overflow: cannot encode UTF-8 string of ${str.length} char(s) at position " +
+                            "$positionValue (limit=$limitValue, remaining=$available)",
+                    )
+                }
                 positionValue += (result.written as Int)
             }
             else -> throw UnsupportedOperationException("Unable to encode in $charset. Must use Charset.UTF8")

--- a/buffer/src/jvmCommonMain/kotlin/com/ditchoom/buffer/BaseJvmBuffer.kt
+++ b/buffer/src/jvmCommonMain/kotlin/com/ditchoom/buffer/BaseJvmBuffer.kt
@@ -436,7 +436,18 @@ abstract class BaseJvmBuffer(
     ): WriteBuffer {
         val encoder = charset.toEncoder()
         encoder.reset()
-        encoder.encode(CharBuffer.wrap(text), byteBuffer, true)
+        val result = encoder.encode(CharBuffer.wrap(text), byteBuffer, true)
+        if (result.isOverflow) {
+            throw BufferOverflowException(
+                "Buffer overflow: cannot encode $charset string of ${text.length} char(s) at position " +
+                    "${position()} (limit=${limit()}, remaining=${remaining()})",
+            )
+        }
+        if (result.isError) {
+            // Malformed input or unmappable character: surface the JDK's typed CharacterCodingException
+            // rather than silently emitting a partial/substituted encoding.
+            result.throwException()
+        }
         return this
     }
 

--- a/buffer/src/linuxMain/kotlin/com/ditchoom/buffer/NativeBuffer.kt
+++ b/buffer/src/linuxMain/kotlin/com/ditchoom/buffer/NativeBuffer.kt
@@ -460,7 +460,10 @@ class NativeBuffer private constructor(
         val str = text.toString()
         val len = str.length
         if (len == 0) return this
-        checkWriteBounds(len) // minimum bytes (ASCII); actual UTF-8 may need more
+        // simdutf writes the full multi-byte UTF-8 output with no destination-capacity cap, so the
+        // bound must be checked against the actual encoded byte count, not the char count. Checking
+        // only `len` (the ASCII minimum) would let a multi-byte string overrun the native buffer.
+        checkWriteBounds(str.utf8Length())
         // SIMD-accelerated UTF-16->UTF-8 conversion via simdutf.
         // toCharArray() copies the String's chars, then simdutf converts directly into native memory.
         // ~28x faster than the per-character loop for large strings (518ms -> 18ms at 16MB).
@@ -1061,7 +1064,10 @@ private class NativeBufferSlice(
         val str = text.toString()
         val len = str.length
         if (len == 0) return this
-        checkWriteBounds(len) // minimum bytes (ASCII); actual UTF-8 may need more
+        // simdutf writes the full multi-byte UTF-8 output with no destination-capacity cap, so the
+        // bound must be checked against the actual encoded byte count, not the char count. Checking
+        // only `len` (the ASCII minimum) would let a multi-byte string overrun the native buffer.
+        checkWriteBounds(str.utf8Length())
         val chars = str.toCharArray()
         val dstAddr = baseAddress + positionValue
         val written =


### PR DESCRIPTION
Fixes #249 and #250 — a companion pair that together produced silent wire-frame corruption (found by the DitchOoM/mqtt fuzzer: every MQTT v5 packet with a property list over 64 bytes truncated silently).

## #250 — `writeString` silently truncated instead of throwing

`writeString` discarded the encoder's overflow signal, writing only the bytes that fit and returning normally. Three distinct defects, all fixed:

- **JVM** (`BaseJvmBuffer`) — ignored the `CharsetEncoder` `CoderResult`. Now throws the library `BufferOverflowException` on `OVERFLOW` (matching the `write(ReadBuffer)` path) and surfaces malformed/unmappable input via `throwException()`.
- **JS** (`JsBuffer`) — `encodeInto` sized its target to `capacity` (not `limit`) and swallowed short writes. Now bounded to the write window and throws when fewer code units were consumed than the input length.
- **Linux native** (`NativeBuffer`, buffer + slice) — worse than truncation: the char-count-only bounds check let simdutf write the full multi-byte UTF-8 **past the buffer** (native heap overrun). Now bounds-checks the actual encoded byte count (`utf8Length()`) before the conversion.

Apple already bounds-checks the exact encoded length; `ByteArrayBuffer`/wasm delegate to `writeBytes()` which checks bounds — both left unchanged. New common `WriteStringOverflowTest` holds every platform actual to the throw-not-truncate contract.

## #249 — codec's fixed 64-byte list scratch corrupted data

The generated encode for a `@LengthPrefixed @UseCodec List<T>` section with BackPatch-sized elements staged the body into `BufferFactory.Default.allocate(64)` before measuring it for the length prefix. Once the section exceeded 64 bytes the scratch overflowed; combined with #250's silent truncation it emitted a structurally-valid frame carrying truncated data — the truncated count is what got length-prefixed, so nothing downstream could detect it.

`WireSize`'s own contract already says BackPatch sections write into a *growable* buffer. Fixed by routing the section through the library's existing growable machinery (the `GrowableWriteBufferPool` that `FramedEncoder` already uses):

- New public `LengthPrefixedListEncoder` grows the scratch to any size, measures the exact body, writes the prefix, then bulk-copies. Adds `GrowableWriteBuffer.freeAndDetach()` for the owns-the-scratch lifecycle (vs `FramedEncoder`'s ownership transfer).
- `CodecEmitterFields` emits a single call to it; removes the now-dead `BUFFER_USE_MN`.

Blast radius is one generated golden (`StringTaggedPropertyBagCodec`).

## Validation

- `WriteStringOverflowTest` (new, common) — 4/4 on **JVM, JS, wasm, native/Linux**; the multi-byte case specifically exercises the native OOB fix.
- New >64-byte codec round-trip (`stringTaggedPropertyBagOver64BytesRoundTrips`) passes; snapshot regen touched only the one expected golden.
- Full suites green locally: buffer 1136, buffer-codec-test 750, buffer-codec-processor 185, plus `ktlintCheck`.
- **Apple**: no Apple-facing change (its `writeString` was already safe) — relying on this PR's macOS CI leg to confirm the full matrix.
