### PR TITLE
docs: interop recipes (kotlinx-io, Okio, Ktor)

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -24,6 +24,11 @@ dependencies {
 
     // Optional: Flow operators + transport abstractions (Connection, ByteStream)
     implementation("com.ditchoom:buffer-flow:<latest-version>")
+
+    // Optional: I/O library interop bridges
+    implementation("com.ditchoom:buffer-kotlinx-io:<latest-version>")  // kotlinx-io RawSource/RawSink
+    implementation("com.ditchoom:buffer-okio:<latest-version>")        // Okio Source/Sink/ByteString
+    implementation("com.ditchoom:buffer-ktor:<latest-version>")        // Ktor channels + codec ContentConverter
 }
 ```
 
@@ -272,3 +277,4 @@ See [Byte Order](./core-concepts/byte-order) for protocol-specific guidance.
 - [Stream Processing](./recipes/stream-processing) - Handle chunked network data
 - [Protocol Codecs](./recipes/protocol-codecs) - Type-safe encode/decode
 - [Buffer Basics](./core-concepts/buffer-basics) - Position, limit, capacity internals
+- [kotlinx-io](./recipes/kotlinx-io-interop) / [Okio](./recipes/okio-interop) / [Ktor](./recipes/ktor-interop) Interop - Bridge buffers into I/O libraries

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -88,6 +88,9 @@ Buffer is the foundation for the [Socket](https://github.com/DitchOoM/socket) li
 ├─────────────────────────────┤
 │  buffer-flow                │  ← com.ditchoom:buffer-flow
 ├─────────────────────────────┤
+│  buffer-kotlinx-io / -okio  │  ← I/O library interop bridges
+│  buffer-ktor                │  ← com.ditchoom:buffer-ktor
+├─────────────────────────────┤
 │  buffer                     │  ← com.ditchoom:buffer
 └─────────────────────────────┘
 ```
