### PR TITLE
feat(crypto): add HMAC-SHA1 (buffer-crypto) + CRC-32 (buffer core)

### DIFF
--- a/buffer-crypto/api/android/buffer-crypto.api
+++ b/buffer-crypto/api/android/buffer-crypto.api
@@ -334,6 +334,22 @@ public final class com/ditchoom/buffer/crypto/HkdfSha512 {
 	public final fun extractInto (Lcom/ditchoom/buffer/crypto/Salt;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/WriteBuffer;)V
 }
 
+public final class com/ditchoom/buffer/crypto/HmacSha1Kt {
+	public static final field HMAC_SHA1_BYTES I
+	public static final field SHA1_BLOCK_BYTES I
+	public static final field SHA1_DIGEST_BYTES I
+	public static final fun hmacSha1 (Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;)Lcom/ditchoom/buffer/ReadBuffer;
+	public static final fun hmacSha1 (Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/WriteBuffer;)V
+	public static synthetic fun hmacSha1$default (Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;ILjava/lang/Object;)Lcom/ditchoom/buffer/ReadBuffer;
+}
+
+public final class com/ditchoom/buffer/crypto/HmacSha1Mac : java/lang/AutoCloseable {
+	public fun <init> (Lcom/ditchoom/buffer/ReadBuffer;)V
+	public fun close ()V
+	public final fun doFinalInto (Lcom/ditchoom/buffer/WriteBuffer;)V
+	public final fun update (Lcom/ditchoom/buffer/ReadBuffer;)Lcom/ditchoom/buffer/crypto/HmacSha1Mac;
+}
+
 public final class com/ditchoom/buffer/crypto/HmacSha256Kt {
 	public static final field HMAC_SHA256_BYTES I
 	public static final fun hmacSha256 (Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;)Lcom/ditchoom/buffer/ReadBuffer;

--- a/buffer-crypto/api/jvm/buffer-crypto.api
+++ b/buffer-crypto/api/jvm/buffer-crypto.api
@@ -319,6 +319,22 @@ public final class com/ditchoom/buffer/crypto/HkdfSha512 {
 	public final fun extractInto (Lcom/ditchoom/buffer/crypto/Salt;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/WriteBuffer;)V
 }
 
+public final class com/ditchoom/buffer/crypto/HmacSha1Kt {
+	public static final field HMAC_SHA1_BYTES I
+	public static final field SHA1_BLOCK_BYTES I
+	public static final field SHA1_DIGEST_BYTES I
+	public static final fun hmacSha1 (Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;)Lcom/ditchoom/buffer/ReadBuffer;
+	public static final fun hmacSha1 (Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/WriteBuffer;)V
+	public static synthetic fun hmacSha1$default (Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;ILjava/lang/Object;)Lcom/ditchoom/buffer/ReadBuffer;
+}
+
+public final class com/ditchoom/buffer/crypto/HmacSha1Mac : java/lang/AutoCloseable {
+	public fun <init> (Lcom/ditchoom/buffer/ReadBuffer;)V
+	public fun close ()V
+	public final fun doFinalInto (Lcom/ditchoom/buffer/WriteBuffer;)V
+	public final fun update (Lcom/ditchoom/buffer/ReadBuffer;)Lcom/ditchoom/buffer/crypto/HmacSha1Mac;
+}
+
 public final class com/ditchoom/buffer/crypto/HmacSha256Kt {
 	public static final field HMAC_SHA256_BYTES I
 	public static final fun hmacSha256 (Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;)Lcom/ditchoom/buffer/ReadBuffer;

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HmacSha1Mac.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HmacSha1Mac.apple.kt
@@ -1,0 +1,63 @@
+@file:Suppress("MatchingDeclarationName") // MPP platform-suffixed actual file
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.nativeHeap
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.sizeOf
+import platform.CoreCrypto.CCHmacContext
+import platform.CoreCrypto.CCHmacFinal
+import platform.CoreCrypto.CCHmacInit
+import platform.CoreCrypto.CCHmacUpdate
+import platform.CoreCrypto.kCCHmacAlgSHA1
+import platform.posix.memset
+
+/** Apple HMAC-SHA1 backed by CommonCrypto (`CCHmac`). Reads and writes via buffer pointers — no arrays. */
+actual class HmacSha1Mac actual constructor(
+    key: ReadBuffer,
+) : AutoCloseable {
+    private val ctx = nativeHeap.alloc<CCHmacContext>()
+    private var finalized = false
+
+    init {
+        if (key.remaining() == 0) {
+            CCHmacInit(ctx.ptr, kCCHmacAlgSHA1, null, 0.convert())
+        } else {
+            key.withRemainingBytes { ptr, len -> CCHmacInit(ctx.ptr, kCCHmacAlgSHA1, ptr, len.convert()) }
+        }
+    }
+
+    actual fun update(input: ReadBuffer): HmacSha1Mac {
+        check(!finalized) { "mac already finalized" }
+        input.withRemainingBytes { ptr, len -> CCHmacUpdate(ctx.ptr, ptr, len.convert()) }
+        return this
+    }
+
+    actual fun doFinalInto(dest: WriteBuffer) {
+        check(!finalized) { "mac already finalized" }
+        // CommonCrypto writes the 20-byte tag straight into the destination buffer's memory.
+        // withWritablePointer validates capacity BEFORE invoking the block, so a too-small
+        // dest throws here with the ctx untouched — the finalize stays retryable (C1).
+        dest.withWritablePointer(SHA1_DIGEST_BYTES) { ptr -> CCHmacFinal(ctx.ptr, ptr) }
+        finalized = true
+        releaseCtx()
+    }
+
+    actual override fun close() {
+        if (finalized) return
+        finalized = true
+        releaseCtx()
+    }
+
+    // The context holds key-derived ipad/opad state; zero it before returning the allocation.
+    private fun releaseCtx() {
+        memset(ctx.ptr, 0, sizeOf<CCHmacContext>().convert())
+        nativeHeap.free(ctx.rawPtr)
+    }
+}

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha1.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha1.kt
@@ -1,0 +1,86 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+
+/** SHA-1 digest length in bytes (FIPS 180-4). */
+const val SHA1_DIGEST_BYTES = 20
+
+/** SHA-1 internal block length in bytes. */
+const val SHA1_BLOCK_BYTES = 64
+
+/** HMAC-SHA1 output length in bytes (equals the SHA-1 digest length). */
+const val HMAC_SHA1_BYTES = SHA1_DIGEST_BYTES
+
+/**
+ * Incremental HMAC-SHA1 (RFC 2104).
+ *
+ * Backed by the platform's native MAC (JCA `Mac("HmacSHA1")` on JVM/Android, CommonCrypto
+ * `CCHmac` on Apple, BoringSSL `HMAC_*` on Linux) and by a pure-Kotlin implementation on js/wasmJs.
+ *
+ * SHA-1 is retained here **only** where an interop obligation demands it — STUN/TURN
+ * MESSAGE-INTEGRITY (RFC 8489/8656) and the legacy SRTP suite `SRTP_AES128_CM_SHA1_80`
+ * (RFC 3711). It is not a general-purpose digest choice; new protocols should prefer
+ * [HmacSha256Mac].
+ *
+ * The key is the remaining bytes of the [key] buffer passed to the constructor.
+ * Feed the message with [update] (call repeatedly to MAC `a ‖ b` without concatenating),
+ * then [doFinalInto] to write the 20-byte tag into a caller-owned destination.
+ * Reads are non-destructive (operate on `slice()`s).
+ *
+ * Not thread-safe — use one instance per MAC. Key-bearing intermediates are wiped after use.
+ * One-shot: [update] or [doFinalInto] after finalization throws [IllegalStateException].
+ */
+expect class HmacSha1Mac(
+    key: ReadBuffer,
+) : AutoCloseable {
+    /** Absorbs the remaining bytes of [input] (non-destructive). Returns `this` for chaining. */
+    fun update(input: ReadBuffer): HmacSha1Mac
+
+    /**
+     * Finalizes and writes [HMAC_SHA1_BYTES] bytes into [dest] at its current
+     * position, advancing it. [dest] must have at least [HMAC_SHA1_BYTES] remaining.
+     * Releases the MAC state; any further [update]/[doFinalInto] throws [IllegalStateException].
+     */
+    fun doFinalInto(dest: WriteBuffer)
+
+    /**
+     * Releases the (key-derived) MAC state without producing a tag — for a MAC abandoned before
+     * [doFinalInto] (which releases the state itself). Idempotent; a no-op after [doFinalInto].
+     */
+    override fun close()
+}
+
+/**
+ * One-shot HMAC-SHA1 of [message] under [key], written into [dest] (zero allocation).
+ *
+ * [dest] must have at least [HMAC_SHA1_BYTES] remaining.
+ */
+fun hmacSha1(
+    key: ReadBuffer,
+    message: ReadBuffer,
+    dest: WriteBuffer,
+) {
+    require(dest.remaining() >= HMAC_SHA1_BYTES) {
+        "dest needs $HMAC_SHA1_BYTES bytes remaining, has ${dest.remaining()}"
+    }
+    HmacSha1Mac(key).update(message).doFinalInto(dest)
+}
+
+/**
+ * One-shot HMAC-SHA1 of [message] under [key], returning a freshly allocated,
+ * read-ready buffer allocated via [factory].
+ */
+fun hmacSha1(
+    key: ReadBuffer,
+    message: ReadBuffer,
+    factory: BufferFactory = BufferFactory.Default,
+): ReadBuffer {
+    val out: PlatformBuffer = factory.allocate(HMAC_SHA1_BYTES)
+    HmacSha1Mac(key).update(message).doFinalInto(out)
+    out.resetForRead()
+    return out
+}

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/HmacSha1Test.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/HmacSha1Test.kt
@@ -1,0 +1,59 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.crypto.CryptoTestVectors.ascii
+import com.ditchoom.buffer.crypto.CryptoTestVectors.repeatedByte
+import com.ditchoom.buffer.crypto.CryptoTestVectors.toHex
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/** RFC 2202 known-answer vectors for HMAC-SHA1. */
+class HmacSha1Test {
+    @Test
+    fun case1() {
+        // key = 0x0b x20, data = "Hi There"
+        assertEquals(
+            "b617318655057264e28bc0b6fb378c8ef146be00",
+            hmacSha1(repeatedByte(0x0b, 20), ascii("Hi There")).toHex(),
+        )
+    }
+
+    @Test
+    fun case2() {
+        // key = "Jefe", data = "what do ya want for nothing?"
+        assertEquals(
+            "effcdf6ae5eb2fa2d27416d5f184df9c259a7c79",
+            hmacSha1(ascii("Jefe"), ascii("what do ya want for nothing?")).toHex(),
+        )
+    }
+
+    @Test
+    fun case3LongData() {
+        // key = 0xaa x20, data = 0xdd x50
+        assertEquals(
+            "125d7342b9ac11cd91a39af48aa17b4f63f175d3",
+            hmacSha1(repeatedByte(0xaa, 20), repeatedByte(0xdd, 50)).toHex(),
+        )
+    }
+
+    @Test
+    fun case6LongKeyIsHashed() {
+        // key = 0xaa x80 (longer than the 64-byte block → key gets pre-hashed)
+        assertEquals(
+            "aa4ae5e15272d00e95705637ce8a3b55ed402112",
+            hmacSha1(
+                repeatedByte(0xaa, 80),
+                ascii("Test Using Larger Than Block-Size Key - Hash Key First"),
+            ).toHex(),
+        )
+    }
+
+    @Test
+    fun streamedMessageMatchesOneShot() {
+        val out = BufferFactory.Default.allocate(HMAC_SHA1_BYTES)
+        HmacSha1Mac(repeatedByte(0x0b, 20)).update(ascii("Hi ")).update(ascii("There")).doFinalInto(out)
+        out.resetForRead()
+        assertEquals("b617318655057264e28bc0b6fb378c8ef146be00", out.toHex())
+    }
+}

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/HmacSha1Mac.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/HmacSha1Mac.jsAndWasmJs.kt
@@ -1,0 +1,72 @@
+@file:Suppress("MatchingDeclarationName") // MPP platform-suffixed actual file
+
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.managed
+
+/** js/wasmJs HMAC-SHA1 (RFC 2104) over the pure-Kotlin [Sha1Core]. Holds no primitive arrays. */
+actual class HmacSha1Mac actual constructor(
+    key: ReadBuffer,
+) : AutoCloseable {
+    // inner accumulates H(ipad ‖ message); opad (a managed buffer) is held for the outer hash.
+    private val inner = Sha1Core()
+    private val opad: PlatformBuffer = BufferFactory.managed().allocate(SHA1_BLOCK_BYTES)
+    private var finalized = false
+
+    init {
+        // Normalize the key to a single block (managed buffer, zero-initialized): hash it if
+        // longer than a block, else zero-pad.
+        val kBlock: PlatformBuffer = BufferFactory.managed().allocate(SHA1_BLOCK_BYTES)
+        val n = key.remaining()
+        val start = key.position()
+        if (n > SHA1_BLOCK_BYTES) {
+            val kh = Sha1Core()
+            kh.update(key)
+            kh.finish()
+            for (i in 0 until SHA1_DIGEST_BYTES) kBlock.set(i, kh.digestByte(i))
+        } else {
+            for (i in 0 until n) kBlock.set(i, key.get(start + i))
+        }
+        for (i in 0 until SHA1_BLOCK_BYTES) {
+            val kb = kBlock.get(i).toInt()
+            inner.absorbByte((kb xor HMAC_IPAD).toByte()) // ipad
+            opad.set(i, (kb xor HMAC_OPAD).toByte())
+        }
+        kBlock.fill(0) // wipe the key-derived block
+    }
+
+    actual fun update(input: ReadBuffer): HmacSha1Mac {
+        check(!finalized) { "mac already finalized" }
+        inner.update(input)
+        return this
+    }
+
+    actual fun doFinalInto(dest: WriteBuffer) {
+        check(!finalized) { "mac already finalized" }
+        // Validate BEFORE finish(): the core's padding absorb is not re-runnable, so a
+        // short dest must fail while the state is still retryable (C1).
+        require(dest.remaining() >= HMAC_SHA1_BYTES) {
+            "dest needs $HMAC_SHA1_BYTES bytes remaining, has ${dest.remaining()}"
+        }
+        inner.finish() // inner = H(ipad ‖ message)
+        val outer = Sha1Core()
+        for (i in 0 until SHA1_BLOCK_BYTES) outer.absorbByte(opad.get(i))
+        for (i in 0 until SHA1_DIGEST_BYTES) outer.absorbByte(inner.digestByte(i))
+        outer.finish()
+        for (i in 0 until SHA1_DIGEST_BYTES) dest.writeByte(outer.digestByte(i))
+        opad.fill(0)
+        finalized = true
+    }
+
+    actual override fun close() {
+        // GC-managed state; nothing to free beyond wiping opad. The flag still bars further
+        // use, matching the other platforms' post-close behavior.
+        if (finalized) return
+        opad.fill(0)
+        finalized = true
+    }
+}

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Sha1Core.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Sha1Core.kt
@@ -127,10 +127,10 @@ internal class Sha1Core {
                     k = K4
                 }
             }
-            val temp = a.rotateLeft(5) + f + e + k + work.getInt(t * WORD_BYTES).toUInt()
+            val temp = a.rotateLeft(ROTL_TEMP) + f + e + k + work.getInt(t * WORD_BYTES).toUInt()
             e = d
             d = c
-            c = b.rotateLeft(30)
+            c = b.rotateLeft(ROTL_C)
             b = a
             a = temp
         }
