### PR TITLE
ci: use full caller-prefixed context names in docs-only no-op mirror

### DIFF
--- a/.github/workflows/review-docs-only.yaml
+++ b/.github/workflows/review-docs-only.yaml
@@ -9,7 +9,11 @@ name: "Build and Test (docs-only no-op)"
 #
 # Fix (the standard GitHub-documented pattern for required checks + path filters):
 # mirror review.yaml with the exact inverse path filter and two jobs sharing the same
-# job id + display name, whose only step is a no-op `echo`. GitHub records that as a
+# job id + display name, whose only step is a no-op `echo`.
+# NOTE: the display names must be the FULL context strings including the caller-job
+# prefix ('build-apple / ...') — the real contexts get that prefix because review.yaml's
+# jobs are reusable-workflow calls (caller-job / callee-job); a plain job only reports
+# its own name, so the prefix must be written literally here to match. GitHub records that as a
 # real success for the same context string, satisfying the required check without
 # running the expensive build.
 #
@@ -34,13 +38,13 @@ permissions:
 
 jobs:
   build-linux:
-    name: "Linux / JVM / JS / WASM / Android"
+    name: "build-linux / Linux / JVM / JS / WASM / Android"
     runs-on: ubuntu-24.04
     steps:
       - run: echo "docs-only change - build not required"
 
   build-apple:
-    name: "Apple Targets"
+    name: "build-apple / Apple Targets"
     runs-on: ubuntu-24.04
     steps:
       - run: echo "docs-only change - build not required"


### PR DESCRIPTION
Follow-up to #260: the mirror jobs' check names were missing the caller-job prefix that reusable-workflow calls add ('build-apple / Apple Targets'), so they never matched the required contexts and docs-only PRs (e.g. #257) stayed BLOCKED even with the mirror green. This names the mirror jobs with the literal full context strings. Verified live on #257: mirror ran and passed but merge state remained BLOCKED with the unprefixed names.