### PR TITLE
fix(stream): release pooled chunk reference in readBuffer exact-match slice path

### DIFF
--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/stream/BufferStream.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/stream/BufferStream.kt
@@ -18,6 +18,7 @@ import com.ditchoom.buffer.ByteOrder
 import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.buffer.pool.PooledBuffer
 
 /**
  * Represents a stream of buffer chunks for protocol parsing.
@@ -649,9 +650,19 @@ internal class DefaultStreamProcessor(
             // before the current position. Slice to ensure position 0 = start of payload,
             // so resetForRead() can't expose those bytes to the caller.
             if (chunk.position() == 0) {
-                return chunk // already clean — zero-copy transfer
+                return chunk // already clean — zero-copy transfer, caller frees it
             }
-            return chunk.slice()
+            val slice = chunk.slice()
+            // The chunk was just removed from the deque, so its original reference must be
+            // released. For a PooledBuffer, slice() bumped the refcount, so the returned slice
+            // keeps the backing alive until the caller frees it; without this release the
+            // pooled buffer's refcount is stuck above zero and it never returns to the pool —
+            // a per-frame direct-memory leak (the Autobahn cat-12 OOM). A non-pooled slice
+            // aliases the parent's storage and is freed through the slice itself, so releasing
+            // the parent there would free memory the slice still points at — only pooled
+            // parents are released here.
+            if (chunk is PooledBuffer) freeConsumedChunk(chunk)
+            return slice
         }
         if (chunk.remaining() > size) {
             // Data is contiguous, return a slice

--- a/buffer/src/commonTest/kotlin/com/ditchoom/buffer/StreamProcessorReadBufferPoolLeakTest.kt
+++ b/buffer/src/commonTest/kotlin/com/ditchoom/buffer/StreamProcessorReadBufferPoolLeakTest.kt
@@ -1,0 +1,87 @@
+package com.ditchoom.buffer
+
+import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Regression for a per-frame pooled-buffer leak in [StreamProcessor.readBuffer].
+ *
+ * When a chunk is consumed EXACTLY (`chunk.remaining() == size`) and its position is
+ * already `> 0` (framing bytes — e.g. a WebSocket frame header — were read first),
+ * `readBuffer` removed the chunk from its deque and returned `chunk.slice()`. `slice()`
+ * bumps the [com.ditchoom.buffer.pool.PooledBuffer] refcount, but the deque's original
+ * chunk reference was dropped without being released — so after the caller frees the
+ * returned slice the refcount is stuck at 1 and the underlying buffer never returns to the
+ * pool. Each such read leaks one full pool buffer.
+ *
+ * This is the real-socket path behind the Autobahn cat-12 ~1 GiB direct-memory OOM: the
+ * socket read pool hands the codec a full-size (hundreds of KB) buffer per frame; the
+ * WebSocket frame reader consumes the 2–14 byte header (position > 0) then reads the payload
+ * with an exact `readBuffer(payloadSize)`, hitting this branch once per message. Under
+ * `deterministic()` (shared-arena FFM, no GC reclamation) the stranded buffers accumulate to
+ * the direct-memory cap and OOM.
+ */
+class StreamProcessorReadBufferPoolLeakTest {
+    /** One frame: header bytes consumed, then an exact readBuffer of the payload. */
+    @Test
+    fun readBufferExactWithConsumedHeaderReturnsChunkToPool() {
+        val pool = BufferPool(maxPoolSize = 4, defaultBufferSize = 512)
+        val processor = StreamProcessor.create(pool)
+
+        val headerSize = 2
+        val payloadSize = 10
+
+        // A pooled chunk carrying [header || payload], as a socket read would deliver.
+        val chunk = pool.acquire(headerSize + payloadSize) as PlatformBuffer
+        repeat(headerSize + payloadSize) { chunk.writeByte(it.toByte()) }
+        chunk.resetForRead()
+        processor.append(chunk)
+
+        // Consume the header → chunk.position() advances to headerSize (> 0).
+        repeat(headerSize) { processor.readByte() }
+
+        // Read the payload exactly. Buggy path: removeFirst + return slice, original
+        // chunk reference orphaned.
+        val payload = processor.readBuffer(payloadSize)
+        assertEquals(payloadSize, payload.remaining(), "payload view must expose exactly the payload")
+
+        // Consumer frees the returned buffer (the codec does this after copying the payload).
+        (payload as PlatformBuffer).freeNativeMemory()
+
+        assertEquals(
+            1,
+            pool.stats().currentPoolSize,
+            "After the consumer frees the payload, the pooled read buffer must be back in the pool " +
+                "(refcount reached 0) — not stranded.",
+        )
+        pool.clear()
+    }
+
+    /** The hot path: one frame per pool buffer, repeated. Every acquire after the first must reuse. */
+    @Test
+    fun repeatedFrameReadsConvergeToFullPoolReuse() {
+        val pool = BufferPool(maxPoolSize = 4, defaultBufferSize = 512)
+        val processor = StreamProcessor.create(pool)
+        val headerSize = 2
+        val payloadSize = 64
+        val iterations = 200
+
+        repeat(iterations) {
+            val chunk = pool.acquire(headerSize + payloadSize) as PlatformBuffer
+            repeat(headerSize + payloadSize) { i -> chunk.writeByte(i.toByte()) }
+            chunk.resetForRead()
+            processor.append(chunk)
+            repeat(headerSize) { processor.readByte() }
+            val payload = processor.readBuffer(payloadSize)
+            (payload as PlatformBuffer).freeNativeMemory()
+        }
+
+        val stats = pool.stats()
+        assertEquals(iterations.toLong(), stats.totalAllocations)
+        assertEquals(1L, stats.poolMisses, "Only the very first frame should miss the pool; the rest reuse.")
+        assertEquals((iterations - 1).toLong(), stats.poolHits)
+        pool.clear()
+    }
+}