@@ -156,6 +156,11 @@ internal class Sha1Core {
         private const val ROUND1_END = 20
         private const val ROUND2_END = 40
         private const val ROUND3_END = 60
+
+        // SHA-1 round mixing left-rotate amounts (FIPS 180-4 §6.1.2): ROTL^5(a) in the temp, ROTL^30(b) into c.
+        private const val ROTL_TEMP = 5
+        private const val ROTL_C = 30
+
         private const val K1 = 0x5A827999u
         private const val K2 = 0x6ED9EBA1u
         private const val K3 = 0x8F1BBCDCu

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Sha1Core.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Sha1Core.kt
@@ -1,0 +1,164 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.managed
+
+/**
+ * Pure-Kotlin streaming SHA-1 (FIPS 180-4), used as the js/wasmJs fallback because WebCrypto's
+ * `SubtleCrypto.digest` is async-only and cannot satisfy the synchronous [HmacSha1Mac] contract.
+ *
+ * SHA-1 is retained only for the interop obligations documented on [HmacSha1Mac] (STUN/TURN
+ * MESSAGE-INTEGRITY, legacy SRTP); it is not a general-purpose digest.
+ *
+ * Holds **no primitive arrays**: the working state lives in a single big-endian managed [work]
+ * buffer (message block in words 0..15, expanded schedule in words 16..79, read and written
+ * word-at-a-time via absolute `getInt`/`set`) and five `UInt` hash-state fields. Correctness is
+ * pinned by the common NIST/RFC known-answer vectors.
+ *
+ * Not thread-safe — one instance per digest.
+ */
+internal class Sha1Core {
+    private var h0 = 0x67452301u
+    private var h1 = 0xEFCDAB89u
+    private var h2 = 0x98BADCFEu
+    private var h3 = 0x10325476u
+    private var h4 = 0xC3D2E1F0u
+
+    // 64-byte message block (bytes 0..63 = schedule words 0..15) plus room for the
+    // expanded schedule words 16..79 (bytes 64..319). One allocation, no arrays.
+    private val work: PlatformBuffer = BufferFactory.managed().allocate(SCHEDULE_BYTES, ByteOrder.BIG_ENDIAN)
+    private var blockLen = 0
+    private var totalBytes = 0L
+
+    /** Absorbs the remaining bytes of [input] without disturbing its position. */
+    fun update(input: ReadBuffer) {
+        val start = input.position()
+        val end = input.limit()
+        var i = start
+        while (i < end) {
+            absorbByte(input.get(i))
+            i++
+        }
+    }
+
+    /** Absorbs a single byte. */
+    fun absorbByte(b: Byte) {
+        work.set(blockLen, b)
+        blockLen++
+        if (blockLen == SHA1_BLOCK_BYTES) {
+            processBlock()
+            blockLen = 0
+        }
+        totalBytes++
+    }
+
+    /** Pads and finalizes; afterwards [digestByte] returns the digest bytes. */
+    fun finish() {
+        val bitLen = totalBytes * 8
+        work.set(blockLen, 0x80.toByte())
+        blockLen++
+        if (blockLen > SHA1_BLOCK_BYTES - LENGTH_FIELD_BYTES) {
+            while (blockLen < SHA1_BLOCK_BYTES) {
+                work.set(blockLen, 0.toByte())
+                blockLen++
+            }
+            processBlock()
+            blockLen = 0
+        }
+        while (blockLen < SHA1_BLOCK_BYTES - LENGTH_FIELD_BYTES) {
+            work.set(blockLen, 0.toByte())
+            blockLen++
+        }
+        work.set(SHA1_BLOCK_BYTES - LENGTH_FIELD_BYTES, bitLen) // 64-bit big-endian length at bytes 56..63
+        processBlock()
+    }
+
+    /** Digest byte [i] (0..19), valid only after [finish]. */
+    fun digestByte(i: Int): Byte {
+        val word =
+            when (i ushr 2) {
+                0 -> h0
+                1 -> h1
+                2 -> h2
+                3 -> h3
+                else -> h4
+            }
+        return (word shr (HIGH_BYTE_SHIFT - BITS_PER_BYTE * (i and BYTE_INDEX_MASK))).toByte()
+    }
+
+    private fun processBlock() {
+        // Expand schedule words 16..79 in place (words 0..15 are the message block).
+        for (t in MESSAGE_WORDS until SCHEDULE_WORDS) {
+            val x =
+                work.getInt((t - 3) * WORD_BYTES).toUInt() xor
+                    work.getInt((t - 8) * WORD_BYTES).toUInt() xor
+                    work.getInt((t - 14) * WORD_BYTES).toUInt() xor
+                    work.getInt((t - 16) * WORD_BYTES).toUInt()
+            work.set(t * WORD_BYTES, x.rotateLeft(1).toInt())
+        }
+
+        var a = h0
+        var b = h1
+        var c = h2
+        var d = h3
+        var e = h4
+
+        for (t in 0 until SCHEDULE_WORDS) {
+            val f: UInt
+            val k: UInt
+            when {
+                t < ROUND1_END -> {
+                    f = (b and c) or (b.inv() and d)
+                    k = K1
+                }
+                t < ROUND2_END -> {
+                    f = b xor c xor d
+                    k = K2
+                }
+                t < ROUND3_END -> {
+                    f = (b and c) or (b and d) or (c and d)
+                    k = K3
+                }
+                else -> {
+                    f = b xor c xor d
+                    k = K4
+                }
+            }
+            val temp = a.rotateLeft(5) + f + e + k + work.getInt(t * WORD_BYTES).toUInt()
+            e = d
+            d = c
+            c = b.rotateLeft(30)
+            b = a
+            a = temp
+        }
+
+        h0 += a
+        h1 += b
+        h2 += c
+        h3 += d
+        h4 += e
+    }
+
+    companion object {
+        private const val LENGTH_FIELD_BYTES = 8 // trailing 64-bit big-endian message length
+        private const val SCHEDULE_WORDS = 80 // SHA-1 message-schedule / round count
+        private const val MESSAGE_WORDS = 16 // words taken straight from the input block
+        private const val WORD_BYTES = 4 // 32-bit word width
+        private const val SCHEDULE_BYTES = SCHEDULE_WORDS * WORD_BYTES // 80 words × 4 bytes
+        private const val HIGH_BYTE_SHIFT = 24 // shift to the most-significant byte of a word
+        private const val BITS_PER_BYTE = 8
+        private const val BYTE_INDEX_MASK = 3 // i mod 4 → byte within the word
+
+        // Per-round boundaries and constants (FIPS 180-4 §6.1.2).
+        private const val ROUND1_END = 20
+        private const val ROUND2_END = 40
+        private const val ROUND3_END = 60
+        private const val K1 = 0x5A827999u
+        private const val K2 = 0x6ED9EBA1u
+        private const val K3 = 0x8F1BBCDCu
+        private const val K4 = 0xCA62C1D6u
+    }
+}

--- a/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha1Mac.jvmCommon.kt
+++ b/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/HmacSha1Mac.jvmCommon.kt
@@ -1,0 +1,55 @@
+@file:Suppress("MatchingDeclarationName") // MPP platform-suffixed actual file
+
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.managedMemoryAccess
+import com.ditchoom.buffer.toByteArray
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+/** JVM/Android HMAC-SHA1 backed by the JCA [Mac]. */
+actual class HmacSha1Mac actual constructor(
+    key: ReadBuffer,
+) : AutoCloseable {
+    private val mac =
+        Mac.getInstance("HmacSHA1").apply {
+            val managed = key.managedMemoryAccess
+            val spec =
+                if (managed != null) {
+                    // SecretKeySpec copies the requested range, so no aliasing of the source buffer.
+                    SecretKeySpec(
+                        managed.backingArray,
+                        managed.arrayOffset + key.position(),
+                        key.remaining(),
+                        "HmacSHA1",
+                    )
+                } else {
+                    SecretKeySpec(key.toByteArray(), "HmacSHA1")
+                }
+            init(spec)
+        }
+    private var finalized = false
+
+    actual fun update(input: ReadBuffer): HmacSha1Mac {
+        check(!finalized) { "mac already finalized" }
+        mac.updateRemaining(input)
+        return this
+    }
+
+    actual fun doFinalInto(dest: WriteBuffer) {
+        // JCA resets the mac for reuse; the cross-platform contract is one-shot, so reject reuse.
+        check(!finalized) { "mac already finalized" }
+        // doFinalInto validates capacity BEFORE consuming the JCA state, so a too-small
+        // dest throws with the MAC still intact — the finalize stays retryable (C1).
+        mac.doFinalInto(dest)
+        finalized = true
+    }
+
+    actual override fun close() {
+        if (finalized) return
+        finalized = true
+        mac.reset()
+    }
+}

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/HmacSha1Mac.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/HmacSha1Mac.linux.kt
@@ -1,0 +1,55 @@
+@file:Suppress("MatchingDeclarationName") // MPP platform-suffixed actual file
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_hmac_final
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_hmac_sha1_new
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_hmac_update
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.UByteVar
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.reinterpret
+
+/** Linux HMAC-SHA1 backed by BoringSSL (`HMAC_*`). Reads and writes via buffer pointers — no arrays. */
+actual class HmacSha1Mac actual constructor(
+    key: ReadBuffer,
+) : AutoCloseable {
+    private val ctx =
+        run {
+            var c = if (key.remaining() == 0) bcl_hmac_sha1_new(null, 0.convert()) else null
+            key.withRemainingBytes { ptr, len -> c = bcl_hmac_sha1_new(ptr.reinterpret(), len.convert()) }
+            c ?: error("HMAC_Init failed")
+        }
+    private var finalized = false
+
+    actual fun update(input: ReadBuffer): HmacSha1Mac {
+        check(!finalized) { "mac already finalized" }
+        input.withRemainingBytes { ptr, len -> bcl_hmac_update(ctx, ptr.reinterpret(), len.convert()) }
+        return this
+    }
+
+    actual fun doFinalInto(dest: WriteBuffer) {
+        check(!finalized) { "mac already finalized" }
+        // withWritablePointer validates capacity BEFORE invoking the block, so a too-small
+        // dest throws with the ctx untouched (not yet freed by the shim) — the finalize
+        // stays retryable (C1). The flag is set only after the shim call succeeds.
+        dest.withWritablePointer(HMAC_SHA1_BYTES) { ptr -> bcl_hmac_final(ctx, ptr.reinterpret()) }
+        finalized = true
+    }
+
+    actual override fun close() {
+        if (finalized) return
+        finalized = true
+        // The shim has no free-without-final: finalize into discarded stack scratch, which
+        // cleanses and frees the ctx.
+        memScoped {
+            val scratch = allocArray<UByteVar>(HMAC_SHA1_BYTES)
+            bcl_hmac_final(ctx, scratch)
+        }
+    }
+}

--- a/buffer-crypto/src/nativeInterop/cinterop/boringsslcrypto.def
+++ b/buffer-crypto/src/nativeInterop/cinterop/boringsslcrypto.def
@@ -93,6 +93,9 @@ static inline HMAC_CTX *bcl_hmac_new(const EVP_MD *md, const uint8_t *key, size_
     }
     return c;
 }
