### PR TITLE
perf(jvm): make JVM 21+ Default a plain direct buffer, not FFM-auto

### DIFF
--- a/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/BufferFactory.kt
+++ b/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/BufferFactory.kt
@@ -20,12 +20,19 @@ private fun ByteOrder.toJavaByteOrder(): java.nio.ByteOrder =
         ByteOrder.LITTLE_ENDIAN -> java.nio.ByteOrder.LITTLE_ENDIAN
     }
 
+// Default = plain direct native memory (DirectByteBuffer), same as the JVM<=20 default. This is
+// GC-managed native memory WITHOUT the FFM per-access `java.nio.Buffer.session()` scope check that
+// an Arena.ofAuto()-backed buffer pays. FfmAutoBuffer's only extra feature over DirectJvmBuffer would
+// be a deterministic free(), but its freeNativeMemory() is a no-op (auto arena) — so Default paid the
+// session() tax for zero benefit (top JVM CPU cost in the Autobahn cat-13 profile). Deterministic
+// free lives in BufferFactory.deterministic() (FfmBuffer). See allocateAutoFfmBuffer for the retained
+// GC-managed-FFM path (no longer the default; kept for explicit opt-in / the factory-options rework).
 internal val defaultBufferFactory: BufferFactory =
     object : BufferFactory {
         override fun allocate(
             size: Int,
             byteOrder: ByteOrder,
-        ): PlatformBuffer = allocateAutoFfmBuffer(size, byteOrder)
+        ): PlatformBuffer = DirectJvmBuffer(ByteBuffer.allocateDirect(size).order(byteOrder.toJavaByteOrder()))
 
         override fun wrap(
             array: ByteArray,
@@ -51,7 +58,7 @@ internal val sharedBufferFactory: BufferFactory =
         override fun allocate(
             size: Int,
             byteOrder: ByteOrder,
-        ): PlatformBuffer = allocateAutoFfmBuffer(size, byteOrder)
+        ): PlatformBuffer = DirectJvmBuffer(ByteBuffer.allocateDirect(size).order(byteOrder.toJavaByteOrder()))
 
         override fun wrap(
             array: ByteArray,

--- a/buffer/src/jvmTest/kotlin/com/ditchoom/buffer/FfmAutoBufferTest.kt
+++ b/buffer/src/jvmTest/kotlin/com/ditchoom/buffer/FfmAutoBufferTest.kt
@@ -7,7 +7,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotEquals
-import kotlin.test.assertTrue
 
 /**
  * Tests for FfmAutoBuffer — GC-managed FFM buffer returned by BufferFactory.Default on JVM 21+.
@@ -89,14 +88,14 @@ class FfmAutoBufferTest {
     }
 
     @Test
-    fun `Default factory returns FfmAutoBuffer on JVM 21+`() {
+    fun `Default factory returns a non-FFM native buffer (no session() overhead)`() {
+        // Default is plain direct native memory on every JVM (DirectJvmBuffer), NOT FfmAutoBuffer:
+        // FFM's per-access session() scope check was pure overhead for the GC-managed default, since
+        // FfmAutoBuffer.freeNativeMemory() is a no-op. Deterministic FFM free lives in deterministic().
         val buffer = BufferFactory.Default.allocate(64)
-        // On JVM 21+ (multi-release JAR), Default should return FfmAutoBuffer
-        // On JVM < 21, this returns DirectJvmBuffer — test passes either way
-        if (buffer is FfmAutoBuffer) {
-            assertFalse(buffer is CloseableBuffer)
-            assertTrue(buffer.nativeAddress != 0L)
-        }
+        assertFalse(buffer is FfmAutoBuffer)
+        assertFalse(buffer is CloseableBuffer) // GC-managed: not closeable
+        assertIs<NativeMemoryAccess>(buffer) // still native-address capable for zero-copy interop
     }
 
     @Test


### PR DESCRIPTION
> **Draft** — the perf fix is complete and validated, but it's intentionally open pending a broader **BufferFactory allocation-options** discussion (see bottom). Happy to fold it into that rework if we go that way.

## What / why

`BufferFactory.Default` on JVM 21+ returned `FfmAutoBuffer` (backed by `Arena.ofAuto()`). Every access on an FFM-derived `ByteBuffer` routes through `java.nio.Buffer.session()` scope validation — the **#1 JVM CPU hotspot** in the fresh Autobahn cat-13 profile (buffer 6.9.3, `platform=all`). And the one thing `FfmAutoBuffer` adds over a plain `DirectByteBuffer` — deterministic `free()` — it doesn't actually provide: `freeNativeMemory()` is a **no-op** (auto arena is GC-collected). So the default paid the `session()` tax for zero benefit.

This returns `DirectJvmBuffer(ByteBuffer.allocateDirect(size))` — **identical to the JVM≤20 default**: GC-managed native memory, no `session()` check. It still implements `NativeMemoryAccess`, so the native address for zero-copy interop is preserved. Deterministic free stays in `BufferFactory.deterministic()` (`FfmBuffer`). `FfmAutoBuffer`/`allocateAutoFfmBuffer` are retained for explicit opt-in / the factory rework.

This is effort-vs-win plan **#4**, which re-ranked to the top JVM lever after #283 (`readString` reuse) removed the allocation that used to dwarf `session()` in the profile.

## Validation

`./gradlew :buffer:jvmFfmTest` (forces the JVM-21 FFM classpath, where `Default` was `FfmAutoBuffer`): **1163 pass**, updated `FfmAutoBufferTest` passes.

⚠️ 4 `DeterministicBufferTest` failures show up locally, but they are **pre-existing on clean `main`** (verified by stashing this change) — a WSL2/JDK-21 FFM *shared*-arena guard issue, unrelated to this PR. Worth a separate look; called out so CI triage isn't misattributed.

## Open question — factory allocation options (why this is a draft)

The API already supports consumer choice well (`Default` / `managed()` / `shared()` / `deterministic()` + `requiring`/`preferring`/`withSizeLimit`/`withPooling` decorators + factory injection). Two gaps this PR surfaces:
1. **`Default` is opaque and JDK-dependent** — it silently meant "FFM on 21, Direct on ≤20". This PR makes it consistently "plain direct native", but should the strategy be *named* rather than implied?
2. Should the GC-managed-FFM buffer remain reachable as an **explicit** preset (e.g. `nativeAuto()`), rather than deleted or dead-code?

I'll follow up with a concrete proposal.