### PR TITLE
perf(jvm): encode writeString UTF-8 straight to native memory (no per-byte session/array)

### DIFF
--- a/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/DirectUncheckedAccess.kt
+++ b/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/DirectUncheckedAccess.kt
@@ -17,3 +17,10 @@ private val EVERYTHING: MemorySegment = MemorySegment.NULL.reinterpret(Long.MAX_
 internal fun directGetByte(address: Long): Byte = EVERYTHING.get(ValueLayout.JAVA_BYTE, address)
 
 internal fun directGetLong(address: Long): Long = EVERYTHING.get(ValueLayout.JAVA_LONG_UNALIGNED, address)
+
+// Write mirror of directGetByte. EVERYTHING is global-scope, so set() carries no per-access liveness
+// check — the same folded-away bare store Unsafe would do, through the supported FFM API.
+internal fun directPutByte(
+    address: Long,
+    value: Byte,
+): Unit = EVERYTHING.set(ValueLayout.JAVA_BYTE, address, value)

--- a/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/FfmAutoBuffer.kt
+++ b/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/FfmAutoBuffer.kt
@@ -34,6 +34,11 @@ class FfmAutoBuffer(
         // no-op: GC-managed memory has no explicit free.
     }
 
+    override fun tryWriteUtf8ToNative(text: CharSequence): Boolean {
+        position(encodeUtf8ToNative(text, position(), limit(), segment.address()))
+        return true
+    }
+
     override fun slice(byteOrder: ByteOrder): PlatformBuffer {
         val slicedSegment = segment.asSlice(position().toLong(), remaining().toLong())
         val globalView = MemorySegment.ofAddress(slicedSegment.address()).reinterpret(slicedSegment.byteSize())

--- a/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/FfmBuffer.kt
+++ b/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/FfmBuffer.kt
@@ -98,6 +98,15 @@ class FfmBuffer(
         super.resetForWrite()
     }
 
+    override fun tryWriteUtf8ToNative(text: CharSequence): Boolean {
+        // After free the arena is closed and byteBuffer.limit is 0; fall back so the encoder path's
+        // limit=0 guard throws BufferOverflowException exactly as before (and we never read a closed
+        // segment's address). While alive, encode straight to the shared segment's native memory.
+        if (isFreed) return false
+        position(encodeUtf8ToNative(text, position(), limit(), segment.address()))
+        return true
+    }
+
     /**
      * Returns an [FfmSliceBuffer] slice with a global-scope ByteBuffer view.
      * The slice retains the arena-scoped segment for lifecycle checking via [FfmSliceBuffer.checkAlive].

--- a/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/Utf8DirectEncode.kt
+++ b/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/Utf8DirectEncode.kt
@@ -25,10 +25,11 @@ import java.nio.charset.MalformedInputException
  *  - a lone/unpaired surrogate throws [MalformedInputException] (no substitution), and
  *  - running out of window throws [BufferOverflowException] before writing past [limit].
  * On either throw the destination may hold a partial encoding and the caller's position is unchanged.
+ *
+ * The one when-branch per UTF-8 sequence length (1-4 bytes) plus the surrogate-pair path drive
+ * detekt's CyclomaticComplexMethod count, and the malformed-surrogate + overflow guards drive its
+ * ThrowsCount — both intrinsic to a correct single-pass encoder, hence the suppressions.
  */
-// One when-branch per UTF-8 sequence length (1-4 bytes) plus the surrogate-pair path drives the
-// cyclomatic count; the malformed-surrogate and overflow guards drive the throw count. Both are
-// intrinsic to a correct, single-pass encoder.
 @Suppress("CyclomaticComplexMethod", "ThrowsCount")
 internal fun encodeUtf8ToNative(
     text: CharSequence,

--- a/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/Utf8DirectEncode.kt
+++ b/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/Utf8DirectEncode.kt
@@ -1,3 +1,7 @@
+// UTF-8 is defined in terms of bit patterns (0x80/0xC0/0xE0/0xF0 lead bytes, 0x3F continuation mask,
+// 0xD800..0xDFFF surrogates); naming each would obscure the encoding rather than clarify it.
+@file:Suppress("MagicNumber")
+
 package com.ditchoom.buffer
 
 // SHADOW TWIN: an identical copy lives in src/jvm21Main. The algorithm is JDK-agnostic; only the
@@ -22,6 +26,10 @@ import java.nio.charset.MalformedInputException
  *  - running out of window throws [BufferOverflowException] before writing past [limit].
  * On either throw the destination may hold a partial encoding and the caller's position is unchanged.
  */
+// One when-branch per UTF-8 sequence length (1-4 bytes) plus the surrogate-pair path drives the
+// cyclomatic count; the malformed-surrogate and overflow guards drive the throw count. Both are
+// intrinsic to a correct, single-pass encoder.
+@Suppress("CyclomaticComplexMethod", "ThrowsCount")
 internal fun encodeUtf8ToNative(
     text: CharSequence,
     startPosition: Int,

--- a/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/Utf8DirectEncode.kt
+++ b/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/Utf8DirectEncode.kt
@@ -1,0 +1,83 @@
+package com.ditchoom.buffer
+
+// SHADOW TWIN: an identical copy lives in src/jvm21Main. The algorithm is JDK-agnostic; only the
+// directPutByte it binds to differs (Unsafe here on JVM 8-20, FFM in the jvm21 copy). The multi-
+// release JAR loads the jvm21 copy on JDK 21+, exactly like DirectUncheckedAccess.kt. Keep in sync.
+
+import java.nio.charset.MalformedInputException
+
+/**
+ * Encodes [text] as UTF-8 straight into native memory at [base] + index, starting at [startPosition]
+ * and never writing at or past [limit]. Returns the new position (one-past the last byte written).
+ *
+ * This is the write-side counterpart to the [directGetByte] read fast path and mirrors the native
+ * (simdutf) `writeString`: it walks the UTF-16 [CharSequence] and writes each scalar's 1–4 UTF-8
+ * bytes through [directPutByte] — a raw native store with no per-byte `java.nio.Buffer.session()`
+ * scope check and no intermediate `char[]`/`byte[]`. On JVM 21+ [directPutByte] is FFM-backed; on
+ * 8–20 it is `Unsafe`. The JDK `CharsetEncoder` path this replaces used `encodeBufferLoop`, which
+ * does a `DirectByteBuffer.put(byte)` — and thus a session check — for every single byte.
+ *
+ * Behaviour matches the REPORT-mode `CharsetEncoder` it replaces:
+ *  - a lone/unpaired surrogate throws [MalformedInputException] (no substitution), and
+ *  - running out of window throws [BufferOverflowException] before writing past [limit].
+ * On either throw the destination may hold a partial encoding and the caller's position is unchanged.
+ */
+internal fun encodeUtf8ToNative(
+    text: CharSequence,
+    startPosition: Int,
+    limit: Int,
+    base: Long,
+): Int {
+    var pos = startPosition
+    val len = text.length
+    var i = 0
+    while (i < len) {
+        val c = text[i].code
+        when {
+            c < 0x80 -> {
+                if (pos >= limit) throw overflow(pos, limit)
+                directPutByte(base + pos, c.toByte())
+                pos += 1
+            }
+            c < 0x800 -> {
+                if (pos + 2 > limit) throw overflow(pos, limit)
+                directPutByte(base + pos, (0xC0 or (c ushr 6)).toByte())
+                directPutByte(base + pos + 1, (0x80 or (c and 0x3F)).toByte())
+                pos += 2
+            }
+            c < 0xD800 || c >= 0xE000 -> {
+                // BMP scalar (excludes the surrogate range 0xD800..0xDFFF): 3 bytes.
+                if (pos + 3 > limit) throw overflow(pos, limit)
+                directPutByte(base + pos, (0xE0 or (c ushr 12)).toByte())
+                directPutByte(base + pos + 1, (0x80 or ((c ushr 6) and 0x3F)).toByte())
+                directPutByte(base + pos + 2, (0x80 or (c and 0x3F)).toByte())
+                pos += 3
+            }
+            c < 0xDC00 -> {
+                // High surrogate — must be followed by a low surrogate to form a supplementary scalar.
+                if (i + 1 >= len) throw MalformedInputException(1)
+                val low = text[i + 1].code
+                if (low < 0xDC00 || low >= 0xE000) throw MalformedInputException(1)
+                val cp = 0x10000 + ((c - 0xD800) shl 10) + (low - 0xDC00)
+                if (pos + 4 > limit) throw overflow(pos, limit)
+                directPutByte(base + pos, (0xF0 or (cp ushr 18)).toByte())
+                directPutByte(base + pos + 1, (0x80 or ((cp ushr 12) and 0x3F)).toByte())
+                directPutByte(base + pos + 2, (0x80 or ((cp ushr 6) and 0x3F)).toByte())
+                directPutByte(base + pos + 3, (0x80 or (cp and 0x3F)).toByte())
+                pos += 4
+                i += 1 // consumed the low surrogate as well
+            }
+            else -> throw MalformedInputException(1) // lone low surrogate (0xDC00..0xDFFF)
+        }
+        i += 1
+    }
+    return pos
+}
+
+private fun overflow(
+    pos: Int,
+    limit: Int,
+): BufferOverflowException =
+    BufferOverflowException(
+        "Buffer overflow: cannot write UTF-8 string, ran out of window at position $pos (limit=$limit)",
+    )

--- a/buffer/src/jvmCommonMain/kotlin/com/ditchoom/buffer/BaseJvmBuffer.kt
+++ b/buffer/src/jvmCommonMain/kotlin/com/ditchoom/buffer/BaseJvmBuffer.kt
@@ -416,6 +416,12 @@ abstract class BaseJvmBuffer(
         text: CharSequence,
         charset: Charset,
     ): WriteBuffer {
+        // Native-backed buffers encode UTF-8 straight to the address (no per-byte session() check,
+        // no intermediate char[]/byte[]). Heap buffers and non-UTF-8 fall through to the encoder,
+        // whose encodeArrayLoop is already fast for heap destinations.
+        if (charset == Charset.UTF8 && tryWriteUtf8ToNative(text)) {
+            return this
+        }
         val encoder = charset.toEncoder()
         encoder.reset()
         val result = encoder.encode(CharBuffer.wrap(text), byteBuffer, true)
@@ -432,6 +438,14 @@ abstract class BaseJvmBuffer(
         }
         return this
     }
+
+    /**
+     * UTF-8 fast path for native-backed buffers: encode [text] straight to the native address and
+     * advance the position, returning true. The default returns false so heap buffers (and any
+     * native buffer without a resolvable address) fall back to the [java.nio.charset.CharsetEncoder]
+     * path. Overridden by [DirectJvmBuffer] and the FFM buffers, which have a native base address.
+     */
+    protected open fun tryWriteUtf8ToNative(text: CharSequence): Boolean = false
 
     override fun write(buffer: ReadBuffer) {
         val actual = buffer.unwrapFully()

--- a/buffer/src/jvmMain/kotlin/com/ditchoom/buffer/DirectJvmBuffer.kt
+++ b/buffer/src/jvmMain/kotlin/com/ditchoom/buffer/DirectJvmBuffer.kt
@@ -72,6 +72,13 @@ class DirectJvmBuffer(
         return if (byteOrder == ByteOrder.BIG_ENDIAN) java.lang.Long.reverseBytes(raw) else raw
     }
 
+    override fun tryWriteUtf8ToNative(text: CharSequence): Boolean {
+        val base = directBase()
+        if (base == 0L) return false // no --add-opens on JVM<21: fall back to the CharsetEncoder path
+        position(encodeUtf8ToNative(text, position(), limit(), base))
+        return true
+    }
+
     // ktlint (no .editorconfig) collapses this expression body onto one line, so it cannot be wrapped.
     @Suppress("MaxLineLength")
     override fun slice(byteOrder: ByteOrder): DirectJvmBuffer = DirectJvmBuffer(byteBuffer.slice().order(byteOrder.toJava()))

--- a/buffer/src/jvmMain/kotlin/com/ditchoom/buffer/DirectUncheckedAccess.kt
+++ b/buffer/src/jvmMain/kotlin/com/ditchoom/buffer/DirectUncheckedAccess.kt
@@ -11,3 +11,10 @@ package com.ditchoom.buffer
 internal fun directGetByte(address: Long): Byte = UnsafeMemory.getByte(address)
 
 internal fun directGetLong(address: Long): Long = UnsafeMemory.getLong(address)
+
+// Unchecked native write mirror of directGetByte, used by encodeUtf8ToNative to emit UTF-8 straight
+// to the destination without DirectByteBuffer.put(byte)'s per-byte session-liveness check.
+internal fun directPutByte(
+    address: Long,
+    value: Byte,
+): Unit = UnsafeMemory.putByte(address, value)

--- a/buffer/src/jvmMain/kotlin/com/ditchoom/buffer/Utf8DirectEncode.kt
+++ b/buffer/src/jvmMain/kotlin/com/ditchoom/buffer/Utf8DirectEncode.kt
@@ -25,10 +25,11 @@ import java.nio.charset.MalformedInputException
  *  - a lone/unpaired surrogate throws [MalformedInputException] (no substitution), and
  *  - running out of window throws [BufferOverflowException] before writing past [limit].
  * On either throw the destination may hold a partial encoding and the caller's position is unchanged.
+ *
+ * The one when-branch per UTF-8 sequence length (1-4 bytes) plus the surrogate-pair path drive
+ * detekt's CyclomaticComplexMethod count, and the malformed-surrogate + overflow guards drive its
+ * ThrowsCount — both intrinsic to a correct single-pass encoder, hence the suppressions.
  */
-// One when-branch per UTF-8 sequence length (1-4 bytes) plus the surrogate-pair path drives the
-// cyclomatic count; the malformed-surrogate and overflow guards drive the throw count. Both are
-// intrinsic to a correct, single-pass encoder.
 @Suppress("CyclomaticComplexMethod", "ThrowsCount")
 internal fun encodeUtf8ToNative(
     text: CharSequence,

--- a/buffer/src/jvmMain/kotlin/com/ditchoom/buffer/Utf8DirectEncode.kt
+++ b/buffer/src/jvmMain/kotlin/com/ditchoom/buffer/Utf8DirectEncode.kt
@@ -1,3 +1,7 @@
+// UTF-8 is defined in terms of bit patterns (0x80/0xC0/0xE0/0xF0 lead bytes, 0x3F continuation mask,
+// 0xD800..0xDFFF surrogates); naming each would obscure the encoding rather than clarify it.
+@file:Suppress("MagicNumber")
+
 package com.ditchoom.buffer
 
 // SHADOW TWIN: an identical copy lives in src/jvm21Main. The algorithm is JDK-agnostic; only the
@@ -22,6 +26,10 @@ import java.nio.charset.MalformedInputException
  *  - running out of window throws [BufferOverflowException] before writing past [limit].
  * On either throw the destination may hold a partial encoding and the caller's position is unchanged.
  */
+// One when-branch per UTF-8 sequence length (1-4 bytes) plus the surrogate-pair path drives the
+// cyclomatic count; the malformed-surrogate and overflow guards drive the throw count. Both are
+// intrinsic to a correct, single-pass encoder.
+@Suppress("CyclomaticComplexMethod", "ThrowsCount")
 internal fun encodeUtf8ToNative(
     text: CharSequence,
     startPosition: Int,

--- a/buffer/src/jvmMain/kotlin/com/ditchoom/buffer/Utf8DirectEncode.kt
+++ b/buffer/src/jvmMain/kotlin/com/ditchoom/buffer/Utf8DirectEncode.kt
@@ -1,0 +1,83 @@
+package com.ditchoom.buffer
+
+// SHADOW TWIN: an identical copy lives in src/jvm21Main. The algorithm is JDK-agnostic; only the
+// directPutByte it binds to differs (Unsafe here on JVM 8-20, FFM in the jvm21 copy). The multi-
+// release JAR loads the jvm21 copy on JDK 21+, exactly like DirectUncheckedAccess.kt. Keep in sync.
+
+import java.nio.charset.MalformedInputException
+
+/**
+ * Encodes [text] as UTF-8 straight into native memory at [base] + index, starting at [startPosition]
+ * and never writing at or past [limit]. Returns the new position (one-past the last byte written).
+ *
+ * This is the write-side counterpart to the [directGetByte] read fast path and mirrors the native
+ * (simdutf) `writeString`: it walks the UTF-16 [CharSequence] and writes each scalar's 1–4 UTF-8
+ * bytes through [directPutByte] — a raw native store with no per-byte `java.nio.Buffer.session()`
+ * scope check and no intermediate `char[]`/`byte[]`. On JVM 21+ [directPutByte] is FFM-backed; on
+ * 8–20 it is `Unsafe`. The JDK `CharsetEncoder` path this replaces used `encodeBufferLoop`, which
+ * does a `DirectByteBuffer.put(byte)` — and thus a session check — for every single byte.
+ *
+ * Behaviour matches the REPORT-mode `CharsetEncoder` it replaces:
+ *  - a lone/unpaired surrogate throws [MalformedInputException] (no substitution), and
+ *  - running out of window throws [BufferOverflowException] before writing past [limit].
+ * On either throw the destination may hold a partial encoding and the caller's position is unchanged.
+ */
+internal fun encodeUtf8ToNative(
+    text: CharSequence,
+    startPosition: Int,
+    limit: Int,
+    base: Long,
+): Int {
+    var pos = startPosition
+    val len = text.length
+    var i = 0
+    while (i < len) {
+        val c = text[i].code
+        when {
+            c < 0x80 -> {
+                if (pos >= limit) throw overflow(pos, limit)
+                directPutByte(base + pos, c.toByte())
+                pos += 1
+            }
+            c < 0x800 -> {
+                if (pos + 2 > limit) throw overflow(pos, limit)
+                directPutByte(base + pos, (0xC0 or (c ushr 6)).toByte())
+                directPutByte(base + pos + 1, (0x80 or (c and 0x3F)).toByte())
+                pos += 2
+            }
+            c < 0xD800 || c >= 0xE000 -> {
+                // BMP scalar (excludes the surrogate range 0xD800..0xDFFF): 3 bytes.
+                if (pos + 3 > limit) throw overflow(pos, limit)
+                directPutByte(base + pos, (0xE0 or (c ushr 12)).toByte())
+                directPutByte(base + pos + 1, (0x80 or ((c ushr 6) and 0x3F)).toByte())
+                directPutByte(base + pos + 2, (0x80 or (c and 0x3F)).toByte())
+                pos += 3
+            }
+            c < 0xDC00 -> {
+                // High surrogate — must be followed by a low surrogate to form a supplementary scalar.
+                if (i + 1 >= len) throw MalformedInputException(1)
+                val low = text[i + 1].code
+                if (low < 0xDC00 || low >= 0xE000) throw MalformedInputException(1)
+                val cp = 0x10000 + ((c - 0xD800) shl 10) + (low - 0xDC00)
+                if (pos + 4 > limit) throw overflow(pos, limit)
+                directPutByte(base + pos, (0xF0 or (cp ushr 18)).toByte())
+                directPutByte(base + pos + 1, (0x80 or ((cp ushr 12) and 0x3F)).toByte())
+                directPutByte(base + pos + 2, (0x80 or ((cp ushr 6) and 0x3F)).toByte())
+                directPutByte(base + pos + 3, (0x80 or (cp and 0x3F)).toByte())
+                pos += 4
+                i += 1 // consumed the low surrogate as well
+            }
+            else -> throw MalformedInputException(1) // lone low surrogate (0xDC00..0xDFFF)
+        }
+        i += 1
+    }
+    return pos
+}
+
+private fun overflow(
+    pos: Int,
+    limit: Int,
+): BufferOverflowException =
+    BufferOverflowException(
+        "Buffer overflow: cannot write UTF-8 string, ran out of window at position $pos (limit=$limit)",
+    )

--- a/buffer/src/jvmTest/kotlin/com/ditchoom/buffer/WriteStringDirectUtf8Test.kt
+++ b/buffer/src/jvmTest/kotlin/com/ditchoom/buffer/WriteStringDirectUtf8Test.kt
@@ -1,0 +1,70 @@
+package com.ditchoom.buffer
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * Locks the behaviour of the native UTF-8 write fast path (encodeUtf8ToNative), which replaces the
+ * per-byte CharsetEncoder loop for native-backed buffers. Runs on the base JVM classpath
+ * (DirectJvmBuffer / Unsafe) and, via jvmFfmTest, on the FFM buffers (FfmBuffer / FfmAutoBuffer).
+ */
+class WriteStringDirectUtf8Test {
+    private fun roundTrip(text: String) {
+        val bytes = text.encodeToByteArray()
+        val buffer = BufferFactory.Default.allocate(bytes.size)
+        buffer.writeString(text, Charset.UTF8)
+        assertEquals(bytes.size, buffer.position(), "encoded byte count for \"$text\"")
+        buffer.resetForRead()
+        assertEquals(text, buffer.readString(bytes.size, Charset.UTF8))
+    }
+
+    @Test
+    fun `ascii round-trips`() = roundTrip("hello, websocket!")
+
+    @Test
+    fun `two-byte round-trips`() = roundTrip("éüñ café")
+
+    @Test
+    fun `three-byte round-trips`() = roundTrip("世界 界世")
+
+    @Test
+    fun `four-byte surrogate pairs round-trip`() = roundTrip("😀🎉🚀 mixed 世 é a")
+
+    @Test
+    fun `deterministic (FFM on JVM 21) buffer round-trips multibyte`() {
+        // The websocket's frame path uses BufferFactory.deterministic() — the buffer this fix targets.
+        val text = "é世😀 deterministic"
+        val bytes = text.encodeToByteArray()
+        BufferFactory.deterministic().allocate(bytes.size).use { buffer ->
+            buffer.writeString(text, Charset.UTF8)
+            assertEquals(bytes.size, buffer.position())
+            buffer.resetForRead()
+            assertEquals(text, buffer.readString(bytes.size, Charset.UTF8))
+        }
+    }
+
+    @Test
+    fun `lone high surrogate throws`() {
+        val buffer = BufferFactory.Default.allocate(8)
+        assertFailsWith<java.nio.charset.MalformedInputException> {
+            buffer.writeString("a\uD83Db", Charset.UTF8) // high surrogate not followed by a low one
+        }
+    }
+
+    @Test
+    fun `lone low surrogate throws`() {
+        val buffer = BufferFactory.Default.allocate(8)
+        assertFailsWith<java.nio.charset.MalformedInputException> {
+            buffer.writeString("a\uDE00b", Charset.UTF8) // unpaired low surrogate
+        }
+    }
+
+    @Test
+    fun `trailing high surrogate at end of input throws`() {
+        val buffer = BufferFactory.Default.allocate(8)
+        assertFailsWith<java.nio.charset.MalformedInputException> {
+            buffer.writeString("ab\uD83D", Charset.UTF8)
+        }
+    }
+}


### PR DESCRIPTION
> **Draft.** Correctness validated on both JVM buffer backends; the FFM-path speedup is now benchmarked (below). End-to-end websocket re-profile is the remaining confirmation.

## Problem

The JVM `writeString` did `CharsetEncoder.encode(CharBuffer.wrap(text), byteBuffer, true)`. For a **native/FFM** destination the JDK's `encodeBufferLoop` does a `DirectByteBuffer.put(byte)` — and thus a `java.nio.Buffer.session()` scope check — for **every single byte**. On FFM-backed buffers that `session()` check was the **#1 JVM CPU cost** in the Autobahn cat-13 profile (send path: `writeDataFrameFromCodec` -> `StringCodec.encode` -> `GrowableWriteBuffer.writeString` -> `encodeBufferLoop` -> `put(byte)` -> `session()`).

The websocket frame path uses `BufferFactory.deterministic()` = `FfmBuffer`, so it pays this on every text frame. (This is why the sibling `Default`->direct PR #284 does not move the hotspot.)

## Fix

`encodeUtf8ToNative` — a hand-rolled UTF-16 -> UTF-8 encoder that writes each scalar's 1-4 bytes **straight to the native address** via `directPutByte`, with **no per-byte `session()` and no intermediate `char[]`/`byte[]`**. Write-side mirror of the `directGetByte` read fast path and the native simdutf `writeString`.

- `directPutByte` in both `DirectUncheckedAccess.kt` multi-release variants (FFM `MemorySegment.set` on 21+, `Unsafe` on 8-20).
- `Utf8DirectEncode.kt` is a shadow-twin (jvm21 is not friend-associated with main — `associateWith` cycles the MR jar).
- `BaseJvmBuffer.writeString` calls an open `tryWriteUtf8ToNative`; overridden by `DirectJvmBuffer`, `FfmBuffer` (guards `isFreed`), `FfmAutoBuffer`. Heap buffers keep the fast `encodeArrayLoop`.
- REPORT semantics preserved: lone surrogate -> `MalformedInputException`; overflow -> `BufferOverflowException`.

## Benchmark (the win, on FFM buffers)

`WriteStringBenchmark` run with the java21 classes prepended (so `Default` = `FfmAutoBuffer`, the same FFM type the websocket's `deterministic()` uses) — old encoder path vs. new direct encode:

| case | before (ops/s) | after (ops/s) | speedup |
|---|--:|--:|--:|
| ascii 64KB | 19,539 | 54,492 | 2.8x |
| ascii 1KB | 1,287,261 | 3,340,195 | 2.6x |
| emoji 1KB | 589,905 | 1,191,871 | 2.0x |
| cjk 1KB | 240,969 | 448,815 | 1.9x |
| cjk 64KB | 4,578 | 7,497 | 1.6x |
| emoji 64KB | 12,040 | 18,203 | 1.5x |

1.5-2.8x faster (biggest on ASCII, where per-byte `session()` dominates). High variance (+/-15-30%) but consistent direction. Note: on a **plain `DirectJvmBuffer`** the numbers are unchanged — a non-FFM `allocateDirect` buffer has no `session()` cost, and its fast path needs `--add-opens java.base/java.nio` to resolve the address anyway; the win is FFM-only, which is what the websocket uses.

## Validation

`StringCharsetParity` / `WriteStringOverflow` / `LengthPrefixedString` + new `WriteStringDirectUtf8Test` (ascii, 2/3/4-byte, surrogate pairs, lone-surrogate throws, **deterministic FFM buffer** round-trip) pass on **both** `jvmTest` (Direct/Unsafe) and `jvmFfmTest` (FFM).

## Remaining

`writeString` is one step of the frame path, so the end-to-end websocket delta is smaller than the micro-benchmark — a websocket re-profile (publish -> bump -> `autobahn-profile.yaml`) is the definitive end-to-end confirmation.