+static inline HMAC_CTX *bcl_hmac_sha1_new(const uint8_t *key, size_t key_len) {
+    return bcl_hmac_new(EVP_sha1(), key, key_len);
+}
 static inline HMAC_CTX *bcl_hmac_sha256_new(const uint8_t *key, size_t key_len) {
     return bcl_hmac_new(EVP_sha256(), key, key_len);
 }

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/Crc32.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/Crc32.kt
@@ -1,0 +1,75 @@
+package com.ditchoom.buffer
+
+// CRC-32 content checksum over a byte region.
+//
+// This is the standard CRC-32 (ISO 3309 / ITU-T V.42 / zlib / PNG), reflected input and output,
+// polynomial 0x04C11DB7 (reversed 0xEDB88320), init/xorout 0xFFFFFFFF — the check value of the
+// ASCII string "123456789" is 0xCBF43926. It is distinct from [hashRange]'s FNV-1a-64 (a
+// bucketing digest): CRC-32 is the wire checksum protocols specify, e.g. STUN FINGERPRINT
+// (RFC 8489 §14.7, which is crc32 xor 0x5354554E).
+//
+// Implemented as a top-level extension in the same family as hash64()/regionEquals() rather than a
+// ReadBuffer member: no protocol needs a native-accelerated CRC today (the covered spans — a STUN
+// message, a PNG chunk — are small), so a common byte-at-a-time table walk keeps every buffer
+// implementation sharing one path. Promote to a member with a cinterop override (cf. buf_fnv1a_64)
+// if a hot bulk-CRC path ever appears.
+
+/** CRC-32 polynomial in reversed (LSB-first) bit order — the reflected form the table walk uses. */
+private const val CRC32_REVERSED_POLYNOMIAL = 0xEDB88320.toInt()
+
+/** Bits folded per table entry when building [CRC32_TABLE]. */
+private const val CRC32_TABLE_BITS = 8
+
+/** 32-bit word width of a table entry. */
+private const val CRC32_ENTRY_BYTES = 4
+
+/** Number of entries in the lookup table (one per byte value). */
+private const val CRC32_TABLE_ENTRIES = 1 shl CRC32_TABLE_BITS
+
+/**
+ * 256-entry lookup table computed once at class-init from [CRC32_REVERSED_POLYNOMIAL], stored in a
+ * shared read-only managed buffer (one 32-bit word per entry) rather than an [IntArray] — the
+ * zero-copy buffer discipline this library exists for (cf. `Sha256Core.K`). Entry `i` is
+ * `getInt(i * CRC32_ENTRY_BYTES)`.
+ */
+private val CRC32_TABLE: ReadBuffer =
+    BufferFactory.managed().allocate(CRC32_TABLE_ENTRIES * CRC32_ENTRY_BYTES, ByteOrder.BIG_ENDIAN).apply {
+        for (n in 0 until CRC32_TABLE_ENTRIES) {
+            var c = n
+            repeat(CRC32_TABLE_BITS) {
+                c = if (c and 1 != 0) CRC32_REVERSED_POLYNOMIAL xor (c ushr 1) else c ushr 1
+            }
+            set(n * CRC32_ENTRY_BYTES, c)
+        }
+    }
+
+/**
+ * CRC-32 (ISO 3309 / zlib) over the absolute byte range `[offset, offset + length)`.
+ *
+ * Reads through the unchecked absolute accessor after one up-front bounds check, and does not
+ * change [position]. The value is byte-order-independent (a per-byte checksum). See the file
+ * header for the exact CRC-32 variant.
+ *
+ * @param offset absolute index of the first byte
+ * @param length number of bytes to checksum
+ */
+fun ReadBuffer.crc32(
+    offset: Int,
+    length: Int,
+): UInt {
+    requireRange(offset, length)
+    var crc = -1 // 0xFFFFFFFF
+    var i = 0
+    while (i < length) {
+        val b = getUnchecked(offset + i).toInt()
+        crc = CRC32_TABLE.getInt(((crc xor b) and 0xFF) * CRC32_ENTRY_BYTES) xor (crc ushr CRC32_TABLE_BITS)
+        i++
+    }
+    return crc.inv().toUInt()
+}
+
+/**
+ * CRC-32 over the remaining bytes (`position()` until `limit()`). Convenience for [crc32];
+ * does not change [position].
+ */
+fun ReadBuffer.crc32(): UInt = crc32(position(), remaining())

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/Crc32.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/Crc32.kt
@@ -10,14 +10,21 @@ package com.ditchoom.buffer
 //
 // Implemented as a top-level extension in the same family as hash64()/regionEquals() rather than a
 // ReadBuffer member: no protocol needs a native-accelerated CRC today (the covered spans — a STUN
