### PR TITLE
perf(jvm): decode readString UTF-8 straight from native memory on FFM (kills decodeBufferLoop)

### DIFF
--- a/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/FfmAutoBuffer.kt
+++ b/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/FfmAutoBuffer.kt
@@ -39,6 +39,22 @@ class FfmAutoBuffer(
         return true
     }
 
+    // Read mirror of tryWriteUtf8ToNative: decode UTF-8 straight off the segment's native address
+    // instead of taking the direct-ByteBuffer decodeBufferLoop. Non-UTF-8 falls back to the base
+    // CharsetDecoder path.
+    override fun readString(
+        length: Int,
+        charset: Charset,
+    ): String {
+        if (charset == Charset.UTF8) {
+            val start = position()
+            val decoded = decodeUtf8FromNative(segment.address(), start, start + length)
+            position(start + length)
+            return decoded
+        }
+        return super.readString(length, charset)
+    }
+
     override fun slice(byteOrder: ByteOrder): PlatformBuffer {
         val slicedSegment = segment.asSlice(position().toLong(), remaining().toLong())
         val globalView = MemorySegment.ofAddress(slicedSegment.address()).reinterpret(slicedSegment.byteSize())

--- a/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/FfmBuffer.kt
+++ b/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/FfmBuffer.kt
@@ -107,6 +107,22 @@ class FfmBuffer(
         return true
     }
 
+    // Read mirror of tryWriteUtf8ToNative: decode UTF-8 straight off the segment's native address
+    // instead of taking the direct-ByteBuffer decodeBufferLoop. Falls back to the base CharsetDecoder
+    // path for non-UTF-8, and for a freed segment (whose closed address must never be read).
+    override fun readString(
+        length: Int,
+        charset: Charset,
+    ): String {
+        if (charset == Charset.UTF8 && !isFreed) {
+            val start = position()
+            val decoded = decodeUtf8FromNative(segment.address(), start, start + length)
+            position(start + length)
+            return decoded
+        }
+        return super.readString(length, charset)
+    }
+
     /**
      * Returns an [FfmSliceBuffer] slice with a global-scope ByteBuffer view.
      * The slice retains the arena-scoped segment for lifecycle checking via [FfmSliceBuffer.checkAlive].

--- a/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/Utf8DirectDecode.kt
+++ b/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/Utf8DirectDecode.kt
@@ -1,0 +1,112 @@
+// UTF-8 is defined in terms of bit patterns (0x80/0xC0/0xE0/0xF0 lead bytes, 0x3F continuation mask,
+// 0xD800..0xDFFF surrogates, 0x10FFFF ceiling); naming each would obscure the decoding rather than
+// clarify it.
+@file:Suppress("MagicNumber")
+
+package com.ditchoom.buffer
+
+import java.nio.charset.MalformedInputException
+
+// FFM-ONLY (jvm21) — deliberately NOT a shadow twin of a jvmMain copy, unlike Utf8DirectEncode.kt.
+// The read fast path pays off only when the per-byte accessor is a JIT intrinsic: here directGetByte
+// is the FFM EVERYTHING.get(JAVA_BYTE, addr), which C2 intrinsifies, so this beats the JDK
+// CharsetDecoder's decodeBufferLoop by 1.4-2.4x (see ReadStringDecodeBench). On the sun.misc.Unsafe
+// path (jvmMain, JVM 8-20 / Android) the equivalent Unsafe.getByte loop measured 2-3x SLOWER than
+// decodeBufferLoop, so that path keeps using the CharsetDecoder — there is no jvmMain counterpart.
+
+/**
+ * Per-thread scratch [CharArray] that [decodeUtf8FromNative] decodes into, grown on demand and kept
+ * for subsequent calls so steady-state reads of similar-sized payloads allocate nothing but the
+ * result String. UTF-8 never produces more chars than input bytes (1/2/3-byte scalars → 1 char,
+ * 4-byte → 2 chars, i.e. ≤1 char per byte), so a scratch of `byteCount` chars can never overflow.
+ */
+private val decodeCharScratch =
+    object : ThreadLocal<CharArray>() {
+        override fun initialValue(): CharArray = CharArray(INITIAL_DECODE_SCRATCH_CHARS)
+    }
+
+private const val INITIAL_DECODE_SCRATCH_CHARS = 1024
+
+/**
+ * Decodes the UTF-8 bytes in native memory at [base] + [[startPosition], [endPosition]) into a
+ * String. Read-side counterpart to [encodeUtf8ToNative]: it pulls each byte through [directGetByte]
+ * — a raw native load with no per-byte `java.nio.Buffer.session()` scope check — instead of the JDK
+ * `CharsetDecoder`, whose `decodeBufferLoop` (the only loop a *direct* ByteBuffer can take, since it
+ * has no backing array) does a `DirectByteBuffer.get()` — and thus a session check — for every byte.
+ * On JVM 21+ [directGetByte] is FFM-backed; on 8–20 it is `Unsafe`.
+ *
+ * Validation is strict and matches the REPORT-mode UTF-8 decoder it replaces: overlong forms
+ * (0xC0/0xC1 leads, and E0/F0 leads with a too-small second byte), UTF-16 surrogate scalars encoded
+ * as UTF-8 (ED A0..BF ...), code points above 0x10FFFF (F4 90.. and F5..FF leads), lone continuation
+ * bytes, and sequences truncated by [endPosition] all throw [MalformedInputException]. On a throw the
+ * caller's position is unchanged and the returned scratch holds a partial decode that is discarded.
+ *
+ * The one when-branch per UTF-8 sequence length (1-4 bytes) plus the continuation/overlong/surrogate
+ * guards drive detekt's CyclomaticComplexMethod and ThrowsCount counts — both intrinsic to a correct
+ * single-pass strict decoder, hence the suppressions.
+ */
+@Suppress("CyclomaticComplexMethod", "ThrowsCount", "NestedBlockDepth", "LongMethod")
+internal fun decodeUtf8FromNative(
+    base: Long,
+    startPosition: Int,
+    endPosition: Int,
+): String {
+    val byteCount = endPosition - startPosition
+    var chars = decodeCharScratch.get()
+    if (chars.size < byteCount) {
+        chars = CharArray(byteCount)
+        decodeCharScratch.set(chars)
+    }
+    var ci = 0
+    var pos = startPosition
+    while (pos < endPosition) {
+        val b0 = directGetByte(base + pos).toInt() and 0xFF
+        when {
+            b0 < 0x80 -> {
+                chars[ci++] = b0.toChar()
+                pos += 1
+            }
+            b0 < 0xC2 -> throw malformed() // 0x80..0xBF lone continuation, or 0xC0/0xC1 overlong lead
+            b0 < 0xE0 -> {
+                // 2-byte scalar 0x80..0x7FF.
+                if (pos + 2 > endPosition) throw malformed()
+                val b1 = directGetByte(base + pos + 1).toInt() and 0xFF
+                if (b1 and 0xC0 != 0x80) throw malformed()
+                chars[ci++] = (((b0 and 0x1F) shl 6) or (b1 and 0x3F)).toChar()
+                pos += 2
+            }
+            b0 < 0xF0 -> {
+                // 3-byte scalar 0x800..0xFFFF, excluding the surrogate range 0xD800..0xDFFF.
+                if (pos + 3 > endPosition) throw malformed()
+                val b1 = directGetByte(base + pos + 1).toInt() and 0xFF
+                val b2 = directGetByte(base + pos + 2).toInt() and 0xFF
+                if (b1 and 0xC0 != 0x80 || b2 and 0xC0 != 0x80) throw malformed()
+                if (b0 == 0xE0 && b1 < 0xA0) throw malformed() // overlong (would fit in 2 bytes)
+                if (b0 == 0xED && b1 >= 0xA0) throw malformed() // encoded UTF-16 surrogate
+                chars[ci++] = (((b0 and 0x0F) shl 12) or ((b1 and 0x3F) shl 6) or (b2 and 0x3F)).toChar()
+                pos += 3
+            }
+            b0 < 0xF5 -> {
+                // 4-byte scalar 0x10000..0x10FFFF → a UTF-16 surrogate pair.
+                if (pos + 4 > endPosition) throw malformed()
+                val b1 = directGetByte(base + pos + 1).toInt() and 0xFF
+                val b2 = directGetByte(base + pos + 2).toInt() and 0xFF
+                val b3 = directGetByte(base + pos + 3).toInt() and 0xFF
+                if (b1 and 0xC0 != 0x80 || b2 and 0xC0 != 0x80 || b3 and 0xC0 != 0x80) throw malformed()
+                if (b0 == 0xF0 && b1 < 0x90) throw malformed() // overlong (would fit in 3 bytes)
+                if (b0 == 0xF4 && b1 >= 0x90) throw malformed() // above 0x10FFFF
+                val cp = ((b0 and 0x07) shl 18) or ((b1 and 0x3F) shl 12) or ((b2 and 0x3F) shl 6) or (b3 and 0x3F)
+                val u = cp - 0x10000
+                chars[ci++] = (0xD800 or (u ushr 10)).toChar()
+                chars[ci++] = (0xDC00 or (u and 0x3FF)).toChar()
+                pos += 4
+            }
+            else -> throw malformed() // 0xF5..0xFF: no lead byte encodes a valid scalar
+        }
+    }
+    return String(chars, 0, ci)
+}
+
+// REPORT-mode decoders report the malformed *length* (the maximal subpart), but since we throw on
+// first error the exact length is immaterial — 1 keeps the exception shape identical to the encoder's.
+private fun malformed(): MalformedInputException = MalformedInputException(1)

--- a/buffer/src/jvmMain/kotlin/com/ditchoom/buffer/DirectJvmBuffer.kt
+++ b/buffer/src/jvmMain/kotlin/com/ditchoom/buffer/DirectJvmBuffer.kt
@@ -79,6 +79,13 @@ class DirectJvmBuffer(
         return true
     }
 
+    // No readString override here: the direct-from-native UTF-8 decode is a win only where the byte
+    // accessor is a JIT intrinsic — the FFM buffers on JDK 21+ (see jvm21Main/Utf8DirectDecode.kt).
+    // On the sun.misc.Unsafe path this class takes (JVM 8-20 / Android) a per-byte Unsafe.getByte loop
+    // measured 2-3x SLOWER than the JDK CharsetDecoder's decodeBufferLoop, so UTF-8 reads stay on the
+    // base BaseJvmBuffer.readString (CharsetDecoder) path. The write side (tryWriteUtf8ToNative) is a
+    // separate, already-shipped decision.
+
     // ktlint (no .editorconfig) collapses this expression body onto one line, so it cannot be wrapped.
     @Suppress("MaxLineLength")
     override fun slice(byteOrder: ByteOrder): DirectJvmBuffer = DirectJvmBuffer(byteBuffer.slice().order(byteOrder.toJava()))

--- a/buffer/src/jvmTest/kotlin/com/ditchoom/buffer/ReadStringDecodeBench.kt
+++ b/buffer/src/jvmTest/kotlin/com/ditchoom/buffer/ReadStringDecodeBench.kt
@@ -1,0 +1,126 @@
+package com.ditchoom.buffer
+
+import java.nio.ByteBuffer
+import kotlin.test.Test
+import kotlin.time.TimeSource
+
+/**
+ * Decode-path comparison for [decodeUtf8FromNative], the read-side counterpart to
+ * [encodeUtf8ToNative].
+ *
+ * The JVM cat-13 Autobahn profile on buffer 6.9.4 showed the JDK `CharsetDecoder` read path —
+ * `sun.nio.cs.UTF_8$Decoder.decodeBufferLoop` (+ its `decodeLoop` dispatcher) — as ~62% of client
+ * JVM CPU. A *direct* ByteBuffer has no backing array, so `CharsetDecoder.decode` can only take
+ * `decodeBufferLoop`, which does a `DirectByteBuffer.get()` — and thus a per-byte
+ * `java.nio.Buffer.session()` scope check — for every byte. `decodeUtf8FromNative` reads each byte
+ * through `directGetByte` (global-scope, no session check) instead, exactly as the write side does.
+ *
+ * This isolates that difference: identical native bytes, decoded to the identical String, once via
+ * the old reused-`CharsetDecoder` path ([CharsetDecoder.decodeReusing], what `readString` used to
+ * call) and once via the new [ReadBuffer.readString] fast path. CSV-friendly for diffing:
+ *
+ *   DECODE content=ascii chars=65536 strategy=native ns_per_op=NNNN mb_per_s=NNNN speedup=N.NN
+ *
+ * Run with:
+ *   ./gradlew :buffer:jvmFfmTest --tests "*.ReadStringDecodeBench"
+ * jvmFfmTest exercises the FFM buffers (FfmBuffer / FfmAutoBuffer) that take the native fast path —
+ * measured 1.4-2.4x over the CharsetDecoder. On the plain :jvmTest (sun.misc.Unsafe / DirectJvmBuffer)
+ * `readString` deliberately stays on the CharsetDecoder, so there the "native" row just re-measures
+ * the baseline (~1.0x): per-byte Unsafe.getByte was 2-3x slower than decodeBufferLoop, so it is not
+ * wired up. See jvm21Main/Utf8DirectDecode.kt for the gating rationale.
+ */
+class ReadStringDecodeBench {
+    @Test
+    fun benchDecode() {
+        val charCounts = listOf(1024, 64 * 1024)
+        val contents =
+            listOf(
+                "ascii" to ::buildAscii,
+                "cjk" to { n: Int -> repeatTo("é世ü界", n) },
+                "emoji" to ::buildEmoji,
+            )
+
+        for ((name, build) in contents) {
+            for (chars in charCounts) {
+                val text = build(chars)
+                val bytes = text.encodeToByteArray()
+
+                // Pre-build both inputs ONCE so the loop measures decode only, not allocation:
+                // a direct ByteBuffer for the CharsetDecoder path, a native-backed buffer for readString.
+                val direct = ByteBuffer.allocateDirect(bytes.size).put(bytes)
+                val decoder = Charset.UTF8.toDecoder()
+                val buffer = BufferFactory.Default.allocate(bytes.size).also { it.writeBytes(bytes) }
+
+                val baseline =
+                    measure {
+                        (direct as java.nio.Buffer).position(0).limit(bytes.size)
+                        decoder.decodeReusing(direct, bytes.size)
+                    }
+                val native =
+                    measure {
+                        buffer.position(0)
+                        buffer.readString(bytes.size, Charset.UTF8)
+                    }
+                for ((strategy, nsPerOp) in listOf("charsetDecoder" to baseline, "native" to native)) {
+                    val mbPerSec = if (nsPerOp > 0.0) bytes.size * 1000.0 / nsPerOp else 0.0
+                    val speedup = if (nsPerOp > 0.0) baseline / nsPerOp else 0.0
+                    println(
+                        "DECODE content=$name chars=$chars bytes=${bytes.size} strategy=$strategy " +
+                            "ns_per_op=${nsPerOp.toLong()} mb_per_s=${mbPerSec.toLong()} " +
+                            "speedup=${(speedup * 100).toLong() / 100.0}",
+                    )
+                }
+            }
+        }
+    }
+
+    /** Returns ns/op. Warms up, then runs for at least [MIN_RUN_MS]. */
+    private fun measure(decode: () -> String): Double {
+        repeat(WARMUP_ITERS) { decode() }
+        var iters = 0L
+        var sink = 0
+        val mark = TimeSource.Monotonic.markNow()
+        while (mark.elapsedNow().inWholeMilliseconds < MIN_RUN_MS) {
+            repeat(BATCH) { sink += decode().length }
+            iters += BATCH
+        }
+        val elapsedNs = mark.elapsedNow().inWholeNanoseconds
+        blackhole = sink
+        return elapsedNs.toDouble() / iters.toDouble()
+    }
+
+    private companion object {
+        @Volatile
+        private var blackhole: Int = 0
+
+        private const val WARMUP_ITERS = 2000
+        private const val BATCH = 128
+        private const val MIN_RUN_MS = 400L
+        private const val PRINTABLE_ASCII_START = 32
+        private const val PRINTABLE_ASCII_RANGE = 95
+
+        private fun buildAscii(charCount: Int): String {
+            val sb = StringBuilder(charCount)
+            for (i in 0 until charCount) {
+                sb.append((PRINTABLE_ASCII_START + (i % PRINTABLE_ASCII_RANGE)).toChar())
+            }
+            return sb.toString()
+        }
+
+        private fun repeatTo(
+            pattern: String,
+            charCount: Int,
+        ): String {
+            val sb = StringBuilder(charCount)
+            while (sb.length < charCount) sb.append(pattern)
+            return sb.substring(0, charCount)
+        }
+
+        private fun buildEmoji(charCount: Int): String {
+            val sb = StringBuilder(charCount)
+            while (sb.length + 2 <= charCount) sb.append('\uD83D').append('\uDE00')
+            while (sb.length < charCount) sb.append(' ')
+            return sb.toString()
+        }
+    }
+}

--- a/buffer/src/jvmTest/kotlin/com/ditchoom/buffer/ReadStringDirectUtf8Test.kt
+++ b/buffer/src/jvmTest/kotlin/com/ditchoom/buffer/ReadStringDirectUtf8Test.kt
@@ -1,0 +1,172 @@
+// UTF-8 bit patterns (0x80/0xC0/0xE0/0xF0 leads, 0x3F continuation, surrogate/overlong/ceiling
+// boundaries) read clearer as literals than named constants in a decoder conformance test. All
+// non-ASCII test text is written as \u escapes / code points so this source stays plain ASCII (a
+// literal U+FFFF/U+10FFFF non-character or U+007F control would make git treat the file as binary).
+@file:Suppress("MagicNumber")
+
+package com.ditchoom.buffer
+
+import java.nio.ByteBuffer
+import java.nio.charset.CharacterCodingException
+import java.nio.charset.CodingErrorAction
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * Locks the behaviour of the native UTF-8 read fast path (decodeUtf8FromNative), which replaces the
+ * direct-ByteBuffer CharsetDecoder loop (decodeBufferLoop) on the FFM buffers. Via jvmFfmTest this
+ * exercises FfmBuffer / FfmAutoBuffer (the native decode); on the base :jvmTest classpath
+ * (DirectJvmBuffer) `readString` stays on the CharsetDecoder, so there these assertions simply
+ * confirm the fallback still matches the reference.
+ *
+ * The decoder must be a byte-for-byte behavioural drop-in for the JDK `CharsetDecoder` in REPORT
+ * mode, so most assertions are *parity* assertions against that reference: same String on success,
+ * same throw on malformed input.
+ */
+class ReadStringDirectUtf8Test {
+    private fun readViaBuffer(bytes: ByteArray): String {
+        val buffer = BufferFactory.Default.allocate(maxOf(bytes.size, 1))
+        buffer.writeBytes(bytes)
+        buffer.resetForRead()
+        return buffer.readString(bytes.size, Charset.UTF8)
+    }
+
+    /** The reference: JDK UTF-8 decoder in REPORT mode, exactly what readString used to delegate to. */
+    private fun jdkDecode(bytes: ByteArray): Result<String> =
+        runCatching {
+            Charsets.UTF_8
+                .newDecoder()
+                .onMalformedInput(CodingErrorAction.REPORT)
+                .onUnmappableCharacter(CodingErrorAction.REPORT)
+                .decode(ByteBuffer.wrap(bytes))
+                .toString()
+        }
+
+    private fun assertParity(bytes: ByteArray) {
+        val reference = jdkDecode(bytes)
+        val ours = runCatching { readViaBuffer(bytes) }
+        val label = bytes.joinToString(" ") { "0x%02X".format(it) }
+        if (reference.isSuccess) {
+            assertTrue(ours.isSuccess, "JDK decoded [$label] but ours threw ${ours.exceptionOrNull()}")
+            assertEquals(reference.getOrNull(), ours.getOrNull(), "decoded value for [$label]")
+        } else {
+            val err = ours.exceptionOrNull()
+            assertTrue(
+                err is CharacterCodingException,
+                "JDK rejected [$label] but ours returned ${ours.getOrNull()?.let { "\"$it\"" } ?: err}",
+            )
+        }
+    }
+
+    @Test
+    fun `valid strings round-trip and match the JDK`() {
+        listOf(
+            "",
+            "hello, websocket!",
+            "héllo café", // 2-byte scalars
+            "世界 界世", // 3-byte CJK
+            cp(0x1F600) + cp(0x1F389) + " mixed 世 é a", // 4-byte emoji + mix
+            "\u007f", // highest 1-byte scalar
+            "߿", // highest 2-byte scalar
+            "\u0800\uffff", // 3-byte range ends (U+FFFF is a valid, non-surrogate scalar)
+            cp(0x10000), // lowest 4-byte scalar
+            cp(0x10FFFF), // highest scalar
+            "a".repeat(5000), // long ASCII run (the cat-13 shape)
+        ).forEach { assertParity(it.encodeToByteArray()) }
+    }
+
+    @Test
+    fun `malformed sequences throw exactly where the JDK does`() {
+        val malformed =
+            listOf(
+                byteArrayOf(0x80.toByte()), // lone continuation
+                byteArrayOf(0xBF.toByte()),
+                byteArrayOf(0xC0.toByte(), 0x80.toByte()), // overlong 2-byte
+                byteArrayOf(0xC1.toByte(), 0xBF.toByte()),
+                byteArrayOf(0xC3.toByte(), 0x28), // bad continuation
+                byteArrayOf(0xC3.toByte()), // truncated 2-byte
+                byteArrayOf(0xE0.toByte(), 0x80.toByte(), 0x80.toByte()), // overlong 3-byte
+                byteArrayOf(0xE0.toByte(), 0x9F.toByte(), 0xBF.toByte()),
+                byteArrayOf(0xED.toByte(), 0xA0.toByte(), 0x80.toByte()), // U+D800 surrogate
+                byteArrayOf(0xED.toByte(), 0xBF.toByte(), 0xBF.toByte()), // U+DFFF surrogate
+                byteArrayOf(0xE4.toByte(), 0xB8.toByte()), // truncated 3-byte
+                byteArrayOf(0xE4.toByte()),
+                byteArrayOf(0xF0.toByte(), 0x80.toByte(), 0x80.toByte(), 0x80.toByte()), // overlong 4-byte
+                byteArrayOf(0xF0.toByte(), 0x8F.toByte(), 0xBF.toByte(), 0xBF.toByte()),
+                byteArrayOf(0xF4.toByte(), 0x90.toByte(), 0x80.toByte(), 0x80.toByte()), // U+110000
+                byteArrayOf(0xF5.toByte(), 0x80.toByte(), 0x80.toByte(), 0x80.toByte()), // invalid lead
+                byteArrayOf(0xF0.toByte(), 0x9F.toByte(), 0x98.toByte()), // truncated 4-byte
+                byteArrayOf(0xF8.toByte()), // invalid lead
+                byteArrayOf(0xFF.toByte()),
+                byteArrayOf(0x61, 0xFF.toByte()), // valid then invalid
+                byteArrayOf(0x61, 0xE4.toByte(), 0xB8.toByte(), 0xAD.toByte(), 0xFF.toByte()), // valid... then bad
+            )
+        malformed.forEach { assertParity(it) }
+    }
+
+    @Test
+    fun `exhaustive two-byte lead x continuation parity`() {
+        // Every (lead 0xC0..0xDF, second 0x00..0xFF) pair: our accept/reject must equal the JDK's.
+        for (lead in 0xC0..0xDF) {
+            for (second in 0x00..0xFF) {
+                assertParity(byteArrayOf(lead.toByte(), second.toByte()))
+            }
+        }
+    }
+
+    @Test
+    fun `every scalar in the BMP and a sweep of astral planes round-trips`() {
+        val sb = StringBuilder()
+        for (scalar in 0..0xFFFF) {
+            if (scalar in 0xD800..0xDFFF) continue // unpaired surrogates aren't valid scalars
+            sb.appendCodePoint(scalar)
+        }
+        var scalar = 0x10000
+        while (scalar <= 0x10FFFF) {
+            sb.appendCodePoint(scalar)
+            scalar += 0x40 // sample the astral planes; a full sweep is 1M+ and adds no new code path
+        }
+        assertParity(sb.toString().encodeToByteArray())
+    }
+
+    @Test
+    fun `malformed read leaves position unchanged for a retry`() {
+        val buffer = BufferFactory.Default.allocate(4)
+        buffer.writeBytes(byteArrayOf(0xC3.toByte(), 0x28, 0x41, 0x42)) // bad pair, then "AB"
+        buffer.resetForRead()
+        assertFailsWith<CharacterCodingException> { buffer.readString(2, Charset.UTF8) }
+        // A throw must not consume input: re-reading the same bytes as a longer window still sees them.
+        assertEquals(0, buffer.position(), "position must be unchanged after a malformed read")
+    }
+
+    @Test
+    fun `non-UTF8 charset falls back to the decoder path`() {
+        val bytes = byteArrayOf(0xE9.toByte(), 0x20) // 0xE9 = U+00E9 in Latin-1
+        val buffer = BufferFactory.Default.allocate(bytes.size)
+        buffer.writeBytes(bytes)
+        buffer.resetForRead()
+        assertEquals("é ", buffer.readString(bytes.size, Charset.ISOLatin1))
+    }
+
+    @Test
+    fun `partial reads advance position across multibyte boundaries`() {
+        val text = "aé世" + cp(0x1F600) + "z" // a, U+00E9 (2B), U+4E16 (3B), emoji (4B), z
+        val bytes = text.encodeToByteArray()
+        val buffer = BufferFactory.Default.allocate(bytes.size)
+        buffer.writeBytes(bytes)
+        buffer.resetForRead()
+        assertEquals("a", buffer.readString(1, Charset.UTF8))
+        assertEquals("é", buffer.readString(2, Charset.UTF8))
+        assertEquals("世", buffer.readString(3, Charset.UTF8))
+        assertEquals(cp(0x1F600) + "z", buffer.readString(bytes.size - 6, Charset.UTF8))
+        if (buffer.remaining() != 0) fail("expected buffer fully consumed")
+    }
+
+    private companion object {
+        /** A String holding the single Unicode scalar [scalar] (a surrogate pair for astral ones). */
+        private fun cp(scalar: Int): String = String(Character.toChars(scalar))
+    }
+}


