### PR TITLE
perf(jvm): reuse thread-local decoder + CharBuffer in readString

### DIFF
--- a/buffer/build.gradle.kts
+++ b/buffer/build.gradle.kts
@@ -534,7 +534,7 @@ benchmark {
             iterations = 5
             iterationTime = 1000
             iterationTimeUnit = "ms"
-            include("(WriteString|Utf8Length)")
+            include("(WriteString|ReadString|Utf8Length)")
         }
         register("codec") {
             warmups = 3

--- a/buffer/src/commonBenchmark/kotlin/com/ditchoom/buffer/benchmark/ReadStringBenchmark.kt
+++ b/buffer/src/commonBenchmark/kotlin/com/ditchoom/buffer/benchmark/ReadStringBenchmark.kt
@@ -1,0 +1,156 @@
+package com.ditchoom.buffer.benchmark
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.BenchmarkMode
+import kotlinx.benchmark.BenchmarkTimeUnit
+import kotlinx.benchmark.Measurement
+import kotlinx.benchmark.Mode
+import kotlinx.benchmark.OutputTimeUnit
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+import kotlinx.benchmark.Warmup
+
+/**
+ * Benchmarks for [PlatformBuffer.readString] — the UTF-8 -> UTF-16 decode hot path on the
+ * WebSocket receive side.
+ *
+ * This is the baseline for optimization #2 from the effort-vs-win plan: on the JVM the
+ * pre-optimization path built a fresh `CharsetDecoder` per call and decoded into a freshly
+ * allocated `HeapCharBuffer` sized to the whole payload — the single largest JVM allocation on the
+ * receive path (~49% of allocations in the Autobahn cat-13 trace). The optimization reuses a
+ * thread-local decoder and CharBuffer; the produced String is the only remaining allocation.
+ * Run with `-prof gc` to see the alloc-rate delta, not just throughput.
+ *
+ * Scenarios (each at 64B / 1KB / 64KB of *chars*, matching [WriteStringBenchmark]):
+ *  - ASCII        — single-byte input, the common WebSocket text-frame case.
+ *  - Multi-byte   — mixed 2- and 3-byte code points (accented Latin + CJK).
+ *  - Emoji        — 4-byte surrogate pairs, exercising the surrogate branch of the decoder.
+ *
+ * The source buffer is [BufferFactory.Default] (native memory on K/N, direct on JVM), the same
+ * allocation type the WebSocket frame path reads from.
+ *
+ * Run with:
+ *   ./gradlew :buffer:jvmBenchmark -PbenchmarkConfig=string
+ *   ./gradlew :buffer:jvmBenchmark -PbenchmarkConfig=string -Pprof=gc
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(BenchmarkTimeUnit.SECONDS)
+open class ReadStringBenchmark {
+    // Char counts, not byte counts. Multi-byte/emoji strings decode from a larger byte payload.
+    private val small = 64
+    private val medium = 1024
+    private val large = 64 * 1024
+
+    private lateinit var asciiSmall: Source
+    private lateinit var asciiMedium: Source
+    private lateinit var asciiLarge: Source
+    private lateinit var cjkSmall: Source
+    private lateinit var cjkMedium: Source
+    private lateinit var cjkLarge: Source
+    private lateinit var emojiSmall: Source
+    private lateinit var emojiMedium: Source
+    private lateinit var emojiLarge: Source
+
+    @Setup
+    fun setup() {
+        asciiSmall = encode(buildAscii(small))
+        asciiMedium = encode(buildAscii(medium))
+        asciiLarge = encode(buildAscii(large))
+        cjkSmall = encode(repeatTo(CJK_PATTERN, small))
+        cjkMedium = encode(repeatTo(CJK_PATTERN, medium))
+        cjkLarge = encode(repeatTo(CJK_PATTERN, large))
+        emojiSmall = encode(repeatSurrogatePairsTo(small))
+        emojiMedium = encode(repeatSurrogatePairsTo(medium))
+        emojiLarge = encode(repeatSurrogatePairsTo(large))
+    }
+
+    private fun read(source: Source): String {
+        source.buffer.position(0)
+        return source.buffer.readString(source.byteLength, Charset.UTF8)
+    }
+
+    @Benchmark fun asciiSmall(): String = read(asciiSmall)
+
+    @Benchmark fun asciiMedium(): String = read(asciiMedium)
+
+    @Benchmark fun asciiLarge(): String = read(asciiLarge)
+
+    @Benchmark fun cjkSmall(): String = read(cjkSmall)
+
+    @Benchmark fun cjkMedium(): String = read(cjkMedium)
+
+    @Benchmark fun cjkLarge(): String = read(cjkLarge)
+
+    @Benchmark fun emojiSmall(): String = read(emojiSmall)
+
+    @Benchmark fun emojiMedium(): String = read(emojiMedium)
+
+    @Benchmark fun emojiLarge(): String = read(emojiLarge)
+
+    /** A source buffer pre-filled with one UTF-8 encoded string, plus its exact byte length. */
+    private class Source(
+        val buffer: PlatformBuffer,
+        val byteLength: Int,
+    )
+
+    companion object {
+        private const val PRINTABLE_ASCII_START = 32
+        private const val PRINTABLE_ASCII_RANGE = 95
+
+        // Worst-case UTF-8 expansion: a surrogate pair (2 chars) encodes to 4 bytes.
+        private const val MAX_UTF8_BYTES_PER_CHAR = 4
+
+        // Mixed 2- and 3-byte code points: accented Latin (é, ü) and CJK (世, 界).
+        private const val CJK_PATTERN = "é世ü界"
+
+        /** Encode [text] to UTF-8 into a fresh buffer and flip it for reading. */
+        private fun encode(text: String): Source {
+            val buffer = BufferFactory.Default.allocate(text.length * MAX_UTF8_BYTES_PER_CHAR)
+            buffer.writeString(text, Charset.UTF8)
+            val byteLength = buffer.position()
+            buffer.resetForRead()
+            return Source(buffer, byteLength)
+        }
+
+        private fun buildAscii(charCount: Int): String {
+            val sb = StringBuilder(charCount)
+            for (i in 0 until charCount) {
+                sb.append((PRINTABLE_ASCII_START + (i % PRINTABLE_ASCII_RANGE)).toChar())
+            }
+            return sb.toString()
+        }
+
+        private fun repeatTo(
+            pattern: String,
+            charCount: Int,
+        ): String {
+            val sb = StringBuilder(charCount)
+            while (sb.length < charCount) {
+                sb.append(pattern)
+            }
+            return sb.substring(0, charCount)
+        }
+
+        // Each grinning-face emoji is a surrogate pair (2 chars, 4 UTF-8 bytes).
+        private fun repeatSurrogatePairsTo(charCount: Int): String {
+            val sb = StringBuilder(charCount)
+            // Append complete surrogate pairs so we never split one at the boundary.
+            while (sb.length + 2 <= charCount) {
+                sb.append('\uD83D').append('\uDE00')
+            }
+            // Pad any odd trailing slot with ASCII to keep the exact char count valid.
+            while (sb.length < charCount) {
+                sb.append(' ')
+            }
+            return sb.toString()
+        }
+    }
+}