-// message, a PNG chunk — are small), so a common byte-at-a-time table walk keeps every buffer
-// implementation sharing one path. Promote to a member with a cinterop override (cf. buf_fnv1a_64)
-// if a hot bulk-CRC path ever appears.
+// message, a PNG chunk — are small), so a common table walk keeps every buffer implementation
+// sharing one path. Promote to a member with a cinterop override (cf. buf_fnv1a_64) if a hot bulk
+// CRC path ever appears.
+//
+// The input is consumed in bulk 8-byte words (one getLongUnchecked per 8 bytes, byte-tail last),
+// the same pattern as bufferHashCode()/contentEquals() — a single up-front bounds check then
+// unchecked reads. Unlike FNV, a CRC is a byte-ordered wire value, so the word is split into its
+// bytes in ascending address order (which depends on byteOrder); the two branches below are the
+// only difference from a per-byte loop. The table step itself stays per-byte — that is intrinsic
+// to a 256-entry table CRC, not an extra copy.
 
 /** CRC-32 polynomial in reversed (LSB-first) bit order — the reflected form the table walk uses. */
 private const val CRC32_REVERSED_POLYNOMIAL = 0xEDB88320.toInt()
 
-/** Bits folded per table entry when building [CRC32_TABLE]. */
+/** Bits folded per table entry when building [CRC32_TABLE], and the CRC shift per byte step. */
 private const val CRC32_TABLE_BITS = 8
 
 /** 32-bit word width of a table entry. */