### PR DESCRIPTION
## Problem

`DefaultStreamProcessor.readBuffer(size)` leaks one full pool buffer per framed read.

When a chunk is consumed exactly (`chunk.remaining() == size`) and its position is already `> 0` (framing bytes — e.g. a WebSocket frame header — were read first), `readBuffer` did:

```kotlin
chunks.removeFirst()
...
return chunk.slice()   // position > 0 branch
```

`PooledBuffer.slice()` calls `addRef()` (refCount 1 → 2) and returns a `TrackedSlice`, but the deque's **original** chunk reference is dropped without being released. Per the documented contract (`PooledSliceLifecycleTests`, `TrackedSlice` KDoc) the underlying buffer returns to the pool only when the chunk reference **and** every slice are released. So after the caller frees the returned slice (refCount → 1), the count is stuck at 1 and the buffer never returns to the pool.

## Impact

Over a socket read pool backed by `deterministic()` (JDK 21 `Arena.ofShared()` FFM, whose memory is **not** GC-reclaimed when dropped without `close()`), the stranded buffers accumulate to the direct-memory cap. This is the root cause of the **Autobahn cat-12 permessage-deflate ~1 GiB `OutOfMemoryError: Cannot reserve … direct buffer memory`** in the websocket library: the frame reader consumes the 2–14 byte header (position > 0) then reads the payload with an exact `readBuffer(payloadSize)`, hitting this branch once per message — ~1 leaked 512 KB pool buffer per message.

Diagnosed with a strong-ref `isFreed()` tracker against the real Autobahn cat-12.2 leg: unfreed buffers grew **+1003 per 1000-message case**, all with the `ReadBufferSource.acquire → LockFreeBufferPool → readBuffer` stack.

## Fix

Release the parent chunk's reference after slicing — but only for `PooledBuffer`. A non-pooled slice aliases the parent's storage and is freed through the slice itself, so freeing the parent there would free memory the slice still points at.

## Test

`StreamProcessorReadBufferPoolLeakTest` models the WebSocket frame-read pattern (consume header → exact `readBuffer` of payload → free slice). Across 200 frames, `poolMisses` goes **200 → 1** with the fix (every buffer was leaking before). Full `:buffer` JVM suite (1161 tests) green.