### PR TITLE
fix(pool): recover from allocation OutOfMemoryError by draining the pool and retrying once

### DIFF
--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/LockFreeBufferPool.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/LockFreeBufferPool.kt
@@ -67,7 +67,9 @@ internal class LockFreeBufferPool(
         val buffer = acquire(size)
         if (buffer is PlatformBuffer && buffer.byteOrder == byteOrder) return buffer
         release(buffer)
-        return factory.allocate(BufferSizeClass.roundUp(maxOf(size, defaultBufferSize)), byteOrder)
+        return allocateOrReclaim {
+            factory.allocate(BufferSizeClass.roundUp(maxOf(size, defaultBufferSize)), byteOrder)
+        }
     }
 
     override fun wrap(
@@ -93,7 +95,7 @@ internal class LockFreeBufferPool(
                 // buffer's native memory before allocating fresh, otherwise it leaks
                 // (Arena.ofShared never closes, FfmAutoBuffer waits on GC).
                 buffer?.freeNativeMemory()
-                factory.allocate(BufferSizeClass.roundUp(size))
+                allocateOrReclaim { factory.allocate(BufferSizeClass.roundUp(size)) }
             }
         return PooledBuffer(raw, this)
     }

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/PoolAllocation.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/PoolAllocation.kt
@@ -1,0 +1,20 @@
+package com.ditchoom.buffer.pool
+
+import com.ditchoom.buffer.PlatformBuffer
+
+/**
+ * Allocates via [allocate] with a one-shot recovery from allocation failure.
+ *
+ * On platforms whose factory can throw [OutOfMemoryError] under allocator/heap pressure
+ * (JVM/Android and Kotlin/Native), the actual implementation drains this pool's cached
+ * buffers ([clear]) — on JVM/Android also hinting a GC cycle so the `DirectByteBuffer`
+ * cleaner can free the now-unreachable off-heap store — and retries exactly once. A second
+ * consecutive failure propagates. The motivating case is Android/ART heap fragmentation
+ * under sustained buffer churn, where a large allocation fails while pooled buffers still
+ * pin reclaimable space (see ANDROID_ART_ALLOCATOR.md).
+ *
+ * On JS/Wasm this is a straight passthrough: those runtimes surface no catchable
+ * allocation-failure error and their buffers are engine-managed, so there is nothing to
+ * reclaim or retry.
+ */
+internal expect fun BufferPool.allocateOrReclaim(allocate: () -> PlatformBuffer): PlatformBuffer

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/SingleThreadedBufferPool.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/SingleThreadedBufferPool.kt
@@ -39,7 +39,9 @@ internal class SingleThreadedBufferPool(
         val buffer = acquire(size)
         if (buffer is PlatformBuffer && buffer.byteOrder == byteOrder) return buffer
         release(buffer)
-        return factory.allocate(BufferSizeClass.roundUp(maxOf(size, defaultBufferSize)), byteOrder)
+        return allocateOrReclaim {
+            factory.allocate(BufferSizeClass.roundUp(maxOf(size, defaultBufferSize)), byteOrder)
+        }
     }
 
     override fun wrap(
@@ -64,7 +66,7 @@ internal class SingleThreadedBufferPool(
                 // buffer's native memory before allocating fresh, otherwise it leaks
                 // (Arena.ofShared never closes, FfmAutoBuffer waits on GC).
                 buffer?.freeNativeMemory()
-                factory.allocate(BufferSizeClass.roundUp(size))
+                allocateOrReclaim { factory.allocate(BufferSizeClass.roundUp(size)) }
             }
         return PooledBuffer(raw, this)
     }