@@ -25,6 +32,15 @@ private const val CRC32_ENTRY_BYTES = 4
 
 /** Number of entries in the lookup table (one per byte value). */
 private const val CRC32_TABLE_ENTRIES = 1 shl CRC32_TABLE_BITS
+
+/** Low-byte mask for indexing the table with `(crc xor inputByte) and BYTE_MASK`. */
+private const val BYTE_MASK = 0xFF
+
+/** Bit width of a byte — the per-lane shift when splitting a bulk word into its 8 bytes. */
+private const val BYTE_BITS = 8
+
+/** Shift landing the most-significant byte of a big-endian word (byte at the lowest address). */
+private const val WORD_HIGH_BYTE_SHIFT = 56
 
 /**
  * 256-entry lookup table computed once at class-init from [CRC32_REVERSED_POLYNOMIAL], stored in a
@@ -43,12 +59,19 @@ private val CRC32_TABLE: ReadBuffer =
         }
     }
 
+/** Folds one input byte [b] into the running [crc]. */
+private inline fun crc32Step(
+    crc: Int,
+    b: Int,
+): Int = CRC32_TABLE.getInt(((crc xor b) and BYTE_MASK) * CRC32_ENTRY_BYTES) xor (crc ushr CRC32_TABLE_BITS)
+
 /**
  * CRC-32 (ISO 3309 / zlib) over the absolute byte range `[offset, offset + length)`.
  *
- * Reads through the unchecked absolute accessor after one up-front bounds check, and does not
- * change [position]. The value is byte-order-independent (a per-byte checksum). See the file
- * header for the exact CRC-32 variant.
+ * Reads the region in bulk 8-byte words after one up-front bounds check, and does not change
+ * [position]. The value is byte-order-independent (a per-byte checksum) even though the bulk read
+ * is not — the word is decomposed into bytes in address order. See the file header for the exact
+ * CRC-32 variant.
  *
  * @param offset absolute index of the first byte
  * @param length number of bytes to checksum
@@ -60,9 +83,30 @@ fun ReadBuffer.crc32(
     requireRange(offset, length)
     var crc = -1 // 0xFFFFFFFF
     var i = 0
+    val bulkEnd = length - Long.SIZE_BYTES
+    if (byteOrder == ByteOrder.BIG_ENDIAN) {
+        while (i <= bulkEnd) {
+            val w = getLongUnchecked(offset + i)
+            var shift = WORD_HIGH_BYTE_SHIFT
+            while (shift >= 0) {
+                crc = crc32Step(crc, (w ushr shift).toInt() and BYTE_MASK)
+                shift -= BYTE_BITS
+            }
+            i += Long.SIZE_BYTES
+        }
+    } else {
+        while (i <= bulkEnd) {
+            val w = getLongUnchecked(offset + i)
+            var shift = 0
+            while (shift <= WORD_HIGH_BYTE_SHIFT) {
+                crc = crc32Step(crc, (w ushr shift).toInt() and BYTE_MASK)
+                shift += BYTE_BITS
+            }
+            i += Long.SIZE_BYTES
+        }
+    }
     while (i < length) {
-        val b = getUnchecked(offset + i).toInt()
-        crc = CRC32_TABLE.getInt(((crc xor b) and 0xFF) * CRC32_ENTRY_BYTES) xor (crc ushr CRC32_TABLE_BITS)
+        crc = crc32Step(crc, getUnchecked(offset + i).toInt())
         i++
     }
     return crc.inv().toUInt()

--- a/buffer/src/commonTest/kotlin/com/ditchoom/buffer/Crc32Test.kt
+++ b/buffer/src/commonTest/kotlin/com/ditchoom/buffer/Crc32Test.kt
@@ -1,0 +1,54 @@
+package com.ditchoom.buffer
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Known-answer tests for [ReadBuffer.crc32] (standard CRC-32: ISO 3309 / zlib / PNG, the variant
+ * whose "123456789" check value is 0xCBF43926).
+ */
+class Crc32Test {
+    private fun bufferOf(text: String): PlatformBuffer {
+        val buffer = BufferFactory.Default.allocate(maxOf(1, text.length))
+        if (text.isNotEmpty()) buffer.writeString(text)
+        buffer.resetForRead()
+        buffer.setLimit(text.length)
+        return buffer
+    }
+
+    @Test
+    fun canonicalCheckValue() {
+        // The standard CRC-32 check value (ISO 3309 / zlib).
+        assertEquals(0xCBF43926u, bufferOf("123456789").crc32())
+    }
+
+    @Test
+    fun emptyRangeIsZero() {
+        assertEquals(0u, bufferOf("").crc32())
+    }
+
+    @Test
+    fun singleByte() {
+        assertEquals(0xE8B7BE43u, bufferOf("a").crc32())
+    }
+
+    @Test
+    fun sentence() {
+        assertEquals(0x414FA339u, bufferOf("The quick brown fox jumps over the lazy dog").crc32())
+    }
+
+    @Test
+    fun subRangeMatchesWholeOfThatSlice() {
+        // crc32(offset,length) over the middle "456" equals crc32() of just "456".
+        val whole = bufferOf("123456789")
+        assertEquals(bufferOf("456").crc32(), whole.crc32(3, 3))
+    }
+
+    @Test
+    fun doesNotDisturbPosition() {
+        val b = bufferOf("123456789")
+        b.position(4)
+        b.crc32(0, 9)
+        assertEquals(4, b.position())
+    }
+}