### PR DESCRIPTION
## What

Read-side counterpart to #285 (`encodeUtf8ToNative`). Replaces the JDK `CharsetDecoder` on the UTF-8 `readString` path for the FFM buffers with `decodeUtf8FromNative`, which reads bytes straight off the native address via `directGetByte` and decodes into a reused thread-local `CharArray`.

## Why (the profile that pointed here)

The JVM cat-13 Autobahn profile on buffer 6.9.4 (which shipped #285's direct-to-native **encode**) showed the JDK **decode** path as the new top cost:

| baseline (6.9.4) hot method | samples | % JVM CPU |
|---|---|---|
| `UTF_8$Decoder.decodeBufferLoop` | 55 | 44.7% |
| `UTF_8$Decoder.decodeLoop` | 21 | 17.1% |
| **decode total** | **76** | **~62%** |

A *direct* `ByteBuffer` has no backing array, so `CharsetDecoder.decode` can only take `decodeBufferLoop`, which does a `DirectByteBuffer.get()` — and thus a per-byte `java.nio.Buffer.session()` scope check — for **every byte**. `decodeUtf8FromNative` reads through `directGetByte` (global-scope FFM access, no session check) instead — exactly the mechanism #285 used on the write side.

## Results

**Micro-benchmark** (`ReadStringDecodeBench`, `:jvmFfmTest`, native vs the reused `CharsetDecoder` on the same direct bytes, median of 3):

| content | 1 KB | 64 KB |
|---|---|---|
| ascii | **2.35×** | **1.94×** |
| cjk   | 1.63× | 1.58× |
| emoji | 1.47× | 1.47× |

**End-to-end** (Autobahn cat-13, 18×1000 msgs, local, JFR `settings=profile` — same harness as `autobahn-profile.yaml`):

- Wall-clock **30.3s → 26.7s (~12% faster)** across the batch — and that *includes* server round-trip time this change can't touch.
- JFR after: `decodeBufferLoop`/`decodeLoop` **gone**, replaced by `decodeUtf8FromNative` (44% of a ~20%-smaller total).
- cat-13 conformance passes.

## Constraints honoured

- **No `ByteArray`** — bytes are read from native memory; output is a `CharArray`, and the one copy is into the result `String` (identical to what the `CharsetDecoder` path already did).
- **No nullable** — per-class `readString` override delegating to `super` on the fallback; no sentinel.
- **No extra copies** vs the path it replaces.

## FFM-only on purpose (not a shadow twin)

Unlike `Utf8DirectEncode.kt`, this lives **only** in `jvm21Main`. The win requires an *intrinsic* byte accessor:

- FFM path (`FfmBuffer`/`FfmAutoBuffer`, JDK 21+): `directGetByte` = `EVERYTHING.get(JAVA_BYTE, addr)`, which C2 intrinsifies → **1.4–2.4×**.
- `sun.misc.Unsafe` path (`DirectJvmBuffer`, JVM 8–20 / Android): a per-byte `Unsafe.getByte` loop measured **2–3× slower** than `decodeBufferLoop`, so that path deliberately **stays on the `CharsetDecoder`**. No `jvmMain` counterpart is added.

(The websocket frame path uses `BufferFactory.deterministic()` = FFM on 21+, so it gets the fast path; the end-to-end run above is that path.)

## Correctness

`decodeUtf8FromNative` is a byte-for-byte behavioural drop-in for the REPORT-mode UTF-8 decoder: overlong forms, encoded UTF-16 surrogates, code points > 0x10FFFF, lone continuations, and sequences truncated by the read window all throw `MalformedInputException`; position is unchanged on a throw.

`ReadStringDirectUtf8Test` asserts **parity against the JDK `CharsetDecoder`** — including an exhaustive 2-byte lead×continuation sweep and a full-BMP + astral-plane sweep — and passes on **both** `:jvmTest` (fallback/`CharsetDecoder`) and `:jvmFfmTest` (native decode). ktlint + detekt clean.

## Status: DRAFT

Holding for review. The Unsafe/Android read path is future work (would need a bulk/8-byte-gulp ASCII decode to beat `decodeBufferLoop`, and real JVM 8–20 benchmarking — this box only has JDK 21).