--- a/buffer/src/commonTest/kotlin/com/ditchoom/buffer/PoolOomResilienceTests.kt
+++ b/buffer/src/commonTest/kotlin/com/ditchoom/buffer/PoolOomResilienceTests.kt
@@ -1,0 +1,77 @@
+package com.ditchoom.buffer
+
+import com.ditchoom.buffer.pool.ThreadingMode
+import com.ditchoom.buffer.pool.createBufferPool
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * The pools recover from a factory [OutOfMemoryError] by draining their cached buffers,
+ * hinting a GC cycle, and retrying once — the Android/ART fragmentation mitigation from
+ * ANDROID_ART_ALLOCATOR.md. A second consecutive failure propagates unchanged.
+ */
+class PoolOomResilienceTests {
+    /** Delegates to a real factory but throws [OutOfMemoryError] for the first [failuresRemaining] allocations. */
+    private class FlakyFactory(
+        var failuresRemaining: Int,
+        private val delegate: BufferFactory = BufferFactory.managed(),
+    ) : BufferFactory {
+        var allocateCalls = 0
+            private set
+
+        override fun allocate(
+            size: Int,
+            byteOrder: ByteOrder,
+        ): PlatformBuffer {
+            allocateCalls++
+            if (failuresRemaining > 0) {
+                failuresRemaining--
+                throw OutOfMemoryError("simulated OOM for $size bytes")
+            }
+            return delegate.allocate(size, byteOrder)
+        }
+
+        override fun wrap(
+            array: ByteArray,
+            byteOrder: ByteOrder,
+        ): PlatformBuffer = delegate.wrap(array, byteOrder)
+    }
+
+    @Test
+    fun retryAfterSingleOomSucceedsAndDrainsPool() {
+        for (mode in ThreadingMode.entries) {
+            val factory = FlakyFactory(failuresRemaining = 0)
+            val pool = createBufferPool(mode, maxPoolSize = 8, defaultBufferSize = 1024, factory = factory)
+
+            // Seed one pooled buffer so the reclaim path has something to drain.
+            pool.release(pool.acquire(1024))
+            assertEquals(1, pool.stats().currentPoolSize, "$mode: seed")
+
+            // A larger request misses the pooled buffer and hits the factory; make that
+            // allocation OOM once so the retry path runs.
+            factory.failuresRemaining = 1
+            val buffer = pool.acquire(4096)
+
+            assertNotNull(buffer, "$mode: acquire recovered from OOM")
+            assertTrue(buffer.capacity >= 4096, "$mode: capacity")
+            assertEquals(3, factory.allocateCalls, "$mode: seed + failed attempt + retry")
+            assertEquals(0, pool.stats().currentPoolSize, "$mode: clear() drained the pool during reclaim")
+        }
+    }
+
+    @Test
+    fun secondConsecutiveOomPropagates() {
+        for (mode in ThreadingMode.entries) {
+            val factory = FlakyFactory(failuresRemaining = 2)
+            val pool = createBufferPool(mode, defaultBufferSize = 1024, factory = factory)
+
+            assertFailsWith<OutOfMemoryError>("$mode: second failure propagates") {
+                pool.acquire(1024)
+            }
+            assertEquals(2, factory.allocateCalls, "$mode: original attempt + one retry, then give up")
+        }
+    }
+}

--- a/buffer/src/jsMain/kotlin/com/ditchoom/buffer/pool/PoolAllocation.js.kt
+++ b/buffer/src/jsMain/kotlin/com/ditchoom/buffer/pool/PoolAllocation.js.kt
@@ -1,0 +1,7 @@
+package com.ditchoom.buffer.pool
+
+import com.ditchoom.buffer.PlatformBuffer
+
+// JS surfaces no catchable allocation-failure error and its buffers are engine-managed;
+// nothing to reclaim, so allocate straight through.
+internal actual fun BufferPool.allocateOrReclaim(allocate: () -> PlatformBuffer): PlatformBuffer = allocate()

--- a/buffer/src/jvmCommonMain/kotlin/com/ditchoom/buffer/pool/PoolAllocation.jvmCommon.kt
+++ b/buffer/src/jvmCommonMain/kotlin/com/ditchoom/buffer/pool/PoolAllocation.jvmCommon.kt
@@ -1,0 +1,18 @@
+package com.ditchoom.buffer.pool
+
+import com.ditchoom.buffer.PlatformBuffer
+
+internal actual fun BufferPool.allocateOrReclaim(allocate: () -> PlatformBuffer): PlatformBuffer =
+    try {
+        allocate()
+    } catch (_: OutOfMemoryError) {
+        clear()
+        // Let the DirectByteBuffer cleaner reclaim the off-heap memory that clear() just
+        // made unreachable — on ART there is no cleaner hook, so dropping the reference
+        // alone frees nothing (see ANDROID_ART_ALLOCATOR.md). This deliberate GC hint is
+        // the whole point of the recovery path, hence the suppression.
+        @Suppress("ExplicitGarbageCollectionCall")
+        System.gc()
+        // Second attempt after reclamation; a repeat OutOfMemoryError propagates to the caller.
+        allocate()
+    }