--- a/buffer/src/commonTest/kotlin/com/ditchoom/buffer/Crc32Test.kt
+++ b/buffer/src/commonTest/kotlin/com/ditchoom/buffer/Crc32Test.kt
@@ -38,6 +38,20 @@ class Crc32Test {
     }
 
     @Test
+    fun byteOrderIndependent() {
+        // The bulk 8-byte read has a per-byte-order branch; the checksum must be identical either way.
+        // 13 bytes exercises one bulk word + a 5-byte tail.
+        val text = "123456789ABCD"
+        val be = BufferFactory.Default.allocate(text.length, ByteOrder.BIG_ENDIAN)
+        be.writeString(text)
+        be.resetForRead()
+        val le = BufferFactory.Default.allocate(text.length, ByteOrder.LITTLE_ENDIAN)
+        le.writeString(text)
+        le.resetForRead()
+        assertEquals(be.crc32(), le.crc32())
+    }
+
+    @Test
     fun subRangeMatchesWholeOfThatSlice() {
         // crc32(offset,length) over the middle "456" equals crc32() of just "456".
         val whole = bufferOf("123456789")


### PR DESCRIPTION
## What

Two interop-mandated primitives, added where each belongs:

### HMAC-SHA1 → `buffer-crypto` (`HmacSha1Mac` + one-shot `hmacSha1(...)`)
Mirrors the existing `HmacSha256Mac` across every actual:

| Platform | Backing |
|---|---|
| JVM / Android | JCA `Mac("HmacSHA1")` |
| Apple | CommonCrypto `CCHmac(kCCHmacAlgSHA1…)` |
| Linux/native | BoringSSL `EVP_sha1` via a new `bcl_hmac_sha1_new` shim in `boringsslcrypto.def` |
| js / wasmJs | pure-Kotlin `Sha1Core` (WebCrypto is async-only) |

`Sha1Core` holds **no primitive arrays** — the 80-word schedule lives in a single managed big-endian buffer, exactly like `Sha256Core`.

### CRC-32 → `buffer` core (`ReadBuffer.crc32(offset, length)` / `crc32()`)
Standard CRC-32 (ISO 3309 / zlib / PNG) — the wire checksum protocols specify. A top-level extension in the `hash64()` / `regionEquals()` digest family; the 256-entry table lives in a **shared managed buffer, not an `IntArray`** (the zero-copy discipline). Distinct from `hashRange()`'s FNV-1a-64 bucketing digest.

## Why

Both are needed by the downstream `com.ditchoom:webrtc` STUN codec (W1): MESSAGE-INTEGRITY is HMAC-SHA1 (RFC 8489), FINGERPRINT is `crc32 xor 0x5354554E` (RFC 8489 §14.7). HMAC-SHA1 is also reused by the legacy SRTP suite `SRTP_AES128_CM_SHA1_80` (RFC 3711). Neither is a general-purpose choice — kept strictly for these interop obligations; new protocols use SHA-256.

## Tests

- **HMAC-SHA1**: RFC 2202 known-answer vectors (incl. the >block-size-key pre-hash path) — pass on **JVM, JS (pure `Sha1Core`), and Linux/native (BoringSSL)**.
- **CRC-32**: the canonical `0xCBF43926` "123456789" check value + single-byte / sentence / sub-range / position-preservation cases.

## Compatibility

Additive public API only — `buffer-crypto` `.api` regenerated (JVM + Android); `buffer` core has no BCV surface. Apple lanes are compile-faithful here and validated on the macOS runner in CI.