### PR TITLE
fix(buffer-pool): size-class buckets to stop Android ART fragmentation OOM

### DIFF
--- a/ANDROID_ART_ALLOCATOR.md
+++ b/ANDROID_ART_ALLOCATOR.md
@@ -1,0 +1,174 @@
+# Android/ART Direct-Buffer Allocation — Findings & OOM Repro Reference
+
+## Current status (2026-07-05) — verified on branch `wip/android-allocator`
+
+Implementation is **complete and verified in the working tree, not yet merged**.
+Committed to `wip/android-allocator` (off `main` @ Kotlin 2.4.0 / v6.4.0).
+
+**In place:**
+- `BufferSizeClass` power-of-two rounding + per-class buckets in `LockFreeBufferPool` /
+  `SingleThreadedBufferPool` (the fix — commonMain, factory-agnostic).
+- Native-memory lifecycle hardening: `String.toReadBuffer` defaults to `managed()`;
+  `ReadBuffer.indexOf(String)` frees its staging needle in a `finally`.
+- `BufferPoolFragmentationTests` (commonTest), `NonMovableOomRegressionTest`
+  (androidInstrumentedTest), `PoolChurnBenchmark` (commonBenchmark).
+
+**Verification (2026-07-05):**
+1. `./gradlew allTests ktlintCheck` — **green**. Every platform's pool exercised
+   (JVM/JS-node/JS-browser/wasmJs/linuxX64/Android unit); 0 failures, 0 errors. The
+   size-class rounding preserves the existing pools' hit/miss and capacity assertions
+   (`popAtLeast` searches the request's bucket and up).
+2. Android instrumented repro on `api34def_oom` (API 34, default AOSP `sdk_phone64`,
+   heap 576m — the exact CI geometry): `case1` **PASSED** (2.83s), `case2` **SKIPPED**
+   (`@Ignore`d, factory routing rejected). `tests=2 failures=0 errors=0 skipped=1`.
+
+**PR:** single PR, **`minor`** label — the pool fix + lifecycle hardening land together
+(both from this investigation); `minor` because `String.toReadBuffer`'s default backing
+changed native→managed, observable to native-interop consumers. The "Implications for the
+fix" section below is the rationale for keeping the factory route out of scope.
+
+---
+
+Reference notes from reproducing the Autobahn case 9.2.5 large-message OOM
+(websocket CI run `28618587934`, job `84868487414`, 2026-07-02). Everything here was
+verified empirically on emulators; keep this document updated if ART behavior changes
+in future API levels or Mainline trains.
+
+## How ART allocates `ByteBuffer.allocateDirect`
+
+On Android, `allocateDirect(n)` → `DirectByteBuffer$MemoryRef` →
+`VMRuntime.newNonMovableArray(byte.class, n)`. The backing memory is a Java `byte[]`
+in the managed heap (it counts against the app's heap growth limit), pinned so it
+never moves. Where that array lands depends on its size:
+
+| Request size | Space | Properties |
+|---|---|---|
+| < 12 KiB (LOS threshold) | **non-moving malloc space** | dlmalloc-style, fixed ~60.7 MB capacity, never compacted — fragments permanently |
+| ≥ 12 KiB | **Large Object Space (LOS)** | freelist over a reserved region; holes reclaim/coalesce, but the region itself can fragment |
+
+**Critical fallback rule:** when an LOS allocation fails, ART retries the allocation
+in the non-moving space. The `OutOfMemoryError` message describes the *fallback*
+space — which is why the CI crash for an 8 MiB buffer reports `malloc_space
+fragmentation ... capacity = 60678144` even though 8 MiB buffers normally never live
+there.
+
+## Reading the OOM message
+
+```
+Failed to allocate a 8388637 byte allocation with 25149440 free bytes and 182MB until OOM,
+target footprint 437558088, growth limit 603979776;
+failed due to malloc_space fragmentation
+(largest possible contiguous allocation 516800 bytes, space in use 49924680 bytes, capacity = 60678144)
+```
+
+- `growth limit` — the app's heap budget (`dalvik.vm.heapgrowthlimit`, or `heapsize`
+  with `largeHeap`). CI: 576 MB. Stock emulator: 192 MB.
+- `capacity` / `space in use` / `largest possible contiguous` — stats of the space the
+  final attempt ran in. `~60.7 MB capacity` identifies the non-moving space.
+- "free bytes" ≫ "largest possible contiguous" is the fragmentation signature: memory
+  is free but no contiguous run fits the request.
+
+## Version / image-flavor matrix (observed 2026-07-02)
+
+| Image | Behavior of large direct buffers | Repro? |
+|---|---|---|
+| android-34 **default** (AOSP) | LOS + non-moving fallback as above | **YES** (CI's image) |
+| android-34 google_apis | growth-limit OOMs only; no fragmentation failures observed | no |
+| android-35 google_apis | 256 MB fill produced zero OOMs (appears native-backed) | no |
+| android-36 google_apis | counts against heap; ART self-heals (OOM thrown internally, GC retry succeeds ~20 ms later) | no |
+| android-26 google_apis | large buffers verifiably in LOS (`255(240MB) LOS objects` freed by GC) | no |
+
+Take-away: the failure depends on the **ART module version** (stock AOSP vs
+Mainline-updated google_apis images), not simply the API level. Real-world devices
+that don't receive ART Mainline updates remain affected regardless of OS age.
+
+## The actual CI failure mechanism (two fronts, both required)
+
+1. **LOS front:** 49 Autobahn cases churn MB-scale, odd-sized message buffers
+   (`LockFreeBufferPool.acquire` misses allocate exact sizes like 8 MiB + 29). The
+   LOS freelist region fragments until an 8 MiB contiguous run no longer exists.
+   This is only reachable when the heap budget (576 MB in CI) is large enough to
+   drive the LOS region toward exhaustion — under the stock 192 MB emulator limit
+   the region always retains a huge untouched tail and the failure is unreachable.
+2. **Non-moving front:** the stream-processor read path churns 8 KiB pool buffers
+   (below the LOS threshold), fragmenting the ~60 MB non-moving space (CI: 47 MB in
+   use, largest contiguous 505 KB).
+3. The 8 MiB request fails in the LOS, falls back to the non-moving space, fails
+   there too → `OutOfMemoryError`, process crash.
+
+## Reproducing locally (30 s instead of the 26-minute CI loop)
+
+Test: `buffer/src/androidInstrumentedTest/kotlin/com/ditchoom/buffer/NonMovableOomRegressionTest.kt`
+- `case2_fragmentedSpaces_largeDefaultAllocationSucceeds` — deterministic two-front
+  repro; asserts the desired behavior, so it is **red until the fix lands**.
+- `case1_pooledLargeMessageChurn_finalLargeAcquireSucceeds` — pool-shaped churn;
+  stays green at this scale (CI needed 22 min of churn), kept as an end-to-end gate.
+
+Setup (WSL2/Linux, exact CI environment):
+
+```bash
+# 1. Exact CI image + AVD
+yes | sdkmanager "system-images;android-34;default;x86_64"
+echo no | avdmanager create avd -n api34def_oom -k "system-images;android-34;default;x86_64" -f
+emulator -avd api34def_oom -no-window -no-audio -no-boot-anim -gpu swiftshader_indirect -no-snapshot &
+
+# 2. CI heap geometry — REQUIRED; emulator -prop silently ignores dalvik.* props.
+#    default-flavor images are rootable; must be re-applied after every emulator boot.
+adb root
+adb shell "setprop dalvik.vm.heapgrowthlimit 576m; setprop dalvik.vm.heapsize 576m; stop; start"
+
+# 3. Run (note: this module's only instrumented variant is `benchmark`;
+#    there is no connectedDebugAndroidTest task)
+./gradlew :buffer:connectedAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.class=com.ditchoom.buffer.NonMovableOomRegressionTest
+```
+
+Local red-run signature (matches CI byte-for-byte in structure):
+
+```
+Failed to allocate a 8388656 byte allocation with 25165824 free bytes and 177MB until OOM,
+target footprint 443534656, growth limit 603979776; failed due to malloc_space fragmentation
+(largest possible contiguous allocation 83568 bytes, space in use 39430464 bytes, capacity = 60698624)
+```
+
+## Validating allocator behavior in tests
+
+- `adb logcat` GC lines report LOS bytes explicitly: `Explicit concurrent copying GC
+  freed 948(32KB) AllocSpace objects, 188(176MB) LOS objects, ...` — the second pair
+  tells you whether your buffers landed in the LOS.
+- `Throwing OutOfMemoryError` lines appear in logcat even when ART recovers (API 36
+  retries internally); a passing test does not mean no OOM was thrown.
+- `getprop dalvik.vm.heapgrowthlimit` / `heapsize` — verify heap geometry before
+  trusting a green fragmentation test.
+
+## Implications for the fix (pool fix landed 2026-07-02; factory routing rejected)
+
+- **Pool (commonMain, factory-agnostic) — LANDED, the fix:** `BufferSizeClass`
+  power-of-two rounding + per-class buckets in `LockFreeBufferPool` /
+  `SingleThreadedBufferPool` stops *both* churn streams (exact odd-size large buffers
+  → LOS front; 8 KiB acquire/release → non-moving front) on every platform. Live
+  block sizes are bounded to <= 31 size classes, so neither freelist can fragment.
+  `NonMovableOomRegressionTest.case1` (pool-shaped churn) pins this red→green.
+- **Factory (androidMain) — IMPLEMENTED, THEN REJECTED:** routing
+  `BufferFactory.Default` allocations >= 12 KiB to an owning native-malloc buffer
+  (`OwnedNativeJvmBuffer`: Unsafe malloc + JNI `NewDirectByteBuffer`) takes both ART
+  spaces out of the picture for large buffers. Rejected because it silently changes
+  the Default-factory lifecycle contract: every large buffer becomes a leak-on-drop
+  `CloseableBuffer`, and no GC safety net can make that safe on ART — derived
+  ByteBuffer views (`duplicate()`/`slice()`/`asReadOnlyBuffer()`, incl.
+  `toNativeData()` handles) share only the internal `MemoryRef` and do NOT retain
+  the original buffer (unlike OpenJDK's `att` chain), so a Cleaner referent can
+  become unreachable while a live view still addresses the memory — premature free
+  (corruption) is strictly worse than the leak it would prevent. Given the narrow
+  affected window (stock non-Mainline ART + largeHeap-scale budget + sustained
+  mixed-size churn) and that the pool fix removes the churn mechanism itself, the
+  contract change wasn't worth it. `NonMovableOomRegressionTest.case2` — the
+  deterministic held-pin repro that only factory routing can satisfy — is kept
+  `@Ignore`d as the repro recipe if this is ever revisited. Note for any revisit:
+  `wrapNativeAddress` is non-owning (`DirectJvmBuffer.freeNativeMemory()` is a
+  no-op); an owning buffer type must also override the API < 27 parcel pipe path,
+  which streams from a background thread after `writeToParcel` returns.
+
+Related: `~/git/ANDROID-NONMOVABLE-OOM-HANDOFF.md` (original handoff; its API-34
+claim was right, but it predates the LOS-fallback mechanism and image-flavor
+findings recorded here).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -513,6 +513,7 @@ class ProtocolConnection(
 ## Platform Notes
 
 - **JVM/Android:** Direct ByteBuffers (`DirectJvmBuffer`) used by default; `HeapJvmBuffer` for `wrap()` and `BufferFactory.managed()`
+- **Android ART allocator behavior** (LOS vs non-moving space routing, fragmentation OOMs, emulator repro recipe): see `ANDROID_ART_ALLOCATOR.md`
 - **Android SharedMemory:** Use `BufferFactory.shared()` for zero-copy IPC via Parcelable (API 27+)
 - **Apple:** `MutableDataBuffer` wraps NSMutableData (native memory); `wrap(ByteArray)` returns `ByteArrayBuffer`
 - **Apple NSData interop:** Use `BufferFactory.Default.wrap(nsData)` or `BufferFactory.Default.wrap(nsMutableData)` for zero-copy Apple API interop

--- a/buffer/build.gradle.kts
+++ b/buffer/build.gradle.kts
@@ -496,6 +496,13 @@ benchmark {
             iterationTimeUnit = "ms"
             include("largeBufferOperations")
         }
+        register("pool") {
+            warmups = 3
+            iterations = 5
+            iterationTime = 500
+            iterationTimeUnit = "ms"
+            include("PoolChurn")
+        }
         register("subset") {
             warmups = 2
             iterations = 3

--- a/buffer/src/androidInstrumentedTest/AndroidManifest.xml
+++ b/buffer/src/androidInstrumentedTest/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-    <!-- Test APK requires minSdk 23 for Android 14+ devices -->
-    <uses-sdk android:minSdkVersion="23" tools:overrideLibrary="androidx.test.rules,androidx.test.runner,androidx.test.core,androidx.test.core.ktx,androidx.test.ext.junit,androidx.test.services.storage,androidx.test.monitor,androidx.test.ext.junit.ktx,androidx.benchmark,androidx.benchmark.common,androidx.benchmark.junit4,androidx.benchmark.traceprocessor"/>
+    <!-- AGP 9 forbids minSdkVersion here; uses-sdk is kept only for tools:overrideLibrary -->
+    <uses-sdk tools:overrideLibrary="androidx.test.rules,androidx.test.runner,androidx.test.core,androidx.test.core.ktx,androidx.test.ext.junit,androidx.test.services.storage,androidx.test.monitor,androidx.test.ext.junit.ktx,androidx.benchmark,androidx.benchmark.common,androidx.benchmark.junit4,androidx.benchmark.traceprocessor"/>
     <application>
         <service
             android:name="com.ditchoom.buffer.IPCSimpleService"

--- a/buffer/src/androidInstrumentedTest/kotlin/com/ditchoom/buffer/NonMovableOomRegressionTest.kt
+++ b/buffer/src/androidInstrumentedTest/kotlin/com/ditchoom/buffer/NonMovableOomRegressionTest.kt
@@ -1,0 +1,156 @@
+package com.ditchoom.buffer
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.buffer.pool.ThreadingMode
+import org.junit.FixMethodOrder
+import org.junit.Ignore
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.MethodSorters
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * Regression tests for the Android large-message OOM caused by non-moving-space
+ * fragmentation (Autobahn case 9.2.5, CI run 28618587934).
+ *
+ * On ART, `ByteBuffer.allocateDirect` is backed by `VMRuntime.newNonMovableArray` in the
+ * non-moving heap space — a fixed-capacity region the GC never compacts. Mixed-size churn
+ * of MB-scale direct buffers fragments it until a large contiguous allocation fails even
+ * with tens of MB free ("malloc_space fragmentation").
+ *
+ * case1 drives the failure through [BufferPool] with the acquire/release pattern the
+ * websocket read path produces: large assembled-message buffers of unique odd sizes
+ * interleaved with small chop buffers held mid-frame. It goes green if either the pool
+ * stops churning (size-class reuse) or the factory stops allocating large buffers in the
+ * non-moving space. The size-class pool fix (BufferSizeClass) is what keeps it green.
+ *
+ * case2 is IGNORED: it asserts that a raw [BufferFactory.Default] allocation succeeds
+ * with both ART spaces already fragmented by held pins — something only a factory-level
+ * fix (routing large allocations to owned native malloc) can guarantee. That fix was
+ * implemented and then rejected: it changes the Default-factory lifecycle contract
+ * (buffers become leak-on-drop CloseableBuffers, and a GC safety net is unsound on ART
+ * because derived ByteBuffer views do not retain the original buffer), which is worse
+ * than the narrow affected window (stock non-Mainline ART + largeHeap budget + hours of
+ * mixed-size churn — see ANDROID_ART_ALLOCATOR.md). The test is kept as the repro
+ * recipe should the factory-level route ever be revisited.
+ */
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+class NonMovableOomRegressionTest {
+    private companion object {
+        const val KIB = 1024
+        const val MIB = 1024 * KIB
+
+        /** 8 MiB + 29 — the exact allocation size that failed in CI (8,388,637 bytes). */
+        const val FAILING_SIZE = 8 * MIB + 29
+    }
+
+    @Test
+    fun case1_pooledLargeMessageChurn_finalLargeAcquireSucceeds() {
+        val pool =
+            BufferPool(
+                threadingMode = ThreadingMode.MultiThreaded,
+                maxPoolSize = 8,
+                defaultBufferSize = 8 * KIB,
+                factory = BufferFactory.Default,
+            )
+        try {
+            // Consecutive Autobahn-style cases: each case acquires one large
+            // assembled-message buffer of a unique odd size while small chop buffers are
+            // held mid-frame. Sizes grow monotonically per round so no dead hole in the
+            // non-moving space exactly fits a later request.
+            repeat(6) { round ->
+                for (mb in intArrayOf(1, 2, 4, 8)) {
+                    val chops = ArrayList<ReadWriteBuffer>()
+                    repeat(8) { chops += pool.acquire(8 * KIB) }
+                    val big = pool.acquire(mb * MIB + 29 + round * 8 * KIB)
+                    big.resetForWrite()
+                    big.writeByte(0)
+                    chops.forEach { pool.release(it) }
+                    pool.release(big)
+                }
+            }
+            val final = pool.acquire(FAILING_SIZE) as PlatformBuffer
+            assertTrue(final.capacity >= FAILING_SIZE)
+            pool.release(final)
+        } catch (e: OutOfMemoryError) {
+            fail("non-moving space fragmentation reproduced through the pool: ${e.message}")
+        } finally {
+            pool.clear()
+        }
+    }
+
+    @Test
+    @Ignore(
+        "Requires factory-level rerouting of large Default allocations to owned native " +
+            "malloc, which was evaluated and rejected (leak-on-drop lifecycle contract; " +
+            "see class KDoc). Kept as the deterministic two-front fragmentation repro.",
+    )
+    // The explicit gc() calls are load-bearing: this repro must force reclamation of the
+    // dropped 1 MiB churn between the two fragmentation fronts, not wait for a background GC.
+    @Suppress("ExplicitGarbageCollectionCall")
+    fun case2_fragmentedSpaces_largeDefaultAllocationSucceeds() {
+        // ART routes newNonMovableArray >= 12 KiB to the Large Object Space and smaller
+        // arrays to the non-moving malloc space; an allocation that fails in the LOS
+        // falls back to the non-moving space. The CI crash needed BOTH fronts degraded:
+        // the LOS freelist region fragmented by large-message churn, and the non-moving
+        // space fragmented by 8 KiB stream-processor churn (its OOM message is the one
+        // reported: 47 MB in use, largest contiguous 516800 bytes). Reproduce both.
+        //
+        // Requires a CI-like heap budget (dalvik.vm.heapgrowthlimit=576m); under the
+        // stock 192m emulator limit the LOS region can never be driven to exhaustion,
+        // so this test cannot go red there.
+        // The freeNativeMemory() calls are no-ops on GC-managed allocateDirect buffers;
+        // they are kept so the cleanup stays correct if an owning factory route returns.
+        val nmPins = ArrayList<PlatformBuffer>() // 8 KiB < LOS threshold -> non-moving space
+        val losPins = ArrayList<PlatformBuffer>() // 16 KiB >= threshold -> LOS
+        var bigs = ArrayList<PlatformBuffer>() // ~1 MiB -> LOS
+        var result: PlatformBuffer? = null
+        try {
+            // Front 1 — non-moving space: alternate pin/drop 8 KiB buffers (~20 MiB
+            // pinned) so every hole between live pins is <= 8 KiB.
+            try {
+                repeat(5000) { i ->
+                    val b = BufferFactory.Default.allocate(8 * KIB)
+                    if (i % 2 == 0) nmPins += b
+                }
+            } catch (expected: OutOfMemoryError) {
+            }
+            // Front 2 — LOS: alternate ~1 MiB churn with 16 KiB pins in address order,
+            // then drop the churn. Freed 1 MiB holes stay bounded by live pins, so no
+            // contiguous run in the freelist region can serve an 8 MiB request.
+            try {
+                repeat(480) {
+                    bigs += BufferFactory.Default.allocate(1 * MIB + 61)
+                    losPins += BufferFactory.Default.allocate(16 * KIB)
+                }
+            } catch (expected: OutOfMemoryError) {
+            }
+            bigs.forEach { it.freeNativeMemory() }
+            bigs = ArrayList()
+            Runtime.getRuntime().gc()
+
+            result =
+                try {
+                    BufferFactory.Default.allocate(FAILING_SIZE)
+                } catch (e: OutOfMemoryError) {
+                    fail(
+                        "large direct allocation failed with fragmented LOS + non-moving space " +
+                            "(nmPins=${nmPins.size}, losPins=${losPins.size}): ${e.message}",
+                    )
+                }
+            assertTrue(result.capacity >= FAILING_SIZE)
+        } finally {
+            bigs.forEach { it.freeNativeMemory() }
+            losPins.forEach { it.freeNativeMemory() }
+            result?.freeNativeMemory()
+            nmPins.clear()
+            losPins.clear()
+            Runtime.getRuntime().gc()
+        }
+    }
+}

--- a/buffer/src/commonBenchmark/kotlin/com/ditchoom/buffer/benchmark/PoolChurnBenchmark.kt
+++ b/buffer/src/commonBenchmark/kotlin/com/ditchoom/buffer/benchmark/PoolChurnBenchmark.kt
@@ -1,0 +1,122 @@
+package com.ditchoom.buffer.benchmark
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.ReadWriteBuffer
+import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.buffer.pool.ThreadingMode
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.BenchmarkMode
+import kotlinx.benchmark.BenchmarkTimeUnit
+import kotlinx.benchmark.Measurement
+import kotlinx.benchmark.Mode
+import kotlinx.benchmark.OutputTimeUnit
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+import kotlinx.benchmark.TearDown
+import kotlinx.benchmark.Warmup
+
+/**
+ * Measures pool acquire/release throughput under the allocation patterns behind the
+ * Autobahn 9.2.5 fragmentation OOM (see ANDROID_ART_ALLOCATOR.md), to quantify the
+ * size-class pooling fix:
+ *
+ *  - [sameSizeHotLoop*]: fixed 8 KiB acquire/release — the pure pool-hit path. Guards
+ *    against the size-class bucketing adding overhead to the case the old exact-size
+ *    pool already handled well.
+ *  - [mixedSizeChurn*]: four KiB-scale sizes with cycling odd offsets so no exact size
+ *    repeats — the assembled-network-message shape. The old pool freed + reallocated on
+ *    most of these acquires; size-class reuse turns them into hits.
+ *  - [interleavedChopAndLarge*]: 4 held small chops + one odd-sized large acquire per
+ *    op — the websocket read-path shape that crashed CI.
+ *
+ * Offsets cycle mod 64 so every odd size stays inside its power-of-two class and the
+ * benchmark is steady-state (an unbounded offset would drift across size classes).
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(BenchmarkTimeUnit.SECONDS)
+// Benchmark bodies are intentionally full of literal sizes/offsets (the churn shapes
+// under test); extracting each to a named constant would obscure the pattern.
+@Suppress("MagicNumber")
+open class PoolChurnBenchmark {
+    private val kib = 1024
+    private val mixedSizesKib = intArrayOf(3, 5, 9, 17)
+
+    private lateinit var singleThreaded: BufferPool
+    private lateinit var multiThreaded: BufferPool
+    private var round = 0
+
+    @Setup
+    fun setup() {
+        singleThreaded = newPool(ThreadingMode.SingleThreaded)
+        multiThreaded = newPool(ThreadingMode.MultiThreaded)
+        round = 0
+    }
+
+    @TearDown
+    fun tearDown() {
+        singleThreaded.clear()
+        multiThreaded.clear()
+    }
+
+    private fun newPool(threadingMode: ThreadingMode) =
+        BufferPool(
+            threadingMode = threadingMode,
+            maxPoolSize = 16,
+            defaultBufferSize = 1 * kib,
+            factory = BufferFactory.Default,
+        )
+
+    @Benchmark
+    fun sameSizeHotLoopSingleThreaded(): Int = sameSizeHotLoop(singleThreaded)
+
+    @Benchmark
+    fun sameSizeHotLoopMultiThreaded(): Int = sameSizeHotLoop(multiThreaded)
+
+    @Benchmark
+    fun mixedSizeChurnSingleThreaded(): Int = mixedSizeChurn(singleThreaded)
+
+    @Benchmark
+    fun mixedSizeChurnMultiThreaded(): Int = mixedSizeChurn(multiThreaded)
+
+    @Benchmark
+    fun interleavedChopAndLargeMultiThreaded(): Int = interleavedChopAndLarge(multiThreaded)
+
+    private fun sameSizeHotLoop(pool: BufferPool): Int {
+        val buffer = pool.acquire(8 * kib)
+        buffer.writeByte(1)
+        val capacity = buffer.capacity
+        pool.release(buffer)
+        return capacity
+    }
+
+    private fun mixedSizeChurn(pool: BufferPool): Int {
+        round = (round + 1) and 63
+        val held = ArrayList<ReadWriteBuffer>(mixedSizesKib.size)
+        var total = 0
+        for (sizeKib in mixedSizesKib) {
+            val buffer = pool.acquire(sizeKib * kib + round * 7 + 1)
+            buffer.writeByte(round.toByte())
+            total += buffer.capacity
+            held += buffer
+        }
+        held.forEach { pool.release(it) }
+        return total
+    }
+
+    private fun interleavedChopAndLarge(pool: BufferPool): Int {
+        round = (round + 1) and 63
+        val chops = ArrayList<ReadWriteBuffer>(4)
+        repeat(4) { chops += pool.acquire(1 * kib) }
+        val big = pool.acquire(29 * kib + round * 13 + 29)
+        big.writeByte(0)
+        val capacity = big.capacity
+        chops.forEach { pool.release(it) }
+        pool.release(big)
+        return capacity
+    }
+}

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/BufferFactory.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/BufferFactory.kt
@@ -16,9 +16,19 @@ private const val UTF8_FOUR_BYTES = 4
 
 fun CharSequence.maxBufferSize(charset: Charset): Int = (charset.maxBytesPerChar * this.length).roundToInt()
 
+/**
+ * Encodes this string into a fresh [ReadBuffer].
+ *
+ * Defaults to [BufferFactory.managed] because the backing buffer is dropped without an
+ * explicit free (only its slice is returned): on platforms whose default factory hands
+ * out owning native buffers (Linux `NativeBuffer`, large Android allocations), a
+ * native-memory default would leak the staging allocation. Pass a [factory] explicitly
+ * to control the allocation — with an owning factory the caller is responsible for the
+ * backing memory's lifetime.
+ */
 fun String.toReadBuffer(
     charset: Charset = Charset.UTF8,
-    factory: BufferFactory = BufferFactory.Default,
+    factory: BufferFactory = BufferFactory.managed(),
 ): ReadBuffer {
     if (this == "") {
         return ReadBuffer.EMPTY_BUFFER

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/ReadBuffer.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/ReadBuffer.kt
@@ -909,10 +909,16 @@ interface ReadBuffer : PositionBuffer {
 
         // Encode the string to bytes
         val needle = BufferFactory.Default.allocate(text.length * 4) // Max 4 bytes per char in UTF-8
-        needle.writeString(text, charset)
-        needle.resetForRead()
-
-        return indexOf(needle)
+        return try {
+            needle.writeString(text, charset)
+            needle.resetForRead()
+            indexOf(needle)
+        } finally {
+            // The needle may be an owning native buffer (large Android / Linux Default
+            // allocations); a no-op on GC-managed buffers. writeString can throw
+            // (unsupported charsets on some platforms), so it must be inside the try.
+            needle.freeNativeMemory()
+        }
     }
 
     // ===== Bulk Primitive Read Operations =====

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/BufferSizeClass.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/BufferSizeClass.kt
@@ -1,0 +1,81 @@
+package com.ditchoom.buffer.pool
+
+/**
+ * Power-of-two size classes for pooled buffer allocations.
+ *
+ * Pools round every allocation up to a size class and index their cached buffers by
+ * class, for two reasons:
+ * - **Allocator fragmentation:** exact odd-sized allocations (e.g. an assembled
+ *   8 MiB + 29 network message) produce unique block sizes that freelist allocators
+ *   cannot coalesce or reuse. On Android/ART this permanently fragments the Large
+ *   Object Space and the non-moving malloc space until MB-scale allocations fail with
+ *   tens of MB free (see ANDROID_ART_ALLOCATOR.md). Rounding keeps live block sizes
+ *   commensurable: power-of-two classes up to 1 MiB, 1 MiB multiples above (capping
+ *   round-up waste at 1 MiB instead of doubling large allocations).
+ * - **Size-aware reuse:** bucketing by class lets acquire() pop a buffer that is
+ *   guaranteed to fit instead of freeing and reallocating on a wrong-sized pop.
+ *
+ * Invariant: a buffer stored in bucket `k` has `capacity >= 1 shl k` (floor log2), and a
+ * request routed to bucket `k` needs at most `1 shl k` bytes (ceil log2), so any buffer
+ * found in bucket `k` or higher satisfies the request. The single exception is bucket 0,
+ * which also holds zero-capacity buffers; acquire() keeps a defensive capacity check.
+ */
+internal object BufferSizeClass {
+    /** Largest power-of-two size representable as a positive Int (2^30 = 1 GiB). */
+    private const val MAX_POW2: Int = 1 shl 30
+
+    /**
+     * Above this size, rounding switches from next-power-of-two to next-multiple-of-this.
+     * Power-of-two rounding wastes up to 100% (a 16 MiB + 29 request would allocate
+     * 32 MiB), which doubles peak memory for large-message workloads — enough to tip
+     * heap-constrained Android over the edge (Autobahn 9.1.6 echoes a 16 MB message on
+     * a 576 MB-cap device). Multiples of a 1 MiB quantum keep every large block size
+     * commensurable — freelist allocators can coalesce and re-split them freely, which
+     * is what actually prevents fragmentation — while capping waste at 1 MiB.
+     */
+    private const val LARGE_GRANULARITY: Int = 1 shl 20
+
+    /** One bucket per power-of-two exponent of a non-negative Int capacity. */
+    const val BUCKET_COUNT: Int = 32
+
+    /**
+     * Rounds [size] up to its size class: the next power of two up to [LARGE_GRANULARITY],
+     * the next [LARGE_GRANULARITY] multiple up to [MAX_POW2], or the exact size above
+     * [MAX_POW2] (where rounding could overflow Int).
+     *
+     * Requests above [MAX_POW2] map to bucket 31, which no capacity's floor log2 can
+     * reach — they always miss and allocate exactly, and are (deliberately) never
+     * served from the pool. Their released buffers land in bucket 30 and remain
+     * reusable for any request up to [MAX_POW2].
+     *
+     * Note that a non-power-of-two rounded size (e.g. 17 MiB) is stored under its floor
+     * log2 bucket, one below where an equal-sized request starts searching — so exact
+     * same-size churn above [LARGE_GRANULARITY] misses the pool and reallocates. That
+     * matches the pre-size-class pool's behavior for mismatched pops; commensurable
+     * block sizes make the free/realloc cycle fragmentation-safe.
+     */
+    fun roundUp(size: Int): Int =
+        when {
+            size <= 1 -> size.coerceAtLeast(0)
+            size > MAX_POW2 -> size
+            size > LARGE_GRANULARITY ->
+                (size + LARGE_GRANULARITY - 1) and (LARGE_GRANULARITY - 1).inv()
+            else -> 1 shl bucketForRequest(size)
+        }
+
+    /** Index of the smallest bucket whose buffers are guaranteed to satisfy [size]. */
+    fun bucketForRequest(size: Int): Int =
+        if (size <= 1) {
+            0
+        } else {
+            (Int.SIZE_BITS - (size - 1).countLeadingZeroBits()).coerceAtMost(BUCKET_COUNT - 1)
+        }
+
+    /** Index of the bucket a buffer of [capacity] is stored in (floor log2). */
+    fun bucketForCapacity(capacity: Int): Int =
+        if (capacity <= 1) {
+            0
+        } else {
+            (Int.SIZE_BITS - 1) - capacity.countLeadingZeroBits()
+        }
+}

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/LockFreeBufferPool.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/LockFreeBufferPool.kt
@@ -15,6 +15,13 @@ import kotlin.concurrent.atomics.ExperimentalAtomicApi
  * Uses Compare-And-Swap (CAS) operations for thread-safe access without locks.
  * Suitable for concurrent access from multiple threads/coroutines.
  *
+ * Allocations are rounded up to size classes (power-of-two up to 1 MiB, 1 MiB
+ * multiples above) and cached buffers are
+ * bucketed by class — one Treiber stack per class ([BufferSizeClass]) — so mixed-size
+ * churn neither allocates unique odd sizes (which fragment freelist allocators,
+ * catastrophically on Android/ART — see ANDROID_ART_ALLOCATOR.md) nor
+ * frees-and-reallocates on wrong-sized pops.
+ *
  * For single-threaded use, prefer [SingleThreadedBufferPool] for better performance.
  *
  * Uses `kotlin.concurrent.atomics` (stdlib) rather than the atomicfu plugin so the
@@ -22,7 +29,12 @@ import kotlin.concurrent.atomics.ExperimentalAtomicApi
  * transform didn't run for the `-android` variant, leaving `kotlinx.atomicfu.AtomicFU`
  * referenced at runtime with no declared dependency (NoClassDefFoundError). Mirrors
  * [com.ditchoom.buffer.codec.GrowableWriteBufferPool].
+ *
+ * `@Suppress("TooManyFunctions")`: the function count exceeds detekt's default cap because
+ * size-class bucketing splits the Treiber-stack helpers (push/pop/popAtLeast/popAny) out
+ * from the BufferPool interface methods; each is a small, single-purpose lock-free primitive.
  */
+@Suppress("TooManyFunctions")
 @OptIn(ExperimentalAtomicApi::class)
 internal class LockFreeBufferPool(
     private val maxPoolSize: Int,
@@ -35,10 +47,11 @@ internal class LockFreeBufferPool(
         val next: Node?,
     )
 
-    // Lock-free stack head
-    private val head = AtomicReference<Node?>(null)
+    // One lock-free stack per size class; a buffer lives in the bucket of its
+    // capacity's floor log2, so every buffer in bucket k has capacity >= 1 shl k.
+    private val heads = Array(BufferSizeClass.BUCKET_COUNT) { AtomicReference<Node?>(null) }
 
-    // Atomic size counter to avoid traversing the list
+    // Atomic size counter across all buckets, to avoid traversing the lists
     private val poolSize = AtomicInt(0)
 
     // Atomic statistics
@@ -54,7 +67,7 @@ internal class LockFreeBufferPool(
         val buffer = acquire(size)
         if (buffer is PlatformBuffer && buffer.byteOrder == byteOrder) return buffer
         release(buffer)
-        return factory.allocate(size, byteOrder)
+        return factory.allocate(BufferSizeClass.roundUp(maxOf(size, defaultBufferSize)), byteOrder)
     }
 
     override fun wrap(
@@ -66,8 +79,8 @@ internal class LockFreeBufferPool(
         totalAllocations.update { it + 1 }
         val size = maxOf(minSize, defaultBufferSize)
 
-        // Try to pop from stack (lock-free)
-        val buffer = pop()
+        // Try to pop a fitting buffer from the size-class stacks (lock-free)
+        val buffer = popAtLeast(size)
 
         val raw =
             if (buffer != null && buffer.capacity >= size) {
@@ -76,11 +89,11 @@ internal class LockFreeBufferPool(
                 buffer
             } else {
                 poolMisses.update { it + 1 }
-                // A too-small popped buffer was removed from the pool; free its native
-                // memory before allocating fresh, otherwise it leaks (Arena.ofShared
-                // never closes, FfmAutoBuffer waits on GC).
+                // Only reachable via bucket 0's zero-capacity edge case; free the popped
+                // buffer's native memory before allocating fresh, otherwise it leaks
+                // (Arena.ofShared never closes, FfmAutoBuffer waits on GC).
                 buffer?.freeNativeMemory()
-                factory.allocate(size)
+                factory.allocate(BufferSizeClass.roundUp(size))
             }
         return PooledBuffer(raw, this)
     }
@@ -123,31 +136,43 @@ internal class LockFreeBufferPool(
         )
 
     override fun clear() {
-        // Pop all elements and free their native memory
+        // Pop all elements and free their native memory, restarting the bucket scan
+        // every iteration: freeNativeMemory() could re-enter release() and push onto
+        // any bucket, including one that was already drained.
         while (true) {
-            val buffer = pop() ?: break
+            val buffer = popAny() ?: break
             buffer.freeNativeMemory()
         }
     }
 
     /**
-     * Lock-free push onto Treiber stack.
+     * Lock-free push onto the Treiber stack for the buffer's size class.
      * Returns true if pushed, false if pool is full.
      */
     private fun push(buffer: PlatformBuffer): Boolean {
+        // Reserve a slot with a bounded CAS-increment BEFORE touching the bucket head.
+        // With one head per size class, pushes to different buckets never contend on
+        // the head CAS, so a plain check-then-push would never re-run its stale size
+        // check and could admit up to (concurrent releasers - 1) buffers past
+        // maxPoolSize. Reserving on the shared counter makes the cap exact; the
+        // counter may transiently exceed the number of linked nodes while a push is
+        // in flight, which only makes concurrent pops/pushes conservatively strict.
         while (true) {
-            // Check size limit before attempting push
             val currentSize = poolSize.load()
             if (currentSize >= maxPoolSize) {
                 return false
             }
+            if (poolSize.compareAndSet(currentSize, currentSize + 1)) break
+        }
 
+        // Slot reserved — the Treiber push always succeeds eventually.
+        val head = heads[BufferSizeClass.bucketForCapacity(buffer.capacity)]
+        while (true) {
             val oldHead = head.load()
             val newNode = Node(buffer, oldHead)
 
             // CAS: if head hasn't changed, update it
             if (head.compareAndSet(oldHead, newNode)) {
-                poolSize.update { it + 1 }
                 return true
             }
             // CAS failed, retry
@@ -155,10 +180,31 @@ internal class LockFreeBufferPool(
     }
 
     /**
-     * Lock-free pop from Treiber stack.
-     * Returns the buffer or null if stack is empty.
+     * Pops a cached buffer guaranteed to hold [size] bytes, searching the request's own
+     * size class first and falling back to larger classes. Returns null on miss.
      */
-    private fun pop(): PlatformBuffer? {
+    private fun popAtLeast(size: Int): PlatformBuffer? {
+        for (bucket in BufferSizeClass.bucketForRequest(size) until BufferSizeClass.BUCKET_COUNT) {
+            val buffer = pop(heads[bucket])
+            if (buffer != null) return buffer
+        }
+        return null
+    }
+
+    /** Pops from any non-empty bucket, smallest class first. Used by [clear]. */
+    private fun popAny(): PlatformBuffer? {
+        for (head in heads) {
+            val buffer = pop(head)
+            if (buffer != null) return buffer
+        }
+        return null
+    }
+
+    /**
+     * Lock-free pop from one size class's Treiber stack.
+     * Returns the buffer or null if that stack is empty.
+     */
+    private fun pop(head: AtomicReference<Node?>): PlatformBuffer? {
         while (true) {
             val oldHead = head.load() ?: return null
             val newHead = oldHead.next

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/SingleThreadedBufferPool.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/SingleThreadedBufferPool.kt
@@ -10,13 +10,22 @@ import com.ditchoom.buffer.ReadWriteBuffer
  *
  * NOT thread-safe. Use when pool is confined to a single coroutine/thread.
  * For multi-threaded access, use [LockFreeBufferPool] instead.
+ *
+ * Allocations are rounded up to size classes (power-of-two up to 1 MiB, 1 MiB
+ * multiples above) and cached buffers are
+ * bucketed by class ([BufferSizeClass]), so mixed-size churn neither allocates unique
+ * odd sizes (which fragment freelist allocators, catastrophically on Android/ART — see
+ * ANDROID_ART_ALLOCATOR.md) nor frees-and-reallocates on wrong-sized pops.
  */
 internal class SingleThreadedBufferPool(
     private val maxPoolSize: Int,
     private val defaultBufferSize: Int,
     private val factory: BufferFactory,
 ) : BufferPool {
-    private val pool = ArrayDeque<PlatformBuffer>(maxPoolSize)
+    // One deque per size class; a buffer lives in the bucket of its capacity's floor
+    // log2, so every buffer in bucket k has capacity >= 1 shl k.
+    private val buckets = Array(BufferSizeClass.BUCKET_COUNT) { ArrayDeque<PlatformBuffer>() }
+    private var pooledCount = 0
 
     private var totalAllocations = 0L
     private var poolHits = 0L
@@ -30,7 +39,7 @@ internal class SingleThreadedBufferPool(
         val buffer = acquire(size)
         if (buffer is PlatformBuffer && buffer.byteOrder == byteOrder) return buffer
         release(buffer)
-        return factory.allocate(size, byteOrder)
+        return factory.allocate(BufferSizeClass.roundUp(maxOf(size, defaultBufferSize)), byteOrder)
     }
 
     override fun wrap(
@@ -42,7 +51,7 @@ internal class SingleThreadedBufferPool(
         totalAllocations++
         val size = maxOf(minSize, defaultBufferSize)
 
-        val buffer = pool.removeLastOrNull()
+        val buffer = popAtLeast(size)
 
         val raw =
             if (buffer != null && buffer.capacity >= size) {
@@ -51,11 +60,11 @@ internal class SingleThreadedBufferPool(
                 buffer
             } else {
                 poolMisses++
-                // A too-small popped buffer was removed from the pool; free its native
-                // memory before allocating fresh, otherwise it leaks (Arena.ofShared
-                // never closes, FfmAutoBuffer waits on GC).
+                // Only reachable via bucket 0's zero-capacity edge case; free the popped
+                // buffer's native memory before allocating fresh, otherwise it leaks
+                // (Arena.ofShared never closes, FfmAutoBuffer waits on GC).
                 buffer?.freeNativeMemory()
-                factory.allocate(size)
+                factory.allocate(BufferSizeClass.roundUp(size))
             }
         return PooledBuffer(raw, this)
     }
@@ -73,10 +82,11 @@ internal class SingleThreadedBufferPool(
                 else -> return
             }
 
-        if (pool.size < maxPoolSize) {
-            pool.addLast(raw)
-            if (pool.size > peakPoolSize) {
-                peakPoolSize = pool.size
+        if (pooledCount < maxPoolSize) {
+            buckets[BufferSizeClass.bucketForCapacity(raw.capacity)].addLast(raw)
+            pooledCount++
+            if (pooledCount > peakPoolSize) {
+                peakPoolSize = pooledCount
             }
         } else {
             raw.freeNativeMemory()
@@ -88,18 +98,34 @@ internal class SingleThreadedBufferPool(
             totalAllocations = totalAllocations,
             poolHits = poolHits,
             poolMisses = poolMisses,
-            currentPoolSize = pool.size,
+            currentPoolSize = pooledCount,
             peakPoolSize = peakPoolSize,
         )
 
     override fun clear() {
-        // Drain-and-free: remove each buffer before freeing it.
-        // Using an iterator (for-in) is unsafe because freeNativeMemory() could
-        // re-enter release() (via PooledBuffer.releaseRef) and modify the ArrayDeque
-        // during iteration, corrupting its internal head/tail indices (size becomes -1).
-        // This pattern matches LockFreeBufferPool.clear().
-        while (pool.isNotEmpty()) {
-            pool.removeFirst().freeNativeMemory()
+        // Drain-and-free: remove each buffer before freeing it, restarting the bucket
+        // scan every iteration. freeNativeMemory() could re-enter release() (via
+        // PooledBuffer.releaseRef) and modify any deque, so neither an iterator (for-in)
+        // nor a cached per-bucket loop is safe. This pattern matches LockFreeBufferPool.
+        while (true) {
+            val deque = buckets.firstOrNull { it.isNotEmpty() } ?: break
+            pooledCount--
+            deque.removeFirst().freeNativeMemory()
         }
+    }
+
+    /**
+     * Removes and returns a cached buffer guaranteed to hold [size] bytes, searching the
+     * request's own size class first and falling back to larger classes, or null.
+     */
+    private fun popAtLeast(size: Int): PlatformBuffer? {
+        for (bucket in BufferSizeClass.bucketForRequest(size) until BufferSizeClass.BUCKET_COUNT) {
+            val buffer = buckets[bucket].removeLastOrNull()
+            if (buffer != null) {
+                pooledCount--
+                return buffer
+            }
+        }
+        return null
     }
 }

--- a/buffer/src/commonTest/kotlin/com/ditchoom/buffer/BufferPoolFragmentationTests.kt
+++ b/buffer/src/commonTest/kotlin/com/ditchoom/buffer/BufferPoolFragmentationTests.kt
@@ -1,0 +1,165 @@
+package com.ditchoom.buffer
+
+import com.ditchoom.buffer.pool.ThreadingMode
+import com.ditchoom.buffer.pool.withPool
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Regression tests for allocator fragmentation caused by pool churn (Autobahn case
+ * 9.2.5 OOM on Android/ART, CI run 28618587934 — see ANDROID_ART_ALLOCATOR.md).
+ *
+ * The failure mechanism was pool-shaped: every acquire() of a unique odd size was a pool
+ * miss that allocated the exact odd size, and every wrong-sized pop freed a buffer just
+ * to reallocate — so MB-scale message churn produced an unbounded stream of unique-sized
+ * allocations that permanently fragmented ART's freelist spaces.
+ *
+ * These tests pin the two pool-level properties that stop that churn on every platform:
+ * size-class rounding (bounded distinct allocation sizes) and size-aware reuse (misses
+ * bounded by the number of distinct size classes, not by the number of acquires).
+ */
+class BufferPoolFragmentationTests {
+    private companion object {
+        const val KIB = 1024
+
+        /** KiB-scale stand-ins for the Autobahn message sizes (8 KiB chops + MB messages). */
+        val CHURN_SIZES_KIB = intArrayOf(3, 5, 9, 17)
+        const val ROUNDS = 20
+    }
+
+    /**
+     * Mixed-size churn where no exact size ever repeats (odd per-round offsets, like
+     * assembled network messages). Misses must stay bounded by the number of distinct
+     * size classes; the old exact-size pool missed (and freed + reallocated) on most
+     * acquires of this pattern.
+     */
+    @Test
+    fun mixedSizeChurnHasBoundedMissesSingleThreaded() = mixedSizeChurnHasBoundedMisses(ThreadingMode.SingleThreaded)
+
+    @Test
+    fun mixedSizeChurnHasBoundedMissesMultiThreaded() = mixedSizeChurnHasBoundedMisses(ThreadingMode.MultiThreaded)
+
+    private fun mixedSizeChurnHasBoundedMisses(threadingMode: ThreadingMode) =
+        withPool(
+            threadingMode = threadingMode,
+            maxPoolSize = 8,
+            defaultBufferSize = 1 * KIB,
+        ) { pool ->
+            repeat(ROUNDS) { round ->
+                val held = ArrayList<ReadWriteBuffer>()
+                for (kib in CHURN_SIZES_KIB) {
+                    // Unique odd size every single acquire across all rounds
+                    val buffer = pool.acquire(kib * KIB + round * 7 + 1)
+                    buffer.writeByte(round.toByte())
+                    held += buffer
+                }
+                held.forEach { pool.release(it) }
+            }
+
+            val stats = pool.stats()
+            assertEquals(
+                (ROUNDS * CHURN_SIZES_KIB.size).toLong(),
+                stats.totalAllocations,
+                "sanity: every acquire counted",
+            )
+            assertTrue(
+                stats.poolMisses <= CHURN_SIZES_KIB.size.toLong(),
+                "misses must be bounded by the number of distinct size classes " +
+                    "(${CHURN_SIZES_KIB.size}), got ${stats.poolMisses} " +
+                    "(hits=${stats.poolHits}, hitRate=${stats.hitRate})",
+            )
+            assertTrue(
+                stats.hitRate >= 0.9,
+                "size-aware reuse must keep the hit rate high under mixed-size churn, " +
+                    "got ${stats.hitRate}",
+            )
+        }
+
+    /**
+     * Interleaved small + growing large acquires — the exact shape of the websocket
+     * read path that crashed CI (8 KiB chops held mid-frame while a large odd-sized
+     * assembled-message buffer is acquired).
+     */
+    @Test
+    fun interleavedChopAndLargeChurnHasBoundedMisses() =
+        withPool(
+            threadingMode = ThreadingMode.MultiThreaded,
+            maxPoolSize = 16,
+            defaultBufferSize = 1 * KIB,
+        ) { pool ->
+            repeat(ROUNDS) { round ->
+                val chops = ArrayList<ReadWriteBuffer>()
+                repeat(4) { chops += pool.acquire(1 * KIB) }
+                val big = pool.acquire(29 * KIB + round * 13 + 29)
+                big.writeByte(0)
+                chops.forEach { pool.release(it) }
+                pool.release(big)
+            }
+
+            val stats = pool.stats()
+            // One class for the chops (1 KiB) + one for the big buffers (32 KiB class),
+            // with 4 chop buffers live at once → at most 4 + 1 initial misses.
+            assertTrue(
+                stats.poolMisses <= 5,
+                "expected at most 5 misses (4 concurrent chop buffers + 1 large class), " +
+                    "got ${stats.poolMisses} (hits=${stats.poolHits})",
+            )
+        }
+
+    /** Acquire sizes are rounded up to their power-of-two size class. */
+    @Test
+    fun acquireRoundsUpToSizeClass() =
+        withPool(maxPoolSize = 4, defaultBufferSize = 1 * KIB) { pool ->
+            val oddSize = 3 * KIB + 5
+            val buffer = pool.acquire(oddSize)
+            assertEquals(
+                4 * KIB,
+                buffer.capacity,
+                "an odd-sized acquire must allocate its power-of-two size class, " +
+                    "not the exact odd size",
+            )
+            pool.release(buffer)
+
+            // A different odd size in the same class must reuse the same buffer
+            val second = pool.acquire(3 * KIB + 999)
+            assertEquals(4 * KIB, second.capacity)
+            assertEquals(1L, pool.stats().poolHits, "same size class must be a pool hit")
+            pool.release(second)
+        }
+
+    /** Power-of-two requests must not be doubled by the rounding. */
+    @Test
+    fun acquireExactPowerOfTwoIsNotRoundedUp() =
+        withPool(maxPoolSize = 4, defaultBufferSize = 1 * KIB) { pool ->
+            val buffer = pool.acquire(8 * KIB)
+            assertEquals(8 * KIB, buffer.capacity)
+            pool.release(buffer)
+        }
+
+    /**
+     * Above 1 MiB, rounding switches to 1 MiB multiples: power-of-two rounding would
+     * double large-message allocations (16 MiB + 29 → 32 MiB), enough to OOM
+     * heap-constrained Android under Autobahn's 16 MB echo cases (9.1.6). 1 MiB
+     * multiples cap the waste while keeping block sizes commensurable.
+     */
+    @Test
+    fun largeAcquireRoundsToMebibyteMultipleNotPowerOfTwo() {
+        val mib = 1024 * KIB
+        withPool(maxPoolSize = 4, defaultBufferSize = 1 * KIB) { pool ->
+            val buffer = pool.acquire(16 * mib + 29)
+            assertEquals(
+                17 * mib,
+                buffer.capacity,
+                "a large odd-sized acquire must round to the next 1 MiB multiple, " +
+                    "not the next power of two",
+            )
+            pool.release(buffer)
+        }
+        withPool(maxPoolSize = 4, defaultBufferSize = 1 * KIB) { pool ->
+            val exact = pool.acquire(4 * mib)
+            assertEquals(4 * mib, exact.capacity, "1 MiB-multiple requests must not be rounded")
+            pool.release(exact)
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Autobahn case 9.2.5 (large-message echo) crashes with an `OutOfMemoryError` on stock AOSP ART (CI run `28618587934`). The OOM reports `malloc_space fragmentation` — tens of MB free, but no contiguous 8 MiB run.

**Mechanism** (full detail in `ANDROID_ART_ALLOCATOR.md`): `ByteBuffer.allocateDirect(n)` is backed by a pinned `VMRuntime.newNonMovableArray`. Mixed-size pool churn fragments *both* ART spaces — the Large Object Space (≥12 KiB) and the ~60 MB non-moving malloc space (<12 KiB) — and an LOS allocation that fails falls back to the non-moving space, so the 8 MiB request ultimately fails there.

The root cause is pool-shaped: every `acquire()` of a unique odd size (an assembled 8 MiB + 29 network message) was a pool miss that allocated the exact odd size, and every wrong-sized pop freed a buffer just to reallocate — an unbounded stream of unique-sized allocations that neither ART freelist can coalesce.

## Fix (pool — commonMain, factory-agnostic, applies to every platform)

- **`BufferSizeClass`**: round every allocation up to a size class — power-of-two up to 1 MiB, 1 MiB multiples above (caps large-message round-up waste at 1 MiB instead of doubling).
- **`LockFreeBufferPool` / `SingleThreadedBufferPool`**: bucket cached buffers by size class, so live block sizes are bounded to ≤31 classes and neither freelist can fragment. `acquire()` searches the request's bucket and up, preserving hit/miss semantics for existing pool tests.

### Native-memory lifecycle hardening
- `String.toReadBuffer` now defaults to `BufferFactory.managed()` — the backing buffer is dropped without an explicit free (only its slice is returned), which would leak on owning-native default factories (Linux `NativeBuffer`, large Android allocations). **This default change is why the PR is labeled `minor`**: the returned buffer is now heap-backed rather than native, observable to native-interop consumers.
- `ReadBuffer.indexOf(String)` frees its staging needle in a `finally`.

## Out of scope (evaluated and rejected)

A factory-level route — allocating large `BufferFactory.Default` buffers via owned native malloc — was implemented and rejected: it silently changes the Default-factory lifecycle to leak-on-drop, and a GC safety net is unsound on ART (derived `ByteBuffer` views don't retain the original buffer, so a Cleaner referent can free memory a live view still addresses). The pool fix removes the churn mechanism itself, so the contract change wasn't worth the narrow affected window. Rationale in `ANDROID_ART_ALLOCATOR.md` → "Implications for the fix".

## Tests / bench

- `BufferPoolFragmentationTests` (commonTest) — size-class rounding + bounded-miss reuse under mixed-size and interleaved-chop churn.
- `NonMovableOomRegressionTest` (androidInstrumentedTest) — `case1` pins the pool fix; `case2` is `@Ignore`d, kept as the deterministic two-front repro for the rejected factory route.
- `PoolChurnBenchmark` (commonBenchmark) — guards the pool-hit hot path against bucketing overhead.

## Verification

- `./gradlew allTests ktlintCheck` — **green** on all platforms (JVM/JS-node/JS-browser/wasmJs/linuxX64/Android unit); 0 failures, 0 errors.
- Android instrumented on `api34def` (API 34, **default AOSP** `sdk_phone64`, heap **576m** — the exact CI geometry): `case1` **PASSED**, `case2` **SKIPPED**. `tests=2 failures=0 errors=0 skipped=1`.

> **CI note:** the `case2` repro only goes red under a 576m-heap **default-AOSP** emulator (rootable to set `dalvik.vm.heapgrowthlimit`; `google_apis`/Mainline-updated ART images self-heal and don't reproduce it). It cannot gate the standard CI matrix — it's kept `@Ignore`d as a manual repro recipe, not a CI check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)