### PR TITLE
feat: streaming frame helpers (ktor decodeFrames/encodeFrame) + buffer-flow .typed() codec pipe

### DIFF
--- a/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/FrameStreaming.kt
+++ b/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/FrameStreaming.kt
@@ -1,0 +1,92 @@
+package com.ditchoom.buffer.codec
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.BufferOverflowException
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.stream.StreamProcessor
+
+private const val MIN_ESTIMATE = 64
+private const val MAX_ENCODE_CAPACITY = 1 shl 30 // 1 GiB safety ceiling
+
+/**
+ * Encodes [value] with this [Encoder] into a fresh [PlatformBuffer] allocated by [factory],
+ * positioned for reading (`position = 0`, `limit = encoded size`).
+ *
+ * When the encoder reports a [WireSize.Exact] size the buffer is allocated exactly once. For
+ * [WireSize.BackPatch] encoders the capacity starts from an estimate and doubles on
+ * [BufferOverflowException] until the value fits (capped at 1 GiB).
+ *
+ * Frees the allocated buffer on any exception from [Encoder.encode] — not just the overflow-retry
+ * path — so a failing encode never leaks native memory.
+ *
+ * This is the canonical home for codec→buffer encoding; the transport bridges (buffer-ktor,
+ * buffer-flow) build their frame helpers on top of it so the overflow-retry policy lives in one
+ * place.
+ *
+ * @param value the value to encode.
+ * @param factory allocator for the destination buffer (default [BufferFactory.Default]).
+ * @param context encode context threaded to the encoder (default [EncodeContext.Empty]).
+ */
+public fun <T> Encoder<T>.encodeToPlatformBuffer(
+    value: T,
+    factory: BufferFactory = BufferFactory.Default,
+    context: EncodeContext = EncodeContext.Empty,
+): PlatformBuffer {
+    var capacity =
+        when (val size = wireSize(value, context)) {
+            is WireSize.Exact -> maxOf(size.bytes, 1)
+            WireSize.BackPatch -> MIN_ESTIMATE
+        }
+    while (true) {
+        val buffer = factory.allocate(capacity)
+        var freeOnExit = true
+        try {
+            encode(buffer, value, context)
+            buffer.resetForRead()
+            freeOnExit = false
+            return buffer
+        } catch (overflow: BufferOverflowException) {
+            freeOnExit = false
+            buffer.freeNativeMemory()
+            if (capacity >= MAX_ENCODE_CAPACITY) throw overflow
+            capacity = minOf(capacity * 2, MAX_ENCODE_CAPACITY)
+        } finally {
+            if (freeOnExit) buffer.freeNativeMemory()
+        }
+    }
+}
+
+/**
+ * Reads the next complete frame from [stream], or returns `null` when the stream does not yet hold
+ * a whole frame (either the framing header hasn't arrived, or the header is present but the body is
+ * still incomplete). A `null` return is the streaming loop's signal to pull more transport bytes,
+ * [StreamProcessor.append] them, and retry.
+ *
+ * Uses this codec's generated [FrameDetector.peekFrameSize] to size the frame without consuming
+ * bytes, then decodes exactly that many via [StreamProcessor.readBufferScoped] so the sliced frame
+ * is released back to the pool after [Decoder.decode] returns.
+ *
+ * @throws IllegalStateException if this codec does not participate in frame detection
+ *   ([PeekResult.NoFraming]) — i.e. its wire format has no determinable frame size. Such a codec
+ *   cannot drive a streaming loop; frame it explicitly (e.g. a length prefix) instead.
+ */
+public fun <T> Codec<T>.readFrame(
+    stream: StreamProcessor,
+    context: DecodeContext = DecodeContext.Empty,
+): T? =
+    when (val peek = peekFrameSize(stream)) {
+        is PeekResult.Complete ->
+            if (stream.available() < peek.bytes) {
+                null
+            } else {
+                stream.readBufferScoped(peek.bytes) { decode(this, context) }
+            }
+        PeekResult.NeedsMoreData -> null
+        PeekResult.NoFraming ->
+            throw IllegalStateException(
+                "Codec ${this::class.simpleName} does not support frame detection " +
+                    "(peekFrameSize returned NoFraming); its wire format has no determinable frame " +
+                    "size. Streaming requires a self-delimiting format (e.g. a length prefix).",
+            )
+    }