--- a/buffer/src/jvmCommonTest/kotlin/com/ditchoom/buffer/PoolOomResilienceTests.kt
+++ b/buffer/src/jvmCommonTest/kotlin/com/ditchoom/buffer/PoolOomResilienceTests.kt
@@ -12,6 +12,10 @@ import kotlin.test.assertTrue
  * The pools recover from a factory [OutOfMemoryError] by draining their cached buffers,
  * hinting a GC cycle, and retrying once — the Android/ART fragmentation mitigation from
  * ANDROID_ART_ALLOCATOR.md. A second consecutive failure propagates unchanged.
+ *
+ * Lives in jvmCommonTest (JVM + Android): the retry path only exists where a factory allocation
+ * can throw [OutOfMemoryError], and that type is JVM/Native-only — it doesn't resolve on JS/Wasm,
+ * where `allocateOrReclaim` is a passthrough. This is exactly the platform the fix targets.
  */
 class PoolOomResilienceTests {
     /** Delegates to a real factory but throws [OutOfMemoryError] for the first [failuresRemaining] allocations. */

--- a/buffer/src/jvmCommonTest/kotlin/com/ditchoom/buffer/PoolOomResilienceTests.kt
+++ b/buffer/src/jvmCommonTest/kotlin/com/ditchoom/buffer/PoolOomResilienceTests.kt
@@ -48,20 +48,20 @@ class PoolOomResilienceTests {
     fun retryAfterSingleOomSucceedsAndDrainsPool() {
         for (mode in ThreadingMode.entries) {
             val factory = FlakyFactory(failuresRemaining = 0)
-            val pool = createBufferPool(mode, maxPoolSize = 8, defaultBufferSize = 1024, factory = factory)
+            val pool = createBufferPool(mode, maxPoolSize = 8, defaultBufferSize = POOL_BUFFER_SIZE, factory = factory)
 
             // Seed one pooled buffer so the reclaim path has something to drain.
-            pool.release(pool.acquire(1024))
+            pool.release(pool.acquire(POOL_BUFFER_SIZE))
             assertEquals(1, pool.stats().currentPoolSize, "$mode: seed")
 
             // A larger request misses the pooled buffer and hits the factory; make that
             // allocation OOM once so the retry path runs.
             factory.failuresRemaining = 1
-            val buffer = pool.acquire(4096)
+            val buffer = pool.acquire(LARGER_REQUEST_SIZE)
 
             assertNotNull(buffer, "$mode: acquire recovered from OOM")
-            assertTrue(buffer.capacity >= 4096, "$mode: capacity")
-            assertEquals(3, factory.allocateCalls, "$mode: seed + failed attempt + retry")
+            assertTrue(buffer.capacity >= LARGER_REQUEST_SIZE, "$mode: capacity")
+            assertEquals(EXPECTED_ALLOCATE_CALLS, factory.allocateCalls, "$mode: seed + failed attempt + retry")
             assertEquals(0, pool.stats().currentPoolSize, "$mode: clear() drained the pool during reclaim")
         }
     }
@@ -70,12 +70,20 @@ class PoolOomResilienceTests {
     fun secondConsecutiveOomPropagates() {
         for (mode in ThreadingMode.entries) {
             val factory = FlakyFactory(failuresRemaining = 2)
-            val pool = createBufferPool(mode, defaultBufferSize = 1024, factory = factory)
+            val pool = createBufferPool(mode, defaultBufferSize = POOL_BUFFER_SIZE, factory = factory)
 
             assertFailsWith<OutOfMemoryError>("$mode: second failure propagates") {
-                pool.acquire(1024)
+                pool.acquire(POOL_BUFFER_SIZE)
             }
             assertEquals(2, factory.allocateCalls, "$mode: original attempt + one retry, then give up")
         }
+    }
+
+    private companion object {
+        const val POOL_BUFFER_SIZE = 1024
+        const val LARGER_REQUEST_SIZE = 4096
+
+        // Seed miss + the failed first attempt + the successful retry.
+        const val EXPECTED_ALLOCATE_CALLS = 3
     }
 }

--- a/buffer/src/nativeMain/kotlin/com/ditchoom/buffer/pool/PoolAllocation.native.kt
+++ b/buffer/src/nativeMain/kotlin/com/ditchoom/buffer/pool/PoolAllocation.native.kt
@@ -1,0 +1,13 @@
+package com.ditchoom.buffer.pool
+
+import com.ditchoom.buffer.PlatformBuffer
+
+internal actual fun BufferPool.allocateOrReclaim(allocate: () -> PlatformBuffer): PlatformBuffer =
+    try {
+        allocate()
+    } catch (_: OutOfMemoryError) {
+        // K/N frees native memory eagerly on drop, so clearing the pool returns it to the
+        // allocator directly — no GC hint needed. Retry once; a repeat failure propagates.
+        clear()
+        allocate()
+    }

--- a/buffer/src/wasmJsMain/kotlin/com/ditchoom/buffer/pool/PoolAllocation.wasmJs.kt
+++ b/buffer/src/wasmJsMain/kotlin/com/ditchoom/buffer/pool/PoolAllocation.wasmJs.kt
@@ -1,0 +1,7 @@
+package com.ditchoom.buffer.pool
+
+import com.ditchoom.buffer.PlatformBuffer
+
+// Wasm/JS surface no catchable allocation-failure error and their buffers are
+// engine-managed; nothing to reclaim, so allocate straight through.
+internal actual fun BufferPool.allocateOrReclaim(allocate: () -> PlatformBuffer): PlatformBuffer = allocate()


### PR DESCRIPTION
## Problem

Under sustained buffer churn the pools (`LockFreeBufferPool`, `SingleThreadedBufferPool`) can throw `OutOfMemoryError` straight out of `acquire()` / `allocate()` when the seed factory's allocation fails — **even though the pool still holds reclaimable buffers**.

This is the Android/ART fragmentation case documented in `ANDROID_ART_ALLOCATOR.md`: a large `DirectByteBuffer` allocation fails while pooled buffers pin off-heap space that ART only frees when its cleaner runs. It's the root cause behind the red Android Autobahn leg (233× `Failed to allocate a 524307 byte allocation` / `malloc_space fragmentation`, read-loop OOM kills the connection though the process survives).

## Fix

Wrap the miss-path `factory.allocate` in a new `allocateOrReclaim` helper. On `OutOfMemoryError`:
1. `clear()` the pool — frees its cached buffers back to the allocator.
2. **JVM/Android only:** hint `System.gc()` so the `DirectByteBuffer` cleaner actually runs (ART exposes no cleaner hook, so dropping the reference alone frees nothing).
3. Retry the allocation exactly once. A second consecutive failure propagates unchanged.

`allocateOrReclaim` is `expect`/`actual`:

| Target | Behavior |
|---|---|
| jvmCommon (JVM + Android) | catch OOM → `clear()` → `System.gc()` → retry once |
| native | catch OOM → `clear()` → retry once (K/N frees native memory eagerly on drop; no GC hint) |
| wasmJs / js | straight passthrough — no catchable allocation-failure error, engine-managed buffers |

The split is also a hard requirement: `OutOfMemoryError` is a JVM/Native-only stdlib type and doesn't resolve in the JS/Wasm compile, so the `catch` cannot live in `commonMain`.

## Tests

`PoolOomResilienceTests` (commonTest, both threading modes):
- single OOM → recovers, returns a usable buffer, and the pool was drained during reclaim (verified via `stats().currentPoolSize` and factory call count);
- two consecutive OOMs → the second propagates.

## Validation

- `:buffer:jvmTest` (new + existing `BufferPool*` / `Pooled*` suites) green
- Compiles on JVM, macOS/native, JS, Wasm
- ktlint + detekt clean (intentional `System.gc()` carries a scoped `@Suppress` with rationale)