### PR TITLE
ci: satisfy required checks on docs-only PRs via no-op mirror jobs

### DIFF
--- a/.github/workflows/review-docs-only.yaml
+++ b/.github/workflows/review-docs-only.yaml
@@ -1,0 +1,46 @@
+name: "Build and Test (docs-only no-op)"
+
+# review.yaml runs build-linux / build-apple on every PR EXCEPT ones that touch only
+# `**/*.md` (paths-ignore). Those two jobs' contexts
+# ("build-linux / Linux / JVM / JS / WASM / Android" and "build-apple / Apple Targets")
+# are required status checks on `main`. A skipped job reports no status at all, so a
+# docs-only PR sits at "Expected — waiting for status to be reported" forever and can
+# never merge.
+#
+# Fix (the standard GitHub-documented pattern for required checks + path filters):
+# mirror review.yaml with the exact inverse path filter and two jobs sharing the same
+# job id + display name, whose only step is a no-op `echo`. GitHub records that as a
+# real success for the same context string, satisfying the required check without
+# running the expensive build.
+#
+# Path filters MUST stay the exact complement of review.yaml's `paths-ignore`:
+#   review.yaml            : paths-ignore: ['**/*.md']  (skips only if ALL files are .md)
+#   review-docs-only.yaml   : paths:        ['**/*.md']  (runs if ANY file is .md)
+# For a PR that mixes .md and non-.md files, both workflows fire: review.yaml's real
+# build-linux/build-apple run for real, and this no-op mirror also runs alongside them.
+# That's harmless (two check runs for the same context, both able to succeed
+# independently) and is the same tradeoff GitHub's own docs call out for this pattern.
+# If either file's trigger conditions change, update the other to match.
+on:
+  pull_request:
+    paths:
+      - "**/*.md"
+    types:
+      - synchronize
+      - opened
+
+permissions:
+  contents: read
+
+jobs:
+  build-linux:
+    name: "Linux / JVM / JS / WASM / Android"
+    runs-on: ubuntu-24.04
+    steps:
+      - run: echo "docs-only change - build not required"
+
+  build-apple:
+    name: "Apple Targets"
+    runs-on: ubuntu-24.04
+    steps:
+      - run: echo "docs-only change - build not required"


### PR DESCRIPTION
## Problem

Branch protection on `main` requires exactly these status contexts:

- `build-linux / Linux / JVM / JS / WASM / Android`
- `build-apple / Apple Targets`
- `scan`

`build-linux` and `build-apple` come from `review.yaml`, which calls the reusable
`build-linux.yaml` / `build-apple.yaml` workflows as jobs named `build-linux` /
`build-apple`. `review.yaml` triggers on `pull_request` with `paths-ignore: ['**/*.md']`,
so a PR that touches **only** `.md` files never triggers `review.yaml` at all — the two
required contexts are never reported, and GitHub shows them stuck at "Expected — waiting
for status to be reported" forever. `mergeStateStatus` sits at `BLOCKED` with no path
forward short of touching a non-doc file (the bandaid used historically, and the reason
#257 is currently stuck).

`scan` (`osv-scanner.yaml`) already has no path filter — it runs on every PR — so it's
unaffected and out of scope here.

## Fix

Standard GitHub-documented pattern for "required check skipped by path filter": a second,
no-op workflow triggered on the exact inverse path filter, with jobs sharing the same job
id + display name as the real ones. A skipped job reports no status (bad); a job that
actually runs and succeeds (even a trivial `echo`) reports a real success for that exact
context string (good).

Added `.github/workflows/review-docs-only.yaml`:

| | `review.yaml` (real builds) | `review-docs-only.yaml` (no-op mirror) |
|---|---|---|
| Trigger | `pull_request`, types `synchronize`/`opened` | same |
| Path filter | `paths-ignore: ['**/*.md']` (skips only if **all** changed files are `.md`) | `paths: ['**/*.md']` (runs if **any** changed file is `.md`) |
| `build-linux` job | calls `build-linux.yaml` (full Linux/JVM/JS/WASM/Android build) | `echo "docs-only change - build not required"` |
| `build-apple` job | calls `build-apple.yaml` (full Apple build) | `echo "docs-only change - build not required"` |

Both jobs keep the exact `name:` the real jobs report (`Linux / JVM / JS / WASM /
Android` and `Apple Targets`), so the resulting context strings
(`build-linux / Linux / JVM / JS / WASM / Android`, `build-apple / Apple Targets`)
are byte-identical to what branch protection requires — no branch-protection config
change needed.

**Docs-only PR:** only the no-op mirror runs; both contexts report success immediately.
**Code-only / mixed PR:** `review.yaml`'s real builds run per the existing filter.
**Mixed PR (touches both `.md` and code):** both workflows fire — `review.yaml` runs the
real build for the real signal, and the no-op mirror also runs, producing a second,
harmless check run under the same context. This overlap is the known, documented
trade-off of this pattern (paths-ignore's "skip only if *all* files match" vs paths'
"run if *any* file matches" aren't true logical complements) and never produces a hung
"expected" check on either side — every triggered job actually runs and reports.

## Verification

- `actionlint` passes clean on the new file (repo-wide `actionlint` has pre-existing,
  unrelated shellcheck notices in other workflow files — untouched by this change).
- This PR itself only touches `.github/workflows/review-docs-only.yaml`, so it exercises
  the `review.yaml` path (non-doc file) — the real `build-linux`/`build-apple` builds are
  expected to run here, not the no-op mirror. Confirms mixed/code-path PRs are unaffected.
- Full proof of the fix (a docs-only PR getting the no-op contexts and merging cleanly)
  can only happen with a follow-up docs-only PR once this merges — flagging that as the
  outstanding validation step.