--- a/buffer-flow/api/android/buffer-flow.api
+++ b/buffer-flow/api/android/buffer-flow.api
@@ -56,6 +56,10 @@ public abstract interface class com/ditchoom/buffer/flow/ByteStreamMux {
 	public abstract fun openUnidirectional (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class com/ditchoom/buffer/flow/ByteStreamResetException : java/lang/IllegalStateException {
+	public fun <init> ()V
+}
+
 public final class com/ditchoom/buffer/flow/BytesWritten {
 	public static final synthetic fun box-impl (I)Lcom/ditchoom/buffer/flow/BytesWritten;
 	public static fun constructor-impl (I)I
@@ -180,6 +184,15 @@ public abstract interface class com/ditchoom/buffer/flow/StreamMux {
 	public abstract fun acceptUnidirectional (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun openBidirectional (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun openUnidirectional (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/ditchoom/buffer/flow/TypedKt {
+	public static final fun typed (Lcom/ditchoom/buffer/flow/ByteSink;Lcom/ditchoom/buffer/codec/Codec;Lcom/ditchoom/buffer/BufferFactory;Lcom/ditchoom/buffer/codec/EncodeContext;)Lcom/ditchoom/buffer/flow/Sender;
+	public static final fun typed (Lcom/ditchoom/buffer/flow/ByteSource;Lcom/ditchoom/buffer/codec/Codec;Lcom/ditchoom/buffer/codec/DecodeContext;Lcom/ditchoom/buffer/ByteOrder;)Lcom/ditchoom/buffer/flow/Receiver;
+	public static final fun typed (Lcom/ditchoom/buffer/flow/ByteStream;Lcom/ditchoom/buffer/codec/Codec;Lcom/ditchoom/buffer/BufferFactory;Lcom/ditchoom/buffer/codec/DecodeContext;Lcom/ditchoom/buffer/codec/EncodeContext;Lcom/ditchoom/buffer/ByteOrder;)Lcom/ditchoom/buffer/flow/Connection;
+	public static synthetic fun typed$default (Lcom/ditchoom/buffer/flow/ByteSink;Lcom/ditchoom/buffer/codec/Codec;Lcom/ditchoom/buffer/BufferFactory;Lcom/ditchoom/buffer/codec/EncodeContext;ILjava/lang/Object;)Lcom/ditchoom/buffer/flow/Sender;
+	public static synthetic fun typed$default (Lcom/ditchoom/buffer/flow/ByteSource;Lcom/ditchoom/buffer/codec/Codec;Lcom/ditchoom/buffer/codec/DecodeContext;Lcom/ditchoom/buffer/ByteOrder;ILjava/lang/Object;)Lcom/ditchoom/buffer/flow/Receiver;
+	public static synthetic fun typed$default (Lcom/ditchoom/buffer/flow/ByteStream;Lcom/ditchoom/buffer/codec/Codec;Lcom/ditchoom/buffer/BufferFactory;Lcom/ditchoom/buffer/codec/DecodeContext;Lcom/ditchoom/buffer/codec/EncodeContext;Lcom/ditchoom/buffer/ByteOrder;ILjava/lang/Object;)Lcom/ditchoom/buffer/flow/Connection;
 }
 
 public abstract interface class com/ditchoom/buffer/flow/WritePolicy {

--- a/buffer-flow/api/jvm/buffer-flow.api
+++ b/buffer-flow/api/jvm/buffer-flow.api
@@ -56,6 +56,10 @@ public abstract interface class com/ditchoom/buffer/flow/ByteStreamMux {
 	public abstract fun openUnidirectional (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class com/ditchoom/buffer/flow/ByteStreamResetException : java/lang/IllegalStateException {
+	public fun <init> ()V
+}
+
 public final class com/ditchoom/buffer/flow/BytesWritten {
 	public static final synthetic fun box-impl (I)Lcom/ditchoom/buffer/flow/BytesWritten;
 	public static fun constructor-impl (I)I
@@ -180,6 +184,15 @@ public abstract interface class com/ditchoom/buffer/flow/StreamMux {
 	public abstract fun acceptUnidirectional (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun openBidirectional (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun openUnidirectional (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/ditchoom/buffer/flow/TypedKt {
+	public static final fun typed (Lcom/ditchoom/buffer/flow/ByteSink;Lcom/ditchoom/buffer/codec/Codec;Lcom/ditchoom/buffer/BufferFactory;Lcom/ditchoom/buffer/codec/EncodeContext;)Lcom/ditchoom/buffer/flow/Sender;
+	public static final fun typed (Lcom/ditchoom/buffer/flow/ByteSource;Lcom/ditchoom/buffer/codec/Codec;Lcom/ditchoom/buffer/codec/DecodeContext;Lcom/ditchoom/buffer/ByteOrder;)Lcom/ditchoom/buffer/flow/Receiver;
+	public static final fun typed (Lcom/ditchoom/buffer/flow/ByteStream;Lcom/ditchoom/buffer/codec/Codec;Lcom/ditchoom/buffer/BufferFactory;Lcom/ditchoom/buffer/codec/DecodeContext;Lcom/ditchoom/buffer/codec/EncodeContext;Lcom/ditchoom/buffer/ByteOrder;)Lcom/ditchoom/buffer/flow/Connection;
+	public static synthetic fun typed$default (Lcom/ditchoom/buffer/flow/ByteSink;Lcom/ditchoom/buffer/codec/Codec;Lcom/ditchoom/buffer/BufferFactory;Lcom/ditchoom/buffer/codec/EncodeContext;ILjava/lang/Object;)Lcom/ditchoom/buffer/flow/Sender;
+	public static synthetic fun typed$default (Lcom/ditchoom/buffer/flow/ByteSource;Lcom/ditchoom/buffer/codec/Codec;Lcom/ditchoom/buffer/codec/DecodeContext;Lcom/ditchoom/buffer/ByteOrder;ILjava/lang/Object;)Lcom/ditchoom/buffer/flow/Receiver;
+	public static synthetic fun typed$default (Lcom/ditchoom/buffer/flow/ByteStream;Lcom/ditchoom/buffer/codec/Codec;Lcom/ditchoom/buffer/BufferFactory;Lcom/ditchoom/buffer/codec/DecodeContext;Lcom/ditchoom/buffer/codec/EncodeContext;Lcom/ditchoom/buffer/ByteOrder;ILjava/lang/Object;)Lcom/ditchoom/buffer/flow/Connection;
 }
 
 public abstract interface class com/ditchoom/buffer/flow/WritePolicy {

--- a/buffer-flow/build.gradle.kts
+++ b/buffer-flow/build.gradle.kts
@@ -166,14 +166,16 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             api(project(":buffer"))
+            // The typed frame pipe (ByteSource/ByteSink/ByteStream.typed) bridges a Codec across a
+            // byte stream, so buffer-codec is part of buffer-flow's public API surface here.
+            api(project(":buffer-codec"))
             api(libs.kotlinx.coroutines.core)
         }
         commonTest.dependencies {
             implementation(kotlin("test"))
             implementation(libs.kotlinx.coroutines.test)
-            // The bridge tests need the actual codec module + the MQTT fixtures
-            // generated into :buffer-codec-test's commonMain by KSP.
-            implementation(project(":buffer-codec"))
+            // The bridge tests need the MQTT fixtures generated into :buffer-codec-test's
+            // commonMain by KSP (buffer-codec itself is now a main dependency, above).
             implementation(project(":buffer-codec-test"))
         }
 

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/ByteStreamResetException.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/ByteStreamResetException.kt
@@ -1,0 +1,8 @@
+package com.ditchoom.buffer.flow
+
+/**
+ * Thrown from a typed [Receiver.receive] flow when the underlying byte stream is
+ * [reset][ReadResult.Reset] by the peer before it completes cleanly. Distinguishes an abrupt reset
+ * from a clean end-of-stream, which instead completes the flow.
+ */
+public class ByteStreamResetException : IllegalStateException("Byte stream was reset by the peer")

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/Typed.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/Typed.kt
@@ -1,0 +1,147 @@
+package com.ditchoom.buffer.flow
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.encodeToPlatformBuffer
+import com.ditchoom.buffer.codec.readFrame
+import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+/**
+ * Views this byte [Receiver][ByteSource] as a typed [Receiver] of [T] by framing and decoding with
+ * [codec].
+ *
+ * Each [receive] collection drives a private [StreamProcessor]: bytes read from this source are
+ * appended, and every complete frame — sized by the codec's generated
+ * [peekFrameSize][com.ditchoom.buffer.codec.FrameDetector.peekFrameSize] — is decoded and emitted
+ * before the next transport read. A clean [ReadResult.End] completes the flow; a
+ * [ReadResult.Reset] fails it with [ByteStreamResetException]. The processor and its pool are
+ * released when collection ends (normally, on error, or on cancellation).
+ *
+ * @param codec the frame codec; must support frame detection (a self-delimiting wire format).
+ * @param context decode context threaded to the codec (default [DecodeContext.Empty]).
+ * @param frameByteOrder byte order for the framing [StreamProcessor]'s scalar peeks
+ *   (default [ByteOrder.BIG_ENDIAN], the network default).
+ */
+public fun <T> ByteSource.typed(
+    codec: Codec<T>,
+    context: DecodeContext = DecodeContext.Empty,
+    frameByteOrder: ByteOrder = ByteOrder.BIG_ENDIAN,
+): Receiver<T> = CodecSource(this, codec, context, frameByteOrder)
+
+/**
+ * Views this byte [Sender][ByteSink] as a typed [Sender] of [T] by encoding each message with
+ * [codec] into a fresh buffer and writing it. The encode buffer is freed after each write, so no
+ * native memory leaks across sends. [Sender.close] delegates to [ByteSink.close] (send-side FIN).
+ *
+ * @param codec the frame codec used to encode outbound messages.
+ * @param factory allocator for the per-message encode buffer (default [BufferFactory.Default]).
+ * @param context encode context threaded to the codec (default [EncodeContext.Empty]).
+ */
+public fun <T> ByteSink.typed(
+    codec: Codec<T>,
+    factory: BufferFactory = BufferFactory.Default,
+    context: EncodeContext = EncodeContext.Empty,
+): Sender<T> = CodecSink(this, codec, factory, context, id = 0L)
+
+/**
+ * Views this bidirectional [ByteStream] as a typed [Connection] of [T]: the receive half frames and
+ * decodes inbound bytes (see [ByteSource.typed]) and the send half encodes outbound messages (see
+ * [ByteSink.typed]). [Connection.close] closes the whole stream.
+ *
+ * Because [ByteStream] is more specific than [ByteSource] / [ByteSink], `stream.typed(codec)`
+ * resolves to this overload and yields a full [Connection]; upcast to a single half first if you
+ * want only a [Receiver] or [Sender].
+ *
+ * @param codec the frame codec used for both directions.
+ * @param factory allocator for per-message encode buffers (default [BufferFactory.Default]).
+ * @param decodeContext decode context threaded to the codec (default [DecodeContext.Empty]).
+ * @param encodeContext encode context threaded to the codec (default [EncodeContext.Empty]).
+ * @param frameByteOrder byte order for the framing [StreamProcessor] (default [ByteOrder.BIG_ENDIAN]).
+ */
+public fun <T> ByteStream.typed(
+    codec: Codec<T>,
+    factory: BufferFactory = BufferFactory.Default,
+    decodeContext: DecodeContext = DecodeContext.Empty,
+    encodeContext: EncodeContext = EncodeContext.Empty,
+    frameByteOrder: ByteOrder = ByteOrder.BIG_ENDIAN,
+): Connection<T> = CodecConnection(this, codec, factory, decodeContext, encodeContext, frameByteOrder)
+
+private class CodecSource<T>(
+    private val source: ByteSource,
+    private val codec: Codec<T>,
+    private val context: DecodeContext,
+    private val frameByteOrder: ByteOrder,
+) : Receiver<T> {
+    override fun receive(): Flow<T> =
+        flow {
+            val pool = BufferPool()
+            val processor = StreamProcessor.create(pool, frameByteOrder)
+            try {
+                while (true) {
+                    // Emit every frame already assembled before blocking on the next transport read.
+                    while (true) {
+                        val frame = codec.readFrame(processor, context) ?: break
+                        emit(frame)
+                    }
+                    when (val result = source.read()) {
+                        is ReadResult.Data -> processor.append(result.buffer)
+                        ReadResult.End -> break
+                        ReadResult.Reset -> throw ByteStreamResetException()
+                    }
+                }
+            } finally {
+                processor.release()
+                pool.clear()
+            }
+        }
+}
+
+private class CodecSink<T>(
+    private val sink: ByteSink,
+    private val codec: Codec<T>,
+    private val factory: BufferFactory,
+    private val context: EncodeContext,
+    override val id: Long,
+) : Sender<T> {
+    override suspend fun send(message: T) {
+        val buffer = codec.encodeToPlatformBuffer(message, factory, context)
+        try {
+            sink.write(buffer)
+        } finally {
+            buffer.freeNativeMemory()
+        }
+    }
+
+    override suspend fun close() {
+        sink.close()
+    }
+}
+
+private class CodecConnection<T>(
+    private val stream: ByteStream,
+    codec: Codec<T>,
+    factory: BufferFactory,
+    decodeContext: DecodeContext,
+    encodeContext: EncodeContext,
+    frameByteOrder: ByteOrder,
+) : Connection<T> {
+    private val sender = CodecSink(stream, codec, factory, encodeContext, id = 0L)
+    private val receiver = CodecSource(stream, codec, decodeContext, frameByteOrder)
+
+    override val id: Long get() = 0L
+
+    override suspend fun send(message: T) = sender.send(message)
+
+    override fun receive(): Flow<T> = receiver.receive()
+
+    override suspend fun close() {
+        stream.close()
+    }
+}

--- a/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/TypedTest.kt
+++ b/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/TypedTest.kt
@@ -1,0 +1,113 @@
+package com.ditchoom.buffer.flow
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.encodeToPlatformBuffer
+import com.ditchoom.buffer.codec.test.protocols.simple.Command
+import com.ditchoom.buffer.codec.test.protocols.simple.CommandCodec
+import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.toList
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.time.Duration
+
+/** Encodes a [Command] to its on-wire bytes via the shared codec encode helper. */
+private fun Command.encodedBytes(): ByteArray {
+    val buffer = CommandCodec.encodeToPlatformBuffer(this)
+    return try {
+        buffer.copyToByteArray(buffer.remaining())
+    } finally {
+        buffer.freeNativeMemory()
+    }
+}
+
+class TypedTest {
+    private val mixed =
+        listOf(
+            Command.Ping(ts = 0x1122334455667788L),
+            Command.Echo(msg = "hi"),
+            Command.Ping(ts = 1L),
+            Command.Echo(msg = "hello world"),
+        )
+
+    @Test
+    fun typedConnectionRoundTripsMixedMessagesInOrder() =
+        runTest {
+            val (a, b) = memoryByteStreamPair()
+            val sender = a.typed(CommandCodec)
+            val receiver = b.typed(CommandCodec)
+
+            val received = async { receiver.receive().take(mixed.size).toList() }
+            mixed.forEach { sender.send(it) }
+
+            assertEquals(mixed, received.await())
+        }
+
+    @Test
+    fun typedSourceReassemblesFrameSplitAcrossSingleByteReads() =
+        runTest {
+            // Concatenate several frames, then deliver the whole run one byte per read so every
+            // frame boundary and length prefix lands mid-chunk.
+            val stream = mixed.fold(ByteArray(0)) { acc, m -> acc + m.encodedBytes() }
+            val inbound = Channel<ReadBuffer>(Channel.UNLIMITED)
+            for (byte in stream) {
+                inbound.send(BufferFactory.Default.wrap(byteArrayOf(byte)))
+            }
+            inbound.close()
+
+            val received = ChannelByteSource(inbound).typed(CommandCodec).receive().toList()
+
+            assertEquals(mixed, received)
+        }
+
+    @Test
+    fun typedSourceCompletesOnCleanEnd() =
+        runTest {
+            val inbound = Channel<ReadBuffer>(Channel.UNLIMITED)
+            inbound.send(BufferFactory.Default.wrap(Command.Ping(ts = 7L).encodedBytes()))
+            inbound.close()
+
+            val received = ChannelByteSource(inbound).typed(CommandCodec).receive().toList()
+
+            assertEquals(listOf(Command.Ping(ts = 7L)), received)
+        }
+
+    @Test
+    fun typedSourceSurfacesResetAsException() =
+        runTest {
+            val resettingSource =
+                object : ByteSource {
+                    override val isOpen: Boolean = true
+                    override val readPolicy: ReadPolicy = ReadPolicy.UntilClosed
+
+                    override suspend fun read(deadline: Duration): ReadResult = ReadResult.Reset
+                }
+
+            assertFailsWith<ByteStreamResetException> {
+                resettingSource.typed(CommandCodec).receive().toList()
+            }
+        }
+
+    @Test
+    fun typedSinkEncodesExactCodecBytesOntoTheWire() =
+        runTest {
+            val outbound = Channel<ReadBuffer>(Channel.UNLIMITED)
+            val sender = ChannelByteSink(outbound).typed(CommandCodec)
+
+            val message = Command.Echo(msg = "on the wire")
+            sender.send(message)
+            outbound.close()
+
+            val onWire =
+                outbound.toList().fold(ByteArray(0)) { acc, buf ->
+                    acc + buf.copyToByteArray(buf.remaining())
+                }
+            assertEquals(message.encodedBytes().toList(), onWire.toList())
+        }
+}

--- a/buffer-ktor/api/android/buffer-ktor.api
+++ b/buffer-ktor/api/android/buffer-ktor.api
@@ -20,6 +20,13 @@ public final class com/ditchoom/buffer/ktor/CodecEncodingKt {
 	public static synthetic fun encodeToPlatformBuffer$default (Lcom/ditchoom/buffer/codec/Encoder;Ljava/lang/Object;Lcom/ditchoom/buffer/BufferFactory;Lcom/ditchoom/buffer/codec/EncodeContext;ILjava/lang/Object;)Lcom/ditchoom/buffer/PlatformBuffer;
 }
 
+public final class com/ditchoom/buffer/ktor/FrameStreamingKt {
+	public static final fun decodeFrames (Lio/ktor/utils/io/ByteReadChannel;Lcom/ditchoom/buffer/codec/Codec;Lcom/ditchoom/buffer/codec/DecodeContext;Lcom/ditchoom/buffer/ByteOrder;I)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun decodeFrames$default (Lio/ktor/utils/io/ByteReadChannel;Lcom/ditchoom/buffer/codec/Codec;Lcom/ditchoom/buffer/codec/DecodeContext;Lcom/ditchoom/buffer/ByteOrder;IILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun encodeFrame (Lio/ktor/utils/io/ByteWriteChannel;Lcom/ditchoom/buffer/codec/Encoder;Ljava/lang/Object;Lcom/ditchoom/buffer/BufferFactory;Lcom/ditchoom/buffer/codec/EncodeContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun encodeFrame$default (Lio/ktor/utils/io/ByteWriteChannel;Lcom/ditchoom/buffer/codec/Encoder;Ljava/lang/Object;Lcom/ditchoom/buffer/BufferFactory;Lcom/ditchoom/buffer/codec/EncodeContext;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
 public final class com/ditchoom/buffer/ktor/WebSocketMaskingKt {
 	public static final fun applyWebSocketMask (Lcom/ditchoom/buffer/ReadWriteBuffer;II)V
 	public static synthetic fun applyWebSocketMask$default (Lcom/ditchoom/buffer/ReadWriteBuffer;IIILjava/lang/Object;)V

--- a/buffer-ktor/api/jvm/buffer-ktor.api
+++ b/buffer-ktor/api/jvm/buffer-ktor.api
@@ -20,6 +20,13 @@ public final class com/ditchoom/buffer/ktor/CodecEncodingKt {
 	public static synthetic fun encodeToPlatformBuffer$default (Lcom/ditchoom/buffer/codec/Encoder;Ljava/lang/Object;Lcom/ditchoom/buffer/BufferFactory;Lcom/ditchoom/buffer/codec/EncodeContext;ILjava/lang/Object;)Lcom/ditchoom/buffer/PlatformBuffer;
 }
 
+public final class com/ditchoom/buffer/ktor/FrameStreamingKt {
+	public static final fun decodeFrames (Lio/ktor/utils/io/ByteReadChannel;Lcom/ditchoom/buffer/codec/Codec;Lcom/ditchoom/buffer/codec/DecodeContext;Lcom/ditchoom/buffer/ByteOrder;I)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun decodeFrames$default (Lio/ktor/utils/io/ByteReadChannel;Lcom/ditchoom/buffer/codec/Codec;Lcom/ditchoom/buffer/codec/DecodeContext;Lcom/ditchoom/buffer/ByteOrder;IILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun encodeFrame (Lio/ktor/utils/io/ByteWriteChannel;Lcom/ditchoom/buffer/codec/Encoder;Ljava/lang/Object;Lcom/ditchoom/buffer/BufferFactory;Lcom/ditchoom/buffer/codec/EncodeContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun encodeFrame$default (Lio/ktor/utils/io/ByteWriteChannel;Lcom/ditchoom/buffer/codec/Encoder;Ljava/lang/Object;Lcom/ditchoom/buffer/BufferFactory;Lcom/ditchoom/buffer/codec/EncodeContext;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
 public final class com/ditchoom/buffer/ktor/WebSocketMaskingKt {
 	public static final fun applyWebSocketMask (Lcom/ditchoom/buffer/ReadWriteBuffer;II)V
 	public static synthetic fun applyWebSocketMask$default (Lcom/ditchoom/buffer/ReadWriteBuffer;IIILjava/lang/Object;)V

--- a/buffer-ktor/src/commonMain/kotlin/com/ditchoom/buffer/ktor/CodecEncoding.kt
+++ b/buffer-ktor/src/commonMain/kotlin/com/ditchoom/buffer/ktor/CodecEncoding.kt
@@ -1,26 +1,20 @@
 package com.ditchoom.buffer.ktor
 
 import com.ditchoom.buffer.BufferFactory
-import com.ditchoom.buffer.BufferOverflowException
 import com.ditchoom.buffer.Default
 import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.codec.EncodeContext
 import com.ditchoom.buffer.codec.Encoder
-import com.ditchoom.buffer.codec.WireSize
-
-private const val MIN_ESTIMATE = 64
-private const val MAX_ENCODE_CAPACITY = 1 shl 30 // 1 GiB safety ceiling
+import com.ditchoom.buffer.codec.encodeToPlatformBuffer as codecEncodeToPlatformBuffer
 
 /**
- * Encodes [value] with this [Encoder] into a fresh [PlatformBuffer] allocated by [factory],
- * positioned for reading (`position = 0`, `limit = encoded size`).
+ * Encodes [value] with this [Encoder] into a fresh [PlatformBuffer] positioned for reading
+ * (`position = 0`, `limit = encoded size`).
  *
- * When the encoder reports an [WireSize.Exact] size the buffer is allocated exactly once. For
- * [WireSize.BackPatch] encoders the capacity starts from an estimate and doubles on
- * [BufferOverflowException] until the value fits (capped at 1 GiB).
- *
- * Frees the allocated buffer on any exception from [Encoder.encode] — not just the
- * overflow-retry path — so a failing encode never leaks native memory.
+ * The overflow-retry policy now lives in buffer-codec as
+ * [com.ditchoom.buffer.codec.encodeToPlatformBuffer] — the canonical home shared by every transport
+ * bridge (buffer-ktor, buffer-flow). This overload re-exports it into the ktor namespace so existing
+ * callers keep resolving it here; it forwards unchanged.
  *
  * @param value the value to encode.
  * @param factory allocator for the destination buffer (default [BufferFactory.Default]).
@@ -30,27 +24,4 @@ public fun <T> Encoder<T>.encodeToPlatformBuffer(
     value: T,
     factory: BufferFactory = BufferFactory.Default,
     context: EncodeContext = EncodeContext.Empty,
-): PlatformBuffer {
-    var capacity =
-        when (val size = wireSize(value, context)) {
-            is WireSize.Exact -> maxOf(size.bytes, 1)
-            WireSize.BackPatch -> MIN_ESTIMATE
-        }
-    while (true) {
-        val buffer = factory.allocate(capacity)
-        var freeOnExit = true
-        try {
-            encode(buffer, value, context)
-            buffer.resetForRead()
-            freeOnExit = false
-            return buffer
-        } catch (overflow: BufferOverflowException) {
-            freeOnExit = false
-            buffer.freeNativeMemory()
-            if (capacity >= MAX_ENCODE_CAPACITY) throw overflow
-            capacity = minOf(capacity * 2, MAX_ENCODE_CAPACITY)
-        } finally {
-            if (freeOnExit) buffer.freeNativeMemory()
-        }
-    }
-}
+): PlatformBuffer = codecEncodeToPlatformBuffer(value, factory, context)

--- a/buffer-ktor/src/commonMain/kotlin/com/ditchoom/buffer/ktor/FrameStreaming.kt
+++ b/buffer-ktor/src/commonMain/kotlin/com/ditchoom/buffer/ktor/FrameStreaming.kt
@@ -1,0 +1,94 @@
+package com.ditchoom.buffer.ktor
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.Encoder
+import com.ditchoom.buffer.codec.encodeToPlatformBuffer
+import com.ditchoom.buffer.codec.readFrame
+import com.ditchoom.buffer.kotlinxio.copyToPlatformBuffer
+import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.buffer.stream.StreamProcessor
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.ByteWriteChannel
+import io.ktor.utils.io.readBuffer
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+private const val DEFAULT_FRAME_CHUNK_SIZE = 8 * 1024
+
+/**
+ * Reads self-delimiting frames from this [ByteReadChannel] and decodes each with [codec], emitting
+ * decoded values as a cold [Flow].
+ *
+ * Each collection drives a private [StreamProcessor]: channel bytes are pulled in chunks and
+ * appended, and every complete frame — sized by the codec's generated
+ * [peekFrameSize][com.ditchoom.buffer.codec.FrameDetector.peekFrameSize] — is decoded and emitted
+ * before the next channel read. The flow completes when the channel closes for read; a trailing
+ * partial frame at clean close is discarded. The processor and its chunk pool are released when
+ * collection ends (normally, on error, or on cancellation).
+ *
+ * The wire format must be self-delimiting (a length prefix, fixed size, or sealed discriminator);
+ * [codec] must therefore support frame detection or [readFrame] throws. This helper adds no framing
+ * of its own — pair it with [encodeFrame], which writes exactly the codec's bytes.
+ *
+ * @param codec the frame codec; must support frame detection.
+ * @param context decode context threaded to the codec (default [DecodeContext.Empty]).
+ * @param frameByteOrder byte order for the framing [StreamProcessor] and appended chunks
+ *   (default [ByteOrder.BIG_ENDIAN], the network default).
+ * @param chunkSize maximum bytes pulled from the channel per read (default 8 KiB).
+ */
+public fun <T> ByteReadChannel.decodeFrames(
+    codec: Codec<T>,
+    context: DecodeContext = DecodeContext.Empty,
+    frameByteOrder: ByteOrder = ByteOrder.BIG_ENDIAN,
+    chunkSize: Int = DEFAULT_FRAME_CHUNK_SIZE,
+): Flow<T> =
+    flow {
+        val pool = BufferPool()
+        val processor = StreamProcessor.create(pool, frameByteOrder)
+        try {
+            while (awaitContent(1)) {
+                val incoming = readBuffer(chunkSize)
+                if (incoming.exhausted()) break
+                processor.append(incoming.copyToPlatformBuffer(pool, frameByteOrder))
+                while (true) {
+                    val frame = codec.readFrame(processor, context) ?: break
+                    emit(frame)
+                }
+            }
+        } finally {
+            processor.release()
+            pool.clear()
+        }
+    }
+
+/**
+ * Encodes [value] with [codec] into a fresh buffer and writes exactly those bytes to this
+ * [ByteWriteChannel], then flushes. The encode buffer is freed after the write, so repeated
+ * [encodeFrame] calls never leak native memory.
+ *
+ * Writes only the codec's own bytes — no extra length prefix — so the wire format must be
+ * self-delimiting for [decodeFrames] to re-frame it on the far side.
+ *
+ * @param codec the frame codec used to encode [value].
+ * @param value the value to encode and send.
+ * @param factory allocator for the encode buffer (default [BufferFactory.Default]).
+ * @param context encode context threaded to the codec (default [EncodeContext.Empty]).
+ */
+public suspend fun <T> ByteWriteChannel.encodeFrame(
+    codec: Encoder<T>,
+    value: T,
+    factory: BufferFactory = BufferFactory.Default,
+    context: EncodeContext = EncodeContext.Empty,
+) {
+    val buffer = codec.encodeToPlatformBuffer(value, factory, context)
+    try {
+        writeBuffer(buffer)
+    } finally {
+        buffer.freeNativeMemory()
+    }
+}

--- a/buffer-ktor/src/commonTest/kotlin/com/ditchoom/buffer/ktor/FrameStreamingTest.kt
+++ b/buffer-ktor/src/commonTest/kotlin/com/ditchoom/buffer/ktor/FrameStreamingTest.kt
@@ -1,0 +1,83 @@
+package com.ditchoom.buffer.ktor
+
+import com.ditchoom.buffer.codec.encodeToPlatformBuffer
+import com.ditchoom.buffer.codec.test.protocols.simple.Command
+import com.ditchoom.buffer.codec.test.protocols.simple.CommandCodec
+import io.ktor.utils.io.ByteChannel
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.writeByteArray
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+/** The on-wire bytes of a [Command] via the shared codec encode helper. */
+private fun Command.wireBytes(): ByteArray {
+    val buffer = CommandCodec.encodeToPlatformBuffer(this)
+    return try {
+        buffer.remainingBytes()
+    } finally {
+        buffer.freeNativeMemory()
+    }
+}
+
+class FrameStreamingTest {
+    private val messages =
+        listOf(
+            Command.Ping(ts = 0x1122334455667788L),
+            Command.Echo(msg = "hi"),
+            Command.Ping(ts = 1L),
+            Command.Echo(msg = "hello world"),
+        )
+
+    @Test
+    fun decodeFrames_overStaticChannel_decodesEveryFrameInOrder() =
+        runTest {
+            val stream = messages.fold(ByteArray(0)) { acc, m -> acc + m.wireBytes() }
+            val decoded = ByteReadChannel(stream).decodeFrames(CommandCodec).toList()
+            assertEquals(messages, decoded)
+        }
+
+    @Test
+    fun encodeFrame_writesExactlyTheCodecBytes() =
+        runTest {
+            val message = Command.Echo(msg = "on the wire")
+            val channel = ByteChannel(autoFlush = true)
+            channel.encodeFrame(CommandCodec, message)
+            channel.flushAndClose()
+
+            assertContentEquals(message.wireBytes(), channel.readRemainingBuffer().remainingBytes())
+        }
+
+    @Test
+    fun encodeFrame_then_decodeFrames_roundTripThroughLiveChannel() =
+        runTest {
+            val channel = ByteChannel(autoFlush = true)
+            val received = async { channel.decodeFrames(CommandCodec).toList() }
+            messages.forEach { channel.encodeFrame(CommandCodec, it) }
+            channel.flushAndClose()
+            assertEquals(messages, received.await())
+        }
+
+    @Test
+    fun decodeFrames_reassemblesFrameDeliveredInFragments() =
+        runTest {
+            val message = Command.Echo(msg = "fragmented across reads")
+            val bytes = message.wireBytes()
+            val channel = ByteChannel(autoFlush = true)
+            val received = async { channel.decodeFrames(CommandCodec).toList() }
+
+            // Deliver the frame in three flushed fragments so the length prefix and body each
+            // straddle a read boundary.
+            channel.writeByteArray(bytes.copyOfRange(0, 1))
+            channel.flush()
+            channel.writeByteArray(bytes.copyOfRange(1, 3))
+            channel.flush()
+            channel.writeByteArray(bytes.copyOfRange(3, bytes.size))
+            channel.flushAndClose()
+
+            assertEquals(listOf(message), received.await())
+        }
+}


### PR DESCRIPTION
Additive follow-up to the interop epic (#256/#258): a codec-framed streaming layer across the transport bridges.

## buffer-codec — canonical home for codec↔buffer framing utilities
- `Encoder<T>.encodeToPlatformBuffer(value, factory, context)` — hoisted here from buffer-ktor so the overflow-retry allocation policy lives in one place.
- `Codec<T>.readFrame(stream, context): T?` — `peekFrameSize`-driven single-frame read; `null` when the stream lacks a whole frame (header not yet arrived, or body incomplete), throws on `PeekResult.NoFraming`.

## buffer-flow — the typed pipe, hoisted per the locked ruling (gains `api(buffer-codec)`)
- `ByteSource/ByteSink/ByteStream.typed(codec)` → `Receiver<T>` / `Sender<T>` / `Connection<T>`. Transport-neutral typed send/receive over the existing byte trichotomy — the socket layer and ktor now bind to this instead of each carrying a bespoke `CodecConnection`.
- `ByteStreamResetException` surfaces a peer `ReadResult.Reset` distinctly from a clean EOF (which completes the flow).

## buffer-ktor — channel-level frame helpers (**ktor-io only, no ktor-websockets**)
- `ByteReadChannel.decodeFrames(codec): Flow<T>` via an auto-filled `StreamProcessor` + generated `peekFrameSize`.
- `ByteWriteChannel.encodeFrame(codec, value)` writes exactly the codec's bytes.
- `encodeToPlatformBuffer` now forwards to the buffer-codec impl — **non-breaking** (symbol preserved).

## Deliberately deferred
The `WebSocketSession` binary-frame pair is **not** included: it's the only piece needing `ktor-websockets`, and hard-depping it would bloat every buffer-ktor consumer and break the existing wire-only masking precedent (`WebSocketMasking.kt` uses ktor-io only). If wanted, it belongs in an opt-in `buffer-ktor-websockets` submodule.

## Verification
- Contract + fragment-reassembly + reset tests on **JVM, JS, WASM, macOS** (local) and **linuxX64** (alien).
- `apiDump` updated — surface delta: buffer-flow +`typed`×3 +`ByteStreamResetException`; buffer-ktor +`decodeFrames`/`encodeFrame`.
- ktlint + detekt clean (root-cause, no baseline edits).

Mini API gate ready for review.