@@ -109,6 +112,11 @@ dependencies {
 
     // Optional: Flow operators + transport abstractions (Connection, ByteStream)
     implementation("com.ditchoom:buffer-flow:<latest-version>")
+
+    // Optional: I/O library interop (kotlinx-io, Okio, Ktor)
+    implementation("com.ditchoom:buffer-kotlinx-io:<latest-version>")
+    implementation("com.ditchoom:buffer-okio:<latest-version>")
+    implementation("com.ditchoom:buffer-ktor:<latest-version>")
 }
 ```
 

--- a/docs/docs/recipes/kotlinx-io-interop.md
+++ b/docs/docs/recipes/kotlinx-io-interop.md
@@ -1,0 +1,147 @@
+---
+sidebar_position: 10
+title: kotlinx-io Interop
+---
+
+# kotlinx-io Interop
+
+The `buffer-kotlinx-io` module bridges `PlatformBuffer` to [kotlinx-io](https://github.com/Kotlin/kotlinx-io)'s
+`RawSource` / `RawSink` and `Buffer` types. Use it to feed a buffer into any kotlinx-io pipeline, or to
+pull kotlinx-io data into a `PlatformBuffer` for zero-copy platform interop and codec decoding.
+
+## Installation
+
+```kotlin
+dependencies {
+    implementation("com.ditchoom:buffer:<latest-version>")
+    implementation("com.ditchoom:buffer-kotlinx-io:<latest-version>")
+}
+```
+
+The module depends on `kotlinx-io-core` (0.8.0) and re-exports it, so you don't need a separate
+kotlinx-io dependency. It ships for the full set of `buffer` targets.
+
+## Copy semantics
+
+Every bridge in this module has an explicit, documented contract:
+
+| Function | Direction | Semantics |
+|----------|-----------|-----------|
+| `WriteBuffer.asRawSink()` | buffer → kotlinx-io | streaming view; writes land in the buffer |
+| `ReadBuffer.asRawSource()` | kotlinx-io → buffer | streaming view; reads drain the buffer |
+| `RawSource.readInto(dst, byteCount)` | kotlinx-io → buffer | copies up to `byteCount` bytes |
+| `RawSource.transferTo(dst)` | kotlinx-io → buffer | copies until source EOF |
+| `ReadBuffer.copyToKotlinxIoBuffer()` | buffer → kotlinx-io | non-destructive copy (position unchanged) |
+| `Buffer.copyToPlatformBuffer(factory, byteOrder)` | kotlinx-io → buffer | non-destructive copy (source not consumed) |
+
+The `as*` views stream through the underlying buffer with **one copy per read/write** and never alias
+our backing array into a kotlinx-io segment. The `copyTo*` helpers take an independent snapshot — the
+copy verb in the name signals the cost at the call site.
+
+## Buffer → kotlinx-io
+
+### Stream a buffer into a `RawSink`
+
+`asRawSink()` returns a `RawSink` view over a `WriteBuffer`. Bytes written to the sink land in the buffer.
+
+```kotlin
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.kotlinxio.asRawSink
+import kotlinx.io.buffered
+import kotlinx.io.writeString
+
+val buffer = BufferFactory.Default.allocate(1024)
+val sink = buffer.asRawSink().buffered()
+sink.writeString("Hello, kotlinx-io!")
+sink.flush()
+
+buffer.resetForRead()
+val text = buffer.readString(buffer.remaining())
+```
+
+### Snapshot a buffer as a kotlinx-io `Buffer`
+
+`copyToKotlinxIoBuffer()` copies the remaining bytes into a fresh kotlinx-io `Buffer` **without moving
+the source position** — the original stays readable.
+
+```kotlin
+import com.ditchoom.buffer.kotlinxio.copyToKotlinxIoBuffer
+
+val payload: ReadBuffer = /* ... */
+val kxBuffer = payload.copyToKotlinxIoBuffer()  // payload.position() unchanged
+// hand kxBuffer to any kotlinx-io API; mutating payload afterwards does not affect it
+```
+
+## kotlinx-io → Buffer
+
+### Read a `RawSource` into a buffer
+
+`readInto` copies up to `byteCount` bytes (defaulting to the destination's remaining capacity) and
+returns how many were actually transferred. It stops at whichever comes first: the destination filling
+up, or the source reaching EOF.
+
+```kotlin
+import com.ditchoom.buffer.kotlinxio.readInto
+
+val dst = BufferFactory.Default.allocate(4096)
+val copied: Long = source.readInto(dst)      // fills dst, or stops at source EOF
+dst.resetForRead()
+```
+
+:::note EOF convention
+kotlinx-io's `RawSource.readAtMostTo` returns `-1` at EOF, but `readInto` folds EOF into its running
+total and **never returns a negative value** — a source already exhausted on entry returns `0`. If the
+last chunk both fills `dst` to `byteCount` and drains the source, `readInto` returns `byteCount`
+directly; it never issues a further probe read that would observe EOF.
+:::
+
+### Drain a whole source
+
+`transferTo` reads until the source is exhausted. There is no `byteCount` stop condition — if the
+source outlasts the destination's capacity, the write fails fast with the underlying overflow
+exception.
+
+```kotlin
+import com.ditchoom.buffer.kotlinxio.transferTo
+
+val dst = BufferFactory.Default.allocate(estimatedSize)
+val total: Long = source.transferTo(dst)     // source-EOF driven
+dst.resetForRead()
+```
+
+### Convert a kotlinx-io `Buffer` into a `PlatformBuffer`
+
+`copyToPlatformBuffer` copies through a **peek**, so the original kotlinx-io `Buffer` is not consumed.
+The result is positioned for reading. Pass your own `factory` (e.g. `BufferFactory.managed()`) and
+`byteOrder` when the defaults don't fit.
+
+```kotlin
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.kotlinxio.copyToPlatformBuffer
+
+val platformBuffer = kxBuffer.copyToPlatformBuffer(
+    factory = BufferFactory.Default,
+    byteOrder = ByteOrder.BIG_ENDIAN,
+)
+val header = platformBuffer.readInt()
+```
+
+## Lifetime rules
+
+The `asRawSource()` / `asRawSink()` views are **thin adapters over the live buffer** — they don't own
+it. Two rules:
+
+- **Don't let a view outlive its buffer.** If the buffer is pooled or deterministic, the view must not
+  be used after the buffer is released or freed. A view over a released
+  [pooled buffer](./buffer-pooling) fails fast rather than reading another acquirer's bytes.
+- **Views are single-buffer.** A `RawSink` view fills exactly one buffer; once the buffer is full,
+  further writes overflow. For a growing stream, drain to a `copyTo*` snapshot or a larger allocation.
+
+Using a view after its buffer is gone throws `IllegalStateException` (`"asRawSource() view has been
+closed"` / `"asRawSink() view has been closed"`).
+
+## See also
+
+- [Okio Interop](./okio-interop) — the same bridge shape for Okio `Source` / `Sink`
+- [Ktor Interop](./ktor-interop) — built on top of this module for Ktor channels
+- [Platform Interop](./platform-interop) — native `toNativeData()` handles for zero-copy platform APIs

