### PR TITLE
fix(buffer-pool): fail fast on use-after-release through TrackedSlice

### DIFF
--- a/buffer/config/detekt/baseline.xml
+++ b/buffer/config/detekt/baseline.xml
@@ -10,6 +10,7 @@
     <ID>LargeClass:BufferPoolTests.kt:BufferPoolTests</ID>
     <ID>LargeClass:BufferStreamTests.kt:BufferStreamTests</ID>
     <ID>LargeClass:BufferTests.kt:BufferTests</ID>
+    <ID>LargeClass:TrackedSlice.kt:TrackedSlice : PlatformBufferPoolReleasable</ID>
     <ID>LargeClass:WrapperTransparencyTests.kt:WrapperTransparencyTests</ID>
     <ID>LongMethod:BaseJvmBuffer.kt:BaseJvmBuffer$override fun xorMaskCopy</ID>
     <ID>LongMethod:FastDirectByteBufferTest.kt:FastDirectByteBufferTest$@Test fun `byte order conversion performance`</ID>
@@ -90,6 +91,7 @@
     <ID>TooManyFunctions:StreamingStringDecoder.linux.kt:LinuxStreamingStringDecoder : StreamingStringDecoder</ID>
     <ID>TooManyFunctions:SuspendingStreamProcessor.kt:SuspendingStreamProcessor</ID>
     <ID>TooManyFunctions:SuspendingStreamProcessor.kt:SyncToSuspendingProcessor : SuspendingStreamProcessor</ID>
+    <ID>TooManyFunctions:TrackedSlice.kt:TrackedSlice : PlatformBufferPoolReleasable</ID>
     <ID>TooManyFunctions:UnsafeMemory.apple.kt:UnsafeMemory</ID>
     <ID>TooManyFunctions:UnsafeMemory.js.kt:UnsafeMemory</ID>
     <ID>TooManyFunctions:UnsafeMemory.jvmCommon.kt:UnsafeMemory</ID>

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/ReadBuffer.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/ReadBuffer.kt
@@ -1095,7 +1095,14 @@ fun ReadBuffer.unwrapFully(): ReadBuffer {
         val unwrapped = unwrap()
         return if (unwrapped !== this) unwrapped.unwrapFully() else this
     }
-    if (this is com.ditchoom.buffer.pool.TrackedSlice) return inner.unwrapFully()
+    if (this is com.ditchoom.buffer.pool.TrackedSlice) {
+        // Fail fast: resolving a released slice to its raw inner buffer would hand out
+        // a reference to storage that may already be back in the pool's freelist. This
+        // also gates the nativeMemoryAccess / managedMemoryAccess extensions and the
+        // toNativeData/toByteArray interop bridges, which all resolve through here.
+        checkNotReleased()
+        return inner.unwrapFully()
+    }
     return this
 }
 

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/TrackedSlice.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/TrackedSlice.kt
@@ -1,7 +1,10 @@
 package com.ditchoom.buffer.pool
 
 import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.Charset
 import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
 import com.ditchoom.buffer.bufferEquals
 import com.ditchoom.buffer.bufferHashCode
 
@@ -15,6 +18,28 @@ import com.ditchoom.buffer.bufferHashCode
  * `PlatformBuffer.slice()` is contractually a `PlatformBuffer`, every slice
  * returned through a PooledBuffer is writable; writes propagate to the parent
  * buffer's underlying memory.
