### PR TITLE
fix(pool): collapse nested BufferPool instead of wrapping (cross-pool release crash)

### DIFF
--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/BufferPool.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/BufferPool.kt
@@ -104,6 +104,16 @@ sealed interface BufferPool : BufferFactory {
      */
     fun clear()
 
+    /**
+     * Whether this pool is safe for concurrent access from multiple threads/coroutines.
+     *
+     * A pool that is shared across coroutines — e.g. one passed to a socket/websocket, where a buffer
+     * is acquired on the read coroutine and freed on the consumer/send coroutine — MUST be
+     * [ThreadingMode.MultiThreaded]. Consumers that hand a pre-built pool to such a library should
+     * check or construct it accordingly; the library may `require` it.
+     */
+    val threadingMode: ThreadingMode
+
     companion object {
         /**
          * Creates a buffer pool with the specified threading model and buffer factory.
@@ -119,12 +129,19 @@ sealed interface BufferPool : BufferFactory {
             defaultBufferSize: Int = DEFAULT_FILE_BUFFER_SIZE,
             factory: BufferFactory = BufferFactory.Default,
         ): BufferPool =
-            when (threadingMode) {
-                ThreadingMode.SingleThreaded ->
-                    SingleThreadedBufferPool(maxPoolSize, defaultBufferSize, factory)
-                ThreadingMode.MultiThreaded ->
-                    LockFreeBufferPool(maxPoolSize, defaultBufferSize, factory)
-            }
+            // Never nest a pool inside a pool. `BufferPool : BufferFactory`, so a pool can be passed
+            // as `factory`; wrapping it would produce PooledBuffer(inner = PooledBuffer(pool = inner),
+            // pool = outer), and a normal free then runs `outer.release(inner)` where inner belongs to
+            // the inner pool — tripping the cross-pool `require` in release() (websocket #19 / 6.8.1
+            // Android crash: socket ReadBufferSource does BufferPool(factory = consumer's shared pool)).
+            // Reuse the existing pool instead — double-pooling is pure overhead with broken accounting.
+            (factory as? BufferPool)
+                ?: when (threadingMode) {
+                    ThreadingMode.SingleThreaded ->
+                        SingleThreadedBufferPool(maxPoolSize, defaultBufferSize, factory)
+                    ThreadingMode.MultiThreaded ->
+                        LockFreeBufferPool(maxPoolSize, defaultBufferSize, factory)
+                }
 
         /**
          * Creates a buffer pool with default single-threaded mode.
@@ -137,7 +154,9 @@ sealed interface BufferPool : BufferFactory {
             maxPoolSize: Int = 64,
             defaultBufferSize: Int = DEFAULT_FILE_BUFFER_SIZE,
             factory: BufferFactory = BufferFactory.Default,
-        ): BufferPool = SingleThreadedBufferPool(maxPoolSize, defaultBufferSize, factory)
+        ): BufferPool =
+            // See the threading-mode overload above: never nest a pool inside a pool.
+            (factory as? BufferPool) ?: SingleThreadedBufferPool(maxPoolSize, defaultBufferSize, factory)
     }
 }
 

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/LockFreeBufferPool.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/LockFreeBufferPool.kt
@@ -41,6 +41,8 @@ internal class LockFreeBufferPool(
     private val defaultBufferSize: Int,
     private val factory: BufferFactory,
 ) : BufferPool {
+    override val threadingMode: ThreadingMode get() = ThreadingMode.MultiThreaded
+
     // Treiber stack node
     private class Node(
         val buffer: PlatformBuffer,
@@ -103,12 +105,23 @@ internal class LockFreeBufferPool(
     override fun release(buffer: ReadWriteBuffer) {
         val raw =
             when (buffer) {
-                is PooledBuffer -> {
-                    require(buffer.pool === this) {
-                        "Cannot release a buffer to a different pool than the one it was acquired from"
+                is PooledBuffer ->
+                    when {
+                        buffer.pool === this -> buffer.inner
+                        // Defensive backstop for nested pools (BufferPool.invoke collapses these, so
+                        // this only fires if one is built directly via the internal constructor): a
+                        // buffer whose owner is THIS pool's own backing factory legitimately belongs to
+                        // that inner pool — route it back there instead of crashing. Genuine misuse
+                        // (an unrelated pool) still throws below.
+                        buffer.pool === factory -> {
+                            buffer.freeNativeMemory()
+                            return
+                        }
+                        else ->
+                            throw IllegalArgumentException(
+                                "Cannot release a buffer to a different pool than the one it was acquired from",
+                            )
                     }
-                    buffer.inner
-                }
                 is PlatformBuffer -> buffer
                 else -> return
             }

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/SingleThreadedBufferPool.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/SingleThreadedBufferPool.kt
@@ -22,6 +22,8 @@ internal class SingleThreadedBufferPool(
     private val defaultBufferSize: Int,
     private val factory: BufferFactory,
 ) : BufferPool {
+    override val threadingMode: ThreadingMode get() = ThreadingMode.SingleThreaded
+
     // One deque per size class; a buffer lives in the bucket of its capacity's floor
     // log2, so every buffer in bucket k has capacity >= 1 shl k.
     private val buckets = Array(BufferSizeClass.BUCKET_COUNT) { ArrayDeque<PlatformBuffer>() }
@@ -74,12 +76,23 @@ internal class SingleThreadedBufferPool(
     override fun release(buffer: ReadWriteBuffer) {
         val raw =
             when (buffer) {
-                is PooledBuffer -> {
-                    require(buffer.pool === this) {
-                        "Cannot release a buffer to a different pool than the one it was acquired from"
+                is PooledBuffer ->
+                    when {
+                        buffer.pool === this -> buffer.inner
+                        // Defensive backstop for nested pools (BufferPool.invoke collapses these, so
+                        // this only fires if one is built directly via the internal constructor): a
+                        // buffer whose owner is THIS pool's own backing factory legitimately belongs to
+                        // that inner pool — route it back there instead of crashing. Genuine misuse
+                        // (an unrelated pool) still throws below.
+                        buffer.pool === factory -> {
+                            buffer.freeNativeMemory()
+                            return
+                        }
+                        else ->
+                            throw IllegalArgumentException(
+                                "Cannot release a buffer to a different pool than the one it was acquired from",
+                            )
                     }
-                    buffer.inner
-                }
                 is PlatformBuffer -> buffer
                 else -> return
             }

--- a/buffer/src/commonTest/kotlin/com/ditchoom/buffer/BufferPoolSafetyTests.kt
+++ b/buffer/src/commonTest/kotlin/com/ditchoom/buffer/BufferPoolSafetyTests.kt
@@ -1,11 +1,13 @@
 package com.ditchoom.buffer
 
 import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.buffer.pool.LockFreeBufferPool
 import com.ditchoom.buffer.pool.withBuffer
 import com.ditchoom.buffer.pool.withPool
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 /**
@@ -81,6 +83,71 @@ class BufferPoolSafetyTests {
         pool1.release(buffer)
         pool1.clear()
         pool2.clear()
+    }
+
+    /**
+     * Regression for the websocket #19 / buffer 6.8.1 cross-pool crash.
+     *
+     * A **nested** pool — one whose backing [factory] is itself a [BufferPool] — is a legal
+     * construction today (`BufferPool : BufferFactory`, so a pool is accepted anywhere a factory
+     * is), and it is exactly the topology the socket transport's `ReadBufferSource` builds when a
+     * consumer passes a shared [BufferPool] as its `bufferFactory`:
+     *
+     * ```
+     * outer.acquire() == PooledBuffer(inner = PooledBuffer(pool = inner), pool = outer)
+     * ```
+     *
+     * Freeing that buffer the normal way runs `PooledBuffer.releaseRef → outer.release(inner)`,
+     * where `inner.pool === inner ≠ outer`, tripping the cross-pool `require` in
+     * `LockFreeBufferPool.release` / `SingleThreadedBufferPool.release` — an
+     * `IllegalArgumentException` thrown from an ordinary free of a legitimately-acquired buffer.
+     *
+     * The cure: `BufferPool(factory = x)` collapses to reuse `x` when `x is BufferPool`, so the
+     * nested structure never forms. This test asserts both the collapse (same-instance) and that a
+     * normal free never raises a cross-pool error.
+     */
+    @Test
+    fun nestedPoolCollapsesAndFreesWithoutCrossPoolError() {
+        val inner = BufferPool(defaultBufferSize = 64)
+        val outer = BufferPool(defaultBufferSize = 64, factory = inner)
+
+        // Collapse: wrapping a pool in a pool must reuse the existing pool, not nest it.
+        assertSame(inner, outer, "BufferPool(factory = aPool) must reuse aPool, not nest it")
+
+        val buffer = outer.acquire(8) as PlatformBuffer
+        buffer.writeInt(42)
+
+        // A normal free of a buffer acquired from `outer` must not raise a cross-pool error.
+        buffer.freeNativeMemory()
+
+        outer.clear()
+        inner.clear()
+    }
+
+    /**
+     * Defensive backstop: even if a nested pool is built *directly* via the internal constructor
+     * (bypassing the `BufferPool.invoke` collapse), a normal free must route the buffer back to its
+     * owner pool instead of throwing the cross-pool error. Genuine misuse (an unrelated pool) still
+     * throws — see [crossPoolReleaseThrows].
+     */
+    @Test
+    fun directlyNestedPoolRoutesReleaseToOwnerInsteadOfThrowing() {
+        val inner = BufferPool(defaultBufferSize = 64)
+        // Force the nested structure the invoke-guard would otherwise collapse.
+        val outer = LockFreeBufferPool(maxPoolSize = 64, defaultBufferSize = 64, factory = inner)
+
+        val buffer = outer.acquire(8) as PlatformBuffer
+        buffer.writeInt(42)
+
+        // Must not throw: the buffer belongs to `inner` (outer's backing factory), so it is routed
+        // there rather than rejected.
+        buffer.freeNativeMemory()
+
+        // The buffer went back to the inner pool, so inner can hand it out again.
+        assertTrue(inner.stats().currentPoolSize >= 1)
+
+        outer.clear()
+        inner.clear()
     }
 
     // ============================================================================


### PR DESCRIPTION
## Problem

`BufferPool` implements `BufferFactory`, so a pool can legally be passed as another pool's `factory`. When it is, buffers get **nested**:

```
PooledBuffer(inner = PooledBuffer(pool = wsPool), pool = transportPool)
```

Freeing a consumed chunk then runs `transportPool.release(inner)` where `inner.pool === wsPool ≠ transportPool`, tripping `require(buffer.pool === this)` at `LockFreeBufferPool.release`.

This is exactly the nesting socket's `ReadBufferSource` creates: it wraps every consumer `bufferFactory` in `BufferPool(MultiThreaded, factory = config.bufferFactory)`. When a consumer passes a **shared pool** as its factory (the DitchOoM/websocket Android config reuses one pool across connections), the transport pool nests the websocket pool, and the first cross-pool chunk free crashes the read loop:

```
java.lang.IllegalArgumentException:
  Cannot release a buffer to a different pool than the one it was acquired from
    LockFreeBufferPool.release(LockFreeBufferPool.kt:107)
    PooledBuffer.freeNativeMemory(PooledBuffer.kt)
    DefaultStreamProcessor.freeConsumedChunk(BufferStream.kt)
    WebSocketCodec.startReadLoop(WebSocketCodec.kt:176)   // finally { stream.release() }
```

Surfaced on DitchOoM/websocket #19 Android CI (buffer 6.8.1), ~case 63/454 of the Autobahn suite.

## Fix

`BufferPool(factory = x)` now **collapses** when `x` is already a pool — it returns the existing pool rather than wrapping it: `(factory as? BufferPool) ?: construct`. The illegal nested topology becomes unrepresentable — `BufferPool(MultiThreaded, factory = wsPool) === wsPool` — so every buffer is always freed to the pool that owns it. Lives in `commonMain`, so it applies to every platform (incl. Android/ART and JVM) and to unpatched socket callers on Central.

`release()` also gains a defensive route-to-owner branch so a stray nested buffer (from any older topology) is freed correctly instead of throwing.

## Tests

`BufferPoolSafetyTests` (commonTest, runs every platform):
- collapse `assertSame` — `BufferPool(factory = pool) === pool`
- route-to-owner in `release()`
- nested-topology repro that used to throw

Also validated downstream: DitchOoM/websocket `AutobahnStressPooledTests[jvm]` (BufferPool MultiThreaded + managed leaf factory) goes 3/3 green against a live Autobahn fuzzingserver — was a ~5s cross-pool crash before this change.

Does **not** touch Central — this PR is the fix; no release label.