--- a/docs/docs/recipes/ktor-interop.md
+++ b/docs/docs/recipes/ktor-interop.md
@@ -1,0 +1,160 @@
+---
+sidebar_position: 12
+title: Ktor Interop
+---
+
+# Ktor Interop
+
+The `buffer-ktor` module connects `PlatformBuffer` and [`buffer-codec`](./protocol-codecs) to
+[Ktor 3](https://ktor.io):
+
+- **Channel bridges** — move bytes between `ByteReadChannel` / `ByteWriteChannel` and `PlatformBuffer`.
+- **`BufferCodecConverter`** — a Ktor `ContentConverter` that (de)serializes a `@ProtocolMessage`
+  codec type over a binary content type via `ContentNegotiation`.
+- **WebSocket masking** — RFC 6455 frame masking backed by the buffer library's SIMD-accelerated
+  `xorMask`.
+
+## Installation
+
+```kotlin
+dependencies {
+    implementation("com.ditchoom:buffer:<latest-version>")
+    implementation("com.ditchoom:buffer-ktor:<latest-version>")
+}
+```
+
+`buffer-ktor` transitively brings in `buffer-kotlinx-io`, `buffer-codec`, and the Ktor 3.2.0 IO / HTTP
+/ serialization artifacts. Ktor's own channels are built on kotlinx-io, so the channel bridges reuse
+the [kotlinx-io bridge](./kotlinx-io-interop) internally.
+
+## Channel bridges
+
+### Read a channel into a buffer
+
+`readRemainingBuffer` copies **all** remaining channel bytes into a fresh `PlatformBuffer` the caller
+owns, positioned for reading.
+
+```kotlin
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ktor.readRemainingBuffer
+
+suspend fun handle(channel: ByteReadChannel) {
+    val buffer = channel.readRemainingBuffer()       // owns its bytes, safe to retain
+    val messageType = buffer.readByte()
+    // ...
+}
+```
+
+### Write a buffer to a channel
+
+`writeBuffer` copies a buffer's remaining bytes to a `ByteWriteChannel` and flushes. It takes a
+non-destructive snapshot, so **the buffer's position is unchanged** and it stays readable afterwards.
+
+```kotlin
+import com.ditchoom.buffer.ktor.writeBuffer
+
+suspend fun send(channel: ByteWriteChannel, payload: ReadBuffer) {
+    channel.writeBuffer(payload)                     // payload.position() unchanged
+}
+```
+
+## Codec content negotiation
+
+`BufferCodecConverter` binds **one codec per message type** to a binary content type. Register it in
+the `ContentNegotiation` plugin; encode/decode then happen automatically on `call.receive<T>()` /
+`call.respond(value)`.
+
+```kotlin
+import com.ditchoom.buffer.ktor.BufferCodecConverter
+import io.ktor.http.ContentType
+import io.ktor.serialization.kotlinx.* // register(...)
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+
+install(ContentNegotiation) {
+    register(ContentType.Application.OctetStream, BufferCodecConverter(DeviceReportCodec))
+}
+
+routing {
+    post("/report") {
+        val report = call.receive<DeviceReport>()   // decoded via DeviceReportCodec
+        call.respond(report)                         // encoded via DeviceReportCodec
+    }
+}
+```
+
+The reified `BufferCodecConverter(codec)` factory infers the message `KClass` for you. You can also
+supply a `factory`, `encodeContext`, and `decodeContext` to control allocation and thread typed
+[codec context](./protocol-codecs) into encode/decode:
+
+```kotlin
+BufferCodecConverter(
+    codec = DeviceReportCodec,
+    factory = BufferFactory.managed(),
+    decodeContext = DecodeContext.Empty.with(MaxSizeKey, 1_000_000),
+)
+```
+
+`serialize` returns `null` for any type other than the one it's bound to, so it composes with other
+converters registered on the same content type.
+
+:::warning Codec ownership contract
+`deserialize` frees its input buffer as soon as `decode` returns — **including when decode throws**.
+A codec bound to this converter must return a value that *owns* its data, not one that aliases the
+input buffer. Follow a canonical decode pattern (decode straight into a typed value, copy into a
+consumer-owned `PlatformBuffer` via `write(source)`, or copy into a `ByteArray` via
+`copyToByteArray(n)`). A codec returning a `slice()` / `readBytes(n)` view of the input will observe
+freed memory once `deserialize` returns. See [Protocol Codecs](./protocol-codecs) for the patterns.
+:::
+
+### Encode a codec value to a buffer directly
+
+Outside content negotiation, `encodeToPlatformBuffer` turns any `Encoder<T>` value into a fresh,
+read-positioned `PlatformBuffer`. Exact-size encoders allocate once; back-patch encoders start from an
+estimate and grow on overflow (capped at 1 GiB), and the buffer is freed on any encode failure.
+
+```kotlin
+import com.ditchoom.buffer.ktor.encodeToPlatformBuffer
+
+val buffer = DeviceReportCodec.encodeToPlatformBuffer(report)
+channel.writeBuffer(buffer)
+buffer.freeNativeMemory()
+```
+
+## WebSocket frame masking
+
+RFC 6455 requires client→server frames to be XOR-masked with a 4-byte key. These helpers delegate to
+the buffer library's SIMD-accelerated `xorMask` / `xorMaskCopy`.
+
+### Mask in place
+
+`applyWebSocketMask` masks a buffer's remaining bytes in place. The XOR transform is symmetric — the
+same call both masks and unmasks. Position and limit are unchanged.
+
+```kotlin
+import com.ditchoom.buffer.ktor.applyWebSocketMask
+
+frame.applyWebSocketMask(maskingKey)                 // mask
+frame.applyWebSocketMask(maskingKey)                 // unmask (symmetric)
+```
+
+Pass `maskOffset` (0–3) to continue a mask across fragmented frames.
+
+### Mask and write in one pass
+
+`writeMaskedWebSocketPayload` fuses the copy and the mask into a single pass into a scratch buffer,
+writes the masked bytes to the channel, and frees the scratch. **The payload is not mutated** and its
+position is unchanged, so it stays reusable.
+
+```kotlin
+import com.ditchoom.buffer.ktor.writeMaskedWebSocketPayload
+
+suspend fun sendMasked(channel: ByteWriteChannel, payload: ReadBuffer, key: Int) {
+    channel.writeMaskedWebSocketPayload(payload, maskingKey = key)
+}
+```
+
+## See also
+
+- [Protocol Codecs](./protocol-codecs) — `@ProtocolMessage` codecs used by `BufferCodecConverter`
+- [kotlinx-io Interop](./kotlinx-io-interop) — the bridge Ktor's channels are built on
+- [Stream Processing](./stream-processing) — framing codec messages off a chunked byte stream

--- a/docs/docs/recipes/okio-interop.md
+++ b/docs/docs/recipes/okio-interop.md
@@ -1,0 +1,150 @@
+---
+sidebar_position: 11
+title: Okio Interop
+---
+
+# Okio Interop
+
+The `buffer-okio` module bridges `PlatformBuffer` to [Okio](https://square.github.io/okio/)'s
+`Source` / `Sink`, `Buffer`, and `ByteString` types. Use it to feed a buffer into an Okio pipeline
+(file I/O, hashing, `BufferedSource` parsing) or to pull Okio data into a `PlatformBuffer`.
+
+## Installation
+
+```kotlin
+dependencies {
+    implementation("com.ditchoom:buffer:<latest-version>")
+    implementation("com.ditchoom:buffer-okio:<latest-version>")
+}
+```
+
+The module depends on Okio (3.17.0) and re-exports it, so you don't need a separate Okio dependency.
+It ships for the full set of `buffer` targets.
+
+## Copy semantics
+
+| Function | Direction | Semantics |
+|----------|-----------|-----------|
+| `WriteBuffer.asOkioSink()` | buffer → okio | streaming view; writes land in the buffer |
+| `ReadBuffer.asOkioSource()` | okio → buffer | streaming view; reads drain the buffer |
+| `Source.readInto(dst, byteCount)` | okio → buffer | copies up to `byteCount` bytes |
+| `Source.transferTo(dst)` | okio → buffer | copies until source EOF |
+| `ReadBuffer.copyToOkioBuffer()` | buffer → okio | non-destructive copy (position unchanged) |
+| `ReadBuffer.copyToByteString()` | buffer → okio | immutable snapshot (always copies) |
+| `Buffer.copyToPlatformBuffer(factory, byteOrder)` | okio → buffer | non-destructive copy (source not consumed) |
+| `ByteString.copyToPlatformBuffer(factory, byteOrder)` | okio → buffer | copy (ByteString is immutable) |
+
+The `as*` views stream through the underlying buffer with **one copy per read/write** and never alias
+our backing array into an Okio segment. The `copyTo*` helpers take an independent snapshot.
+
+## Buffer → Okio
+
+### Stream a buffer into a `Sink`
+
+`asOkioSink()` returns an Okio `Sink` view over a `WriteBuffer`. Bytes written to the sink land in the
+buffer. Wrap it with `.buffer()` for the ergonomic `BufferedSink` API.
+
+```kotlin
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.okio.asOkioSink
+import okio.buffer
+
+val buffer = BufferFactory.Default.allocate(1024)
+val sink = buffer.asOkioSink().buffer()
+sink.writeUtf8("Hello, Okio!")
+sink.flush()
+
+buffer.resetForRead()
+val text = buffer.readString(buffer.remaining())
+```
+
+### Snapshot a buffer as an Okio `Buffer` or `ByteString`
+
+`copyToOkioBuffer()` copies the remaining bytes into a fresh Okio `Buffer` **without moving the source
+position**. `copyToByteString()` produces an immutable `ByteString` snapshot — ideal as a map key, for
+hashing, or for equality checks.
+
+```kotlin
+import com.ditchoom.buffer.okio.copyToOkioBuffer
+import com.ditchoom.buffer.okio.copyToByteString
+
+val payload: ReadBuffer = /* ... */
+val okioBuffer = payload.copyToOkioBuffer()   // payload.position() unchanged
+val digest = payload.copyToByteString().sha256()
+```
+
+## Okio → Buffer
+
+### Read a `Source` into a buffer
+
+`readInto` copies up to `byteCount` bytes (defaulting to the destination's remaining capacity) and
+returns how many were actually transferred, stopping at destination-full or source-EOF.
+
+```kotlin
+import com.ditchoom.buffer.okio.readInto
+
+val dst = BufferFactory.Default.allocate(4096)
+val copied: Long = source.readInto(dst)      // fills dst, or stops at source EOF
+dst.resetForRead()
+```
+
+### Drain a whole source
+
+`transferTo` reads until the source is exhausted. If the source outlasts the destination's capacity,
+the write fails fast with the underlying overflow exception.
+
+```kotlin
+import com.ditchoom.buffer.okio.transferTo
+
+val dst = BufferFactory.Default.allocate(estimatedSize)
+val total: Long = source.transferTo(dst)     // source-EOF driven
+dst.resetForRead()
+```
+
+### Convert an Okio `Buffer` or `ByteString` into a `PlatformBuffer`
+
+`copyToPlatformBuffer` on an Okio `Buffer` copies through a **peek**, so the original is not consumed.
+On a `ByteString` it always copies (immutable, no backing-array access). Both leave the result
+positioned for reading.
+
+```kotlin
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.okio.copyToPlatformBuffer
+
+val fromBuffer = okioBuffer.copyToPlatformBuffer()               // Buffer not consumed
+val fromBytes = byteString.copyToPlatformBuffer(
+    factory = BufferFactory.Default,
+    byteOrder = ByteOrder.LITTLE_ENDIAN,
+)
+```
+
+## Example: hash a buffer with Okio
+
+```kotlin
+import com.ditchoom.buffer.okio.asOkioSource
+import okio.HashingSink
+import okio.blackholeSink
+import okio.buffer
+
+val payload: ReadBuffer = /* ... */
+val hashing = HashingSink.sha256(blackholeSink())
+payload.asOkioSource().buffer().use { it.readAll(hashing) }
+val sha256 = hashing.hash        // payload streamed through Okio, one copy
+```
+
+## Lifetime rules
+
+The `asOkioSource()` / `asOkioSink()` views are thin adapters over the live buffer — they don't own it.
+
+- **Don't let a view outlive its buffer.** A view over a released [pooled buffer](./buffer-pooling)
+  fails fast rather than reading another acquirer's bytes.
+- **Views are single-buffer.** A `Sink` view fills exactly one buffer; for a growing stream, drain to
+  a `copyTo*` snapshot or a larger allocation.
+
+Using a view after its buffer is gone throws `IllegalStateException` (`"asOkioSource() view has been
+closed"` / `"asOkioSink() view has been closed"`).
+
+## See also
+
+- [kotlinx-io Interop](./kotlinx-io-interop) — the same bridge shape for kotlinx-io `RawSource` / `RawSink`
+- [Platform Interop](./platform-interop) — native `toNativeData()` handles for zero-copy platform APIs

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -17,6 +17,9 @@ const sidebars: SidebarsConfig = {
         'recipes/basic-operations',
         'recipes/platform-interop',
         'recipes/cryptography',
+        'recipes/kotlinx-io-interop',
+        'recipes/okio-interop',
+        'recipes/ktor-interop',
       ],
     },
     {


### PR DESCRIPTION
## What

Documentation for the three I/O interop modules shipped in the interop release (buffer-kotlinx-io, buffer-okio, buffer-ktor). Docs-only, no code — `skip-release`.

### New recipe pages
- **`recipes/kotlinx-io-interop.md`** — `asRawSource`/`asRawSink`, `readInto`/`transferTo`, `copyToKotlinxIoBuffer`/`copyToPlatformBuffer`, EOF convention, view-lifetime rules.
- **`recipes/okio-interop.md`** — `asOkioSource`/`asOkioSink`, `readInto`/`transferTo`, `copyToOkioBuffer`/`copyToByteString`/`copyToPlatformBuffer` (Buffer + ByteString), a hashing example.
- **`recipes/ktor-interop.md`** — `readRemainingBuffer`/`writeBuffer` channel bridges, `BufferCodecConverter` ContentConverter (with the codec ownership contract), `encodeToPlatformBuffer`, RFC 6455 WebSocket masking (`applyWebSocketMask`, `writeMaskedWebSocketPayload`).

Each page documents the **exact public API signatures**, per-function **copy-vs-alias semantics**, and the **view-lifetime rules** (fail-fast on use past buffer release).

### Wiring
- Registered the three pages in the Recipes sidebar.
- Added the modules to the `intro.md` layer diagram + dependency block and the `getting-started.md` dependency block + Next Steps, for discoverability.

## Verification
- `npm run build` in `docs/` succeeds; no broken links from the new pages (the lone broken-anchor warning is pre-existing on `/playground#aes-gcm`, unrelated).
- API snippets checked against the shipped `commonMain` sources (signatures, defaults, import paths).

## Notes
- Versions referenced via the repo-standard `<latest-version>` placeholder — no hardcoded version.
- Lands after the interop release publishes to Maven Central so the artifacts the docs reference exist.