--- a/buffer/src/jvmCommonMain/kotlin/com/ditchoom/buffer/BaseJvmBuffer.kt
+++ b/buffer/src/jvmCommonMain/kotlin/com/ditchoom/buffer/BaseJvmBuffer.kt
@@ -4,7 +4,6 @@ import java.io.RandomAccessFile
 import java.nio.Buffer
 import java.nio.ByteBuffer
 import java.nio.CharBuffer
-import java.nio.charset.CodingErrorAction
 
 // IndexOutOfBoundsException is exactly the type the JDK throws from absolute-index
 // ByteBuffer.get/put(index, ...) and System.arraycopy; it is the most specific catchable
@@ -279,26 +278,9 @@ abstract class BaseJvmBuffer(
         val finalPosition = buffer.position() + length
         val readBuffer = byteBuffer.asReadOnlyBuffer()
         (readBuffer as Buffer).limit(finalPosition)
-        val charsetConverted =
-            when (charset) {
-                Charset.UTF8 -> Charsets.UTF_8
-                Charset.UTF16 -> Charsets.UTF_16
-                Charset.UTF16BigEndian -> Charsets.UTF_16BE
-                Charset.UTF16LittleEndian -> Charsets.UTF_16LE
-                Charset.ASCII -> Charsets.US_ASCII
-                Charset.ISOLatin1 -> Charsets.ISO_8859_1
-                Charset.UTF32 -> Charsets.UTF_32
-                Charset.UTF32LittleEndian -> Charsets.UTF_32LE
-                Charset.UTF32BigEndian -> Charsets.UTF_32BE
-            }
-        val decoded =
-            charsetConverted
-                .newDecoder()
-                .onMalformedInput(CodingErrorAction.REPORT)
-                .onUnmappableCharacter(CodingErrorAction.REPORT)
-                .decode(readBuffer)
+        val decoded = charset.toDecoder().decodeReusing(readBuffer, length)
         buffer.position(finalPosition)
-        return decoded.toString()
+        return decoded
     }
 
     override fun writeByte(byte: Byte): WriteBuffer {

--- a/buffer/src/jvmCommonMain/kotlin/com/ditchoom/buffer/CharsetDecoderHelper.kt
+++ b/buffer/src/jvmCommonMain/kotlin/com/ditchoom/buffer/CharsetDecoderHelper.kt
@@ -1,0 +1,104 @@
+package com.ditchoom.buffer
+
+import java.nio.Buffer
+import java.nio.ByteBuffer
+import java.nio.CharBuffer
+import java.nio.charset.CharsetDecoder
+import java.nio.charset.CodingErrorAction
+
+internal fun Charset.toDecoder(): CharsetDecoder =
+    when (this) {
+        Charset.UTF8 -> utf8Decoder
+        Charset.UTF16 -> utf16Decoder
+        Charset.UTF16BigEndian -> utf16BEDecoder
+        Charset.UTF16LittleEndian -> utf16LEDecoder
+        Charset.ASCII -> utfAsciiDecoder
+        Charset.ISOLatin1 -> utfISOLatin1Decoder
+        Charset.UTF32 -> utf32Decoder
+        Charset.UTF32LittleEndian -> utf32LEDecoder
+        Charset.UTF32BigEndian -> utf32BEDecoder
+    }.get()
+
+/**
+ * Per-thread [CharsetDecoder]. Mirrors [DefaultEncoder]: constructing a decoder per
+ * [ReadBuffer.readString] call allocated a fresh decoder plus a `HeapCharBuffer` sized to the
+ * whole payload — the dominant JVM allocation on the WebSocket receive path. A thread-local
+ * decoder is safe because `readString` is non-suspend and decodes synchronously start to finish,
+ * so the decoder is never shared across a suspension point. The REPORT actions are configured once
+ * here (they survive [CharsetDecoder.reset]) instead of on every call.
+ */
+internal class DefaultDecoder(
+    private val charset: java.nio.charset.Charset,
+) : ThreadLocal<CharsetDecoder>() {
+    override fun initialValue(): CharsetDecoder =
+        charset
+            .newDecoder()
+            .onMalformedInput(CodingErrorAction.REPORT)
+            .onUnmappableCharacter(CodingErrorAction.REPORT)
+
+    override fun get(): CharsetDecoder = super.get()!!
+}
+
+internal val utf8Decoder = DefaultDecoder(Charsets.UTF_8)
+internal val utf16Decoder = DefaultDecoder(Charsets.UTF_16)
+internal val utf16BEDecoder = DefaultDecoder(Charsets.UTF_16BE)
+internal val utf16LEDecoder = DefaultDecoder(Charsets.UTF_16LE)
+internal val utfAsciiDecoder = DefaultDecoder(Charsets.US_ASCII)
+internal val utfISOLatin1Decoder = DefaultDecoder(Charsets.ISO_8859_1)
+internal val utf32Decoder = DefaultDecoder(Charsets.UTF_32)
+internal val utf32LEDecoder = DefaultDecoder(Charsets.UTF_32LE)
+internal val utf32BEDecoder = DefaultDecoder(Charsets.UTF_32BE)
+
+private const val INITIAL_DECODE_BUFFER_CHARS = 1024
+
+/**
+ * Per-thread scratch [CharBuffer] that [decodeReusing] decodes into, grown on demand and kept for
+ * subsequent calls so steady-state reads of similar-sized payloads allocate nothing but the result
+ * String. Shared across charsets on the thread; each call clears it before use.
+ */
+private val decodeCharBufferHolder =
+    object : ThreadLocal<CharBuffer>() {
+        override fun initialValue(): CharBuffer = CharBuffer.allocate(INITIAL_DECODE_BUFFER_CHARS)
+    }
+
+/**
+ * Decode [byteCount] bytes of [input] into a String using this thread-local decoder and a reused
+ * thread-local [CharBuffer], avoiding the per-call decoder + `HeapCharBuffer` allocation that
+ * [CharsetDecoder.decode] performs. [input] must have exactly [byteCount] bytes remaining.
+ *
+ * The scratch buffer is sized at `maxCharsPerByte * byteCount`, the decoder's guaranteed upper
+ * bound on produced chars, so a single `decode(endOfInput=true)` + `flush` never overflows.
+ */
+internal fun CharsetDecoder.decodeReusing(
+    input: ByteBuffer,
+    byteCount: Int,
+): String {
+    reset()
+    val requiredChars = (byteCount * maxCharsPerByte()).toInt() + 1
+    var out = decodeCharBufferHolder.get()
+    if (out.capacity() < requiredChars) {
+        out = CharBuffer.allocate(requiredChars)
+        decodeCharBufferHolder.set(out)
+    } else {
+        (out as Buffer).clear()
+    }
+
+    val decodeResult = decode(input, out, true)
+    if (decodeResult.isError) {
+        decodeResult.throwException()
+    }
+    check(!decodeResult.isOverflow) {
+        "Decode overflow despite maxCharsPerByte sizing (byteCount=$byteCount, capacity=${out.capacity()})"
+    }
+
+    val flushResult = flush(out)
+    if (flushResult.isError) {
+        flushResult.throwException()
+    }
+    check(!flushResult.isOverflow) {
+        "Flush overflow despite maxCharsPerByte sizing (byteCount=$byteCount, capacity=${out.capacity()})"
+    }
+
+    (out as Buffer).flip()
+    return out.toString()
+}

--- a/buffer/src/jvmTest/kotlin/com/ditchoom/buffer/ReadStringDecoderReuseTest.kt
+++ b/buffer/src/jvmTest/kotlin/com/ditchoom/buffer/ReadStringDecoderReuseTest.kt
@@ -1,0 +1,58 @@
+package com.ditchoom.buffer
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * Guards the thread-local decoder + reused CharBuffer path added for effort-vs-win optimization #2
+ * ([DefaultDecoder] / decodeReusing in CharsetDecoderHelper). The reuse must not leak state between
+ * calls and must preserve the CodingErrorAction.REPORT behaviour the previous per-call decoder had.
+ */
+class ReadStringDecoderReuseTest {
+    private fun bufferOf(bytes: ByteArray): PlatformBuffer {
+        val buffer = BufferFactory.Default.allocate(bytes.size)
+        buffer.writeBytes(bytes)
+        buffer.resetForRead()
+        return buffer
+    }
+
+    @Test
+    fun `malformed UTF-8 still throws instead of substituting`() {
+        // 0xC3 starts a 2-byte sequence; 0x28 '(' is not a valid continuation byte.
+        val buffer = bufferOf(byteArrayOf(0xC3.toByte(), 0x28))
+        assertFailsWith<java.nio.charset.CharacterCodingException> {
+            buffer.readString(2, Charset.UTF8)
+        }
+    }
+
+    @Test
+    fun `reused decoder is reset between calls after a malformed read`() {
+        val malformed = bufferOf(byteArrayOf(0xC3.toByte(), 0x28))
+        assertFailsWith<java.nio.charset.CharacterCodingException> {
+            malformed.readString(2, Charset.UTF8)
+        }
+        // A subsequent well-formed read on the same thread must not inherit stale decoder state.
+        val ok = bufferOf("hello".encodeToByteArray())
+        assertEquals("hello", ok.readString(5, Charset.UTF8))
+    }
+
+    @Test
+    fun `back-to-back reads of shrinking then growing payloads are correct`() {
+        // Exercises the reused CharBuffer at different sizes: a large read grows it, a small read
+        // reuses the grown buffer (must clear, not read stale tail), then a larger read again.
+        val big = "A".repeat(5000)
+        val small = "hi"
+        val bigger = "Z".repeat(9000)
+        assertEquals(big, bufferOf(big.encodeToByteArray()).readString(5000, Charset.UTF8))
+        assertEquals(small, bufferOf(small.encodeToByteArray()).readString(2, Charset.UTF8))
+        assertEquals(bigger, bufferOf(bigger.encodeToByteArray()).readString(9000, Charset.UTF8))
+    }
+
+    @Test
+    fun `multibyte and emoji round-trip through the reused CharBuffer`() {
+        val text = "é世ü界😀"
+        val bytes = text.encodeToByteArray()
+        assertEquals(text, bufferOf(bytes).readString(bytes.size, Charset.UTF8))
+    }
+}


### PR DESCRIPTION
## What

Effort-vs-win plan **opt #2 (JVM `readString`)**. `BaseJvmBuffer.readString` built a fresh `CharsetDecoder` per call and decoded into a `HeapCharBuffer` sized to the whole payload — the single largest JVM allocation on the WebSocket receive path (~49% of allocations in the Autobahn cat-13 trace).

New `CharsetDecoderHelper.kt` mirrors the existing `ThreadLocal<CharsetEncoder>` in `CharsetEncoderHelper`: a per-thread `CharsetDecoder` (REPORT actions set once) decoding into a reused, grown-on-demand thread-local `CharBuffer` via `decode(endOfInput=true)` + `flush`, sized at `maxCharsPerByte` so a single pass never overflows. Safe because `readString` is non-suspend and decodes start-to-finish. Zero ByteArray; malformed input still throws (REPORT preserved).

## JMH (jvmBenchmark, `-prof gc`, gc.alloc.rate.norm before → after)

| scenario | B/op before | after | throughput |
|---|--:|--:|--:|
| ascii 64B | 408 | 168 | 1.59× |
| ascii 1KB | 3288 | 1128 | 1.69× |
| ascii 64KB | 196825 | 65640 | 1.60× |
| cjk 1KB | 8424 | 3192 | 1.28× |
| emoji 64KB | 458985 | 196729 | 1.53× |

Remaining B/op is the result `String` itself; the `HeapCharBuffer` churn is gone.

## Tests

- New `ReadStringBenchmark` (commonBenchmark), wired into the `string` benchmark config.
- New `ReadStringDecoderReuseTest` (JVM): reuse/reset across calls, malformed-input still throws, multibyte/emoji round-trip.
- Existing StringCharsetParity / LengthPrefixedString / WriteStringOverflow / StreamingStringDecoder pass on both JVM buffer backends (heap + FFM). ktlint clean.

Follow-on to #281 (opt #1/#3, native writeString).