+ *
+ * ## Use-after-release safety
+ *
+ * A [TrackedSlice] aliases the pooled chunk's backing storage. Once the slice is
+ * released **and** the parent's refcount reaches zero, that storage returns to the
+ * pool's freelist and may be handed to the next acquirer. A retained reference to
+ * a released slice would then silently read/write memory it no longer owns.
+ *
+ * To make that hazard fail fast instead of corrupting silently, every data-path
+ * operation is explicitly overridden to call [checkNotReleased] before delegating
+ * to [inner]. `PlatformBuffer by inner` delegation would otherwise forward each
+ * call straight to the raw slice with no liveness check — including the methods
+ * that carry default implementations, since Kotlin interface delegation shadows
+ * defaults. The overrides are therefore exhaustive across the read, write,
+ * absolute-index, bulk, search, fill and slice surfaces. The check is a single
+ * boolean field read (no locking); [ReadBuffer.unwrapFully] and the
+ * `nativeMemoryAccess` / `managedMemoryAccess` extensions resolve through the same
+ * guard, so interop bridges (`toNativeData`, `toByteArray`, …) fail fast too.
+ *
+ * Pure positional getters ([position], [limit], [byteOrder], [capacity],
+ * [remaining]) are intentionally left to delegation: they touch no backing bytes,
+ * so reading them on a released slice cannot corrupt memory.
  */
 internal class TrackedSlice(
     internal val inner: PlatformBuffer,
@@ -22,6 +47,16 @@ internal class TrackedSlice(
 ) : PlatformBuffer by inner,
     PoolReleasable {
     private var released = false
+
+    /**
+     * Fails fast if this slice has been released back to the pool. Mirrors
+     * [PooledBuffer]'s `checkNotFreed` use-after-free contract (same exception
+     * type and intent). Internal so [ReadBuffer.unwrapFully] can gate wrapper
+     * resolution on it.
+     */
+    internal fun checkNotReleased() {
+        if (released) throw IllegalStateException("Buffer slice has been released back to the pool")
+    }
 
     override fun releaseToPool() {
         if (!released) {
@@ -39,8 +74,866 @@ internal class TrackedSlice(
     }
 
     override fun slice(byteOrder: ByteOrder): PlatformBuffer {
+        checkNotReleased()
         parent.addRef()
         return TrackedSlice(inner.slice(byteOrder), parent)
+    }
+
+    @Suppress("DEPRECATION")
+    override fun unwrap(): PlatformBuffer {
+        checkNotReleased()
+        return inner.unwrap()
+    }
+
+    // ========================================================================
+    // PositionBuffer — cursor mutation
+    // ========================================================================
+
+    override fun setLimit(limit: Int) {
+        checkNotReleased()
+        inner.setLimit(limit)
+    }
+
+    override fun position(newPosition: Int) {
+        checkNotReleased()
+        inner.position(newPosition)
+    }
+
+    // ========================================================================
+    // ReadBuffer — relative reads
+    // ========================================================================
+
+    override fun resetForRead() {
+        checkNotReleased()
+        inner.resetForRead()
+    }
+
+    override fun readByte(): Byte {
+        checkNotReleased()
+        return inner.readByte()
+    }
+
+    override fun readUnsignedByte(): UByte {
+        checkNotReleased()
+        return inner.readUnsignedByte()
+    }
+
+    override fun readUByte(): UByte {
+        checkNotReleased()
+        return inner.readUByte()
+    }
+
+    override fun readShort(): Short {
+        checkNotReleased()
+        return inner.readShort()
+    }
+
+    override fun readUnsignedShort(): UShort {
+        checkNotReleased()
+        return inner.readUnsignedShort()
+    }
+
+    override fun readUShort(): UShort {
+        checkNotReleased()
+        return inner.readUShort()
+    }
+
+    override fun readInt(): Int {
+        checkNotReleased()
+        return inner.readInt()
+    }
+
+    override fun readUnsignedInt(): UInt {
+        checkNotReleased()
+        return inner.readUnsignedInt()
+    }
+
+    override fun readUInt(): UInt {
+        checkNotReleased()
+        return inner.readUInt()
+    }
+
+    override fun readLong(): Long {
+        checkNotReleased()
+        return inner.readLong()
+    }
+
+    override fun readUnsignedLong(): ULong {
+        checkNotReleased()
+        return inner.readUnsignedLong()
+    }
+
+    override fun readULong(): ULong {
+        checkNotReleased()
+        return inner.readULong()
+    }
+
+    override fun readFloat(): Float {
+        checkNotReleased()
+        return inner.readFloat()
+    }
+
+    override fun readDouble(): Double {
+        checkNotReleased()
+        return inner.readDouble()
+    }
+
+    override fun readString(
+        length: Int,
+        charset: Charset,
+    ): String {
+        checkNotReleased()
+        return inner.readString(length, charset)
+    }
+
+    override fun readLine(): CharSequence {
+        checkNotReleased()
+        return inner.readLine()
+    }
+
+    override fun readNumberWithByteSize(numberOfBytes: Int): Long {
+        checkNotReleased()
+        return inner.readNumberWithByteSize(numberOfBytes)
+    }
+
+    override fun getNumberWithStartIndexAndByteSize(
+        startIndex: Int,
+        numberOfBytes: Int,
+    ): Long {
+        checkNotReleased()
+        return inner.getNumberWithStartIndexAndByteSize(startIndex, numberOfBytes)
+    }
+
+    // ========================================================================
+    // ReadBuffer — zero-copy views and byte-array reads
+    // ========================================================================
+
+    override fun readBytes(size: Int): ReadBuffer {
+        checkNotReleased()
+        return inner.readBytes(size)
+    }
+
+    override fun readByteArray(size: Int): ByteArray {
+        checkNotReleased()
+        return inner.readByteArray(size)
+    }
+
+    override fun copyToByteArray(size: Int): ByteArray {
+        checkNotReleased()
+        return inner.copyToByteArray(size)
+    }
+
+    override fun readInto(
+        dst: ByteArray,
+        offset: Int,
+        length: Int,
+    ) {
+        checkNotReleased()
+        inner.readInto(dst, offset, length)
+    }
+
+    // ========================================================================
+    // ReadBuffer — absolute reads
+    // ========================================================================
+
+    override fun get(index: Int): Byte {
+        checkNotReleased()
+        return inner.get(index)
+    }
+
+    override fun getUnchecked(index: Int): Byte {
+        checkNotReleased()
+        return inner.getUnchecked(index)
+    }
+
+    override fun getUnsignedByte(index: Int): UByte {
+        checkNotReleased()
+        return inner.getUnsignedByte(index)
+    }
+
+    override fun getShort(index: Int): Short {
+        checkNotReleased()
+        return inner.getShort(index)
+    }
+
+    override fun getUnsignedShort(index: Int): UShort {
+        checkNotReleased()
+        return inner.getUnsignedShort(index)
+    }
+
+    override fun getInt(index: Int): Int {
+        checkNotReleased()
+        return inner.getInt(index)
+    }
+
+    override fun getUnsignedInt(index: Int): UInt {
+        checkNotReleased()
+        return inner.getUnsignedInt(index)
+    }
+
+    override fun getLong(index: Int): Long {
+        checkNotReleased()
+        return inner.getLong(index)
+    }
+
+    override fun getLongUnchecked(index: Int): Long {
+        checkNotReleased()
+        return inner.getLongUnchecked(index)
+    }
+
+    override fun getUnsignedLong(index: Int): ULong {
+        checkNotReleased()
+        return inner.getUnsignedLong(index)
+    }
+
+    override fun getFloat(index: Int): Float {
+        checkNotReleased()
+        return inner.getFloat(index)
+    }
+
+    override fun getDouble(index: Int): Double {
+        checkNotReleased()
+        return inner.getDouble(index)
+    }
+
+    // ========================================================================
+    // ReadBuffer — bulk primitive reads
+    // ========================================================================
+
+    override fun readShorts(count: Int): ShortArray {
+        checkNotReleased()
+        return inner.readShorts(count)
+    }
+
+    override fun readInts(count: Int): IntArray {
+        checkNotReleased()
+        return inner.readInts(count)
+    }
+
+    override fun readLongs(count: Int): LongArray {
+        checkNotReleased()
+        return inner.readLongs(count)
+    }
+
+    override fun readFloats(count: Int): FloatArray {
+        checkNotReleased()
+        return inner.readFloats(count)
+    }
+
+    override fun readDoubles(count: Int): DoubleArray {
+        checkNotReleased()
+        return inner.readDoubles(count)
+    }
+
+    override fun readShorts(
+        dest: ShortArray,
+        offset: Int,
+        length: Int,
+    ) {
+        checkNotReleased()
+        inner.readShorts(dest, offset, length)
+    }
+
+    override fun readInts(
+        dest: IntArray,
+        offset: Int,
+        length: Int,
+    ) {
+        checkNotReleased()
+        inner.readInts(dest, offset, length)
+    }
+
+    override fun readLongs(
+        dest: LongArray,
+        offset: Int,
+        length: Int,
+    ) {
+        checkNotReleased()
+        inner.readLongs(dest, offset, length)
+    }
+
+    override fun readFloats(
+        dest: FloatArray,
+        offset: Int,
+        length: Int,
+    ) {
+        checkNotReleased()
+        inner.readFloats(dest, offset, length)
+    }
+
+    override fun readDoubles(
+        dest: DoubleArray,
+        offset: Int,
+        length: Int,
+    ) {
+        checkNotReleased()
+        inner.readDoubles(dest, offset, length)
+    }
+
+    // ========================================================================
+    // ReadBuffer — search & comparison
+    // ========================================================================
+
+    override fun contentEquals(other: ReadBuffer): Boolean {
+        checkNotReleased()
+        return inner.contentEquals(other)
+    }
+
+    override fun mismatch(other: ReadBuffer): Int {
+        checkNotReleased()
+        return inner.mismatch(other)
+    }
+
+    override fun hashRange(
+        offset: Int,
+        length: Int,
+    ): Long {
+        checkNotReleased()
+        return inner.hashRange(offset, length)
+    }
+
+    override fun indexOf(needle: ReadBuffer): Int {
+        checkNotReleased()
+        return inner.indexOf(needle)
+    }
+
+    override fun indexOf(byte: Byte): Int {
+        checkNotReleased()
+        return inner.indexOf(byte)
+    }
+
+    override fun indexOf(
+        value: Short,
+        aligned: Boolean,
+    ): Int {
+        checkNotReleased()
+        return inner.indexOf(value, aligned)
+    }
+
+    override fun indexOf(
+        value: Int,
+        aligned: Boolean,
+    ): Int {
+        checkNotReleased()
+        return inner.indexOf(value, aligned)
+    }
+
+    override fun indexOf(
+        value: Long,
+        aligned: Boolean,
+    ): Int {
+        checkNotReleased()
+        return inner.indexOf(value, aligned)
+    }
+
+    override fun indexOf(
+        text: CharSequence,
+        charset: Charset,
+    ): Int {
+        checkNotReleased()
+        return inner.indexOf(text, charset)
+    }
+
+    // ========================================================================
+    // ReadBuffer — hex / base64 transforms
+    // ========================================================================
+
+    override fun encodeHexInto(
+        dest: WriteBuffer,
+        offset: Int,
+        length: Int,
+        upperCase: Boolean,
+    ) {
+        checkNotReleased()
+        inner.encodeHexInto(dest, offset, length, upperCase)
+    }
+
+    override fun decodeHexInto(
+        dest: WriteBuffer,
+        offset: Int,
+        length: Int,
+    ) {
+        checkNotReleased()
+        inner.decodeHexInto(dest, offset, length)
+    }
+
+    override fun encodeBase64Into(
+        dest: WriteBuffer,
+        offset: Int,
+        length: Int,
+        urlSafe: Boolean,
+        padded: Boolean,
+    ) {
+        checkNotReleased()
+        inner.encodeBase64Into(dest, offset, length, urlSafe, padded)
+    }
+
+    override fun decodeBase64Into(
+        dest: WriteBuffer,
+        offset: Int,
+        length: Int,
+    ) {
+        checkNotReleased()
+        inner.decodeBase64Into(dest, offset, length)
+    }
+
+    // ========================================================================
+    // WriteBuffer — relative writes
+    // ========================================================================
+
+    override fun resetForWrite() {
+        checkNotReleased()
+        inner.resetForWrite()
+    }
+
+    override fun writeByte(byte: Byte): WriteBuffer {
+        checkNotReleased()
+        inner.writeByte(byte)
+        return this
+    }
+
+    override fun writeUByte(uByte: UByte): WriteBuffer {
+        checkNotReleased()
+        inner.writeUByte(uByte)
+        return this
+    }
+
+    override fun writeBytes(bytes: ByteArray): WriteBuffer {
+        checkNotReleased()
+        inner.writeBytes(bytes)
+        return this
+    }
+
+    override fun writeBytes(
+        bytes: ByteArray,
+        offset: Int,
+        length: Int,
+    ): WriteBuffer {
+        checkNotReleased()
+        inner.writeBytes(bytes, offset, length)
+        return this
+    }
+
+    override fun writeShort(short: Short): WriteBuffer {
+        checkNotReleased()
+        inner.writeShort(short)
+        return this
+    }
+
+    override fun writeUShort(uShort: UShort): WriteBuffer {
+        checkNotReleased()
+        inner.writeUShort(uShort)
+        return this
+    }
+
+    override fun writeInt(int: Int): WriteBuffer {
+        checkNotReleased()
+        inner.writeInt(int)
+        return this
+    }
+
+    override fun writeUInt(uInt: UInt): WriteBuffer {
+        checkNotReleased()
+        inner.writeUInt(uInt)
+        return this
+    }
+
+    override fun writeLong(long: Long): WriteBuffer {
+        checkNotReleased()
+        inner.writeLong(long)
+        return this
+    }
+
+    override fun writeULong(uLong: ULong): WriteBuffer {
+        checkNotReleased()
+        inner.writeULong(uLong)
+        return this
+    }
+
+    override fun writeFloat(float: Float): WriteBuffer {
+        checkNotReleased()
+        inner.writeFloat(float)
+        return this
+    }
+
+    override fun writeDouble(double: Double): WriteBuffer {
+        checkNotReleased()
+        inner.writeDouble(double)
+        return this
+    }
+
+    override fun writeString(
+        text: CharSequence,
+        charset: Charset,
+    ): WriteBuffer {
+        checkNotReleased()
+        inner.writeString(text, charset)
+        return this
+    }
+
+    override fun writeNumberOfByteSize(
+        number: Long,
+        byteSize: Int,
+    ): WriteBuffer {
+        checkNotReleased()
+        inner.writeNumberOfByteSize(number, byteSize)
+        return this
+    }
+
+    override fun setIndexNumberAndByteSize(
+        index: Int,
+        number: Long,
+        byteSize: Int,
+    ): WriteBuffer {
+        checkNotReleased()
+        inner.setIndexNumberAndByteSize(index, number, byteSize)
+        return this
+    }
+
+    override fun write(buffer: ReadBuffer) {
+        checkNotReleased()
+        inner.write(buffer)
+    }
+
+    // ========================================================================
+    // WriteBuffer — absolute writes
+    // ========================================================================
+
+    override fun set(
+        index: Int,
+        byte: Byte,
+    ): WriteBuffer {
+        checkNotReleased()
+        inner.set(index, byte)
+        return this
+    }
+
+    override fun set(
+        index: Int,
+        short: Short,
+    ): WriteBuffer {
+        checkNotReleased()
+        inner.set(index, short)
+        return this
+    }
+
+    override fun set(
+        index: Int,
+        int: Int,
+    ): WriteBuffer {
+        checkNotReleased()
+        inner.set(index, int)
+        return this
+    }
+
+    override fun set(
+        index: Int,
+        long: Long,
+    ): WriteBuffer {
+        checkNotReleased()
+        inner.set(index, long)
+        return this
+    }
+
+    override fun set(
+        index: Int,
+        float: Float,
+    ): WriteBuffer {
+        checkNotReleased()
+        inner.set(index, float)
+        return this
+    }
+
+    override fun set(
+        index: Int,
+        double: Double,
+    ): WriteBuffer {
+        checkNotReleased()
+        inner.set(index, double)
+        return this
+    }
+
+    override fun set(
+        index: Int,
+        uByte: UByte,
+    ): WriteBuffer {
+        checkNotReleased()
+        inner.set(index, uByte)
+        return this
+    }
+
+    override fun set(
+        index: Int,
+        uShort: UShort,
+    ): WriteBuffer {
+        checkNotReleased()
+        inner.set(index, uShort)
+        return this
+    }
+
+    override fun set(
+        index: Int,
+        uInt: UInt,
+    ): WriteBuffer {
+        checkNotReleased()
+        inner.set(index, uInt)
+        return this
+    }
+
+    override fun set(
+        index: Int,
+        uLong: ULong,
+    ): WriteBuffer {
+        checkNotReleased()
+        inner.set(index, uLong)
+        return this
+    }
+
+    // ========================================================================
+    // WriteBuffer — bulk primitive writes
+    // ========================================================================
+
+    override fun writeShorts(shorts: ShortArray): WriteBuffer {
+        checkNotReleased()
+        inner.writeShorts(shorts)
+        return this
+    }
+
+    override fun writeInts(ints: IntArray): WriteBuffer {
+        checkNotReleased()
+        inner.writeInts(ints)
+        return this
+    }
+
+    override fun writeLongs(longs: LongArray): WriteBuffer {
+        checkNotReleased()
+        inner.writeLongs(longs)
+        return this
+    }
+
+    override fun writeFloats(floats: FloatArray): WriteBuffer {
+        checkNotReleased()
+        inner.writeFloats(floats)
+        return this
+    }
+
+    override fun writeDoubles(doubles: DoubleArray): WriteBuffer {
+        checkNotReleased()
+        inner.writeDoubles(doubles)
+        return this
+    }
+
+    override fun writeShorts(
+        shorts: ShortArray,
+        offset: Int,
+        length: Int,
+    ): WriteBuffer {
+        checkNotReleased()
+        inner.writeShorts(shorts, offset, length)
+        return this
+    }
+
+    override fun writeInts(
+        ints: IntArray,
+        offset: Int,
+        length: Int,
+    ): WriteBuffer {
+        checkNotReleased()
+        inner.writeInts(ints, offset, length)
+        return this
+    }
+
+    override fun writeLongs(
+        longs: LongArray,
+        offset: Int,
+        length: Int,
+    ): WriteBuffer {
+        checkNotReleased()
+        inner.writeLongs(longs, offset, length)
+        return this
+    }
+
+    override fun writeFloats(
+        floats: FloatArray,
+        offset: Int,
+        length: Int,
+    ): WriteBuffer {
+        checkNotReleased()
+        inner.writeFloats(floats, offset, length)
+        return this
+    }
+
+    override fun writeDoubles(
+        doubles: DoubleArray,
+        offset: Int,
+        length: Int,
+    ): WriteBuffer {
+        checkNotReleased()
+        inner.writeDoubles(doubles, offset, length)
+        return this
+    }
+
+    // ========================================================================
+    // ReadWriteBuffer — fill & masking
+    // ========================================================================
+
+    override fun fill(value: Byte): WriteBuffer {
+        checkNotReleased()
+        inner.fill(value)
+        return this
+    }
+
+    override fun fill(value: Short): WriteBuffer {
+        checkNotReleased()
+        inner.fill(value)
+        return this
+    }
+
+    override fun fill(value: Int): WriteBuffer {
+        checkNotReleased()
+        inner.fill(value)
+        return this
+    }
+
+    override fun fill(value: Long): WriteBuffer {
+        checkNotReleased()
+        inner.fill(value)
+        return this
+    }
+
+    override fun xorMask(
+        mask: Int,
+        maskOffset: Int,
+    ) {
+        checkNotReleased()
+        inner.xorMask(mask, maskOffset)
+    }
+
+    override fun xorMaskCopy(
+        source: ReadBuffer,
+        mask: Int,
+        maskOffset: Int,
+    ) {
+        checkNotReleased()
+        inner.xorMaskCopy(source, mask, maskOffset)
+    }
+
+    // ========================================================================
+    // Deprecated data-path overloads — still callable, still alias storage, so
+    // they must fail fast too. Routed to the non-deprecated inner primitives.
+    // ========================================================================
+
+    @Deprecated("Use readString instead", ReplaceWith("readString(bytes.toInt(), Charset.UTF8)"))
+    override fun readUtf8(bytes: UInt): CharSequence {
+        checkNotReleased()
+        return inner.readString(bytes.toInt(), Charset.UTF8)
+    }
+
+    @Deprecated("Use readString instead", ReplaceWith("readString(bytes, Charset.UTF8)"))
+    override fun readUtf8(bytes: Int): CharSequence {
+        checkNotReleased()
+        return inner.readString(bytes, Charset.UTF8)
+    }
+
+    @Deprecated("Use readLine instead", ReplaceWith("readLine()"))
+    override fun readUtf8Line(): CharSequence {
+        checkNotReleased()
+        return inner.readLine()
+    }
+
+    @Deprecated("Use writeString instead", ReplaceWith("writeString(text, Charset.UTF8)"))
+    override fun writeUtf8(text: CharSequence): WriteBuffer {
+        checkNotReleased()
+        inner.writeString(text, Charset.UTF8)
+        return this
+    }
+
+    @Deprecated("Use writeByte for explicitness.", ReplaceWith("writeByte(byte)"))
+    override fun write(byte: Byte): WriteBuffer {
+        checkNotReleased()
+        inner.writeByte(byte)
+        return this
+    }
+
+    @Deprecated("Use writeBytes for explicitness.", ReplaceWith("writeBytes(bytes)"))
+    override fun write(bytes: ByteArray): WriteBuffer {
+        checkNotReleased()
+        inner.writeBytes(bytes)
+        return this
+    }
+
+    @Deprecated("Use writeBytes for explicitness.", ReplaceWith("writeBytes(bytes, offset, length)"))
+    override fun write(
+        bytes: ByteArray,
+        offset: Int,
+        length: Int,
+    ): WriteBuffer {
+        checkNotReleased()
+        inner.writeBytes(bytes, offset, length)
+        return this
+    }
+
+    @Deprecated("Use writeUByte for explicitness.", ReplaceWith("writeUByte(uByte)"))
+    override fun write(uByte: UByte): WriteBuffer {
+        checkNotReleased()
+        inner.writeUByte(uByte)
+        return this
+    }
+
+    @Deprecated("Use writeShort for explicitness.", ReplaceWith("writeShort(short)"))
+    override fun write(short: Short): WriteBuffer {
+        checkNotReleased()
+        inner.writeShort(short)
+        return this
+    }
+
+    @Deprecated("Use writeUShort for explicitness.", ReplaceWith("writeUShort(uShort)"))
+    override fun write(uShort: UShort): WriteBuffer {
+        checkNotReleased()
+        inner.writeUShort(uShort)
+        return this
+    }
+
+    @Deprecated("Use writeInt for explicitness.", ReplaceWith("writeInt(int)"))
+    override fun write(int: Int): WriteBuffer {
+        checkNotReleased()
+        inner.writeInt(int)
+        return this
+    }
+
+    @Deprecated("Use writeUInt for explicitness.", ReplaceWith("writeUInt(uInt)"))
+    override fun write(uInt: UInt): WriteBuffer {
+        checkNotReleased()
+        inner.writeUInt(uInt)
+        return this
+    }
+
+    @Deprecated("Use writeLong for explicitness.", ReplaceWith("writeLong(long)"))
+    override fun write(long: Long): WriteBuffer {
+        checkNotReleased()
+        inner.writeLong(long)
+        return this
+    }
+
+    @Deprecated("Use writeULong for explicitness.", ReplaceWith("writeULong(uLong)"))
+    override fun write(uLong: ULong): WriteBuffer {
+        checkNotReleased()
+        inner.writeULong(uLong)
+        return this
+    }
+
+    @Deprecated("Use writeFloat for explicitness.", ReplaceWith("writeFloat(float)"))
+    override fun write(float: Float): WriteBuffer {
+        checkNotReleased()
+        inner.writeFloat(float)
+        return this
+    }
+
+    @Deprecated("Use writeDouble for explicitness.", ReplaceWith("writeDouble(double)"))
+    override fun write(double: Double): WriteBuffer {
+        checkNotReleased()
+        inner.writeDouble(double)
+        return this
     }
 
     override fun equals(other: Any?): Boolean = bufferEquals(this, other)

--- a/buffer/src/commonTest/kotlin/com/ditchoom/buffer/TrackedSliceLifetimeTest.kt
+++ b/buffer/src/commonTest/kotlin/com/ditchoom/buffer/TrackedSliceLifetimeTest.kt
@@ -1,0 +1,358 @@
+package com.ditchoom.buffer
+
+import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.buffer.pool.PoolReleasable
+import com.ditchoom.buffer.pool.TrackedSlice
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Use-after-release safety invariants for [TrackedSlice] — the slice wrapper
+ * returned by [com.ditchoom.buffer.pool.PooledBuffer.slice].
+ *
+ * A [TrackedSlice] shares the underlying pooled chunk's backing storage. Once the
+ * slice is released ([PoolReleasable.releaseToPool] / [freeNativeMemory]) AND the
+ * parent chunk's refcount reaches zero, the raw buffer is returned to the pool's
+ * freelist and may be handed to the next acquirer. A retained reference to a
+ * released slice — or anything resolved through it (managed/native memory access,
+ * `unwrapFully()`) — would then silently read/write memory owned by that next
+ * acquirer. These tests pin fail-fast behavior: every data-path operation on a
+ * released slice must throw [IllegalStateException] rather than corrupt memory.
+ *
+ * Runs on every platform via commonTest; the corruption manifests differently per
+ * backend (DirectByteBuffer on JVM, malloc on Linux, NSData on Apple, Int8Array on
+ * JS) but the guard lives in commonMain.
+ */
+class TrackedSliceLifetimeTest {
+    private fun newPool(size: Int = 256): BufferPool =
+        BufferPool(maxPoolSize = 4, defaultBufferSize = size, factory = BufferFactory.managed())
+
+    // ========================================================================
+    // (a) Released slice reads must throw
+    // ========================================================================
+
+    @Test
+    fun releasedSliceRelativeReadThrows() {
+        val pool = newPool()
+        val chunk = pool.acquire(64) as PlatformBuffer
+        chunk.writeInt(0x11223344)
+        chunk.resetForRead()
+
+        val slice = chunk.slice()
+        (slice as PoolReleasable).releaseToPool()
+
+        assertFailsWith<IllegalStateException>("relative read on released slice must throw") {
+            slice.readInt()
+        }
+        chunk.freeNativeMemory()
+        pool.clear()
+    }
+
+    @Test
+    fun releasedSliceAbsoluteReadThrows() {
+        val pool = newPool()
+        val chunk = pool.acquire(64) as PlatformBuffer
+        chunk.writeInt(0x11223344)
+        chunk.resetForRead()
+
+        val slice = chunk.slice()
+        (slice as PoolReleasable).releaseToPool()
+
+        assertFailsWith<IllegalStateException>("absolute get on released slice must throw") {
+            slice.getInt(0)
+        }
+        chunk.freeNativeMemory()
+        pool.clear()
+    }
+
+    @Test
+    fun releasedSliceReadByteArrayThrows() {
+        val pool = newPool()
+        val chunk = pool.acquire(64) as PlatformBuffer
+        chunk.writeBytes(byteArrayOf(1, 2, 3, 4))
+        chunk.resetForRead()
+
+        val slice = chunk.slice()
+        (slice as PoolReleasable).releaseToPool()
+
+        assertFailsWith<IllegalStateException>("readByteArray on released slice must throw") {
+            slice.readByteArray(4)
+        }
+        assertFailsWith<IllegalStateException>("copyToByteArray on released slice must throw") {
+            slice.copyToByteArray(4)
+        }
+        chunk.freeNativeMemory()
+        pool.clear()
+    }
+
+    @Test
+    fun releasedSliceSliceAndReadBytesThrow() {
+        val pool = newPool()
+        val chunk = pool.acquire(64) as PlatformBuffer
+        chunk.writeBytes(byteArrayOf(1, 2, 3, 4))
+        chunk.resetForRead()
+
+        val slice = chunk.slice()
+        (slice as PoolReleasable).releaseToPool()
+
+        assertFailsWith<IllegalStateException>("slice() on released slice must throw") {
+            slice.slice()
+        }
+        assertFailsWith<IllegalStateException>("readBytes() on released slice must throw") {
+            slice.readBytes(2)
+        }
+        chunk.freeNativeMemory()
+        pool.clear()
+    }
+
+    // ========================================================================
+    // (b) Released slice writes must throw
+    // ========================================================================
+
+    @Test
+    fun releasedSliceRelativeWriteThrows() {
+        val pool = newPool()
+        val chunk = pool.acquire(64) as PlatformBuffer
+        val slice = chunk.slice()
+        (slice as PoolReleasable).releaseToPool()
+
+        assertFailsWith<IllegalStateException>("relative write on released slice must throw") {
+            slice.writeInt(0xDEADBEEF.toInt())
+        }
+        chunk.freeNativeMemory()
+        pool.clear()
+    }
+
+    @Test
+    fun releasedSliceAbsoluteWriteThrows() {
+        val pool = newPool()
+        val chunk = pool.acquire(64) as PlatformBuffer
+        val slice = chunk.slice()
+        (slice as PoolReleasable).releaseToPool()
+
+        assertFailsWith<IllegalStateException>("absolute set on released slice must throw") {
+            slice.set(0, 0x42.toByte())
+        }
+        chunk.freeNativeMemory()
+        pool.clear()
+    }
+
+    @Test
+    fun releasedSliceBulkWriteAndFillThrow() {
+        val pool = newPool()
+        val chunk = pool.acquire(64) as PlatformBuffer
+        val slice = chunk.slice()
+        (slice as PoolReleasable).releaseToPool()
+
+        assertFailsWith<IllegalStateException>("writeBytes on released slice must throw") {
+            slice.writeBytes(byteArrayOf(1, 2, 3))
+        }
+        assertFailsWith<IllegalStateException>("fill on released slice must throw") {
+            slice.fill(0x00.toByte())
+        }
+        assertFailsWith<IllegalStateException>("write(ReadBuffer) on released slice must throw") {
+            val src = BufferFactory.managed().allocate(4)
+            src.writeInt(1)
+            src.resetForRead()
+            slice.write(src)
+        }
+        chunk.freeNativeMemory()
+        pool.clear()
+    }
+
+    // ========================================================================
+    // (c) Access-bridge resolution through a released slice must throw
+    // ========================================================================
+
+    @Test
+    fun releasedSliceManagedMemoryAccessThrows() {
+        val pool = newPool()
+        val chunk = pool.acquire(64) as PlatformBuffer
+        chunk.writeBytes(byteArrayOf(1, 2, 3))
+        chunk.resetForRead()
+
+        val slice = chunk.slice()
+        (slice as PoolReleasable).releaseToPool()
+
+        assertFailsWith<IllegalStateException>("managedMemoryAccess through released slice must throw") {
+            slice.managedMemoryAccess
+        }
+        chunk.freeNativeMemory()
+        pool.clear()
+    }
+
+    @Test
+    fun releasedSliceNativeMemoryAccessThrows() {
+        val pool = newPool()
+        val chunk = pool.acquire(64) as PlatformBuffer
+        chunk.writeInt(42)
+        chunk.resetForRead()
+
+        val slice = chunk.slice()
+        (slice as PoolReleasable).releaseToPool()
+
+        assertFailsWith<IllegalStateException>("nativeMemoryAccess through released slice must throw") {
+            slice.nativeMemoryAccess
+        }
+        chunk.freeNativeMemory()
+        pool.clear()
+    }
+
+    @Test
+    fun releasedSliceUnwrapFullyThrows() {
+        val pool = newPool()
+        val chunk = pool.acquire(64) as PlatformBuffer
+        chunk.writeInt(42)
+        chunk.resetForRead()
+
+        val slice = chunk.slice()
+        (slice as PoolReleasable).releaseToPool()
+
+        assertFailsWith<IllegalStateException>("unwrapFully on released slice must throw") {
+            slice.unwrapFully()
+        }
+        chunk.freeNativeMemory()
+        pool.clear()
+    }
+
+    @Test
+    fun releasedSliceToNativeDataThrows() {
+        val pool = newPool()
+        val chunk = pool.acquire(64) as PlatformBuffer
+        chunk.writeInt(42)
+        chunk.resetForRead()
+
+        val slice = chunk.slice()
+        (slice as PoolReleasable).releaseToPool()
+
+        assertFailsWith<IllegalStateException>("toNativeData on released slice must throw") {
+            slice.toNativeData()
+        }
+        chunk.freeNativeMemory()
+        pool.clear()
+    }
+
+    // ========================================================================
+    // (d) Slice released but parent still holding other references
+    // ========================================================================
+
+    @Test
+    fun releasingOneSliceDoesNotDisableParentOrSiblings() {
+        val pool = newPool()
+        val chunk = pool.acquire(64) as PlatformBuffer
+        chunk.writeInt(0x0A0B0C0D)
+        chunk.resetForRead()
+
+        val s1 = chunk.slice()
+        val s2 = chunk.slice()
+
+        // Release only s1. The parent chunk and sibling slice s2 remain valid.
+        (s1 as PoolReleasable).releaseToPool()
+
+        assertFailsWith<IllegalStateException>("released slice s1 must throw") {
+            s1.readInt()
+        }
+
+        // Parent still usable (slice() does not advance the parent's position).
+        assertEquals(0x0A0B0C0D, chunk.readInt(), "parent chunk must still read correctly")
+
+        // Sibling still usable.
+        assertEquals(0x0A0B0C0D, s2.readInt(), "sibling slice must still read correctly")
+
+        (s2 as PoolReleasable).releaseToPool()
+        chunk.freeNativeMemory()
+        pool.clear()
+    }
+
+    // ========================================================================
+    // (e) Parent fully released while slice not yet released.
+    //
+    // Refcount design (PooledBuffer): starts at 1; each slice() addRef()s; each
+    // release decrements. The chunk returns to the pool ONLY when refCount hits 0.
+    // So freeing the parent chunk alone while an un-released slice is outstanding
+    // must NOT reclaim the storage — the outstanding slice keeps it pinned and
+    // remains fully readable/writable.
+    // ========================================================================
+
+    @Test
+    fun parentFreedWhileSliceOutstandingKeepsSliceUsable() {
+        val pool = newPool()
+        val chunk = pool.acquire(64) as PlatformBuffer
+        chunk.writeInt(0x12345678)
+        chunk.resetForRead()
+
+        val slice = chunk.slice()
+
+        // Free the parent chunk. refCount 2 -> 1: storage stays pinned by the slice.
+        chunk.freeNativeMemory()
+        assertEquals(0, pool.stats().currentPoolSize, "outstanding slice must pin the chunk")
+
+        // The un-released slice is still valid and reads the original data.
+        assertEquals(0x12345678, slice.readInt(), "outstanding slice must remain readable after parent free")
+
+        // Releasing the slice now drops refCount to 0 and recycles the chunk.
+        (slice as PoolReleasable).releaseToPool()
+        assertEquals(1, pool.stats().currentPoolSize, "chunk recycles once the last reference is released")
+        pool.clear()
+    }
+
+    // ========================================================================
+    // Full silent-corruption repro: released slice must not read the next
+    // acquirer's data.
+    // ========================================================================
+
+    @Test
+    fun releasedSliceDoesNotObserveNextAcquirersWrites() {
+        val pool = newPool(size = 64)
+
+        val chunk = pool.acquire(64) as PlatformBuffer
+        chunk.writeInt(0xAAAAAAAA.toInt()) // pattern A
+        chunk.resetForRead()
+
+        val staleSlice = chunk.slice()
+
+        // Drop all references so the raw buffer returns to the freelist.
+        chunk.freeNativeMemory()
+        (staleSlice as PoolReleasable).releaseToPool()
+        assertEquals(1, pool.stats().currentPoolSize, "raw buffer must be back in the pool")
+
+        // Next acquire pops the SAME raw buffer and writes a different pattern.
+        val reused = pool.acquire(64) as PlatformBuffer
+        assertEquals(0, pool.stats().currentPoolSize, "re-acquire must reuse the pooled buffer")
+        reused.writeInt(0xBBBBBBBB.toInt()) // pattern B
+        reused.resetForRead()
+
+        // The stale slice must fail fast, NOT silently observe pattern B.
+        assertFailsWith<IllegalStateException>("stale slice must not read the reused buffer's data") {
+            staleSlice.readInt()
+        }
+
+        reused.freeNativeMemory()
+        pool.clear()
+    }
+
+    // ========================================================================
+    // Sanity: a live (un-released) slice still works and is not a false positive.
+    // ========================================================================
+
+    @Test
+    fun liveSliceStillReadsAndWrites() {
+        val pool = newPool()
+        val chunk = pool.acquire(64) as PlatformBuffer
+        chunk.writeInt(0x01020304)
+        chunk.resetForRead()
+
+        val slice = chunk.slice()
+        assertFalse(slice.unwrapFully() is TrackedSlice, "unwrapFully strips the wrapper on a live slice")
+        assertEquals(0x01020304, slice.readInt(), "live slice must read correctly")
+
+        assertTrue(slice.managedMemoryAccess != null, "live managed slice exposes managedMemoryAccess")
+
+        (slice as PoolReleasable).releaseToPool()
+        chunk.freeNativeMemory()
+        pool.clear()
+    }
+}


### PR DESCRIPTION
## The hazard: silent memory corruption after slice release

`TrackedSlice` (`PlatformBuffer by inner`) did **not** gate its read/write surface on the `released` flag — that flag only made `releaseToPool()` idempotent. And `ReadBuffer.unwrapFully()` resolved a `TrackedSlice` straight to `inner`, a raw slice that shares the pooled chunk's backing storage, with no liveness check.

Consequence: once `slice.releaseToPool()` drops the parent `PooledBuffer`'s refcount to 0, the raw buffer returns to the pool's freelist and can be handed to the next acquirer. A retained reference to the released slice — or anything resolved through it (`managedMemoryAccess`, `nativeMemoryAccess`, the `toNativeData` / `toByteArray` / `toMutableNativeData` interop bridges) — then **silently reads/writes memory now owned by that next acquirer. No exception was ever thrown.**

### Repro chain

```
pool.acquire            -> chunk (PooledBuffer), write patternA
chunk.slice()           -> staleSlice (shares chunk storage)
chunk.freeNativeMemory()  // refCount 2 -> 1
staleSlice.releaseToPool()// refCount 1 -> 0, raw buffer -> freelist
pool.acquire()          -> pops the SAME raw object, write patternB
staleSlice.readInt()    -> observed patternB  ❌ (silent corruption)
```

After this fix, that last read throws `IllegalStateException` instead.

## The fix (root cause, in core)

1. **`TrackedSlice` fails fast on every data-path op.** `checkNotReleased()` (a single boolean field read — no locking) runs before delegating. Kotlin interface delegation shadows the interfaces' *default* bodies too and forwards them to `inner` unguarded, so the overrides are exhaustive: relative/absolute reads and writes, unsigned + bulk primitives, `contentEquals`/`mismatch`/`indexOf`/`hashRange`, hex/base64, `fill`/`xorMask`, `slice()`/`readBytes`, and the deprecated convenience overloads (`write(...)`, `readUtf8`). 125 guarded overrides.
2. **`unwrapFully()` throws on a released `TrackedSlice`.** This single choke point also gates the `nativeMemoryAccess` / `managedMemoryAccess` extensions and the `toNativeData` / `toByteArray` / `toMutableNativeData` bridges, which all resolve through it.
3. **Exception type/intent mirrors `PooledBuffer.checkNotFreed`** (`IllegalStateException`), matching the existing use-after-free convention.
4. **Refcount semantics unchanged:** freeing the parent chunk alone while an un-released slice is outstanding still keeps the storage pinned and the slice fully usable (pinned by refcount) — only releasing the slice itself invalidates that handle.

## Tests (red-first)

New `TrackedSliceLifetimeTest` (commonTest) was written and confirmed **failing on `main`** (13/15 must-throw assertions passed through silently before the fix), then made green by the fix. Covers: released relative/absolute reads, `readByteArray`/`copyToByteArray`, `slice()`/`readBytes`, relative/absolute/bulk writes + `fill` + `write(ReadBuffer)`, `managedMemoryAccess`/`nativeMemoryAccess`/`unwrapFully`/`toNativeData` resolution, slice-released-while-parent-alive, parent-freed-while-slice-outstanding (refcount), the full silent-corruption repro, and a live-slice sanity case.

Green on **jvmTest, macosArm64Test, jsNodeTest** (full existing buffer suite green too: `WrapperTransparencyTests`, `PooledSliceLifecycleTests`, `BufferPoolSafetyTests`, `PooledBufferConsumerEscapeTests`).

## apiCheck / detekt / benchmark

- **apiCheck:** the core `buffer` module has no binary-compatibility-validator (BCV is only applied to `buffer-crypto` / `buffer-flow`), and `TrackedSlice` is `internal` — **no public-API or ABI change is possible.**
- **detekt:** `TrackedSlice` now trips `TooManyFunctions` (126) and `LargeClass` — the exact situation of every other exhaustive-override buffer class (`PooledBuffer`, `BaseJvmBuffer`, `ByteArrayBuffer`, `JsBuffer`, …), all already in the baseline. Verified detekt runs `buildUponDefaultConfig` with no custom config, so `TooManyFunctions.ignoreOverridden` is at its default (it does **not** ignore overrides — restructuring into a private helper would not lower the count). Added the two `TrackedSlice` entries via the sanctioned `detektBaseline` mechanism (diff = exactly those 2 lines). **No `@Suppress` used.**
- **benchmark:** `jvmBenchmarkPoolBenchmark` (PoolChurn) before/after is within noise (mixed/interleaved ±1-2%; `sameSizeHotLoopSingleThreaded` read 224M / 197M / 212M ops/s across runs of provably-identical code — that benchmark never calls `slice()`, so it exercises zero modified code). No pool-path regression.

Default patch release label.