### PR TITLE
perf(jvm): devirtualize writeString char read via String bind (kills String.charAt #2 hotspot)

### DIFF
--- a/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/Utf8DirectEncode.kt
+++ b/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/Utf8DirectEncode.kt
@@ -21,6 +21,16 @@ import java.nio.charset.MalformedInputException
  * 8–20 it is `Unsafe`. The JDK `CharsetEncoder` path this replaces used `encodeBufferLoop`, which
  * does a `DirectByteBuffer.put(byte)` — and thus a session check — for every single byte.
  *
+ * The char read is bound to a `String` up front ([text] itself when it already is one — the frame
+ * path always passes a `String`, so this is a same-object bind with **no copy**; a non-`String`
+ * `CharSequence` is materialized once via `toString()`). Indexing a statically-`String` reference
+ * makes `s[i]` an inlinable `String.charAt` (invokevirtual on the final class) instead of the
+ * megamorphic `CharSequence.get` (invokeinterface) the JIT could not inline across this function's
+ * call sites — the post-#285 re-profile showed that dispatch (`java.lang.String.charAt`) as the #2
+ * JVM CPU frame. Measured char-access speedup: ~1.5× multi-byte, ~neutral ASCII, no regression
+ * (see WriteStringCharAccessBench). A bulk `getChars`-into-`char[]` variant was faster on ASCII but
+ * adds a copy and regresses 4-byte/surrogate content, so it was rejected in favour of this no-copy form.
+ *
  * Behaviour matches the REPORT-mode `CharsetEncoder` it replaces:
  *  - a lone/unpaired surrogate throws [MalformedInputException] (no substitution), and
  *  - running out of window throws [BufferOverflowException] before writing past [limit].
@@ -37,11 +47,14 @@ internal fun encodeUtf8ToNative(
     limit: Int,
     base: Long,
 ): Int {
+    // Bind to a String so the per-char read below is a devirtualized String.charAt, not an
+    // invokeinterface CharSequence.get. Same object (no copy) when text is already a String.
+    val s = if (text is String) text else text.toString()
     var pos = startPosition
-    val len = text.length
+    val len = s.length
     var i = 0
     while (i < len) {
-        val c = text[i].code
+        val c = s[i].code
         when {
             c < 0x80 -> {
                 if (pos >= limit) throw overflow(pos, limit)
@@ -65,7 +78,7 @@ internal fun encodeUtf8ToNative(
             c < 0xDC00 -> {
                 // High surrogate — must be followed by a low surrogate to form a supplementary scalar.
                 if (i + 1 >= len) throw MalformedInputException(1)
-                val low = text[i + 1].code
+                val low = s[i + 1].code
                 if (low < 0xDC00 || low >= 0xE000) throw MalformedInputException(1)
                 val cp = 0x10000 + ((c - 0xD800) shl 10) + (low - 0xDC00)
                 if (pos + 4 > limit) throw overflow(pos, limit)

--- a/buffer/src/jvmMain/kotlin/com/ditchoom/buffer/Utf8DirectEncode.kt
+++ b/buffer/src/jvmMain/kotlin/com/ditchoom/buffer/Utf8DirectEncode.kt
@@ -21,6 +21,16 @@ import java.nio.charset.MalformedInputException
  * 8–20 it is `Unsafe`. The JDK `CharsetEncoder` path this replaces used `encodeBufferLoop`, which
  * does a `DirectByteBuffer.put(byte)` — and thus a session check — for every single byte.
  *
+ * The char read is bound to a `String` up front ([text] itself when it already is one — the frame
+ * path always passes a `String`, so this is a same-object bind with **no copy**; a non-`String`
+ * `CharSequence` is materialized once via `toString()`). Indexing a statically-`String` reference
+ * makes `s[i]` an inlinable `String.charAt` (invokevirtual on the final class) instead of the
+ * megamorphic `CharSequence.get` (invokeinterface) the JIT could not inline across this function's
+ * call sites — the post-#285 re-profile showed that dispatch (`java.lang.String.charAt`) as the #2
+ * JVM CPU frame. Measured char-access speedup: ~1.5× multi-byte, ~neutral ASCII, no regression
+ * (see WriteStringCharAccessBench). A bulk `getChars`-into-`char[]` variant was faster on ASCII but
+ * adds a copy and regresses 4-byte/surrogate content, so it was rejected in favour of this no-copy form.
+ *
  * Behaviour matches the REPORT-mode `CharsetEncoder` it replaces:
  *  - a lone/unpaired surrogate throws [MalformedInputException] (no substitution), and
  *  - running out of window throws [BufferOverflowException] before writing past [limit].
@@ -37,11 +47,14 @@ internal fun encodeUtf8ToNative(
     limit: Int,
     base: Long,
 ): Int {
+    // Bind to a String so the per-char read below is a devirtualized String.charAt, not an
+    // invokeinterface CharSequence.get. Same object (no copy) when text is already a String.
+    val s = if (text is String) text else text.toString()
     var pos = startPosition
-    val len = text.length
+    val len = s.length
     var i = 0
     while (i < len) {
-        val c = text[i].code
+        val c = s[i].code
         when {
             c < 0x80 -> {
                 if (pos >= limit) throw overflow(pos, limit)
@@ -65,7 +78,7 @@ internal fun encodeUtf8ToNative(
             c < 0xDC00 -> {
                 // High surrogate — must be followed by a low surrogate to form a supplementary scalar.
                 if (i + 1 >= len) throw MalformedInputException(1)
-                val low = text[i + 1].code
+                val low = s[i + 1].code
                 if (low < 0xDC00 || low >= 0xE000) throw MalformedInputException(1)
                 val cp = 0x10000 + ((c - 0xD800) shl 10) + (low - 0xDC00)
                 if (pos + 4 > limit) throw overflow(pos, limit)

--- a/buffer/src/jvmTest/kotlin/com/ditchoom/buffer/WriteStringCharAccessBench.kt
+++ b/buffer/src/jvmTest/kotlin/com/ditchoom/buffer/WriteStringCharAccessBench.kt
@@ -1,0 +1,247 @@
+// UTF-8 bit patterns (0x80/0xC0/0xE0/0xF0 leads, 0x3F continuation, 0xD800..0xDFFF surrogates) are
+// clearer as literals than as named constants; this is a benchmark, not production.
+@file:Suppress("MagicNumber")
+
+package com.ditchoom.buffer
+
+import kotlin.test.Test
+import kotlin.time.TimeSource
+
+/**
+ * Char-access strategy comparison for the [encodeUtf8ToNative] hot path.
+ *
+ * The JVM re-profile of the Autobahn cat-13 run on buffer 6.9.4 (which shipped #285's direct-to-native
+ * UTF-8 encode, eliminating `java.nio.Buffer.session()`) showed the new #2 JVM CPU frame is
+ * `java.lang.String.charAt` (108 samples / 35% of execution). That is the per-char read in the encode
+ * loop: `encodeUtf8ToNative` walks a `CharSequence`, so `text[i]` compiles to an **invokeinterface**
+ * `CharSequence.get(int)` — a virtual dispatch the JIT struggles to inline across the three call sites.
+ *
+ * This isolates the char-access cost from everything else by running the identical UTF-8 transform into
+ * an identical reused `ByteArray` scratch (byte-store side held constant), varying only how chars are
+ * read. Because the production byte-write via `directPutByte` is likewise constant across strategies,
+ * the throughput delta measured here is the delta the production change would capture.
+ *
+ *  - A `charSequence` — `text[i]` on a `CharSequence` (invokeinterface). Matches today's encoder.
+ *  - B `getChars`     — one bulk `String.getChars` into a reused `char[]`, then `chars[i]` (caload).
+ *                       One copy into thread-local-style scratch, no per-call allocation.
+ *  - C `stringCharAt` — `(text as String)` then `text[i]` (invokevirtual on the final `String`,
+ *                       inlinable). No copy — honours the "avoid copies" constraint.
+ *
+ * Content-shaped because the win scales with per-char branch count: ASCII (cheapest branch) shows the
+ * most char-access-bound behaviour; 3-byte CJK and 4-byte emoji (surrogate branch) do more work per
+ * char so the relative delta shrinks. CSV-friendly for diffing:
+ *
+ *   CHARACCESS content=ascii chars=65536 strategy=getChars ns_per_op=NNNN mb_per_s=NNNN speedup=N.NN
+ *
+ * Run with:
+ *   ./gradlew :buffer:jvmTest --tests "*.WriteStringCharAccessBench"
+ * (JDK 21 toolchain also exercises the same char-access code; the byte-store side is a plain array.)
+ */
+class WriteStringCharAccessBench {
+    @Test
+    fun benchCharAccess() {
+        val charCounts = listOf(1024, 64 * 1024)
+        val contents =
+            listOf(
+                "ascii" to ::buildAscii,
+                "cjk" to { n: Int -> repeatTo("é世ü界", n) },
+                "emoji" to ::buildEmoji,
+            )
+
+        val dst = ByteArray(64 * 1024 * MAX_UTF8_BYTES_PER_CHAR)
+        val scratch = CharArray(64 * 1024)
+
+        for ((name, build) in contents) {
+            for (chars in charCounts) {
+                val text = build(chars)
+                val baseline = measure(text) { t -> encodeViaCharSequence(t, dst) }
+                val strategies =
+                    listOf(
+                        "charSequence" to baseline,
+                        "getChars" to measure(text) { t -> encodeViaGetChars(t, scratch, dst) },
+                        "stringCharAt" to measure(text) { t -> encodeViaStringCharAt(t, dst) },
+                    )
+                for ((strategy, result) in strategies) {
+                    val (nsPerOp, byteLen) = result
+                    val mbPerSec = if (nsPerOp > 0.0) byteLen * 1000.0 / nsPerOp else 0.0
+                    val speedup = if (nsPerOp > 0.0) baseline.first / nsPerOp else 0.0
+                    println(
+                        "CHARACCESS content=$name chars=$chars bytes=$byteLen strategy=$strategy " +
+                            "ns_per_op=${nsPerOp.toLong()} mb_per_s=${mbPerSec.toLong()} " +
+                            "speedup=${(speedup * 100).toLong() / 100.0}",
+                    )
+                }
+            }
+        }
+    }
+
+    /** Returns (ns/op, encoded byte count). Warms up, then runs for at least [MIN_RUN_MS]. */
+    private fun measure(
+        text: String,
+        encode: (String) -> Int,
+    ): Pair<Double, Int> {
+        repeat(WARMUP_ITERS) { encode(text) }
+        val byteLen = encode(text)
+
+        var iters = 0L
+        var sink = 0L
+        val mark = TimeSource.Monotonic.markNow()
+        while (mark.elapsedNow().inWholeMilliseconds < MIN_RUN_MS) {
+            repeat(BATCH) { sink += encode(text) }
+            iters += BATCH
+        }
+        val elapsedNs = mark.elapsedNow().inWholeNanoseconds
+        blackhole = sink
+        return (elapsedNs.toDouble() / iters.toDouble()) to byteLen
+    }
+
+    // --- Strategy A: CharSequence.get (invokeinterface) — mirrors the current encodeUtf8ToNative. ---
+    @Suppress("CyclomaticComplexMethod")
+    private fun encodeViaCharSequence(
+        text: CharSequence,
+        dst: ByteArray,
+    ): Int {
+        var j = 0
+        val len = text.length
+        var i = 0
+        while (i < len) {
+            val c = text[i].code
+            when {
+                c < 0x80 -> dst[j++] = c.toByte()
+                c < 0x800 -> {
+                    dst[j++] = (0xC0 or (c ushr 6)).toByte()
+                    dst[j++] = (0x80 or (c and 0x3F)).toByte()
+                }
+                c < 0xD800 || c >= 0xE000 -> {
+                    dst[j++] = (0xE0 or (c ushr 12)).toByte()
+                    dst[j++] = (0x80 or ((c ushr 6) and 0x3F)).toByte()
+                    dst[j++] = (0x80 or (c and 0x3F)).toByte()
+                }
+                else -> {
+                    val low = text[i + 1].code
+                    val cp = 0x10000 + ((c - 0xD800) shl 10) + (low - 0xDC00)
+                    dst[j++] = (0xF0 or (cp ushr 18)).toByte()
+                    dst[j++] = (0x80 or ((cp ushr 12) and 0x3F)).toByte()
+                    dst[j++] = (0x80 or ((cp ushr 6) and 0x3F)).toByte()
+                    dst[j++] = (0x80 or (cp and 0x3F)).toByte()
+                    i += 1
+                }
+            }
+            i += 1
+        }
+        return j
+    }
+
+    // --- Strategy B: bulk getChars into a reused char[], then plain array loads (caload). ---
+    @Suppress("CyclomaticComplexMethod")
+    private fun encodeViaGetChars(
+        text: String,
+        chars: CharArray,
+        dst: ByteArray,
+    ): Int {
+        val len = text.length
+        // Kotlin's String.toCharArray(destination, ...) delegates to the JVM String.getChars intrinsic.
+        text.toCharArray(chars, 0, 0, len)
+        var j = 0
+        var i = 0
+        while (i < len) {
+            val c = chars[i].code
+            when {
+                c < 0x80 -> dst[j++] = c.toByte()
+                c < 0x800 -> {
+                    dst[j++] = (0xC0 or (c ushr 6)).toByte()
+                    dst[j++] = (0x80 or (c and 0x3F)).toByte()
+                }
+                c < 0xD800 || c >= 0xE000 -> {
+                    dst[j++] = (0xE0 or (c ushr 12)).toByte()
+                    dst[j++] = (0x80 or ((c ushr 6) and 0x3F)).toByte()
+                    dst[j++] = (0x80 or (c and 0x3F)).toByte()
+                }
+                else -> {
+                    val low = chars[i + 1].code
+                    val cp = 0x10000 + ((c - 0xD800) shl 10) + (low - 0xDC00)
+                    dst[j++] = (0xF0 or (cp ushr 18)).toByte()
+                    dst[j++] = (0x80 or ((cp ushr 12) and 0x3F)).toByte()
+                    dst[j++] = (0x80 or ((cp ushr 6) and 0x3F)).toByte()
+                    dst[j++] = (0x80 or (cp and 0x3F)).toByte()
+                    i += 1
+                }
+            }
+            i += 1
+        }
+        return j
+    }
+
+    // --- Strategy C: String smart-cast — invokevirtual charAt on the final String, no copy. ---
+    @Suppress("CyclomaticComplexMethod")
+    private fun encodeViaStringCharAt(
+        text: String,
+        dst: ByteArray,
+    ): Int {
+        var j = 0
+        val len = text.length
+        var i = 0
+        while (i < len) {
+            val c = text[i].code
+            when {
+                c < 0x80 -> dst[j++] = c.toByte()
+                c < 0x800 -> {
+                    dst[j++] = (0xC0 or (c ushr 6)).toByte()
+                    dst[j++] = (0x80 or (c and 0x3F)).toByte()
+                }
+                c < 0xD800 || c >= 0xE000 -> {
+                    dst[j++] = (0xE0 or (c ushr 12)).toByte()
+                    dst[j++] = (0x80 or ((c ushr 6) and 0x3F)).toByte()
+                    dst[j++] = (0x80 or (c and 0x3F)).toByte()
+                }
+                else -> {
+                    val low = text[i + 1].code
+                    val cp = 0x10000 + ((c - 0xD800) shl 10) + (low - 0xDC00)
+                    dst[j++] = (0xF0 or (cp ushr 18)).toByte()
+                    dst[j++] = (0x80 or ((cp ushr 12) and 0x3F)).toByte()
+                    dst[j++] = (0x80 or ((cp ushr 6) and 0x3F)).toByte()
+                    dst[j++] = (0x80 or (cp and 0x3F)).toByte()
+                    i += 1
+                }
+            }
+            i += 1
+        }
+        return j
+    }
+
+    private companion object {
+        @Volatile
+        private var blackhole: Long = 0
+
+        private const val WARMUP_ITERS = 2000
+        private const val BATCH = 128
+        private const val MIN_RUN_MS = 400L
+        private const val MAX_UTF8_BYTES_PER_CHAR = 4
+        private const val PRINTABLE_ASCII_START = 32
+        private const val PRINTABLE_ASCII_RANGE = 95
+
+        private fun buildAscii(charCount: Int): String {
+            val sb = StringBuilder(charCount)
+            for (i in 0 until charCount) {
+                sb.append((PRINTABLE_ASCII_START + (i % PRINTABLE_ASCII_RANGE)).toChar())
+            }
+            return sb.toString()
+        }
+
+        private fun repeatTo(
+            pattern: String,
+            charCount: Int,
+        ): String {
+            val sb = StringBuilder(charCount)
+            while (sb.length < charCount) sb.append(pattern)
+            return sb.substring(0, charCount)
+        }
+
+        private fun buildEmoji(charCount: Int): String {
+            val sb = StringBuilder(charCount)
+            while (sb.length + 2 <= charCount) sb.append('\uD83D').append('\uDE00')
+            while (sb.length < charCount) sb.append(' ')
+            return sb.toString()
+        }
+    }
+}


### PR DESCRIPTION
## Why

Buffer **6.9.4** shipped #285 (encode `writeString` UTF-8 straight to native memory), which eliminated the per-byte `java.nio.Buffer.session()` scope check — previously the **#1 JVM CPU frame (38%)** in the websocket Autobahn cat-13 re-profile. That re-profile (all-platform, run `29161713410`, diffed vs the 6.9.3 baseline `29153218400`) confirmed `session()` dropped to **0** and total JVM exec samples fell **516 → 306 (−41%)**.

The re-profile also surfaced the **new #2 JVM frame: `java.lang.String.charAt` — 108 samples / 35% of execution.** That's the per-char read inside `encodeUtf8ToNative`: because the encoder takes a `CharSequence`, `text[i]` compiles to an **`invokeinterface CharSequence.get(int)`** — a virtual dispatch the JIT can't inline across the encoder's three call sites (`DirectJvmBuffer`, `FfmBuffer`, `FfmAutoBuffer`).

## The change

Bind `text` to a `String` once at the top of `encodeUtf8ToNative`:

```kotlin
val s = if (text is String) text else text.toString()
```

For the frame path (always a `String`) this is a **same-object bind — no copy**. Indexing a statically-`String` reference makes `s[i]` an **inlinable `String.charAt`** (`invokevirtual` on the final class). Non-`String` `CharSequence` (rare: `StringBuilder`, …) is materialized once via `toString()` on the cold path. Single loop, **no nullable, no `ByteArray`, no copy on the hot path.**

## Options compared

`WriteStringCharAccessBench` (new, `jvmTest`) isolates the variable: it runs the **identical** UTF-8 transform into an **identical reused byte scratch**, changing *only* how chars are read. Since the production byte-write (`directPutByte`) is constant across strategies, the throughput delta here is the delta the change captures. Median speedup vs the `CharSequence.get` baseline over 3 runs:

| content | size | **B: getChars→char[]** | **C: String smart-cast (shipped)** |
|---|---|---|---|
| ascii | 1 KB | 1.21× | 1.03× |
| ascii | 64 KB | 1.11× | 0.98× |
| **cjk** (2–3 byte) | 1 KB | 1.77× | **1.53×** |
| **cjk** (2–3 byte) | 64 KB | 1.67× | **1.59×** |
| emoji (4-byte/surrogate) | 1 KB | 0.91× | 0.93× |
| emoji (4-byte/surrogate) | 64 KB | **0.88×** | 0.94× |

**Why C over B:** `getChars` (Option B) is faster on ASCII but **adds a copy** (a full-length `char[]` extraction) and **regresses 4-byte/surrogate content** (~0.88×) — the upfront copy is dead weight once encoding is compute-bound. Option C keeps the big multi-byte win with **zero copy and no regression anywhere**, satisfying the no-copy / no-nullable constraints.

**Rejected — Option D (String internals):** reading `String.value` (a `byte[]`) + `String.coder` via VarHandle/Unsafe for a Latin1 fast path would be fastest for ASCII, but it touches a JDK-internal `byte[]` (violates the no-`ByteArray` rule), needs `--add-opens`, and is fragile across JDKs.

## Correctness

Unchanged. `WriteStringDirectUtf8Test`, `StringCharsetParity`, `WriteStringOverflow` all pass on **both** JVM backends — default `Unsafe` (`jvmTest`) and FFM `jvm21` (`jvmFfmTest`, which exercises the shadow twin). Lone-surrogate → `MalformedInputException`, overflow → `BufferOverflowException` semantics preserved. Shadow twin (`jvmMain` + `jvm21Main`) kept in sync. ktlint clean.

## Draft — pending

Kept as **draft** until the **end-to-end Autobahn re-profile** confirms the real-traffic delta (cat-13 content skews ASCII, where C is ~neutral; the win concentrates in multi-byte payloads). Plan: publish this branch's `maven-local-linux` artifact via PR CI, bump the websocket to it, re-run `autobahn-profile.yaml`, and confirm `String.charAt` drops out of the JVM top frames — same loop used to validate #283/#285.
