### PR TITLE
fix(buffer-crypto): resolve Swift back-compat libs on the CryptoKitShim cinterop cache link (#253)

### DIFF
--- a/buffer-crypto/build.gradle.kts
+++ b/buffer-crypto/build.gradle.kts
@@ -409,6 +409,16 @@ kotlin {
                     "lib${shim.archiveName}.a",
                     "-libraryPath",
                     shim.outDir.absolutePath,
+                    // #253: bake the toolchain's per-SDK Swift runtime lib dir into the cinterop
+                    // klib's own link options. The Swift shim archive auto-links the Swift back-compat
+                    // libs (swiftCompatibility56 / swiftCompatibilityConcurrency / swiftCompatibilityPacks);
+                    // on Xcode 26.5 / K/N 2.4.0 the pre-built cinterop *static cache* link doesn't inherit
+                    // the final-binary linkerOpts below, so those symbols go unresolved (`ld: symbol(s)
+                    // not found`). The compat libs live in the same per-SDK dir as swiftCore/swiftFoundation
+                    // (shim.swiftLibDir = .../usr/lib/swift/<sdk>), so a single -L there resolves them for
+                    // the cached-link path too, without disabling the native cache.
+                    "-linkerOpts",
+                    "-L${shim.swiftLibDir}",
                 )
             }
             // The cinterop task is registered by the KMP plugin under a derived name; wire the


### PR DESCRIPTION
Closes #253.

## Problem

Linking a Kotlin/Native **iOS** binary that depends on `buffer-crypto` fails at `ld` on **Xcode 26.5 / K/N 2.4.0**. The CryptoKitShim cinterop's pre-built **static cache** (`buffer-crypto-cinterop-cryptokitshim-cache.a`) auto-links the Swift back-compat symbols `swiftCompatibility56` / `swiftCompatibilityConcurrency` / `swiftCompatibilityPacks`, but the cached-link step never gets the toolchain's Swift lib dir on its search path:

```
ld: warning: Could not find or use auto-linked library 'swiftCompatibility56'
Undefined symbols for architecture arm64:
  "__swift_FORCE_LOAD_$_swiftCompatibility56", referenced from:
      ... in libcom.ditchoom:buffer-crypto-cinterop-cryptokitshim-cache.a[3](CryptoKitShim-1.o)
ld: symbol(s) not found for architecture arm64
```

This was previously masked by the HKDF body-lowering StackOverflow (fixed in 6.3.2 / #251); once that fix lets the build reach linking, this surfaces.

## Root cause

The Swift runtime lib dir (`shim.swiftLibDir` = `.../usr/lib/swift/<sdk>`) was only added to the **final-binary** link (`binaries.all { linkerOpts(...) }`). The Kotlin/Native **cinterop static-cache** link is a separate step that does **not** inherit those `linkerOpts`, so the auto-linked compat libs go unresolved. The compat libs live in the same per-SDK dir as `swiftCore`/`swiftFoundation`.

## Fix

Bake `-L${shim.swiftLibDir}` into the cinterop's **own** link options via `extraOpts`, so the cached-link path resolves the compat libs too — without disabling the native cache (the consumer-side `disableNativeCache` workaround forfeits it).

## Validation

- ✅ Build script configures cleanly; Kotlin DSL valid (Linux).
- ⚠️ **Apple/iOS-only — not exercisable on Linux CI.** Needs macOS CI to confirm `linkDebugTestIosSimulatorArm64` links green. This is what the build-apple leg on this PR validates.
- Note: the exact konan-cinterop linker flag spelling (`-linkerOpts`) is validated by the first macOS run; if rejected it fails loudly at the cinterop step (fallbacks: `-linker-option`, or `.def` `linkerOpts`).