### PR TITLE
feat(crypto): non-exportable software keys + WebCrypto provider (additive minor)

### DIFF
--- a/buffer-crypto/SECURITY.md
+++ b/buffer-crypto/SECURITY.md
@@ -82,6 +82,10 @@ Run the full suite:
 - Key agreement: `KeyAgreementKatTest`, `KeyAgreementWycheproofTest`, `KeyAgreementTest`
 - HPKE / DHKEM (RFC 9180): `HpkeKatTest` (RFC 9180 Appendix A vectors, all four modes),
   `HpkeRoundTripTest`, `HpkeTamperTest`, `HpkeBackingTests`, `HpkeCapabilityTest`
+- Non-exportable / hardware-backed keys & custody: `HardwareKeyConformanceTest` (SPI +
+  gated-closure machinery, via a fake secure element), `KeyProviderResolverTest` (total
+  per-algorithm routing + `requireTier`), `WebCryptoProtectedKeyProviderTest` (the js/wasmJs
+  WebCrypto non-exportable provider end-to-end: ECDSA, AES-GCM, ECDH, HPKE `openBase`)
 - Foundation: `ConstantTimeTest`, `CryptoRandomTest`, `SecureBufferTest`,
   `WycheproofRunnerSelfTest`
 - Vendored Wycheproof vector sets (curated, in `WycheproofVectors*.kt`): AES-GCM,
@@ -156,6 +160,15 @@ prevented by API/type design · **(e)** out of scope / documented trust assumpti
 | Message-sequence overflow forcing nonce reuse | **(d)** HPKE per-context monotonic seq throws `MessageLimitReached` before wrap (see §3 HPKE) |
 | `L > 255·HashLen` HKDF expansion | **(a)/(b)** length cap (see §3 KDF/MAC) |
 
+### Non-exportable & hardware-backed keys (key custody)
+| Vector | Defense |
+|---|---|
+| Private key material readable in process memory | **(d)** a non-exportable key is **not** a `SyncCapable*` type, so no blocking / material-reading op accepts it (a compile error, not a runtime throw); every use routes through a `suspend` gated closure that drives the backend — WebCrypto `CryptoKey`, Android Keystore, Secure Enclave — and the material seam throws for it as a defensive backstop |
+| Non-exportable *software* key mis-reported as a secure element | **(d)** custody is one sealed `KeyCustody` value, not free boolean fields, so impossible states (an exportable secure-element key, a software "dedicated element") do not typecheck. WebCrypto `extractable:false` is `NonExportable.Software`; `CryptoCapabilities.hardware` reports `Available` **only** for a real secure element, so a software-isolated key never masquerades as hardware |
+| Silent downgrade when the required custody is absent | **(b)/(d)** `keyProvider()` routes per-algorithm to the strongest eligible tier with the software floor as fallback (never a custody throw at the default); a caller that *requires* a stronger tier asserts it with `requireTier(alg, tier)`, which throws the structured, non-secret `InsufficientKeyCustody` rather than degrading |
+| HPKE recipient scalar leaking to the process on the web | **(d)** the DHKEM decap `DH(skR, enc)` runs through the key's gated closure (`subtle.deriveBits` over the non-exportable handle); the recipient scalar never enters process memory, and `hpke().openBase(...)` composes unchanged via `hpkeRecipientPrivateKey` |
+| Advisory-gate bypass on a provider key | **(b)** the provider evaluates `ProtectedKeySpec.authorization` before **every** gated op, throwing `AuthorizationFailed` (a structured `CryptoMisuseException`) on deny — never proceeding with the crypto op |
+
 ## 4. Platform support & capability gating
 
 These are tested error paths, not assumptions — the capability flag drives a `true`→works /
@@ -181,6 +194,38 @@ KEM encodings (raw X25519 u-coordinate, uncompressed SEC1 EC points); the RFC 91
 known-answer vectors (raw private scalars) run on JVM/Android, and Apple/web get HPKE round-trip
 coverage with platform-generated keys.
 
+### Key custody (non-exportable & hardware-backed keys)
+
+Separate from *op* availability above is **key custody** — where a private key's secret lives and
+whether this process can read it. `CryptoCapabilities.keyProvider()` is **total**: it always returns
+a usable `KeyProvider`, resolving each algorithm to the strongest custody the platform offers with a
+commonMain software floor beneath it (so it never returns `null` and never throws for custody reasons
+at the default). The tiers, weakest → strongest (`CustodyTier`): `ExportableSoftware` <
+`NonExportableSoftware` < `Hardware`.
+
+| Platform | Strongest custody | Backing | Algorithms at that tier |
+|---|---|---|---|
+| JVM / Linux | `ExportableSoftware` | in-process software keys | (floor) all — no portable non-exportable store exists |
+| **JS / WASM** | `NonExportableSoftware` | **WebCrypto `extractable:false`** — software isolation, *not* a secure element | ECDSA P-256/384/521, AES-GCM, ECDH P-256/384/521; X25519 where the engine exposes it (feature-detected). Ed25519 excluded (uneven engine support) → routes to the floor |
+| Android (API 28+) | `Hardware` | Android Keystore — StrongBox secure element where present, else TEE | AES-GCM, ECDSA P-256 |
+| Apple | `Hardware` | Secure Enclave | ECDSA P-256 |
+
+Whatever an algorithm's platform tier does not back routes **down** to the next eligible tier
+(ultimately the software floor), so `keyProvider().generateSigning(EcdsaP521, …)` on a secure element
+that backs only P-256 transparently produces a software key instead of throwing. Keys are
+self-describing — each carries its own `KeyCustody` — so a consumer can `when`-branch on, or assert
+(`requireTier`) the custody it actually received.
+
+**Non-exportable ≠ hardware.** Exportability (can the process read the secret?) and provenance (where
+the secret lives) are orthogonal axes. A WebCrypto key is non-exportable *software*: the process heap
+never sees the private bytes, yet it is not a dedicated secure element. Filing it under `Hardware`
+would corrupt the signal the `hardware` accessor carries, so it is `NonExportable.Software`, surfaced
+through `CryptoCapabilities.protectedKeys` (the non-exportable superset) but **not**
+`CryptoCapabilities.hardware` (the secure-element-only refinement). Desktop JVM / Linux have no
+portable non-exportable store (DPAPI / Keychain / Secret Service are all platform-native, none
+reachable from pure KMP), so they stay at the exportable software floor — a key-on-disk is
+exportable and is never surfaced behind `protectedKeys` / `hardware`.
+
 ## 5. Known limitations & tracked follow-ups
 
 These are **not vulnerabilities** — every case below is gated by a capability flag that is
@@ -199,6 +244,12 @@ tracked to completion:
   compile-time one.
 - **Linux** — no native crypto target is registered yet; deferred. When added it will wrap
   BoringSSL (not OpenSSL), consistent with the sibling networking module.
+- **Non-exportable key persistence & desktop custody** — the provider mints an in-process
+  non-exportable *handle* and returns a key; persisting it across sessions (IndexedDB on web, a
+  keystore alias on a device) is application policy and out of scope here. Desktop JVM / Linux
+  expose no portable non-exportable store, so `keyProvider()` resolves them to the exportable
+  software floor (see §4) — this is by design, not a capability that throws; a key-on-disk is
+  exportable and is deliberately never surfaced behind `protectedKeys` / `hardware`.
 
 Open tracking issues are linked from the pull request that introduces this module.
 

--- a/buffer-crypto/api/android/buffer-crypto.api
+++ b/buffer-crypto/api/android/buffer-crypto.api
@@ -598,6 +598,7 @@ public final class com/ditchoom/buffer/crypto/HpkeKt {
 	public static final fun hpkeGenerateKeyPair (Lcom/ditchoom/buffer/crypto/HpkeKem;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun hpkeImportPrivateKey (Lcom/ditchoom/buffer/crypto/HpkeKem;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/ReadBuffer;)Lcom/ditchoom/buffer/crypto/HpkePrivateKey;
 	public static final fun hpkeImportPublicKey (Lcom/ditchoom/buffer/crypto/HpkeKem;Lcom/ditchoom/buffer/ReadBuffer;)Lcom/ditchoom/buffer/crypto/HpkePublicKey;
+	public static final fun hpkeRecipientPrivateKey (Lcom/ditchoom/buffer/crypto/HpkeKem;Lcom/ditchoom/buffer/crypto/KeyAgreementKeyPair;)Lcom/ditchoom/buffer/crypto/HpkePrivateKey;
 }
 
 public abstract interface class com/ditchoom/buffer/crypto/HpkeMode {

--- a/buffer-crypto/api/android/buffer-crypto.api
+++ b/buffer-crypto/api/android/buffer-crypto.api
@@ -232,17 +232,6 @@ public final class com/ditchoom/buffer/crypto/EcdsaSignatureEncoding : java/lang
 	public static fun values ()[Lcom/ditchoom/buffer/crypto/EcdsaSignatureEncoding;
 }
 
-public final class com/ditchoom/buffer/crypto/HardwareAlgorithm : java/lang/Enum {
-	public static final field AesGcm Lcom/ditchoom/buffer/crypto/HardwareAlgorithm;
-	public static final field EcdsaP256 Lcom/ditchoom/buffer/crypto/HardwareAlgorithm;
-	public static final field EcdsaP384 Lcom/ditchoom/buffer/crypto/HardwareAlgorithm;
-	public static final field EcdsaP521 Lcom/ditchoom/buffer/crypto/HardwareAlgorithm;
-	public static final field Ed25519 Lcom/ditchoom/buffer/crypto/HardwareAlgorithm;
-	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public static fun valueOf (Ljava/lang/String;)Lcom/ditchoom/buffer/crypto/HardwareAlgorithm;
-	public static fun values ()[Lcom/ditchoom/buffer/crypto/HardwareAlgorithm;
-}
-
 public abstract interface class com/ditchoom/buffer/crypto/HardwareAuthorization {
 	public abstract fun authorize (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
@@ -271,18 +260,10 @@ public final class com/ditchoom/buffer/crypto/HardwareKeyException$UserAuthentic
 }
 
 public abstract interface class com/ditchoom/buffer/crypto/HardwareKeyProvider {
-	public abstract fun eligible (Lcom/ditchoom/buffer/crypto/HardwareAlgorithm;)Z
-	public abstract fun generateAesGcm (Lcom/ditchoom/buffer/crypto/HardwareKeySpec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun generateSigning (Lcom/ditchoom/buffer/crypto/SignatureScheme;Lcom/ditchoom/buffer/crypto/HardwareKeySpec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun eligible (Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;)Z
+	public abstract fun generateAesGcm (Lcom/ditchoom/buffer/crypto/ProtectedKeySpec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun generateSigning (Lcom/ditchoom/buffer/crypto/SignatureScheme;Lcom/ditchoom/buffer/crypto/ProtectedKeySpec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getDedicatedSecureElement ()Z
-}
-
-public final class com/ditchoom/buffer/crypto/HardwareKeySpec {
-	public fun <init> ()V
-	public fun <init> (Lcom/ditchoom/buffer/crypto/HardwareAuthorization;I)V
-	public synthetic fun <init> (Lcom/ditchoom/buffer/crypto/HardwareAuthorization;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getAesKeySizeBits ()I
-	public final fun getAuthorization ()Lcom/ditchoom/buffer/crypto/HardwareAuthorization;
 }
 
 public final class com/ditchoom/buffer/crypto/HardwareKeysKt {
@@ -955,6 +936,29 @@ public final class com/ditchoom/buffer/crypto/OptionalAead$Unavailable : com/dit
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/ditchoom/buffer/crypto/ProtectedKeyAlgorithm : java/lang/Enum {
+	public static final field AesGcm Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
+	public static final field EcdhP256 Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
+	public static final field EcdhP384 Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
+	public static final field EcdhP521 Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
+	public static final field EcdsaP256 Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
+	public static final field EcdsaP384 Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
+	public static final field EcdsaP521 Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
+	public static final field Ed25519 Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
+	public static final field X25519 Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
+	public static fun values ()[Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
+}
+
+public final class com/ditchoom/buffer/crypto/ProtectedKeySpec {
+	public fun <init> ()V
+	public fun <init> (Lcom/ditchoom/buffer/crypto/HardwareAuthorization;I)V
+	public synthetic fun <init> (Lcom/ditchoom/buffer/crypto/HardwareAuthorization;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAesKeySizeBits ()I
+	public final fun getAuthorization ()Lcom/ditchoom/buffer/crypto/HardwareAuthorization;
+}
+
 public abstract interface class com/ditchoom/buffer/crypto/Salt {
 }
 
@@ -1310,7 +1314,7 @@ public abstract interface class com/ditchoom/buffer/crypto/SyncCapableSigningKey
 }
 
 public abstract interface class com/ditchoom/buffer/crypto/UserAuthenticatedKeyProvider {
-	public abstract fun eligible (Lcom/ditchoom/buffer/crypto/HardwareAlgorithm;)Z
+	public abstract fun eligible (Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;)Z
 	public abstract fun generateAesGcm (Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun generateAesGcm$default (Lcom/ditchoom/buffer/crypto/UserAuthenticatedKeyProvider;Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public abstract fun generateSigning (Lcom/ditchoom/buffer/crypto/SignatureScheme;Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/buffer-crypto/api/android/buffer-crypto.api
+++ b/buffer-crypto/api/android/buffer-crypto.api
@@ -101,7 +101,8 @@ public final class com/ditchoom/buffer/crypto/Aead_jvmCommonKt {
 
 public abstract interface class com/ditchoom/buffer/crypto/AesGcmKey : com/ditchoom/buffer/crypto/AeadKey, java/lang/AutoCloseable {
 	public static final field Companion Lcom/ditchoom/buffer/crypto/AesGcmKey$Companion;
-	public abstract fun getProvenance ()Lcom/ditchoom/buffer/crypto/KeyProvenance;
+	public abstract fun getCustody ()Lcom/ditchoom/buffer/crypto/KeyCustody;
+	public fun getProvenance ()Lcom/ditchoom/buffer/crypto/KeyProvenance;
 	public abstract fun getSizeBits ()I
 	public fun getSizeBytes ()I
 }
@@ -112,6 +113,7 @@ public final class com/ditchoom/buffer/crypto/AesGcmKey$Companion {
 }
 
 public final class com/ditchoom/buffer/crypto/AesGcmKey$DefaultImpls {
+	public static fun getProvenance (Lcom/ditchoom/buffer/crypto/AesGcmKey;)Lcom/ditchoom/buffer/crypto/KeyProvenance;
 	public static fun getSizeBytes (Lcom/ditchoom/buffer/crypto/AesGcmKey;)I
 }
 
@@ -143,6 +145,15 @@ public final class com/ditchoom/buffer/crypto/ChaChaPolyKey$Companion {
 	public static synthetic fun of$default (Lcom/ditchoom/buffer/crypto/ChaChaPolyKey$Companion;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/ChaChaPolyKey;
 }
 
+public abstract interface class com/ditchoom/buffer/crypto/ConcreteKeyProvider : com/ditchoom/buffer/crypto/KeyProvider {
+	public fun custodyFor (Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;)Lcom/ditchoom/buffer/crypto/KeyCustody;
+	public abstract fun getCustody ()Lcom/ditchoom/buffer/crypto/KeyCustody;
+}
+
+public final class com/ditchoom/buffer/crypto/ConcreteKeyProvider$DefaultImpls {
+	public static fun custodyFor (Lcom/ditchoom/buffer/crypto/ConcreteKeyProvider;Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;)Lcom/ditchoom/buffer/crypto/KeyCustody;
+}
+
 public final class com/ditchoom/buffer/crypto/ConstantTimeKt {
 	public static final fun constantTimeEquals (Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/ReadBuffer;)Z
 }
@@ -168,6 +179,15 @@ public final class com/ditchoom/buffer/crypto/CryptoRandomKt {
 
 public final class com/ditchoom/buffer/crypto/CryptoRandom_jvmCommonKt {
 	public static final fun cryptoRandomInto (Lcom/ditchoom/buffer/WriteBuffer;)V
+}
+
+public final class com/ditchoom/buffer/crypto/CustodyTier : java/lang/Enum {
+	public static final field ExportableSoftware Lcom/ditchoom/buffer/crypto/CustodyTier;
+	public static final field Hardware Lcom/ditchoom/buffer/crypto/CustodyTier;
+	public static final field NonExportableSoftware Lcom/ditchoom/buffer/crypto/CustodyTier;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/ditchoom/buffer/crypto/CustodyTier;
+	public static fun values ()[Lcom/ditchoom/buffer/crypto/CustodyTier;
 }
 
 public final class com/ditchoom/buffer/crypto/EcEncodingError : java/lang/Enum {
@@ -259,11 +279,19 @@ public final class com/ditchoom/buffer/crypto/HardwareKeyException$UnsupportedHa
 public final class com/ditchoom/buffer/crypto/HardwareKeyException$UserAuthenticationRequired : com/ditchoom/buffer/crypto/HardwareKeyException {
 }
 
-public abstract interface class com/ditchoom/buffer/crypto/HardwareKeyProvider {
+public abstract interface class com/ditchoom/buffer/crypto/HardwareKeyProvider : com/ditchoom/buffer/crypto/ProtectedKeyProvider {
 	public abstract fun eligible (Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;)Z
 	public abstract fun generateAesGcm (Lcom/ditchoom/buffer/crypto/ProtectedKeySpec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun generateSigning (Lcom/ditchoom/buffer/crypto/SignatureScheme;Lcom/ditchoom/buffer/crypto/ProtectedKeySpec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getCustody ()Lcom/ditchoom/buffer/crypto/KeyCustody$NonExportable$Hardware;
+	public synthetic fun getCustody ()Lcom/ditchoom/buffer/crypto/KeyCustody$NonExportable;
+	public synthetic fun getCustody ()Lcom/ditchoom/buffer/crypto/KeyCustody;
 	public abstract fun getDedicatedSecureElement ()Z
+}
+
+public final class com/ditchoom/buffer/crypto/HardwareKeyProvider$DefaultImpls {
+	public static fun custodyFor (Lcom/ditchoom/buffer/crypto/HardwareKeyProvider;Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;)Lcom/ditchoom/buffer/crypto/KeyCustody;
+	public static fun getCustody (Lcom/ditchoom/buffer/crypto/HardwareKeyProvider;)Lcom/ditchoom/buffer/crypto/KeyCustody$NonExportable$Hardware;
 }
 
 public final class com/ditchoom/buffer/crypto/HardwareKeysKt {
@@ -879,12 +907,65 @@ public final class com/ditchoom/buffer/crypto/KeyAgreement_jvmCommonKt {
 	public static final fun keyAgreement (Lcom/ditchoom/buffer/crypto/CryptoCapabilities;Lcom/ditchoom/buffer/crypto/KeyAgreementCurve;)Lcom/ditchoom/buffer/crypto/KeyAgreementSupport;
 }
 
+public abstract interface class com/ditchoom/buffer/crypto/KeyCustody {
+	public abstract fun getTier ()Lcom/ditchoom/buffer/crypto/CustodyTier;
+}
+
+public final class com/ditchoom/buffer/crypto/KeyCustody$ExportableSoftware : com/ditchoom/buffer/crypto/KeyCustody {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/KeyCustody$ExportableSoftware;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getTier ()Lcom/ditchoom/buffer/crypto/CustodyTier;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/KeyCustody$NonExportable : com/ditchoom/buffer/crypto/KeyCustody {
+}
+
+public final class com/ditchoom/buffer/crypto/KeyCustody$NonExportable$Hardware : com/ditchoom/buffer/crypto/KeyCustody$NonExportable {
+	public fun <init> (Z)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Lcom/ditchoom/buffer/crypto/KeyCustody$NonExportable$Hardware;
+	public static synthetic fun copy$default (Lcom/ditchoom/buffer/crypto/KeyCustody$NonExportable$Hardware;ZILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/KeyCustody$NonExportable$Hardware;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDedicatedSecureElement ()Z
+	public fun getTier ()Lcom/ditchoom/buffer/crypto/CustodyTier;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/KeyCustody$NonExportable$Software : com/ditchoom/buffer/crypto/KeyCustody$NonExportable {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/KeyCustody$NonExportable$Software;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getTier ()Lcom/ditchoom/buffer/crypto/CustodyTier;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/KeyCustodyKt {
+	public static final fun getDedicatedSecureElement (Lcom/ditchoom/buffer/crypto/KeyCustody;)Z
+	public static final fun getExportable (Lcom/ditchoom/buffer/crypto/KeyCustody;)Z
+	public static final fun getProvenance (Lcom/ditchoom/buffer/crypto/KeyCustody;)Lcom/ditchoom/buffer/crypto/KeyProvenance;
+}
+
 public final class com/ditchoom/buffer/crypto/KeyProvenance : java/lang/Enum {
 	public static final field Hardware Lcom/ditchoom/buffer/crypto/KeyProvenance;
 	public static final field Software Lcom/ditchoom/buffer/crypto/KeyProvenance;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/ditchoom/buffer/crypto/KeyProvenance;
 	public static fun values ()[Lcom/ditchoom/buffer/crypto/KeyProvenance;
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/KeyProvider {
+	public abstract fun custodyFor (Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;)Lcom/ditchoom/buffer/crypto/KeyCustody;
+	public abstract fun eligible (Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;)Z
+	public abstract fun generateAesGcm (Lcom/ditchoom/buffer/crypto/ProtectedKeySpec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun generateKeyAgreement (Lcom/ditchoom/buffer/crypto/KeyAgreementCurve;Lcom/ditchoom/buffer/crypto/ProtectedKeySpec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun generateSigning (Lcom/ditchoom/buffer/crypto/SignatureScheme;Lcom/ditchoom/buffer/crypto/ProtectedKeySpec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/ditchoom/buffer/crypto/KeyProviderKt {
+	public static final fun getProtectedKeys (Lcom/ditchoom/buffer/crypto/CryptoCapabilities;)Lcom/ditchoom/buffer/crypto/ProtectedKeySupport;
 }
 
 public final class com/ditchoom/buffer/crypto/MessageLimitReached : com/ditchoom/buffer/crypto/CryptoMisuseException {
@@ -951,12 +1032,42 @@ public final class com/ditchoom/buffer/crypto/ProtectedKeyAlgorithm : java/lang/
 	public static fun values ()[Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
 }
 
+public abstract interface class com/ditchoom/buffer/crypto/ProtectedKeyProvider : com/ditchoom/buffer/crypto/ConcreteKeyProvider {
+	public abstract fun getCustody ()Lcom/ditchoom/buffer/crypto/KeyCustody$NonExportable;
+	public synthetic fun getCustody ()Lcom/ditchoom/buffer/crypto/KeyCustody;
+}
+
+public final class com/ditchoom/buffer/crypto/ProtectedKeyProvider$DefaultImpls {
+	public static fun custodyFor (Lcom/ditchoom/buffer/crypto/ProtectedKeyProvider;Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;)Lcom/ditchoom/buffer/crypto/KeyCustody;
+}
+
 public final class com/ditchoom/buffer/crypto/ProtectedKeySpec {
 	public fun <init> ()V
 	public fun <init> (Lcom/ditchoom/buffer/crypto/HardwareAuthorization;I)V
 	public synthetic fun <init> (Lcom/ditchoom/buffer/crypto/HardwareAuthorization;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAesKeySizeBits ()I
 	public final fun getAuthorization ()Lcom/ditchoom/buffer/crypto/HardwareAuthorization;
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/ProtectedKeySupport {
+}
+
+public final class com/ditchoom/buffer/crypto/ProtectedKeySupport$Available : com/ditchoom/buffer/crypto/ProtectedKeySupport {
+	public fun <init> (Lcom/ditchoom/buffer/crypto/ProtectedKeyProvider;)V
+	public final fun component1 ()Lcom/ditchoom/buffer/crypto/ProtectedKeyProvider;
+	public final fun copy (Lcom/ditchoom/buffer/crypto/ProtectedKeyProvider;)Lcom/ditchoom/buffer/crypto/ProtectedKeySupport$Available;
+	public static synthetic fun copy$default (Lcom/ditchoom/buffer/crypto/ProtectedKeySupport$Available;Lcom/ditchoom/buffer/crypto/ProtectedKeyProvider;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/ProtectedKeySupport$Available;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getProvider ()Lcom/ditchoom/buffer/crypto/ProtectedKeyProvider;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/ProtectedKeySupport$Unavailable : com/ditchoom/buffer/crypto/ProtectedKeySupport {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/ProtectedKeySupport$Unavailable;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class com/ditchoom/buffer/crypto/Salt {
@@ -1287,7 +1398,8 @@ public final class com/ditchoom/buffer/crypto/Signatures_jvmCommonKt {
 
 public abstract interface class com/ditchoom/buffer/crypto/SigningKey : java/lang/AutoCloseable {
 	public static final field Companion Lcom/ditchoom/buffer/crypto/SigningKey$Companion;
-	public abstract fun getProvenance ()Lcom/ditchoom/buffer/crypto/KeyProvenance;
+	public abstract fun getCustody ()Lcom/ditchoom/buffer/crypto/KeyCustody;
+	public fun getProvenance ()Lcom/ditchoom/buffer/crypto/KeyProvenance;
 	public abstract fun getScheme ()Lcom/ditchoom/buffer/crypto/SignatureScheme;
 	public abstract fun getVerifyKey ()Lcom/ditchoom/buffer/crypto/VerifyKey;
 }
@@ -1303,14 +1415,23 @@ public final class com/ditchoom/buffer/crypto/SigningKey$Companion {
 	public static synthetic fun ed25519$default (Lcom/ditchoom/buffer/crypto/SigningKey$Companion;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/crypto/VerifyKey;Lcom/ditchoom/buffer/BufferFactory;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/SyncCapableSigningKey;
 }
 
+public final class com/ditchoom/buffer/crypto/SigningKey$DefaultImpls {
+	public static fun getProvenance (Lcom/ditchoom/buffer/crypto/SigningKey;)Lcom/ditchoom/buffer/crypto/KeyProvenance;
+}
+
 public abstract interface class com/ditchoom/buffer/crypto/SyncCapableAesGcmKey : com/ditchoom/buffer/crypto/AesGcmKey {
 }
 
 public final class com/ditchoom/buffer/crypto/SyncCapableAesGcmKey$DefaultImpls {
+	public static fun getProvenance (Lcom/ditchoom/buffer/crypto/SyncCapableAesGcmKey;)Lcom/ditchoom/buffer/crypto/KeyProvenance;
 	public static fun getSizeBytes (Lcom/ditchoom/buffer/crypto/SyncCapableAesGcmKey;)I
 }
 
 public abstract interface class com/ditchoom/buffer/crypto/SyncCapableSigningKey : com/ditchoom/buffer/crypto/SigningKey {
+}
+
+public final class com/ditchoom/buffer/crypto/SyncCapableSigningKey$DefaultImpls {
+	public static fun getProvenance (Lcom/ditchoom/buffer/crypto/SyncCapableSigningKey;)Lcom/ditchoom/buffer/crypto/KeyProvenance;
 }
 
 public abstract interface class com/ditchoom/buffer/crypto/UserAuthenticatedKeyProvider {

--- a/buffer-crypto/api/android/buffer-crypto.api
+++ b/buffer-crypto/api/android/buffer-crypto.api
@@ -753,6 +753,12 @@ public final class com/ditchoom/buffer/crypto/Info$Of : com/ditchoom/buffer/cryp
 	public final synthetic fun unbox-impl ()Lcom/ditchoom/buffer/ReadBuffer;
 }
 
+public final class com/ditchoom/buffer/crypto/InsufficientKeyCustody : com/ditchoom/buffer/crypto/CryptoMisuseException {
+	public final fun getAlg ()Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
+	public final fun getAvailable ()Lcom/ditchoom/buffer/crypto/CustodyTier;
+	public final fun getRequired ()Lcom/ditchoom/buffer/crypto/CustodyTier;
+}
+
 public final class com/ditchoom/buffer/crypto/InvalidPublicKey : com/ditchoom/buffer/crypto/CryptoMisuseException {
 	public final fun getCurve ()Lcom/ditchoom/buffer/crypto/KeyAgreementCurve;
 }
@@ -966,6 +972,11 @@ public abstract interface class com/ditchoom/buffer/crypto/KeyProvider {
 
 public final class com/ditchoom/buffer/crypto/KeyProviderKt {
 	public static final fun getProtectedKeys (Lcom/ditchoom/buffer/crypto/CryptoCapabilities;)Lcom/ditchoom/buffer/crypto/ProtectedKeySupport;
+}
+
+public final class com/ditchoom/buffer/crypto/KeyProviderResolutionKt {
+	public static final fun keyProvider (Lcom/ditchoom/buffer/crypto/CryptoCapabilities;)Lcom/ditchoom/buffer/crypto/KeyProvider;
+	public static final fun requireTier (Lcom/ditchoom/buffer/crypto/KeyProvider;Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;Lcom/ditchoom/buffer/crypto/CustodyTier;)Lcom/ditchoom/buffer/crypto/KeyProvider;
 }
 
 public final class com/ditchoom/buffer/crypto/MessageLimitReached : com/ditchoom/buffer/crypto/CryptoMisuseException {

--- a/buffer-crypto/api/jvm/buffer-crypto.api
+++ b/buffer-crypto/api/jvm/buffer-crypto.api
@@ -101,7 +101,8 @@ public final class com/ditchoom/buffer/crypto/Aead_jvmCommonKt {
 
 public abstract interface class com/ditchoom/buffer/crypto/AesGcmKey : com/ditchoom/buffer/crypto/AeadKey, java/lang/AutoCloseable {
 	public static final field Companion Lcom/ditchoom/buffer/crypto/AesGcmKey$Companion;
-	public abstract fun getProvenance ()Lcom/ditchoom/buffer/crypto/KeyProvenance;
+	public abstract fun getCustody ()Lcom/ditchoom/buffer/crypto/KeyCustody;
+	public fun getProvenance ()Lcom/ditchoom/buffer/crypto/KeyProvenance;
 	public abstract fun getSizeBits ()I
 	public fun getSizeBytes ()I
 }
@@ -112,6 +113,7 @@ public final class com/ditchoom/buffer/crypto/AesGcmKey$Companion {
 }
 
 public final class com/ditchoom/buffer/crypto/AesGcmKey$DefaultImpls {
+	public static fun getProvenance (Lcom/ditchoom/buffer/crypto/AesGcmKey;)Lcom/ditchoom/buffer/crypto/KeyProvenance;
 	public static fun getSizeBytes (Lcom/ditchoom/buffer/crypto/AesGcmKey;)I
 }
 
@@ -126,6 +128,15 @@ public abstract interface class com/ditchoom/buffer/crypto/ChaChaPolyKey : com/d
 public final class com/ditchoom/buffer/crypto/ChaChaPolyKey$Companion {
 	public final fun of (Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;)Lcom/ditchoom/buffer/crypto/ChaChaPolyKey;
 	public static synthetic fun of$default (Lcom/ditchoom/buffer/crypto/ChaChaPolyKey$Companion;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/ChaChaPolyKey;
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/ConcreteKeyProvider : com/ditchoom/buffer/crypto/KeyProvider {
+	public fun custodyFor (Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;)Lcom/ditchoom/buffer/crypto/KeyCustody;
+	public abstract fun getCustody ()Lcom/ditchoom/buffer/crypto/KeyCustody;
+}
+
+public final class com/ditchoom/buffer/crypto/ConcreteKeyProvider$DefaultImpls {
+	public static fun custodyFor (Lcom/ditchoom/buffer/crypto/ConcreteKeyProvider;Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;)Lcom/ditchoom/buffer/crypto/KeyCustody;
 }
 
 public final class com/ditchoom/buffer/crypto/ConstantTimeKt {
@@ -153,6 +164,15 @@ public final class com/ditchoom/buffer/crypto/CryptoRandomKt {
 
 public final class com/ditchoom/buffer/crypto/CryptoRandom_jvmCommonKt {
 	public static final fun cryptoRandomInto (Lcom/ditchoom/buffer/WriteBuffer;)V
+}
+
+public final class com/ditchoom/buffer/crypto/CustodyTier : java/lang/Enum {
+	public static final field ExportableSoftware Lcom/ditchoom/buffer/crypto/CustodyTier;
+	public static final field Hardware Lcom/ditchoom/buffer/crypto/CustodyTier;
+	public static final field NonExportableSoftware Lcom/ditchoom/buffer/crypto/CustodyTier;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/ditchoom/buffer/crypto/CustodyTier;
+	public static fun values ()[Lcom/ditchoom/buffer/crypto/CustodyTier;
 }
 
 public final class com/ditchoom/buffer/crypto/EcEncodingError : java/lang/Enum {
@@ -244,11 +264,19 @@ public final class com/ditchoom/buffer/crypto/HardwareKeyException$UnsupportedHa
 public final class com/ditchoom/buffer/crypto/HardwareKeyException$UserAuthenticationRequired : com/ditchoom/buffer/crypto/HardwareKeyException {
 }
 
-public abstract interface class com/ditchoom/buffer/crypto/HardwareKeyProvider {
+public abstract interface class com/ditchoom/buffer/crypto/HardwareKeyProvider : com/ditchoom/buffer/crypto/ProtectedKeyProvider {
 	public abstract fun eligible (Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;)Z
 	public abstract fun generateAesGcm (Lcom/ditchoom/buffer/crypto/ProtectedKeySpec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun generateSigning (Lcom/ditchoom/buffer/crypto/SignatureScheme;Lcom/ditchoom/buffer/crypto/ProtectedKeySpec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getCustody ()Lcom/ditchoom/buffer/crypto/KeyCustody$NonExportable$Hardware;
+	public synthetic fun getCustody ()Lcom/ditchoom/buffer/crypto/KeyCustody$NonExportable;
+	public synthetic fun getCustody ()Lcom/ditchoom/buffer/crypto/KeyCustody;
 	public abstract fun getDedicatedSecureElement ()Z
+}
+
+public final class com/ditchoom/buffer/crypto/HardwareKeyProvider$DefaultImpls {
+	public static fun custodyFor (Lcom/ditchoom/buffer/crypto/HardwareKeyProvider;Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;)Lcom/ditchoom/buffer/crypto/KeyCustody;
+	public static fun getCustody (Lcom/ditchoom/buffer/crypto/HardwareKeyProvider;)Lcom/ditchoom/buffer/crypto/KeyCustody$NonExportable$Hardware;
 }
 
 public final class com/ditchoom/buffer/crypto/HardwareKeysKt {
@@ -864,12 +892,65 @@ public final class com/ditchoom/buffer/crypto/KeyAgreement_jvmCommonKt {
 	public static final fun keyAgreement (Lcom/ditchoom/buffer/crypto/CryptoCapabilities;Lcom/ditchoom/buffer/crypto/KeyAgreementCurve;)Lcom/ditchoom/buffer/crypto/KeyAgreementSupport;
 }
 
+public abstract interface class com/ditchoom/buffer/crypto/KeyCustody {
+	public abstract fun getTier ()Lcom/ditchoom/buffer/crypto/CustodyTier;
+}
+
+public final class com/ditchoom/buffer/crypto/KeyCustody$ExportableSoftware : com/ditchoom/buffer/crypto/KeyCustody {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/KeyCustody$ExportableSoftware;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getTier ()Lcom/ditchoom/buffer/crypto/CustodyTier;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/KeyCustody$NonExportable : com/ditchoom/buffer/crypto/KeyCustody {
+}
+
+public final class com/ditchoom/buffer/crypto/KeyCustody$NonExportable$Hardware : com/ditchoom/buffer/crypto/KeyCustody$NonExportable {
+	public fun <init> (Z)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Lcom/ditchoom/buffer/crypto/KeyCustody$NonExportable$Hardware;
+	public static synthetic fun copy$default (Lcom/ditchoom/buffer/crypto/KeyCustody$NonExportable$Hardware;ZILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/KeyCustody$NonExportable$Hardware;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDedicatedSecureElement ()Z
+	public fun getTier ()Lcom/ditchoom/buffer/crypto/CustodyTier;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/KeyCustody$NonExportable$Software : com/ditchoom/buffer/crypto/KeyCustody$NonExportable {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/KeyCustody$NonExportable$Software;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getTier ()Lcom/ditchoom/buffer/crypto/CustodyTier;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/KeyCustodyKt {
+	public static final fun getDedicatedSecureElement (Lcom/ditchoom/buffer/crypto/KeyCustody;)Z
+	public static final fun getExportable (Lcom/ditchoom/buffer/crypto/KeyCustody;)Z
+	public static final fun getProvenance (Lcom/ditchoom/buffer/crypto/KeyCustody;)Lcom/ditchoom/buffer/crypto/KeyProvenance;
+}
+
 public final class com/ditchoom/buffer/crypto/KeyProvenance : java/lang/Enum {
 	public static final field Hardware Lcom/ditchoom/buffer/crypto/KeyProvenance;
 	public static final field Software Lcom/ditchoom/buffer/crypto/KeyProvenance;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/ditchoom/buffer/crypto/KeyProvenance;
 	public static fun values ()[Lcom/ditchoom/buffer/crypto/KeyProvenance;
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/KeyProvider {
+	public abstract fun custodyFor (Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;)Lcom/ditchoom/buffer/crypto/KeyCustody;
+	public abstract fun eligible (Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;)Z
+	public abstract fun generateAesGcm (Lcom/ditchoom/buffer/crypto/ProtectedKeySpec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun generateKeyAgreement (Lcom/ditchoom/buffer/crypto/KeyAgreementCurve;Lcom/ditchoom/buffer/crypto/ProtectedKeySpec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun generateSigning (Lcom/ditchoom/buffer/crypto/SignatureScheme;Lcom/ditchoom/buffer/crypto/ProtectedKeySpec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/ditchoom/buffer/crypto/KeyProviderKt {
+	public static final fun getProtectedKeys (Lcom/ditchoom/buffer/crypto/CryptoCapabilities;)Lcom/ditchoom/buffer/crypto/ProtectedKeySupport;
 }
 
 public final class com/ditchoom/buffer/crypto/MessageLimitReached : com/ditchoom/buffer/crypto/CryptoMisuseException {
@@ -936,12 +1017,42 @@ public final class com/ditchoom/buffer/crypto/ProtectedKeyAlgorithm : java/lang/
 	public static fun values ()[Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
 }
 
+public abstract interface class com/ditchoom/buffer/crypto/ProtectedKeyProvider : com/ditchoom/buffer/crypto/ConcreteKeyProvider {
+	public abstract fun getCustody ()Lcom/ditchoom/buffer/crypto/KeyCustody$NonExportable;
+	public synthetic fun getCustody ()Lcom/ditchoom/buffer/crypto/KeyCustody;
+}
+
+public final class com/ditchoom/buffer/crypto/ProtectedKeyProvider$DefaultImpls {
+	public static fun custodyFor (Lcom/ditchoom/buffer/crypto/ProtectedKeyProvider;Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;)Lcom/ditchoom/buffer/crypto/KeyCustody;
+}
+
 public final class com/ditchoom/buffer/crypto/ProtectedKeySpec {
 	public fun <init> ()V
 	public fun <init> (Lcom/ditchoom/buffer/crypto/HardwareAuthorization;I)V
 	public synthetic fun <init> (Lcom/ditchoom/buffer/crypto/HardwareAuthorization;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAesKeySizeBits ()I
 	public final fun getAuthorization ()Lcom/ditchoom/buffer/crypto/HardwareAuthorization;
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/ProtectedKeySupport {
+}
+
+public final class com/ditchoom/buffer/crypto/ProtectedKeySupport$Available : com/ditchoom/buffer/crypto/ProtectedKeySupport {
+	public fun <init> (Lcom/ditchoom/buffer/crypto/ProtectedKeyProvider;)V
+	public final fun component1 ()Lcom/ditchoom/buffer/crypto/ProtectedKeyProvider;
+	public final fun copy (Lcom/ditchoom/buffer/crypto/ProtectedKeyProvider;)Lcom/ditchoom/buffer/crypto/ProtectedKeySupport$Available;
+	public static synthetic fun copy$default (Lcom/ditchoom/buffer/crypto/ProtectedKeySupport$Available;Lcom/ditchoom/buffer/crypto/ProtectedKeyProvider;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/ProtectedKeySupport$Available;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getProvider ()Lcom/ditchoom/buffer/crypto/ProtectedKeyProvider;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/ProtectedKeySupport$Unavailable : com/ditchoom/buffer/crypto/ProtectedKeySupport {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/ProtectedKeySupport$Unavailable;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class com/ditchoom/buffer/crypto/Salt {
@@ -1270,7 +1381,8 @@ public final class com/ditchoom/buffer/crypto/Signatures_jvmCommonKt {
 
 public abstract interface class com/ditchoom/buffer/crypto/SigningKey : java/lang/AutoCloseable {
 	public static final field Companion Lcom/ditchoom/buffer/crypto/SigningKey$Companion;
-	public abstract fun getProvenance ()Lcom/ditchoom/buffer/crypto/KeyProvenance;
+	public abstract fun getCustody ()Lcom/ditchoom/buffer/crypto/KeyCustody;
+	public fun getProvenance ()Lcom/ditchoom/buffer/crypto/KeyProvenance;
 	public abstract fun getScheme ()Lcom/ditchoom/buffer/crypto/SignatureScheme;
 	public abstract fun getVerifyKey ()Lcom/ditchoom/buffer/crypto/VerifyKey;
 }
@@ -1286,14 +1398,23 @@ public final class com/ditchoom/buffer/crypto/SigningKey$Companion {
 	public static synthetic fun ed25519$default (Lcom/ditchoom/buffer/crypto/SigningKey$Companion;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/crypto/VerifyKey;Lcom/ditchoom/buffer/BufferFactory;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/SyncCapableSigningKey;
 }
 
+public final class com/ditchoom/buffer/crypto/SigningKey$DefaultImpls {
+	public static fun getProvenance (Lcom/ditchoom/buffer/crypto/SigningKey;)Lcom/ditchoom/buffer/crypto/KeyProvenance;
+}
+
 public abstract interface class com/ditchoom/buffer/crypto/SyncCapableAesGcmKey : com/ditchoom/buffer/crypto/AesGcmKey {
 }
 
 public final class com/ditchoom/buffer/crypto/SyncCapableAesGcmKey$DefaultImpls {
+	public static fun getProvenance (Lcom/ditchoom/buffer/crypto/SyncCapableAesGcmKey;)Lcom/ditchoom/buffer/crypto/KeyProvenance;
 	public static fun getSizeBytes (Lcom/ditchoom/buffer/crypto/SyncCapableAesGcmKey;)I
 }
 
 public abstract interface class com/ditchoom/buffer/crypto/SyncCapableSigningKey : com/ditchoom/buffer/crypto/SigningKey {
+}
+
+public final class com/ditchoom/buffer/crypto/SyncCapableSigningKey$DefaultImpls {
+	public static fun getProvenance (Lcom/ditchoom/buffer/crypto/SyncCapableSigningKey;)Lcom/ditchoom/buffer/crypto/KeyProvenance;
 }
 
 public abstract interface class com/ditchoom/buffer/crypto/UserAuthenticatedKeyProvider {

--- a/buffer-crypto/api/jvm/buffer-crypto.api
+++ b/buffer-crypto/api/jvm/buffer-crypto.api
@@ -217,17 +217,6 @@ public final class com/ditchoom/buffer/crypto/EcdsaSignatureEncoding : java/lang
 	public static fun values ()[Lcom/ditchoom/buffer/crypto/EcdsaSignatureEncoding;
 }
 
-public final class com/ditchoom/buffer/crypto/HardwareAlgorithm : java/lang/Enum {
-	public static final field AesGcm Lcom/ditchoom/buffer/crypto/HardwareAlgorithm;
-	public static final field EcdsaP256 Lcom/ditchoom/buffer/crypto/HardwareAlgorithm;
-	public static final field EcdsaP384 Lcom/ditchoom/buffer/crypto/HardwareAlgorithm;
-	public static final field EcdsaP521 Lcom/ditchoom/buffer/crypto/HardwareAlgorithm;
-	public static final field Ed25519 Lcom/ditchoom/buffer/crypto/HardwareAlgorithm;
-	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public static fun valueOf (Ljava/lang/String;)Lcom/ditchoom/buffer/crypto/HardwareAlgorithm;
-	public static fun values ()[Lcom/ditchoom/buffer/crypto/HardwareAlgorithm;
-}
-
 public abstract interface class com/ditchoom/buffer/crypto/HardwareAuthorization {
 	public abstract fun authorize (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
@@ -256,18 +245,10 @@ public final class com/ditchoom/buffer/crypto/HardwareKeyException$UserAuthentic
 }
 
 public abstract interface class com/ditchoom/buffer/crypto/HardwareKeyProvider {
-	public abstract fun eligible (Lcom/ditchoom/buffer/crypto/HardwareAlgorithm;)Z
-	public abstract fun generateAesGcm (Lcom/ditchoom/buffer/crypto/HardwareKeySpec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun generateSigning (Lcom/ditchoom/buffer/crypto/SignatureScheme;Lcom/ditchoom/buffer/crypto/HardwareKeySpec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun eligible (Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;)Z
+	public abstract fun generateAesGcm (Lcom/ditchoom/buffer/crypto/ProtectedKeySpec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun generateSigning (Lcom/ditchoom/buffer/crypto/SignatureScheme;Lcom/ditchoom/buffer/crypto/ProtectedKeySpec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getDedicatedSecureElement ()Z
-}
-
-public final class com/ditchoom/buffer/crypto/HardwareKeySpec {
-	public fun <init> ()V
-	public fun <init> (Lcom/ditchoom/buffer/crypto/HardwareAuthorization;I)V
-	public synthetic fun <init> (Lcom/ditchoom/buffer/crypto/HardwareAuthorization;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getAesKeySizeBits ()I
-	public final fun getAuthorization ()Lcom/ditchoom/buffer/crypto/HardwareAuthorization;
 }
 
 public final class com/ditchoom/buffer/crypto/HardwareKeysKt {
@@ -940,6 +921,29 @@ public final class com/ditchoom/buffer/crypto/OptionalAead$Unavailable : com/dit
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/ditchoom/buffer/crypto/ProtectedKeyAlgorithm : java/lang/Enum {
+	public static final field AesGcm Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
+	public static final field EcdhP256 Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
+	public static final field EcdhP384 Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
+	public static final field EcdhP521 Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
+	public static final field EcdsaP256 Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
+	public static final field EcdsaP384 Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
+	public static final field EcdsaP521 Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
+	public static final field Ed25519 Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
+	public static final field X25519 Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
+	public static fun values ()[Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
+}
+
+public final class com/ditchoom/buffer/crypto/ProtectedKeySpec {
+	public fun <init> ()V
+	public fun <init> (Lcom/ditchoom/buffer/crypto/HardwareAuthorization;I)V
+	public synthetic fun <init> (Lcom/ditchoom/buffer/crypto/HardwareAuthorization;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAesKeySizeBits ()I
+	public final fun getAuthorization ()Lcom/ditchoom/buffer/crypto/HardwareAuthorization;
+}
+
 public abstract interface class com/ditchoom/buffer/crypto/Salt {
 }
 
@@ -1293,7 +1297,7 @@ public abstract interface class com/ditchoom/buffer/crypto/SyncCapableSigningKey
 }
 
 public abstract interface class com/ditchoom/buffer/crypto/UserAuthenticatedKeyProvider {
-	public abstract fun eligible (Lcom/ditchoom/buffer/crypto/HardwareAlgorithm;)Z
+	public abstract fun eligible (Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;)Z
 	public abstract fun generateAesGcm (Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun generateAesGcm$default (Lcom/ditchoom/buffer/crypto/UserAuthenticatedKeyProvider;Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public abstract fun generateSigning (Lcom/ditchoom/buffer/crypto/SignatureScheme;Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/buffer-crypto/api/jvm/buffer-crypto.api
+++ b/buffer-crypto/api/jvm/buffer-crypto.api
@@ -738,6 +738,12 @@ public final class com/ditchoom/buffer/crypto/Info$Of : com/ditchoom/buffer/cryp
 	public final synthetic fun unbox-impl ()Lcom/ditchoom/buffer/ReadBuffer;
 }
 
+public final class com/ditchoom/buffer/crypto/InsufficientKeyCustody : com/ditchoom/buffer/crypto/CryptoMisuseException {
+	public final fun getAlg ()Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
+	public final fun getAvailable ()Lcom/ditchoom/buffer/crypto/CustodyTier;
+	public final fun getRequired ()Lcom/ditchoom/buffer/crypto/CustodyTier;
+}
+
 public final class com/ditchoom/buffer/crypto/InvalidPublicKey : com/ditchoom/buffer/crypto/CryptoMisuseException {
 	public final fun getCurve ()Lcom/ditchoom/buffer/crypto/KeyAgreementCurve;
 }
@@ -951,6 +957,11 @@ public abstract interface class com/ditchoom/buffer/crypto/KeyProvider {
 
 public final class com/ditchoom/buffer/crypto/KeyProviderKt {
 	public static final fun getProtectedKeys (Lcom/ditchoom/buffer/crypto/CryptoCapabilities;)Lcom/ditchoom/buffer/crypto/ProtectedKeySupport;
+}
+
+public final class com/ditchoom/buffer/crypto/KeyProviderResolutionKt {
+	public static final fun keyProvider (Lcom/ditchoom/buffer/crypto/CryptoCapabilities;)Lcom/ditchoom/buffer/crypto/KeyProvider;
+	public static final fun requireTier (Lcom/ditchoom/buffer/crypto/KeyProvider;Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;Lcom/ditchoom/buffer/crypto/CustodyTier;)Lcom/ditchoom/buffer/crypto/KeyProvider;
 }
 
 public final class com/ditchoom/buffer/crypto/MessageLimitReached : com/ditchoom/buffer/crypto/CryptoMisuseException {

--- a/buffer-crypto/api/jvm/buffer-crypto.api
+++ b/buffer-crypto/api/jvm/buffer-crypto.api
@@ -583,6 +583,7 @@ public final class com/ditchoom/buffer/crypto/HpkeKt {
 	public static final fun hpkeGenerateKeyPair (Lcom/ditchoom/buffer/crypto/HpkeKem;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun hpkeImportPrivateKey (Lcom/ditchoom/buffer/crypto/HpkeKem;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/ReadBuffer;)Lcom/ditchoom/buffer/crypto/HpkePrivateKey;
 	public static final fun hpkeImportPublicKey (Lcom/ditchoom/buffer/crypto/HpkeKem;Lcom/ditchoom/buffer/ReadBuffer;)Lcom/ditchoom/buffer/crypto/HpkePublicKey;
+	public static final fun hpkeRecipientPrivateKey (Lcom/ditchoom/buffer/crypto/HpkeKem;Lcom/ditchoom/buffer/crypto/KeyAgreementKeyPair;)Lcom/ditchoom/buffer/crypto/HpkePrivateKey;
 }
 
 public abstract interface class com/ditchoom/buffer/crypto/HpkeMode {

--- a/buffer-crypto/config/detekt/baseline.xml
+++ b/buffer-crypto/config/detekt/baseline.xml
@@ -14,20 +14,25 @@
     <ID>MagicNumber:EcInterop.kt:48</ID>
     <ID>MagicNumber:EcInterop.kt:65</ID>
     <ID>MagicNumber:EcInterop.kt:66</ID>
+    <ID>MagicNumber:HardwareKeys.jsAndWasmJs.kt:256</ID>
+    <ID>MagicNumber:HardwareKeys.jsAndWasmJs.kt:384</ID>
+    <ID>MagicNumber:HardwareKeys.jsAndWasmJs.kt:528</ID>
     <ID>MagicNumber:Signatures.apple.kt:32</ID>
     <ID>MagicNumber:Signatures.apple.kt:48</ID>
     <ID>MagicNumber:Signatures.apple.kt:66</ID>
+    <ID>MagicNumber:WebCryptoProtectedKeyProviderTest.kt:WebCryptoProtectedKeyProviderTest$64</ID>
+    <ID>MatchingDeclarationName:HardwareKeys.jsAndWasmJs.kt:WebCryptoProtectedKeyProvider : ProtectedKeyProvider</ID>
     <ID>MatchingDeclarationName:NativeCryptoException.apple.kt:NativeCryptoException : Exception</ID>
     <ID>MatchingDeclarationName:NativeCryptoException.jsAndWasmJs.kt:NativeCryptoException : Exception</ID>
     <ID>MatchingDeclarationName:NativeCryptoException.linux.kt:NativeCryptoException : Exception</ID>
-    <ID>MaxLineLength:AeadKeyCloseTest.kt:AeadKeyCloseTest$for (i in 0 until key.requireInMemoryMaterial().limit()) assertEquals(0, key.requireInMemoryMaterial().get(i).toInt())</ID>
     <ID>MaxLineLength:AeadTamperTest.kt:AeadTamperTest$assertFailsWith&lt;VerificationFailed> { ops.open(sealed, wrongKey, Aad.Of(ascii(aad)), BufferFactory.Default) }</ID>
     <ID>MaxLineLength:EcInteropTest.kt:EcInteropTest$assertEquals(1 + curve.privateKeyBytes, compressed.remaining(), "${curve.curveName} compressed width")</ID>
     <ID>MaxLineLength:EcInteropTest.kt:EcInteropTest$private fun ByteArray.toHexString: String</ID>
     <ID>MaxLineLength:EcInteropTest.kt:EcInteropTest$val e = assertFailsWith&lt;EcEncodingException> { ecPublicKeyDecompress(KeyAgreementCurve.P256, hexBuffer("02$pHex")) }</ID>
     <ID>MaxLineLength:EcInteropTest.kt:EcInteropTest$val e = assertFailsWith&lt;EcEncodingException> { ecdsaSignatureToP1363(SignatureScheme.EcdsaP256, hexBuffer(der)) }</ID>
-    <ID>MaxLineLength:FakeHardware.kt:FakeHardware$override fun eligible: Boolean</ID>
-    <ID>MaxLineLength:FakeHardware.kt:FakeHardware$require</ID>
+    <ID>MaxLineLength:HardwareKeys.js.kt:internal actual suspend fun webCryptoGenerateNonExportableAesGcm: String</ID>
+    <ID>MaxLineLength:HardwareKeys.js.kt:internal actual suspend fun webCryptoGenerateNonExportableEcdh: String</ID>
+    <ID>MaxLineLength:HardwareKeys.js.kt:internal actual suspend fun webCryptoGenerateNonExportableEcdsa: String</ID>
     <ID>MaxLineLength:HardwareKeys.kt:suspend (nonce: ReadBuffer, aad: ReadBuffer?, ciphertextAndTag: ReadBuffer, factory: BufferFactory) -> PlatformBuffer</ID>
     <ID>MaxLineLength:HkdfSha384Sha512Test.kt:HkdfSha384Sha512Test$assertEquals(max384, HkdfSha384.derive(Salt.Of(salt), ikm, Info.Of(info), max384, BufferFactory.Default).remaining())</ID>
     <ID>MaxLineLength:HkdfSha384Sha512Test.kt:HkdfSha384Sha512Test$assertEquals(max512, HkdfSha512.derive(Salt.Of(salt), ikm, Info.Of(info), max512, BufferFactory.Default).remaining())</ID>
@@ -39,12 +44,14 @@
     <ID>MaxLineLength:HpkeContext.kt:dhkemAuthEncapWithEphemeral(suite.kem, recipientPublicKey.keyAgreementKey(), senderPrivateKey, ephemeral)</ID>
     <ID>MaxLineLength:KeyAgreement.apple.kt:internal actual suspend fun generateKeyPairAsyncPlatform: KeyAgreementKeyPair</ID>
     <ID>MaxLineLength:KeyAgreement.jvmCommon.kt:internal actual suspend fun generateKeyPairAsyncPlatform: KeyAgreementKeyPair</ID>
-    <ID>MaxLineLength:KeyAgreement.kt:KeyAgreementAsyncOpsImpl$)</ID>
+    <ID>MaxLineLength:KeyAgreement.kt:KeyAgreementAsyncOpsImpl$deriveSharedSecretAsyncPlatform(privateKey, peerPublicKey, info.bytesOrNull, length, salt.bytesOrNull, factory)</ID>
     <ID>MaxLineLength:KeyAgreement.kt:KeyAgreementBlockingOpsImpl$)</ID>
     <ID>MaxLineLength:KeyAgreement.linux.kt:internal actual suspend fun generateKeyPairAsyncPlatform: KeyAgreementKeyPair</ID>
     <ID>MaxLineLength:KeyAgreementTest.kt:KeyAgreementTest$assertEquals(viaOriginal, viaReimport, "${curve.curveName} re-imported private key must derive the same secret")</ID>
     <ID>MaxLineLength:KeyAgreementWitnessSupport.kt:?:</ID>
     <ID>MaxLineLength:KeyAgreementWitnessSupport.kt:internal</ID>
+    <ID>MaxLineLength:KeyProviderResolution.kt:ResolvingKeyProvider$override suspend fun generateAesGcm: AesGcmKey</ID>
+    <ID>MaxLineLength:KeyProviderResolution.kt:ResolvingKeyProvider$private fun pick: ConcreteKeyProvider</ID>
     <ID>MaxLineLength:SignatureBackingTest.kt:SignatureBackingTest$val sig = SigningKey.ecdsaP256(scalar, VerifyKey.ecdsaP256(hexBuffer(p256Point))).use { signAsync(it, message) }</ID>
     <ID>MaxLineLength:SignatureBackingTest.kt:SignatureBackingTest$val sig = SigningKey.ed25519(seed, VerifyKey.ed25519(hexBuffer(edPub))).use { signAsync(it, message) }</ID>
     <ID>MaxLineLength:SignatureGenerateTest.kt:SignatureGenerateTest$assertTrue(ops.verify(sk.verifyKey, message, sig), "$scheme generated key verifies its own signature")</ID>
@@ -52,7 +59,14 @@
     <ID>MaxLineLength:Signatures.jsAndWasmJs.kt:)</ID>
     <ID>MaxLineLength:Signatures.kt:SignatureBlockingOpsImpl$override fun generateSigningKeyBlocking: SyncCapableSigningKey</ID>
     <ID>MaxLineLength:Signatures.kt:SignatureBlockingOpsImpl$override suspend fun generateSigningKey: SyncCapableSigningKey</ID>
-    <ID>NestedBlockDepth:HkdfCore.kt:HkdfEngine$fun expandInto</ID>
+    <ID>MaxLineLength:WebCryptoProtectedKeyProviderTest.kt:WebCryptoProtectedKeyProviderTest$assertEquals(KeyProvenance.Software, p.custody.provenance, "WebCrypto is software-backed, not a secure element")</ID>
+    <ID>MaxLineLength:WebCryptoProtectedKeyProviderTest.kt:WebCryptoProtectedKeyProviderTest$assertEquals(keyToWrap.toHex(), recovered.toHex(), "HPKE openBase composes with a non-exportable recipient key")</ID>
+    <ID>MaxLineLength:WebCryptoProtectedKeyProviderTest.kt:WebCryptoProtectedKeyProviderTest$assertEquals(plaintext.toHex(), opened.toHex(), "AES-256-GCM round-trips through the non-exportable key")</ID>
+    <ID>MaxLineLength:WebCryptoProtectedKeyProviderTest.kt:WebCryptoProtectedKeyProviderTest$assertFalse(verifyAsync(sk.verifyKey, ascii("a different message"), signature), "a tampered message is rejected")</ID>
+    <ID>MaxLineLength:WebCryptoProtectedKeyProviderTest.kt:WebCryptoProtectedKeyProviderTest$assertTrue(protectedPair.privateKey is ProtectedKeyAgreementPrivateKey, "the KA private key is non-exportable")</ID>
+    <ID>MaxLineLength:WebCryptoProtectedKeyProviderTest.kt:WebCryptoProtectedKeyProviderTest$val fromProtected = deriveSharedSecretAsync(protectedPair.privateKey, softwarePeer.publicKey, info, 32, salt)</ID>
+    <ID>MaxLineLength:WebCryptoProtectedKeyProviderTest.kt:WebCryptoProtectedKeyProviderTest$val fromSoftware = deriveSharedSecretAsync(softwarePeer.privateKey, protectedPair.publicKey, info, 32, salt)</ID>
+    <ID>MaxLineLength:WebCryptoProtectedKeyProviderTest.kt:WebCryptoProtectedKeyProviderTest$val recovered = ops.openBase(recipientPrivate, sealed.enc, Info.Of(info), sealed.ciphertext, Aad.Of(aad))</ID>
     <ID>ReturnCount:EcInterop.kt:DerCursor$fun matchOid: Boolean</ID>
     <ID>ReturnCount:HpkeKatTest.kt:HpkeKatTest$private suspend fun runVector: Int</ID>
     <ID>ReturnCount:Signatures.apple.kt:private fun appleEcdsaVerify: Boolean</ID>
@@ -65,9 +79,15 @@
     <ID>ReturnCount:Signatures.linux.kt:private fun ed25519Verify: Boolean</ID>
     <ID>ReturnCount:Signatures.linux.kt:private fun inRangeOneToOrder: Boolean</ID>
     <ID>ReturnCount:Signatures.linux.kt:private fun isCanonicalEcdsaDer: Boolean</ID>
+    <ID>ThrowsCount:HardwareKeys.jsAndWasmJs.kt:WebCryptoProtectedKeyProvider$override suspend fun generateAesGcm: AesGcmKey</ID>
+    <ID>ThrowsCount:HardwareKeys.jsAndWasmJs.kt:WebCryptoProtectedKeyProvider$override suspend fun generateKeyAgreement: KeyAgreementKeyPair</ID>
     <ID>TooManyFunctions:Aead.jvmCommon.kt:com.ditchoom.buffer.crypto.Aead.jvmCommon.kt</ID>
     <ID>TooManyFunctions:Aead.kt:com.ditchoom.buffer.crypto.Aead.kt</ID>
     <ID>TooManyFunctions:EcInterop.kt:com.ditchoom.buffer.crypto.EcInterop.kt</ID>
+    <ID>TooManyFunctions:HardwareKeys.android.kt:AndroidKeystoreHardwareKeyProvider : HardwareKeyProvider</ID>
+    <ID>TooManyFunctions:HardwareKeys.js.kt:com.ditchoom.buffer.crypto.HardwareKeys.js.kt</ID>
+    <ID>TooManyFunctions:HardwareKeys.jsAndWasmJs.kt:com.ditchoom.buffer.crypto.HardwareKeys.jsAndWasmJs.kt</ID>
+    <ID>TooManyFunctions:HardwareKeys.wasmJs.kt:com.ditchoom.buffer.crypto.HardwareKeys.wasmJs.kt</ID>
     <ID>TooManyFunctions:Hpke.kt:com.ditchoom.buffer.crypto.Hpke.kt</ID>
     <ID>TooManyFunctions:HpkeContext.kt:com.ditchoom.buffer.crypto.HpkeContext.kt</ID>
     <ID>TooManyFunctions:KeyAgreement.apple.kt:com.ditchoom.buffer.crypto.KeyAgreement.apple.kt</ID>

--- a/buffer-crypto/src/androidInstrumentedTest/kotlin/com/ditchoom/buffer/crypto/StrongBoxInstrumentedTest.kt
+++ b/buffer-crypto/src/androidInstrumentedTest/kotlin/com/ditchoom/buffer/crypto/StrongBoxInstrumentedTest.kt
@@ -39,7 +39,7 @@ class StrongBoxInstrumentedTest {
     fun dedicatedSecureElementMatchesDeviceStrongBox() =
         runTest {
             val provider = provider()
-            val signing = provider.generateSigning(SignatureScheme.EcdsaP256, HardwareKeySpec())
+            val signing = provider.generateSigning(SignatureScheme.EcdsaP256, ProtectedKeySpec())
             try {
                 assertEquals(KeyProvenance.Hardware, signing.provenance)
                 // The dedicated-secure-element claim must equal the device's StrongBox capability.
@@ -65,7 +65,7 @@ class StrongBoxInstrumentedTest {
     fun aesGcmRoundTripsOnDevice() =
         runTest {
             val provider = provider()
-            val key = provider.generateAesGcm(HardwareKeySpec())
+            val key = provider.generateAesGcm(ProtectedKeySpec())
             try {
                 assertEquals(KeyProvenance.Hardware, key.provenance)
                 val ops = aesGcmAsyncOps()

--- a/buffer-crypto/src/androidMain/kotlin/com/ditchoom/buffer/crypto/BiometricAuth.android.kt
+++ b/buffer-crypto/src/androidMain/kotlin/com/ditchoom/buffer/crypto/BiometricAuth.android.kt
@@ -140,7 +140,7 @@ class BiometricPromptAuthenticator(
  * no nullable downstream, no runtime validation state).
  */
 internal sealed interface ResolvedAndroidPolicy {
-    /** No OS binding; [gate] is the advisory [HardwareKeySpec.authorization]. */
+    /** No OS binding; [gate] is the advisory [ProtectedKeySpec.authorization]. */
     class Advisory(
         val gate: HardwareAuthorization,
     ) : ResolvedAndroidPolicy
@@ -168,7 +168,7 @@ internal class AndroidUserAuthenticatedKeyProvider(
     private val base: AndroidKeystoreHardwareKeyProvider,
     private val prompt: BiometricAuthorization,
 ) : UserAuthenticatedKeyProvider {
-    override fun eligible(alg: HardwareAlgorithm): Boolean = base.eligible(alg)
+    override fun eligible(alg: ProtectedKeyAlgorithm): Boolean = base.eligible(alg)
 
     override suspend fun generateAesGcm(
         policy: UserAuthenticationPolicy,

--- a/buffer-crypto/src/androidMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.android.kt
+++ b/buffer-crypto/src/androidMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.android.kt
@@ -105,18 +105,18 @@ internal class AndroidKeystoreHardwareKeyProvider : HardwareKeyProvider {
      */
     override val dedicatedSecureElement: Boolean by lazy { probeStrongBox() }
 
-    override fun eligible(alg: HardwareAlgorithm): Boolean =
+    override fun eligible(alg: ProtectedKeyAlgorithm): Boolean =
         when (alg) {
-            HardwareAlgorithm.AesGcm, HardwareAlgorithm.EcdsaP256 -> true
+            ProtectedKeyAlgorithm.AesGcm, ProtectedKeyAlgorithm.EcdsaP256 -> true
             else -> false
         }
 
-    override suspend fun generateAesGcm(spec: HardwareKeySpec): AesGcmKey =
+    override suspend fun generateAesGcm(spec: ProtectedKeySpec): AesGcmKey =
         generateAesGcmBound(ResolvedAndroidPolicy.Advisory(spec.authorization), spec.aesKeySizeBits)
 
     override suspend fun generateSigning(
         scheme: SignatureScheme,
-        spec: HardwareKeySpec,
+        spec: ProtectedKeySpec,
     ): SigningKey = generateSigningBound(ResolvedAndroidPolicy.Advisory(spec.authorization), scheme)
 
     /** Generates an AES-GCM keystore key under [policy] — the shared path for unbound and OS-bound keys. */
@@ -186,7 +186,7 @@ internal class AndroidKeystoreHardwareKeyProvider : HardwareKeyProvider {
         policy: ResolvedAndroidPolicy,
         scheme: SignatureScheme,
     ): SigningKey {
-        if (!eligible(scheme.toHardwareAlgorithm())) throw HardwareKeyException.AlgorithmNotEligible()
+        if (!eligible(scheme.toProtectedKeyAlgorithm())) throw HardwareKeyException.AlgorithmNotEligible()
         val alias = newAlias("ec")
         val keyPair = keystoreOp { generateEcKeyPair(alias, policy) }
         val privateKey = keyPair.private

--- a/buffer-crypto/src/androidMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.android.kt
+++ b/buffer-crypto/src/androidMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.android.kt
@@ -119,6 +119,13 @@ internal class AndroidKeystoreHardwareKeyProvider : HardwareKeyProvider {
         spec: ProtectedKeySpec,
     ): SigningKey = generateSigningBound(ResolvedAndroidPolicy.Advisory(spec.authorization), scheme)
 
+    override suspend fun generateKeyAgreement(
+        curve: KeyAgreementCurve,
+        spec: ProtectedKeySpec,
+    ): KeyAgreementKeyPair =
+        // Android Keystore backs no app-controlled ECDH/X25519 agreement key here; not eligible.
+        throw HardwareKeyException.AlgorithmNotEligible()
+
     /** Generates an AES-GCM keystore key under [policy] — the shared path for unbound and OS-bound keys. */
     internal suspend fun generateAesGcmBound(
         policy: ResolvedAndroidPolicy,
@@ -130,8 +137,9 @@ internal class AndroidKeystoreHardwareKeyProvider : HardwareKeyProvider {
         if (!validSize) throw HardwareKeyException.UnsupportedHardwareKey()
         val alias = newAlias("aes")
         val key = keystoreOp { generateAesKey(alias, aesKeySizeBits, policy) }
-        return HardwareAesGcmKey(
+        return ProtectedAesGcmKey(
             sizeBits = aesKeySizeBits,
+            custody = custody,
             gatedSeal = { aad, plaintext, factory ->
                 gatedOp(
                     policy = policy,
@@ -191,8 +199,9 @@ internal class AndroidKeystoreHardwareKeyProvider : HardwareKeyProvider {
         val keyPair = keystoreOp { generateEcKeyPair(alias, policy) }
         val privateKey = keyPair.private
         val verifyKey = VerifyKey.ecdsaP256(uncompressedPoint(keyPair.public as ECPublicKey))
-        return HardwareSigningKey(
+        return ProtectedSigningKey(
             scheme = SignatureScheme.EcdsaP256,
+            custody = custody,
             gatedSign = { message, factory ->
                 gatedOp(
                     policy = policy,
@@ -383,7 +392,7 @@ private fun aesSpec(
         .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
         .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
         // Randomized encryption stays *required* (the default): the keystore picks a fresh GCM IV
-        // per seal, which the witness reads back and frames (see HardwareAesGcmKey.gatedSeal). The
+        // per seal, which the witness reads back and frames (see ProtectedAesGcmKey.gatedSeal). The
         // library never supplies a seal nonce — one reused GCM (key, nonce) pair is catastrophic.
         .setIsStrongBoxBacked(strongBox)
         .apply { applyUserAuth(policy) }
@@ -496,4 +505,4 @@ private val androidProvider: HardwareKeyProvider? by lazy {
     }
 }
 
-internal actual fun platformHardwareKeyProvider(): HardwareKeyProvider? = androidProvider
+internal actual fun platformProtectedKeyProvider(): ProtectedKeyProvider? = androidProvider

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.apple.kt
@@ -71,15 +71,15 @@ import kotlin.time.TimeSource
 internal class SecureEnclaveHardwareKeyProvider : HardwareKeyProvider {
     override val dedicatedSecureElement: Boolean get() = true
 
-    override fun eligible(alg: HardwareAlgorithm): Boolean = alg == HardwareAlgorithm.EcdsaP256
+    override fun eligible(alg: ProtectedKeyAlgorithm): Boolean = alg == ProtectedKeyAlgorithm.EcdsaP256
 
-    override suspend fun generateAesGcm(spec: HardwareKeySpec): AesGcmKey =
+    override suspend fun generateAesGcm(spec: ProtectedKeySpec): AesGcmKey =
         // No app-controlled non-exportable symmetric Enclave key exists on Apple.
         throw HardwareKeyException.AlgorithmNotEligible()
 
     override suspend fun generateSigning(
         scheme: SignatureScheme,
-        spec: HardwareKeySpec,
+        spec: ProtectedKeySpec,
     ): SigningKey = generateSigningBound(ResolvedApplePolicy.Advisory(spec.authorization), scheme)
 
     /** Generates an Enclave P-256 key under [policy] — the shared path for unbound and OS-bound keys. */
@@ -87,7 +87,7 @@ internal class SecureEnclaveHardwareKeyProvider : HardwareKeyProvider {
         policy: ResolvedApplePolicy,
         scheme: SignatureScheme,
     ): SigningKey {
-        if (!eligible(scheme.toHardwareAlgorithm())) throw HardwareKeyException.AlgorithmNotEligible()
+        if (!eligible(scheme.toProtectedKeyAlgorithm())) throw HardwareKeyException.AlgorithmNotEligible()
         val generated =
             when (policy) {
                 is ResolvedApplePolicy.Advisory -> enclaveGenerateP256()
@@ -183,7 +183,7 @@ internal class SecureEnclaveHardwareKeyProvider : HardwareKeyProvider {
  * authenticator" is unrepresentable.
  */
 internal sealed interface ResolvedApplePolicy {
-    /** No `SecAccessControl`; [gate] is the advisory [HardwareKeySpec.authorization]. */
+    /** No `SecAccessControl`; [gate] is the advisory [ProtectedKeySpec.authorization]. */
     class Advisory(
         val gate: HardwareAuthorization,
     ) : ResolvedApplePolicy
@@ -209,7 +209,7 @@ internal class AppleUserAuthenticatedKeyProvider(
     private val base: SecureEnclaveHardwareKeyProvider,
     private val authenticator: LocalAuthAuthenticator,
 ) : UserAuthenticatedKeyProvider {
-    override fun eligible(alg: HardwareAlgorithm): Boolean = base.eligible(alg)
+    override fun eligible(alg: ProtectedKeyAlgorithm): Boolean = base.eligible(alg)
 
     override suspend fun generateAesGcm(
         policy: UserAuthenticationPolicy,

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.apple.kt
@@ -82,6 +82,13 @@ internal class SecureEnclaveHardwareKeyProvider : HardwareKeyProvider {
         spec: ProtectedKeySpec,
     ): SigningKey = generateSigningBound(ResolvedApplePolicy.Advisory(spec.authorization), scheme)
 
+    override suspend fun generateKeyAgreement(
+        curve: KeyAgreementCurve,
+        spec: ProtectedKeySpec,
+    ): KeyAgreementKeyPair =
+        // The Secure Enclave backs no app-controlled ECDH agreement key through this SPI; not eligible.
+        throw HardwareKeyException.AlgorithmNotEligible()
+
     /** Generates an Enclave P-256 key under [policy] — the shared path for unbound and OS-bound keys. */
     internal suspend fun generateSigningBound(
         policy: ResolvedApplePolicy,
@@ -94,8 +101,9 @@ internal class SecureEnclaveHardwareKeyProvider : HardwareKeyProvider {
                 is ResolvedApplePolicy.Session -> enclaveGenerateP256AccessControlled(policy.method)
                 is ResolvedApplePolicy.PerUse -> enclaveGenerateP256AccessControlled(policy.method)
             }
-        return HardwareSigningKey(
+        return ProtectedSigningKey(
             scheme = SignatureScheme.EcdsaP256,
+            custody = custody,
             gatedSign = gatedSign(policy, generated.blob),
             verifyKey = VerifyKey.ecdsaP256(generated.point),
         )
@@ -423,4 +431,4 @@ private val appleProvider: HardwareKeyProvider? by lazy {
     }
 }
 
-internal actual fun platformHardwareKeyProvider(): HardwareKeyProvider? = appleProvider
+internal actual fun platformProtectedKeyProvider(): ProtectedKeyProvider? = appleProvider

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/KeyAgreement.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/KeyAgreement.apple.kt
@@ -265,7 +265,7 @@ internal actual fun deriveSharedSecretPlatform(
  * Raw DH secret seam for HPKE/DHKEM (no KDF). Delegates to the same Security-framework exchange
  * as [deriveSharedSecret] and applies the audited [validateRawSecret] post-check.
  */
-internal actual suspend fun dhRawSecret(
+internal actual suspend fun dhRawSecretInMemory(
     privateKey: KeyAgreementPrivateKey,
     peerPublicKey: KeyAgreementPublicKey,
 ): PlatformBuffer = validateRawSecret(privateKey.curve, rawAgreeApple(privateKey, peerPublicKey))

--- a/buffer-crypto/src/appleTest/kotlin/com/ditchoom/buffer/crypto/LocalAuthAuthenticatorTest.kt
+++ b/buffer-crypto/src/appleTest/kotlin/com/ditchoom/buffer/crypto/LocalAuthAuthenticatorTest.kt
@@ -38,7 +38,9 @@ class LocalAuthAuthenticatorTest {
 
     @Test
     fun userAuthenticatedRefusesAClosedAuthenticator() {
-        val provider = platformProtectedKeyProvider() ?: return // no Enclave provider on this runner
+        // The seam now returns the broad ProtectedKeyProvider; userAuthenticated is a HardwareKeyProvider
+        // extension, so narrow to it (the Apple Enclave provider is one). No Enclave provider ⇒ skip.
+        val provider = platformProtectedKeyProvider() as? HardwareKeyProvider ?: return
         val auth = LocalAuthAuthenticator(reason = "unit test")
         if (!auth.available) return
         auth.close()

--- a/buffer-crypto/src/appleTest/kotlin/com/ditchoom/buffer/crypto/LocalAuthAuthenticatorTest.kt
+++ b/buffer-crypto/src/appleTest/kotlin/com/ditchoom/buffer/crypto/LocalAuthAuthenticatorTest.kt
@@ -38,7 +38,7 @@ class LocalAuthAuthenticatorTest {
 
     @Test
     fun userAuthenticatedRefusesAClosedAuthenticator() {
-        val provider = platformHardwareKeyProvider() ?: return // no Enclave provider on this runner
+        val provider = platformProtectedKeyProvider() ?: return // no Enclave provider on this runner
         val auth = LocalAuthAuthenticator(reason = "unit test")
         if (!auth.available) return
         auth.close()

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/Aead.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/Aead.kt
@@ -91,8 +91,15 @@ sealed interface AesGcmKey :
     /** 128 or 256 — the AES key size in bits. */
     val sizeBits: Int
 
-    /** Whether the key material is in software memory or hardware-backed. */
-    val provenance: KeyProvenance
+    /**
+     * This key's custody — where its secret lives and whether the process can read it. A key is
+     * self-describing: it carries its own [KeyCustody] so it stays honest across module boundaries,
+     * independent of the provider that minted it.
+     */
+    val custody: KeyCustody
+
+    /** Whether the key material is in software memory or hardware-backed. Derived from [custody]. */
+    val provenance: KeyProvenance get() = custody.provenance
 
     /** Key size in bytes (16 for AES-128, 32 for AES-256). */
     val sizeBytes: Int get() = sizeBits / 8
@@ -132,7 +139,7 @@ internal class InMemoryAesGcmKey(
     override val sizeBits: Int,
     private val material: PlatformBuffer,
 ) : SyncCapableAesGcmKey {
-    override val provenance: KeyProvenance get() = KeyProvenance.Software
+    override val custody: KeyCustody get() = KeyCustody.ExportableSoftware
     private var closed = false
 
     override fun close() {
@@ -214,7 +221,7 @@ internal fun AesGcmKey.requireInMemoryMaterial(): PlatformBuffer =
         // not supported for it — hardware keys operate only through the async witness ops, which
         // dispatch to the gated closures and never reach here. This throw is the safety net if a
         // caller routes a hardware key into a blocking op (e.g. AES-GCM is Blocking on the JVM).
-        is HardwareAesGcmKey -> throw UnsupportedOperationException("hardware AES-GCM key has no synchronous path")
+        is ProtectedAesGcmKey -> throw UnsupportedOperationException("hardware AES-GCM key has no synchronous path")
     }
 
 /** See [AesGcmKey.requireInMemoryMaterial]. */
@@ -230,14 +237,14 @@ internal fun ChaChaPolyKey.requireInMemoryMaterial(): PlatformBuffer =
  * catastrophic), so this is a passthrough. Shared by the async- and blocking-witness ops so a
  * hardware key behaves the same regardless of which witness resolved.
  */
-private suspend fun HardwareAesGcmKey.sealFramed(
+private suspend fun ProtectedAesGcmKey.sealFramed(
     plaintext: ReadBuffer,
     aad: Aad,
     factory: BufferFactory,
 ): PlatformBuffer = gatedSeal(aad.bytesOrNull, plaintext, factory)
 
 /** Opens a `nonce ‖ ciphertext ‖ tag` buffer through a hardware key's gated closure. */
-private suspend fun HardwareAesGcmKey.openFramed(
+private suspend fun ProtectedAesGcmKey.openFramed(
     sealed: ReadBuffer,
     aad: Aad,
     factory: BufferFactory,
@@ -504,7 +511,7 @@ internal object AesGcmBlockingOps : AeadBlockingOps<AesGcmKey, SyncCapableAesGcm
     ): PlatformBuffer =
         when (key) {
             is InMemoryAesGcmKey -> sealBlocking(key, plaintext, aad, factory)
-            is HardwareAesGcmKey -> key.sealFramed(plaintext, aad, factory)
+            is ProtectedAesGcmKey -> key.sealFramed(plaintext, aad, factory)
         }
 
     override suspend fun open(
@@ -515,7 +522,7 @@ internal object AesGcmBlockingOps : AeadBlockingOps<AesGcmKey, SyncCapableAesGcm
     ): PlatformBuffer =
         when (key) {
             is InMemoryAesGcmKey -> openBlocking(sealed, key, aad, factory)
-            is HardwareAesGcmKey -> key.openFramed(sealed, aad, factory)
+            is ProtectedAesGcmKey -> key.openFramed(sealed, aad, factory)
         }
 }
 
@@ -563,8 +570,8 @@ internal object AesGcmAsyncOps : AeadAsyncOps<AesGcmKey, SyncCapableAesGcmKey> {
                 out
             }
             // A hardware key has no in-process material, so it routes through its gated closure;
-            // adding HardwareAesGcmKey forces this branch (the sealed-impl point).
-            is HardwareAesGcmKey -> key.sealFramed(plaintext, aad, factory)
+            // adding ProtectedAesGcmKey forces this branch (the sealed-impl point).
+            is ProtectedAesGcmKey -> key.sealFramed(plaintext, aad, factory)
         }
 
     override suspend fun open(
@@ -578,7 +585,7 @@ internal object AesGcmAsyncOps : AeadAsyncOps<AesGcmKey, SyncCapableAesGcmKey> {
                 val (nonce, ctAndTag, _) = splitFramed(sealed)
                 aesGcmOpenWithNonceAsync(key, nonce, aad.bytesOrNull, ctAndTag, factory)
             }
-            is HardwareAesGcmKey -> key.openFramed(sealed, aad, factory)
+            is ProtectedAesGcmKey -> key.openFramed(sealed, aad, factory)
         }
 }
 

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/CryptoException.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/CryptoException.kt
@@ -83,6 +83,18 @@ class InvalidPublicKey internal constructor(
 class AuthorizationFailed internal constructor() : CryptoMisuseException("hardware key authorization denied")
 
 /**
+ * A [KeyProvider.requireTier] assertion failed: the platform's strongest eligible custody for [alg]
+ * ([available]) is weaker than the [required] tier the caller demanded. Structured and non-secret —
+ * it names only public tiers, never key material — so a security-sensitive caller can branch on it.
+ * Only ever constructed on the unmet path, so an "available ≥ required" instance is unrepresentable.
+ */
+class InsufficientKeyCustody internal constructor(
+    val alg: ProtectedKeyAlgorithm,
+    val required: CustodyTier,
+    val available: CustodyTier,
+) : CryptoMisuseException("$alg requires custody $required, platform offers only $available")
+
+/**
  * A hardware-backed key operation failed in the secure element / keystore itself. `sealed` so every
  * distinct outcome is its own type — callers handle them exhaustively without parsing a message, and
  * each maps to a natural platform exception (e.g. on Android: `StrongBoxUnavailableException`,

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/CryptoException.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/CryptoException.kt
@@ -120,7 +120,7 @@ sealed class HardwareKeyException protected constructor(
     class UnsupportedHardwareKey internal constructor() : HardwareKeyException("unsupported hardware key parameters")
 
     /**
-     * Generation was requested for a [HardwareAlgorithm] where [HardwareKeyProvider.eligible] is
+     * Generation was requested for a [ProtectedKeyAlgorithm] where [HardwareKeyProvider.eligible] is
      * `false` (e.g. AES-GCM on the Apple Secure Enclave). Typed — not an
      * `IllegalArgumentException` with a message — so a caller can branch on it exhaustively; the
      * fix is to consult [HardwareKeyProvider.eligible] before generating.

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.kt
@@ -339,6 +339,17 @@ internal typealias HardwareSign =
     suspend (message: ReadBuffer, factory: BufferFactory) -> ReadBuffer
 
 /**
+ * A gated raw Diffie–Hellman: computes `DH(sk, peer)` inside the non-exportable backend and yields
+ * the **raw** shared secret in a wiped [SecureBuffer] (read-ready, `curve.sharedSecretBytes` bytes),
+ * or throws [AuthorizationFailed] / [InvalidPublicKey]. This is exactly the KEM's `DH(sk, enc)`
+ * primitive: the caller (the common key-agreement / DHKEM seam) runs the HKDF / all-zero rejection
+ * above it, so the whole `keyAgreement()` / `hpke()` machinery composes with a non-exportable
+ * private key whose scalar never enters process memory.
+ */
+internal typealias HardwareDh =
+    suspend (peer: KeyAgreementPublicKey) -> PlatformBuffer
+
+/**
  * Non-exportable [AesGcmKey]: an opaque handle with no exportable material. Seal/open route through
  * the provider-supplied gated closures; the blocking witness path is unreachable because
  * [requireInMemoryMaterial] throws for this type. The [custody] param type [KeyCustody.NonExportable]

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.kt
@@ -11,7 +11,7 @@ import kotlin.time.Duration.Companion.seconds
  * keystore backend can land later as a non-breaking minor.
  *
  * The whole family is built so that "hardware key" is never a special case a consumer must remember
- * to handle: a [HardwareAesGcmKey] is an [AesGcmKey] and a [HardwareSigningKey] is a [SigningKey], so
+ * to handle: a [ProtectedAesGcmKey] is an [AesGcmKey] and a [ProtectedSigningKey] is a [SigningKey], so
  * they flow through the exact same capability witnesses ([CryptoCapabilities.aesGcm],
  * [CryptoCapabilities.signatures]). What differs is reified in the type system, not in runtime
  * branching the caller writes:
@@ -241,29 +241,37 @@ typealias HardwareKeySpec = ProtectedKeySpec
  * the op exactly once; [UserAuthenticationPolicy.PerUse]: for every op, bound to the exact crypto
  * operation where the platform supports binding.
  */
-interface HardwareKeyProvider {
+interface HardwareKeyProvider : ProtectedKeyProvider {
     /**
      * `true` if keys live in a dedicated secure element (StrongBox / Secure Enclave), `false` for a
      * software-isolated keystore (TEE-only). Informational; does not change the op contract.
      */
     val dedicatedSecureElement: Boolean
 
+    /**
+     * A hardware provider's keys are always [KeyCustody.NonExportable.Hardware]; the narrowed return
+     * type re-states, at the type level, that a hardware key can never be exportable or
+     * software-backed. Derived from [dedicatedSecureElement] so the two can never disagree.
+     */
+    override val custody: KeyCustody.NonExportable.Hardware
+        get() = KeyCustody.NonExportable.Hardware(dedicatedSecureElement)
+
     /** Whether this provider can generate a key for [alg] (a secure element backs only a subset). */
-    fun eligible(alg: ProtectedKeyAlgorithm): Boolean
+    override fun eligible(alg: ProtectedKeyAlgorithm): Boolean
 
     /**
      * Generates a fresh AES-GCM key inside the secure element. The returned [AesGcmKey] has
      * [KeyProvenance.Hardware] and no exportable material; it operates only through the async AEAD
      * witness ops, gated by [spec]'s [ProtectedKeySpec.authorization].
      */
-    suspend fun generateAesGcm(spec: ProtectedKeySpec): AesGcmKey
+    override suspend fun generateAesGcm(spec: ProtectedKeySpec): AesGcmKey
 
     /**
      * Generates a fresh signing key for [scheme] inside the secure element. The returned [SigningKey]
      * has [KeyProvenance.Hardware] and no exportable material; it signs only through the async
      * signature witness ops, gated by [spec]'s [ProtectedKeySpec.authorization].
      */
-    suspend fun generateSigning(
+    override suspend fun generateSigning(
         scheme: SignatureScheme,
         spec: ProtectedKeySpec,
     ): SigningKey
@@ -291,22 +299,17 @@ sealed interface HardwareSupport {
  * [HardwareSupport.Unavailable] elsewhere (JVM, JS/WASM, Linux).
  *
  * A plain `val` (not `expect`/`actual`) by design: the *public* signature is frozen, and a backend
- * resolves through the **internal** [platformHardwareKeyProvider] seam, so a later platform can wire
+ * resolves through the **internal** [platformProtectedKeyProvider] seam, so a later platform can wire
  * a provider without changing this declaration. The seam is `internal`, so it never enters the
- * public ABI.
+ * public ABI. This is the secure-element-only refinement of [CryptoCapabilities.protectedKeys]: it
+ * reports [HardwareSupport.Available] only when the platform's non-exportable provider is a
+ * [HardwareKeyProvider], so a non-exportable *software* provider (WebCrypto) is deliberately not
+ * surfaced here.
  */
 val CryptoCapabilities.hardware: HardwareSupport get() =
-    platformHardwareKeyProvider()
+    (platformProtectedKeyProvider() as? HardwareKeyProvider)
         ?.let { HardwareSupport.Available(it) }
         ?: HardwareSupport.Unavailable
-
-/**
- * The platform's hardware-backed key provider, or `null` when this platform wires none (or the
- * secure element is present but not actually usable — e.g. an unentitled test binary). `internal`
- * and `expect`/`actual` so it stays out of the public ABI while [CryptoCapabilities.hardware]'s
- * signature remains frozen. Implementations resolve a cheap, cached singleton.
- */
-internal expect fun platformHardwareKeyProvider(): HardwareKeyProvider?
 
 // =============================================================================
 // Internal hardware-backed key impls — gated async closures, never exportable material
@@ -336,18 +339,19 @@ internal typealias HardwareSign =
     suspend (message: ReadBuffer, factory: BufferFactory) -> ReadBuffer
 
 /**
- * Hardware-backed [AesGcmKey]: an opaque handle with no exportable material. Seal/open route through
+ * Non-exportable [AesGcmKey]: an opaque handle with no exportable material. Seal/open route through
  * the provider-supplied gated closures; the blocking witness path is unreachable because
- * [requireInMemoryMaterial] throws for this type.
+ * [requireInMemoryMaterial] throws for this type. The [custody] param type [KeyCustody.NonExportable]
+ * makes an *exportable* protected key unconstructable — it is either non-exportable software
+ * (WebCrypto) or hardware. [provenance] is derived from it and can never disagree.
  */
-internal class HardwareAesGcmKey(
+internal class ProtectedAesGcmKey(
     override val sizeBits: Int,
+    override val custody: KeyCustody.NonExportable,
     val gatedSeal: HardwareAesGcmSeal,
     val gatedOpen: HardwareAesGcmOpen,
     private val onClose: () -> Unit = {},
 ) : AesGcmKey {
-    override val provenance: KeyProvenance get() = KeyProvenance.Hardware
-
     /**
      * Opaque handle; there is no process-memory material to wipe. [onClose] lets a provider release
      * an out-of-process resource (e.g. delete the keystore alias). Defaults to a no-op.
@@ -356,19 +360,19 @@ internal class HardwareAesGcmKey(
 }
 
 /**
- * Hardware-backed [SigningKey]: an opaque handle with no exportable material. Signing routes through
+ * Non-exportable [SigningKey]: an opaque handle with no exportable material. Signing routes through
  * the provider-supplied gated closure; the blocking witness path is unreachable because
- * [requireInMemoryMaterial] throws for this type.
+ * [requireInMemoryMaterial] throws for this type. The [custody] param type [KeyCustody.NonExportable]
+ * makes an *exportable* protected key unconstructable; [provenance] is derived from it.
  */
-internal class HardwareSigningKey(
+internal class ProtectedSigningKey(
     override val scheme: SignatureScheme,
+    override val custody: KeyCustody.NonExportable,
     val gatedSign: HardwareSign,
     /** The public key matching this signing key, captured by the provider at generation. */
     override val verifyKey: VerifyKey,
     private val onClose: () -> Unit = {},
 ) : SigningKey {
-    override val provenance: KeyProvenance get() = KeyProvenance.Hardware
-
     /**
      * Opaque handle; there is no process-memory material to wipe. [onClose] lets a provider release
      * an out-of-process resource (e.g. delete the keystore alias). Defaults to a no-op.

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.kt
@@ -35,10 +35,10 @@ import kotlin.time.Duration.Companion.seconds
 
 /**
  * The algorithms a [HardwareKeyProvider] may be asked to generate keys for. A flat, closed enum (not
- * free-text identifiers) so eligibility checks and dispatch are exhaustive and typo-proof. Only the
- * families a secure element actually backs appear here.
+ * free-text identifiers) so eligibility checks and dispatch are exhaustive and typo-proof. Covers the
+ * families a non-exportable key backend (secure element or non-exportable software) actually mints.
  */
-enum class HardwareAlgorithm {
+enum class ProtectedKeyAlgorithm {
     /** AES-256-GCM (symmetric AEAD). */
     AesGcm,
 
@@ -53,15 +53,31 @@ enum class HardwareAlgorithm {
 
     /** ECDSA over NIST P-521 with SHA-512. */
     EcdsaP521,
+
+    /** X25519 key agreement (RFC 7748). */
+    X25519,
+
+    /** ECDH key agreement over NIST P-256. */
+    EcdhP256,
+
+    /** ECDH key agreement over NIST P-384. */
+    EcdhP384,
+
+    /** ECDH key agreement over NIST P-521. */
+    EcdhP521,
 }
 
-/** The [HardwareAlgorithm] a signature [scheme] maps to, for eligibility checks. */
-internal fun SignatureScheme.toHardwareAlgorithm(): HardwareAlgorithm =
+/** Renamed to [ProtectedKeyAlgorithm]. */
+@Deprecated("Renamed to ProtectedKeyAlgorithm", ReplaceWith("ProtectedKeyAlgorithm"))
+typealias HardwareAlgorithm = ProtectedKeyAlgorithm
+
+/** The [ProtectedKeyAlgorithm] a signature [scheme] maps to, for eligibility checks. */
+internal fun SignatureScheme.toProtectedKeyAlgorithm(): ProtectedKeyAlgorithm =
     when (this) {
-        SignatureScheme.Ed25519 -> HardwareAlgorithm.Ed25519
-        SignatureScheme.EcdsaP256 -> HardwareAlgorithm.EcdsaP256
-        SignatureScheme.EcdsaP384 -> HardwareAlgorithm.EcdsaP384
-        SignatureScheme.EcdsaP521 -> HardwareAlgorithm.EcdsaP521
+        SignatureScheme.Ed25519 -> ProtectedKeyAlgorithm.Ed25519
+        SignatureScheme.EcdsaP256 -> ProtectedKeyAlgorithm.EcdsaP256
+        SignatureScheme.EcdsaP384 -> ProtectedKeyAlgorithm.EcdsaP384
+        SignatureScheme.EcdsaP521 -> ProtectedKeyAlgorithm.EcdsaP521
     }
 
 /**
@@ -138,7 +154,7 @@ sealed interface UserAuthenticationPolicy {
 /**
  * Mints hardware keys that are **bound to user authentication inside the secure element** — an op
  * on an unauthenticated key fails in hardware no matter what the process does, unlike the advisory
- * [HardwareKeySpec.authorization] gate on [HardwareKeyProvider]'s unbound keys.
+ * [ProtectedKeySpec.authorization] gate on [HardwareKeyProvider]'s unbound keys.
  *
  * Obtained from a [HardwareKeyProvider] through a **platform** `userAuthenticated(...)` extension
  * (androidMain takes a `BiometricAuthorization` prompt host, appleMain a `LocalAuthAuthenticator`),
@@ -156,7 +172,7 @@ sealed interface UserAuthenticationPolicy {
  */
 interface UserAuthenticatedKeyProvider {
     /** Whether the underlying secure element can generate a key for [alg] (same subset as the base provider). */
-    fun eligible(alg: HardwareAlgorithm): Boolean
+    fun eligible(alg: ProtectedKeyAlgorithm): Boolean
 
     /**
      * Generates a fresh AES-GCM key inside the secure element, OS-bound to [policy].
@@ -176,10 +192,10 @@ interface UserAuthenticatedKeyProvider {
 }
 
 /**
- * Generation parameters for a hardware-backed key. Carried by value (no platform handles) so the
- * shape is identical on every target.
+ * Generation parameters for a protected (non-exportable) key. Carried by value (no platform handles)
+ * so the shape is identical on every target.
  */
-class HardwareKeySpec(
+class ProtectedKeySpec(
     /**
      * The advisory gate evaluated before each use of the generated key. The default authorizes
      * unconditionally. Library code deciding whether to proceed — *not* an OS binding; for keys
@@ -194,6 +210,10 @@ class HardwareKeySpec(
     val aesKeySizeBits: Int = AES_256_KEY_BYTES * Byte.SIZE_BITS,
 )
 
+/** Renamed to [ProtectedKeySpec]. */
+@Deprecated("Renamed to ProtectedKeySpec", ReplaceWith("ProtectedKeySpec"))
+typealias HardwareKeySpec = ProtectedKeySpec
+
 /**
  * Service-provider interface a platform implements to mint hardware-backed keys from a secure
  * element / keystore. No platform ships one in 6.0; the type is the integration seam a later minor
@@ -206,7 +226,7 @@ class HardwareKeySpec(
  * closures a provider builds into each key, but the *gate itself is the provider's responsibility* —
  * the common code holds no authorization to evaluate. Therefore an implementation **MUST**, for every
  * key it generates:
- *  1. evaluate [HardwareKeySpec.authorization] (`authorize()`) before each use of the key, and throw
+ *  1. evaluate [ProtectedKeySpec.authorization] (`authorize()`) before each use of the key, and throw
  *     [AuthorizationFailed] when it returns `false` or throws — never proceed with the crypto op;
  *  2. keep secret key material inside the secure element — never expose it through any returned type
  *     (the [KeyProvenance.Hardware] key types carry no exportable material by construction);
@@ -229,23 +249,23 @@ interface HardwareKeyProvider {
     val dedicatedSecureElement: Boolean
 
     /** Whether this provider can generate a key for [alg] (a secure element backs only a subset). */
-    fun eligible(alg: HardwareAlgorithm): Boolean
+    fun eligible(alg: ProtectedKeyAlgorithm): Boolean
 
     /**
      * Generates a fresh AES-GCM key inside the secure element. The returned [AesGcmKey] has
      * [KeyProvenance.Hardware] and no exportable material; it operates only through the async AEAD
-     * witness ops, gated by [spec]'s [HardwareKeySpec.authorization].
+     * witness ops, gated by [spec]'s [ProtectedKeySpec.authorization].
      */
-    suspend fun generateAesGcm(spec: HardwareKeySpec): AesGcmKey
+    suspend fun generateAesGcm(spec: ProtectedKeySpec): AesGcmKey
 
     /**
      * Generates a fresh signing key for [scheme] inside the secure element. The returned [SigningKey]
      * has [KeyProvenance.Hardware] and no exportable material; it signs only through the async
-     * signature witness ops, gated by [spec]'s [HardwareKeySpec.authorization].
+     * signature witness ops, gated by [spec]'s [ProtectedKeySpec.authorization].
      */
     suspend fun generateSigning(
         scheme: SignatureScheme,
-        spec: HardwareKeySpec,
+        spec: ProtectedKeySpec,
     ): SigningKey
 }
 

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/Hpke.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/Hpke.kt
@@ -715,6 +715,28 @@ fun hpkeImportPrivateKey(
     return hpkePrivateKeyOf(kem, importPrivateKey(kem.curve, privateEncoded), pubCopy)
 }
 
+/**
+ * Adapts an existing [KeyAgreementKeyPair] — in particular a **non-exportable** one minted by
+ * [KeyProvider.generateKeyAgreement] — into an [HpkePrivateKey] for [kem], so it composes with
+ * [HpkeOps.openBase] and the receiver setups with no change to the HPKE surface. The pair's
+ * [KeyAgreementKeyPair.curve] must equal [kem]'s curve.
+ *
+ * Unlike [hpkeImportPrivateKey], which requires the raw private scalar, this takes the live key pair
+ * whole: the DHKEM decap's single `DH(skR, enc)` step runs through the pair's private key — for a
+ * non-exportable pair, through its gated closure, so the recipient scalar never enters process memory.
+ * The returned key **shares** the pair's private key; close the pair (not this) to release it, and do
+ * not use the pair independently afterward.
+ */
+fun hpkeRecipientPrivateKey(
+    kem: HpkeKem,
+    keyPair: KeyAgreementKeyPair,
+): HpkePrivateKey {
+    require(keyPair.curve == kem.curve) {
+        "key pair curve ${keyPair.curve.curveName} does not match ${kem.kemName}"
+    }
+    return hpkePrivateKeyOf(kem, keyPair.privateKey, copyBuffer(keyPair.publicKey.encoded, BufferFactory.Default))
+}
+
 // =============================================================================
 // Encapsulation results
 // =============================================================================

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/KeyAgreement.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/KeyAgreement.kt
@@ -214,6 +214,34 @@ sealed interface KeyAgreementKeyPair : AutoCloseable {
     }
 }
 
+/**
+ * A **non-exportable** [KeyAgreementPrivateKey]: an opaque handle whose private scalar never enters
+ * process memory (WebCrypto `extractable:false`, or a secure element). It carries no exportable
+ * material — [exportEncoded] throws — and its Diffie–Hellman routes through the provider-supplied
+ * [gatedDh] closure, so it flows through the ordinary `keyAgreement()` / `hpke()` witnesses unchanged
+ * (see [dhRawSecret] and the witness `deriveSharedSecret` dispatch). The [custody] param type
+ * [KeyCustody.NonExportable] makes an *exportable* protected agreement key unconstructable;
+ * [provenance] is derived from it and can never disagree.
+ */
+internal class ProtectedKeyAgreementPrivateKey(
+    override val curve: KeyAgreementCurve,
+    val custody: KeyCustody.NonExportable,
+    val gatedDh: HardwareDh,
+    private val onClose: () -> Unit = {},
+) : KeyAgreementPrivateKey {
+    override val provenance: KeyProvenance get() = custody.provenance
+
+    /**
+     * Opaque handle; there is no process-memory scalar to wipe. [onClose] lets a provider release an
+     * out-of-process resource (e.g. drop the WebCrypto key handle). Defaults to a no-op.
+     */
+    override fun close() = onClose()
+
+    /** A non-exportable key holds no exportable material; export is unsupported by construction. */
+    override fun exportEncoded(factory: BufferFactory): ReadBuffer =
+        throw UnsupportedOperationException("non-exportable key-agreement key has no exportable material")
+}
+
 /** In-memory [KeyAgreementKeyPair] produced by the platform glue / imports. */
 internal class InMemoryKeyAgreementKeyPair(
     override val curve: KeyAgreementCurve,
@@ -229,7 +257,29 @@ internal class InMemoryKeyAgreementKeyPair(
 internal fun KeyAgreementPrivateKey.requireInMemoryMaterial(): PlatformBuffer =
     when (this) {
         is InMemoryKeyAgreementPrivateKey -> requireOpen()
+        // A non-exportable key holds no in-process scalar; its DH routes through the gated closure and
+        // never reaches here. This throw is the safety net if a caller routes one into a path that
+        // reads raw material. See [ProtectedKeyAgreementPrivateKey].
+        is ProtectedKeyAgreementPrivateKey ->
+            throw UnsupportedOperationException("non-exportable key-agreement key has no synchronous material")
     }
+
+/**
+ * Derives shared key material from a **non-exportable** private key by running its [gatedDh] closure
+ * (the raw `DH(sk, peer)`) through the single audited [deriveFromRawSecret] KDF path — the same
+ * all-zero rejection + HKDF the in-memory path uses. Shared by both key-agreement witness impls so a
+ * non-exportable key behaves identically regardless of which witness resolved.
+ */
+internal suspend fun ProtectedKeyAgreementPrivateKey.deriveShared(
+    peerPublicKey: KeyAgreementPublicKey,
+    info: ReadBuffer?,
+    length: Int,
+    salt: ReadBuffer?,
+    factory: BufferFactory,
+): ReadBuffer {
+    require(curve == peerPublicKey.curve) { "private/public key curve mismatch" }
+    return deriveFromRawSecret(curve, gatedDh(peerPublicKey), info, length, salt, factory)
+}
 
 /** Builds an in-memory private key wrapping [material] (a wiped [SecureBuffer], read-ready). */
 internal fun keyAgreementPrivateKeyOf(
@@ -389,7 +439,14 @@ internal class KeyAgreementBlockingOpsImpl(
         length: Int,
         salt: Salt,
         factory: BufferFactory,
-    ): ReadBuffer = deriveSharedSecretBlocking(privateKey, peerPublicKey, info, length, salt, factory)
+    ): ReadBuffer =
+        // A non-exportable key has no in-process scalar for the blocking primitive, so even on a
+        // Blocking platform it derives through its gated closure.
+        if (privateKey is ProtectedKeyAgreementPrivateKey) {
+            privateKey.deriveShared(peerPublicKey, info.bytesOrNull, length, salt.bytesOrNull, factory)
+        } else {
+            deriveSharedSecretBlocking(privateKey, peerPublicKey, info, length, salt, factory)
+        }
 }
 
 /** Key-agreement ops over the async-only primitives (WebCrypto on JS/WASM). */
@@ -405,7 +462,14 @@ internal class KeyAgreementAsyncOpsImpl(
         length: Int,
         salt: Salt,
         factory: BufferFactory,
-    ): ReadBuffer = deriveSharedSecretAsyncPlatform(privateKey, peerPublicKey, info.bytesOrNull, length, salt.bytesOrNull, factory)
+    ): ReadBuffer =
+        // A non-exportable key derives through its gated closure (no in-process scalar to marshal to
+        // WebCrypto); an in-memory key goes through the platform primitive.
+        if (privateKey is ProtectedKeyAgreementPrivateKey) {
+            privateKey.deriveShared(peerPublicKey, info.bytesOrNull, length, salt.bytesOrNull, factory)
+        } else {
+            deriveSharedSecretAsyncPlatform(privateKey, peerPublicKey, info.bytesOrNull, length, salt.bytesOrNull, factory)
+        }
 }
 
 // =============================================================================

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/KeyAgreementRaw.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/KeyAgreementRaw.kt
@@ -26,7 +26,27 @@ import com.ditchoom.buffer.ReadBuffer
  * @throws InvalidPublicKey for a rejected peer point (or X25519 all-zero secret).
  * @throws UnsupportedOperationException if the curve has no support on this platform.
  */
-internal expect suspend fun dhRawSecret(
+internal suspend fun dhRawSecret(
+    privateKey: KeyAgreementPrivateKey,
+    peerPublicKey: KeyAgreementPublicKey,
+): PlatformBuffer =
+    // A non-exportable key computes DH inside its backend (WebCrypto / secure element) via the gated
+    // closure — its scalar never enters process memory, so it never reaches the in-memory actual. The
+    // closure returns the raw secret; [validateRawSecret] applies the shared X25519 all-zero rejection
+    // in one audited place, exactly as the in-memory actuals do.
+    when (privateKey) {
+        is ProtectedKeyAgreementPrivateKey -> {
+            require(privateKey.curve == peerPublicKey.curve) { "private/public key curve mismatch" }
+            validateRawSecret(privateKey.curve, privateKey.gatedDh(peerPublicKey))
+        }
+        else -> dhRawSecretInMemory(privateKey, peerPublicKey)
+    }
+
+/**
+ * The in-memory raw-DH seam: the platform's native agreement over an [InMemoryKeyAgreementPrivateKey].
+ * Non-exportable keys never reach it (they route through the gated closure in [dhRawSecret]).
+ */
+internal expect suspend fun dhRawSecretInMemory(
     privateKey: KeyAgreementPrivateKey,
     peerPublicKey: KeyAgreementPublicKey,
 ): PlatformBuffer

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/KeyCustody.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/KeyCustody.kt
@@ -1,0 +1,72 @@
+package com.ditchoom.buffer.crypto
+
+/**
+ * The complete, canonical description of a key's custody — where its secret lives and whether this
+ * process can ever read it. Only *legal* states are constructible: exportability and backing are not
+ * independent axes (a secure-element key that is exportable, or an in-memory key that is a dedicated
+ * secure element, are physically impossible), so they are encoded as one sealed value rather than as
+ * separate boolean fields that could disagree. [exportable], [KeyProvenance] ([provenance]), and
+ * [dedicatedSecureElement] are all *derived* off this single value and therefore can never contradict
+ * it.
+ *
+ * The three real states:
+ *
+ * | Key                                   | value                        | witness path |
+ * |---------------------------------------|------------------------------|--------------|
+ * | in-memory software key                | [ExportableSoftware]         | sync + async |
+ * | non-exportable software (WebCrypto)   | [NonExportable.Software]     | async only   |
+ * | secure element (Android / Apple)      | [NonExportable.Hardware]     | async only   |
+ */
+sealed interface KeyCustody {
+    /** Ordered custody strength (weakest → strongest). Derived from the subtype, never stored. */
+    val tier: CustodyTier
+
+    /** In-process key: the material is a buffer this process can read. The software fallback. */
+    data object ExportableSoftware : KeyCustody {
+        override val tier: CustodyTier get() = CustodyTier.ExportableSoftware
+    }
+
+    /**
+     * A key whose secret never enters process memory. `exportable == false` is guaranteed by *being*
+     * this subtype, not by a boolean field, so a non-exportable-yet-readable key cannot be built.
+     */
+    sealed interface NonExportable : KeyCustody {
+        /** Software isolation — the secret never reaches process memory (WebCrypto `extractable:false`). */
+        data object Software : NonExportable {
+            override val tier: CustodyTier get() = CustodyTier.NonExportableSoftware
+        }
+
+        /**
+         * A secure element / OS keystore holds the secret. [dedicatedSecureElement] distinguishes a
+         * dedicated element (StrongBox / Secure Enclave) from a TEE-only keystore.
+         */
+        data class Hardware(
+            val dedicatedSecureElement: Boolean,
+        ) : NonExportable {
+            override val tier: CustodyTier get() = CustodyTier.Hardware
+        }
+    }
+}
+
+/** Ordered custody thresholds, weakest → strongest, for [KeyCustody.tier] comparisons. */
+enum class CustodyTier {
+    ExportableSoftware,
+    NonExportableSoftware,
+    Hardware,
+}
+
+/** `true` only for [KeyCustody.ExportableSoftware] — the one state whose secret this process can read. */
+val KeyCustody.exportable: Boolean get() = this is KeyCustody.ExportableSoftware
+
+/**
+ * The 6.0 [KeyProvenance] projected off custody (kept for source compatibility). Only a
+ * [KeyCustody.NonExportable.Hardware] key is [KeyProvenance.Hardware]; both software states — whether
+ * exportable or not — are [KeyProvenance.Software], because provenance is *where the key lives*, not
+ * whether it is exportable.
+ */
+val KeyCustody.provenance: KeyProvenance get() =
+    if (this is KeyCustody.NonExportable.Hardware) KeyProvenance.Hardware else KeyProvenance.Software
+
+/** `true` when the key lives in a dedicated secure element (StrongBox / Secure Enclave). */
+val KeyCustody.dedicatedSecureElement: Boolean get() =
+    this is KeyCustody.NonExportable.Hardware && dedicatedSecureElement

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/KeyProvider.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/KeyProvider.kt
@@ -1,0 +1,97 @@
+package com.ditchoom.buffer.crypto
+
+/**
+ * The common supertype for anything that generates keys. A *router* (the resolver added in a later
+ * step) also implements this, so [KeyProvider] carries no single custody value — the custody you get
+ * can differ per algorithm, which is why it is queried per-algorithm via [custodyFor] rather than
+ * exposed as one field here. A single-tier backend is a [ConcreteKeyProvider], which does expose a
+ * constant [ConcreteKeyProvider.custody].
+ */
+interface KeyProvider {
+    /** The exact [KeyCustody] a key generated for [alg] will have on this platform (routing introspection). */
+    fun custodyFor(alg: ProtectedKeyAlgorithm): KeyCustody
+
+    /** Whether this provider can generate a key for [alg]. */
+    fun eligible(alg: ProtectedKeyAlgorithm): Boolean
+
+    /** Generates a fresh signing key for [scheme], per [spec]. */
+    suspend fun generateSigning(
+        scheme: SignatureScheme,
+        spec: ProtectedKeySpec,
+    ): SigningKey
+
+    /** Generates a fresh AES-GCM key, per [spec]. */
+    suspend fun generateAesGcm(spec: ProtectedKeySpec): AesGcmKey
+
+    /**
+     * Mints a key-agreement private key on [curve]; on a non-exportable provider the private scalar
+     * never leaves the backend. The result is an ordinary [KeyAgreementKeyPair] whose
+     * `deriveSharedSecret` routes through the provider, so it flows through the existing
+     * `keyAgreement()` / `hpke()` witnesses unchanged.
+     */
+    suspend fun generateKeyAgreement(
+        curve: KeyAgreementCurve,
+        spec: ProtectedKeySpec,
+    ): KeyAgreementKeyPair
+}
+
+/**
+ * A single-tier provider (software / WebCrypto / secure element): every key it mints has the same
+ * [custody], so [custodyFor] is that value for any algorithm. A *router* is deliberately **not** a
+ * [ConcreteKeyProvider], because its custody varies per algorithm.
+ */
+interface ConcreteKeyProvider : KeyProvider {
+    /** The single custody every key from this provider carries. */
+    val custody: KeyCustody
+
+    override fun custodyFor(alg: ProtectedKeyAlgorithm): KeyCustody = custody
+}
+
+/**
+ * A provider whose keys are non-exportable. The [custody] return type narrows to
+ * [KeyCustody.NonExportable], so `exportable == false` is enforced by the *type* — a
+ * [ProtectedKeyProvider] whose custody is [KeyCustody.ExportableSoftware] does not compile. This is
+ * the broad tier: it covers both a secure element ([HardwareKeyProvider]) and non-exportable software
+ * (WebCrypto `extractable:false`, wired in a later step).
+ */
+interface ProtectedKeyProvider : ConcreteKeyProvider {
+    override val custody: KeyCustody.NonExportable
+}
+
+/**
+ * Whether a non-exportable key provider — secure element **or** non-exportable software (WebCrypto
+ * `extractable:false`) — is available on this platform. Strictly broader than [HardwareSupport], which
+ * is the secure-element-only refinement: everything [HardwareSupport.Available] is also
+ * [ProtectedKeySupport.Available], but not the reverse.
+ */
+sealed interface ProtectedKeySupport {
+    /** No non-exportable key provider on this platform. */
+    data object Unavailable : ProtectedKeySupport
+
+    /** A non-exportable key [provider] is available. */
+    data class Available(
+        val provider: ProtectedKeyProvider,
+    ) : ProtectedKeySupport
+}
+
+/**
+ * The platform's strongest non-exportable key provider, or `null` when this platform wires none.
+ * `internal` + `expect`/`actual` so it stays out of the public ABI while the public accessors
+ * ([CryptoCapabilities.protectedKeys], [CryptoCapabilities.hardware]) keep their frozen signatures.
+ * This one internal seam replaces the 6.0 `platformHardwareKeyProvider()`.
+ */
+internal expect fun platformProtectedKeyProvider(): ProtectedKeyProvider?
+
+/**
+ * The non-exportable key capability on this platform: [ProtectedKeySupport.Available] where either a
+ * secure element (Android / Apple) or non-exportable software keys are wired,
+ * [ProtectedKeySupport.Unavailable] otherwise (JVM, Linux, and web until WebCrypto lands).
+ *
+ * A plain `val` (not `expect`/`actual`) by design: the *public* signature is frozen, and a backend
+ * resolves through the **internal** [platformProtectedKeyProvider] seam, so a later platform can wire
+ * a provider without changing this declaration.
+ */
+val CryptoCapabilities.protectedKeys: ProtectedKeySupport get() =
+    platformProtectedKeyProvider()
+        ?.let { ProtectedKeySupport.Available(it) }
+        ?: ProtectedKeySupport.Unavailable

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/KeyProviderResolution.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/KeyProviderResolution.kt
@@ -1,0 +1,109 @@
+package com.ditchoom.buffer.crypto
+
+/**
+ * The always-present commonMain fallback: mints ordinary **exportable in-memory** keys by composing
+ * the primitives that exist on every platform — the signature witness for signing keys, `cryptoRandom`
+ * + [AesGcmKey.of] for AES, and the key-agreement witness for agreement keys. Because it lives in
+ * commonMain and leans only on those witnesses, it is the guaranteed floor beneath [keyProvider] on
+ * every target; platforms differ only in whether a stronger rung ([platformProtectedKeyProvider]) sits
+ * above it.
+ */
+internal object SoftwareKeyProvider : ConcreteKeyProvider {
+    override val custody: KeyCustody get() = KeyCustody.ExportableSoftware
+
+    // The floor serves every algorithm via the platform's own primitives; custodyFor defaults to
+    // [custody] (ConcreteKeyProvider), so every eligible alg reports ExportableSoftware.
+    override fun eligible(alg: ProtectedKeyAlgorithm): Boolean = true
+
+    override suspend fun generateSigning(
+        scheme: SignatureScheme,
+        spec: ProtectedKeySpec,
+    ): SigningKey {
+        val ops =
+            when (val support = CryptoCapabilities.signatures(scheme)) {
+                is SignatureSupport.Blocking -> support.ops
+                is SignatureSupport.AsyncOnly -> support.ops
+                SignatureSupport.Unavailable -> throw HardwareKeyException.AlgorithmNotEligible()
+            }
+        return ops.generateSigningKey()
+    }
+
+    override suspend fun generateAesGcm(spec: ProtectedKeySpec): AesGcmKey =
+        AesGcmKey.of(cryptoRandom(spec.aesKeySizeBits / Byte.SIZE_BITS))
+
+    override suspend fun generateKeyAgreement(
+        curve: KeyAgreementCurve,
+        spec: ProtectedKeySpec,
+    ): KeyAgreementKeyPair = keyAgreementAsyncOps(curve).generateKeyPair()
+}
+
+/** The [ProtectedKeyAlgorithm] a key-agreement [KeyAgreementCurve] maps to, for per-algorithm routing. */
+internal fun KeyAgreementCurve.toProtectedKeyAlgorithm(): ProtectedKeyAlgorithm =
+    when (this) {
+        KeyAgreementCurve.X25519 -> ProtectedKeyAlgorithm.X25519
+        KeyAgreementCurve.P256 -> ProtectedKeyAlgorithm.EcdhP256
+        KeyAgreementCurve.P384 -> ProtectedKeyAlgorithm.EcdhP384
+        KeyAgreementCurve.P521 -> ProtectedKeyAlgorithm.EcdhP521
+    }
+
+/**
+ * The router handed to consumers by [keyProvider]. Routes each request to the strongest tier that is
+ * *eligible for that algorithm*, with [SoftwareKeyProvider] as the floor — so it never hands back a
+ * provider that throws for custody reasons at the default, and never routes P-521 to a secure element
+ * that only backs P-256. It is a [KeyProvider] but deliberately **not** a [ConcreteKeyProvider],
+ * because its custody varies per algorithm.
+ */
+internal class ResolvingKeyProvider(
+    private val strong: ProtectedKeyProvider?,
+) : KeyProvider {
+    private fun pick(alg: ProtectedKeyAlgorithm): ConcreteKeyProvider = strong?.takeIf { it.eligible(alg) } ?: SoftwareKeyProvider
+
+    override fun custodyFor(alg: ProtectedKeyAlgorithm): KeyCustody = pick(alg).custody
+
+    override fun eligible(alg: ProtectedKeyAlgorithm): Boolean = true
+
+    override suspend fun generateSigning(
+        scheme: SignatureScheme,
+        spec: ProtectedKeySpec,
+    ): SigningKey = pick(scheme.toProtectedKeyAlgorithm()).generateSigning(scheme, spec)
+
+    override suspend fun generateAesGcm(spec: ProtectedKeySpec): AesGcmKey = pick(ProtectedKeyAlgorithm.AesGcm).generateAesGcm(spec)
+
+    override suspend fun generateKeyAgreement(
+        curve: KeyAgreementCurve,
+        spec: ProtectedKeySpec,
+    ): KeyAgreementKeyPair = pick(curve.toProtectedKeyAlgorithm()).generateKeyAgreement(curve, spec)
+}
+
+/**
+ * The **total**, non-null key-provider entry point: a [KeyProvider] that always works, routing each
+ * request per algorithm to the strongest custody the platform offers and falling back to the
+ * commonMain [SoftwareKeyProvider] floor. Never returns null and never throws for custody reasons at
+ * the default — the only `?:` is internal, against the [platformProtectedKeyProvider] seam.
+ *
+ * "I require a stronger tier" is expressed as an assertion on the inspectable custody
+ * ([KeyProvider.requireTier] / [KeyProvider.custodyFor]), not as a nullable return. The two capability
+ * queries ([CryptoCapabilities.protectedKeys] / [CryptoCapabilities.hardware]) remain for callers who
+ * want to branch on raw availability instead of routing.
+ */
+fun CryptoCapabilities.keyProvider(): KeyProvider = ResolvingKeyProvider(strong = platformProtectedKeyProvider())
+
+/**
+ * Asserts the platform can serve [alg] at **at least** [tier], and returns the same [KeyProvider] for
+ * chaining. Throws [InsufficientKeyCustody] when the strongest eligible custody is weaker — no
+ * nullable, no `!!`. Custody tiers are ordered ([CustodyTier]), so "at least" is a simple comparison.
+ *
+ * ```kotlin
+ * val hw = CryptoCapabilities.keyProvider()
+ *     .requireTier(ProtectedKeyAlgorithm.EcdsaP256, CustodyTier.Hardware)
+ *     .generateSigning(SignatureScheme.EcdsaP256, ProtectedKeySpec())
+ * ```
+ */
+fun KeyProvider.requireTier(
+    alg: ProtectedKeyAlgorithm,
+    tier: CustodyTier,
+): KeyProvider =
+    also {
+        val got = custodyFor(alg).tier
+        if (got < tier) throw InsufficientKeyCustody(alg = alg, required = tier, available = got)
+    }

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/Signatures.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/Signatures.kt
@@ -122,8 +122,15 @@ sealed interface SigningKey : AutoCloseable {
     /** The scheme this key signs under. */
     val scheme: SignatureScheme
 
-    /** Whether the key material is in software memory or hardware-backed. */
-    val provenance: KeyProvenance
+    /**
+     * This key's custody — where its secret lives and whether the process can read it. A key is
+     * self-describing: it carries its own [KeyCustody] so it stays honest across module boundaries,
+     * independent of the provider that minted it.
+     */
+    val custody: KeyCustody
+
+    /** Whether the key material is in software memory or hardware-backed. Derived from [custody]. */
+    val provenance: KeyProvenance get() = custody.provenance
 
     /**
      * The public [VerifyKey] matching this signing key. Every signing key knows its verifier:
@@ -204,7 +211,7 @@ internal class InMemorySigningKey(
     private val material: PlatformBuffer,
     override val verifyKey: VerifyKey,
 ) : SyncCapableSigningKey {
-    override val provenance: KeyProvenance get() = KeyProvenance.Software
+    override val custody: KeyCustody get() = KeyCustody.ExportableSoftware
     private var closed = false
 
     /** Zeroes and frees the key material. Idempotent. */
@@ -276,8 +283,8 @@ internal fun SigningKey.requireInMemoryMaterial(): PlatformBuffer =
         is InMemorySigningKey -> requireOpen()
         // A hardware signing key holds no exportable material; it signs only through the async
         // witness op (the gated closure) and never reaches here. This throw is the safety net if a
-        // caller routes a hardware key into the blocking sign path. See [HardwareSigningKey].
-        is HardwareSigningKey -> throw UnsupportedOperationException("hardware signing key has no synchronous path")
+        // caller routes a hardware key into the blocking sign path. See [ProtectedSigningKey].
+        is ProtectedSigningKey -> throw UnsupportedOperationException("hardware signing key has no synchronous path")
     }
 
 /** See [SigningKey.requireInMemoryMaterial]. */
@@ -496,7 +503,7 @@ internal class SignatureBlockingOpsImpl(
     ): ReadBuffer =
         when (key) {
             is InMemorySigningKey -> signBlocking(key, message, factory)
-            is HardwareSigningKey -> key.gatedSign(message, factory)
+            is ProtectedSigningKey -> key.gatedSign(message, factory)
         }
 
     override suspend fun verify(
@@ -522,10 +529,10 @@ internal class SignatureAsyncOpsImpl(
         factory: BufferFactory,
     ): ReadBuffer =
         // A hardware key signs through its gated closure (no in-process material); an in-memory key
-        // goes through the platform primitive. Adding HardwareSigningKey forces this branch.
+        // goes through the platform primitive. Adding ProtectedSigningKey forces this branch.
         when (key) {
             is InMemorySigningKey -> signAsyncPlatform(key, message, factory)
-            is HardwareSigningKey -> key.gatedSign(message, factory)
+            is ProtectedSigningKey -> key.gatedSign(message, factory)
         }
 
     override suspend fun verify(

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/FakeHardware.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/FakeHardware.kt
@@ -12,7 +12,7 @@ import kotlin.time.TimeSource
  * It models a secure element with software crypto behind an auth gate:
  *  - The gated closures perform real AES-GCM / ECDSA via the module's own async primitives, so a
  *    successful op produces standard ciphertext / signatures (proving the seam wires through).
- *  - Each use is gated on [HardwareKeySpec.authorization]; a denying gate raises [AuthorizationFailed],
+ *  - Each use is gated on [ProtectedKeySpec.authorization]; a denying gate raises [AuthorizationFailed],
  *    exactly as a refused biometric / keystore unlock would.
  *  - Eligibility is a realistic subset: AES-GCM and ECDSA P-256 only. ChaCha20-Poly1305 and Ed25519
  *    are rejected (Enclave/StrongBox do not back them), matching the no-hardware-variant decision.
@@ -66,19 +66,19 @@ internal class FakeHardware(
      */
     fun userAuthenticated(gate: HardwareAuthorization): UserAuthenticatedKeyProvider =
         object : UserAuthenticatedKeyProvider {
-            override fun eligible(alg: HardwareAlgorithm): Boolean = this@FakeHardware.eligible(alg)
+            override fun eligible(alg: ProtectedKeyAlgorithm): Boolean = this@FakeHardware.eligible(alg)
 
             override suspend fun generateAesGcm(
                 policy: UserAuthenticationPolicy,
                 aesKeySizeBits: Int,
-            ): AesGcmKey = aesGcmPair(HardwareKeySpec(gate, aesKeySizeBits), policy).hardware
+            ): AesGcmKey = aesGcmPair(ProtectedKeySpec(gate, aesKeySizeBits), policy).hardware
 
             override suspend fun generateSigning(
                 scheme: SignatureScheme,
                 policy: UserAuthenticationPolicy,
             ): SigningKey {
-                if (!eligible(scheme.toHardwareAlgorithm())) throw HardwareKeyException.AlgorithmNotEligible()
-                return signingPair(HardwareKeySpec(gate), policy).hardware
+                if (!eligible(scheme.toProtectedKeyAlgorithm())) throw HardwareKeyException.AlgorithmNotEligible()
+                return signingPair(ProtectedKeySpec(gate), policy).hardware
             }
         }
 
@@ -94,21 +94,22 @@ internal class FakeHardware(
         val verifyKey: VerifyKey,
     )
 
-    override fun eligible(alg: HardwareAlgorithm): Boolean = alg == HardwareAlgorithm.AesGcm || alg == HardwareAlgorithm.EcdsaP256
+    override fun eligible(alg: ProtectedKeyAlgorithm): Boolean =
+        alg == ProtectedKeyAlgorithm.AesGcm || alg == ProtectedKeyAlgorithm.EcdsaP256
 
-    override suspend fun generateAesGcm(spec: HardwareKeySpec): AesGcmKey = aesGcmPair(spec).hardware
+    override suspend fun generateAesGcm(spec: ProtectedKeySpec): AesGcmKey = aesGcmPair(spec).hardware
 
     override suspend fun generateSigning(
         scheme: SignatureScheme,
-        spec: HardwareKeySpec,
+        spec: ProtectedKeySpec,
     ): SigningKey {
-        if (!eligible(scheme.toHardwareAlgorithm())) throw HardwareKeyException.AlgorithmNotEligible()
+        if (!eligible(scheme.toProtectedKeyAlgorithm())) throw HardwareKeyException.AlgorithmNotEligible()
         return signingPair(spec).hardware
     }
 
     /** Richer result for the conformance test: the hardware key and a software twin with the same key. */
     fun aesGcmPair(
-        spec: HardwareKeySpec,
+        spec: ProtectedKeySpec,
         policy: UserAuthenticationPolicy? = null,
     ): AesGcmPair {
         if (spec.aesKeySizeBits != AES_128_KEY_BYTES * Byte.SIZE_BITS &&
@@ -150,7 +151,7 @@ internal class FakeHardware(
 
     /** Richer result for the conformance test: the hardware signing key and its public verify key. */
     fun signingPair(
-        spec: HardwareKeySpec,
+        spec: ProtectedKeySpec,
         policy: UserAuthenticationPolicy? = null,
     ): SigningPair {
         val verifyKey = VerifyKey.ecdsaP256(hexBuffer(P256_POINT_HEX))

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/FakeHardware.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/FakeHardware.kt
@@ -20,8 +20,8 @@ import kotlin.time.TimeSource
  *    fixed NIST P-256 test keypair (buffer-crypto exposes no ECDSA keypair generation, so a known
  *    keypair is used so the test can build the matching public [VerifyKey] — verify keys are public).
  *
- * Because commonTest sees the module's `internal` declarations, it can construct [HardwareAesGcmKey]
- * / [HardwareSigningKey] directly — which is how a real provider in a later minor would build them.
+ * Because commonTest sees the module's `internal` declarations, it can construct [ProtectedAesGcmKey]
+ * / [ProtectedSigningKey] directly — which is how a real provider in a later minor would build them.
  */
 internal class FakeHardware(
     override val dedicatedSecureElement: Boolean = true,
@@ -107,6 +107,14 @@ internal class FakeHardware(
         return signingPair(spec).hardware
     }
 
+    override suspend fun generateKeyAgreement(
+        curve: KeyAgreementCurve,
+        spec: ProtectedKeySpec,
+    ): KeyAgreementKeyPair =
+        // The fake secure element backs only AES-GCM + ECDSA P-256, matching Enclave/StrongBox; a
+        // key-agreement request is not eligible, exactly as on the real hardware providers.
+        throw HardwareKeyException.AlgorithmNotEligible()
+
     /** Richer result for the conformance test: the hardware key and a software twin with the same key. */
     fun aesGcmPair(
         spec: ProtectedKeySpec,
@@ -126,8 +134,9 @@ internal class FakeHardware(
         val twin = AesGcmKey.of(material)
         val auth = FakeAuthPolicy(spec.authorization, policy)
         val hardware =
-            HardwareAesGcmKey(
+            ProtectedAesGcmKey(
                 sizeBits = spec.aesKeySizeBits,
+                custody = custody,
                 gatedSeal = { aad, plaintext, factory ->
                     auth.beforeOp()
                     // A real secure element generates the nonce itself, so the seam hands the closure
@@ -158,8 +167,9 @@ internal class FakeHardware(
         val inner = SigningKey.ecdsaP256(hexBuffer(P256_SCALAR_HEX), verifyKey)
         val auth = FakeAuthPolicy(spec.authorization, policy)
         val hardware =
-            HardwareSigningKey(
+            ProtectedSigningKey(
                 scheme = SignatureScheme.EcdsaP256,
+                custody = custody,
                 gatedSign = { message, factory ->
                     auth.beforeOp()
                     signAsyncPlatform(inner, message, factory)

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/HardwareKeyConformanceTest.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/HardwareKeyConformanceTest.kt
@@ -56,6 +56,11 @@ class HardwareKeyConformanceTest {
         val signing = provider.generateSigning(SignatureScheme.EcdsaP256, grant)
         try {
             assertEquals(KeyProvenance.Hardware, signing.provenance)
+            // A real hardware key self-describes as non-exportable hardware custody, and its 6.0
+            // provenance is exactly the derivation off that single value.
+            assertTrue(signing.custody is KeyCustody.NonExportable.Hardware, "real hw signing key is hardware custody")
+            assertFalse(signing.custody.exportable, "a hardware key is never exportable")
+            assertEquals(signing.custody.provenance, signing.provenance)
             val vk = signing.verifyKey
             val ops = signatureAsyncOrNull(SignatureScheme.EcdsaP256)
             if (ops != null) {
@@ -98,6 +103,91 @@ class HardwareKeyConformanceTest {
         runTest {
             assertEquals(KeyProvenance.Hardware, provider.generateAesGcm(grant).provenance)
             assertEquals(KeyProvenance.Hardware, provider.generateSigning(SignatureScheme.EcdsaP256, grant).provenance)
+        }
+
+    @Test
+    fun generatedKeysCarrySelfDescribingHardwareCustody() =
+        runTest {
+            val aes = provider.generateAesGcm(grant)
+            val signing = provider.generateSigning(SignatureScheme.EcdsaP256, grant)
+            try {
+                for (key in listOf<Any>(aes, signing)) {
+                    val custody = if (key is AesGcmKey) key.custody else (key as SigningKey).custody
+                    // One canonical value; every other custody fact is derived from it, so they can
+                    // never disagree.
+                    assertTrue(custody is KeyCustody.NonExportable.Hardware, "hw key custody is NonExportable.Hardware")
+                    assertFalse(custody.exportable, "a hardware key is never exportable")
+                    assertEquals(KeyProvenance.Hardware, custody.provenance)
+                    assertEquals(CustodyTier.Hardware, custody.tier)
+                    assertTrue(custody.dedicatedSecureElement, "the fake models a dedicated secure element")
+                }
+                // Custody is an exhaustive sealed value — this `when` compiles without an `else`.
+                val label =
+                    when (signing.custody) {
+                        KeyCustody.ExportableSoftware -> "exportable-software"
+                        KeyCustody.NonExportable.Software -> "non-exportable-software"
+                        is KeyCustody.NonExportable.Hardware -> "hardware"
+                    }
+                assertEquals("hardware", label)
+            } finally {
+                aes.close()
+                signing.close()
+            }
+        }
+
+    @Test
+    fun custodyReflectsDedicatedSecureElementFlag() =
+        runTest {
+            // A TEE-only provider (no dedicated element) must yield keys whose custody says so — the
+            // one field flows all the way into the minted key, unforgeable at the call site.
+            val teeOnly = FakeHardware(dedicatedSecureElement = false)
+            val key = teeOnly.generateSigning(SignatureScheme.EcdsaP256, grant)
+            try {
+                val custody = key.custody
+                assertTrue(custody is KeyCustody.NonExportable.Hardware, "still hardware custody")
+                assertFalse(custody.dedicatedSecureElement, "a TEE-only key must not claim a dedicated element")
+                assertEquals(CustodyTier.Hardware, custody.tier)
+            } finally {
+                key.close()
+            }
+        }
+
+    @Test
+    fun providerAdvertisesItsCustodyPerAlgorithm() {
+        // A single-tier provider reports the same custody for every eligible algorithm, and a hardware
+        // provider is (by type) also a non-exportable ProtectedKeyProvider.
+        assertEquals(KeyCustody.NonExportable.Hardware(dedicatedSecureElement = true), provider.custody)
+        assertEquals(provider.custody, provider.custodyFor(ProtectedKeyAlgorithm.EcdsaP256))
+        assertEquals(provider.custody, provider.custodyFor(ProtectedKeyAlgorithm.AesGcm))
+        // The tier relationship is compile-time: this assignment only type-checks because a
+        // HardwareKeyProvider IS a (non-exportable) ProtectedKeyProvider, and its custody narrows to
+        // NonExportable — an exportable hardware provider would not compile.
+        val protected: ProtectedKeyProvider = provider
+        val nonExportable: KeyCustody.NonExportable = protected.custody
+        assertEquals(provider.custody, nonExportable)
+    }
+
+    @Test
+    fun inMemoryKeysReportExportableSoftwareCustody() {
+        // The software floor: an in-memory key self-describes as exportable software — the counter-tier
+        // that the hardware assertions above are distinguished from.
+        AesGcmKey.of(ascii("0123456789abcdef")).use { aes ->
+            assertEquals(KeyCustody.ExportableSoftware, aes.custody)
+            assertTrue(aes.custody.exportable, "an in-memory key is exportable")
+            assertEquals(KeyProvenance.Software, aes.provenance)
+            assertEquals(CustodyTier.ExportableSoftware, aes.custody.tier)
+            assertFalse(aes.custody.dedicatedSecureElement, "software custody is not a dedicated element")
+        }
+    }
+
+    @Test
+    fun generateKeyAgreementIsNotEligibleOnHardware() =
+        runTest {
+            // The hardware providers back no app-controlled agreement key; the request is refused with
+            // the same typed error as any ineligible algorithm.
+            assertFailsWith<HardwareKeyException.AlgorithmNotEligible> {
+                provider.generateKeyAgreement(KeyAgreementCurve.P256, grant)
+            }
         }
 
     @Test

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/HardwareKeyConformanceTest.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/HardwareKeyConformanceTest.kt
@@ -32,8 +32,8 @@ import kotlin.time.TestTimeSource
  */
 class HardwareKeyConformanceTest {
     private val provider = FakeHardware()
-    private val grant = HardwareKeySpec()
-    private val deny = HardwareKeySpec(authorization = HardwareAuthorization { false })
+    private val grant = ProtectedKeySpec()
+    private val deny = ProtectedKeySpec(authorization = HardwareAuthorization { false })
 
     @Test
     fun hardwareCapabilityReflectsThePlatformBackend() =
@@ -52,7 +52,7 @@ class HardwareKeyConformanceTest {
     /** A real (non-fake) provider must round-trip its eligible primitives and expose the verify key. */
     private suspend fun assertRealProviderWorks(provider: HardwareKeyProvider) {
         // Every shipping secure element backs ECDSA P-256; prove a real sign → verify-under-public-key.
-        assertTrue(provider.eligible(HardwareAlgorithm.EcdsaP256), "a real provider backs ECDSA P-256")
+        assertTrue(provider.eligible(ProtectedKeyAlgorithm.EcdsaP256), "a real provider backs ECDSA P-256")
         val signing = provider.generateSigning(SignatureScheme.EcdsaP256, grant)
         try {
             assertEquals(KeyProvenance.Hardware, signing.provenance)
@@ -68,7 +68,7 @@ class HardwareKeyConformanceTest {
         }
 
         // AES-GCM is backed by StrongBox/TEE (Android) but not the Enclave (Apple) — gate on eligibility.
-        if (provider.eligible(HardwareAlgorithm.AesGcm)) {
+        if (provider.eligible(ProtectedKeyAlgorithm.AesGcm)) {
             val aes = provider.generateAesGcm(grant)
             try {
                 assertEquals(KeyProvenance.Hardware, aes.provenance)
@@ -85,12 +85,12 @@ class HardwareKeyConformanceTest {
 
     @Test
     fun eligibilityIsARealisticSubset() {
-        assertTrue(provider.eligible(HardwareAlgorithm.AesGcm), "AES-GCM is eligible")
-        assertTrue(provider.eligible(HardwareAlgorithm.EcdsaP256), "ECDSA P-256 is eligible")
+        assertTrue(provider.eligible(ProtectedKeyAlgorithm.AesGcm), "AES-GCM is eligible")
+        assertTrue(provider.eligible(ProtectedKeyAlgorithm.EcdsaP256), "ECDSA P-256 is eligible")
         // A secure element backs neither ChaCha20-Poly1305 nor Ed25519 (nor P-384/P-521 here).
-        assertTrue(!provider.eligible(HardwareAlgorithm.Ed25519), "Ed25519 not eligible")
-        assertTrue(!provider.eligible(HardwareAlgorithm.EcdsaP384), "P-384 not eligible")
-        assertTrue(!provider.eligible(HardwareAlgorithm.EcdsaP521), "P-521 not eligible")
+        assertTrue(!provider.eligible(ProtectedKeyAlgorithm.Ed25519), "Ed25519 not eligible")
+        assertTrue(!provider.eligible(ProtectedKeyAlgorithm.EcdsaP384), "P-384 not eligible")
+        assertTrue(!provider.eligible(ProtectedKeyAlgorithm.EcdsaP521), "P-521 not eligible")
     }
 
     @Test
@@ -114,7 +114,7 @@ class HardwareKeyConformanceTest {
     fun generateAesGcmRejectsUnsupportedKeySizeTyped() =
         runTest {
             assertFailsWith<HardwareKeyException.UnsupportedHardwareKey> {
-                provider.generateAesGcm(HardwareKeySpec(aesKeySizeBits = 192))
+                provider.generateAesGcm(ProtectedKeySpec(aesKeySizeBits = 192))
             }
         }
 

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/KeyProviderResolverTest.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/KeyProviderResolverTest.kt
@@ -1,0 +1,89 @@
+package com.ditchoom.buffer.crypto
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * The commonMain custody resolver: [CryptoCapabilities.keyProvider] is total (never null, always at
+ * least the software floor), routing is per-algorithm, and [KeyProvider.requireTier] enforces a
+ * minimum custody with a structured throw. Routing *with* a stronger tier is driven through
+ * [FakeHardware] (commonTest sees the module internals), since no platform ships a non-software
+ * provider in a host test run.
+ */
+class KeyProviderResolverTest {
+    @Test
+    fun keyProviderIsTotalAndSoftwareFloored() =
+        runTest {
+            val keys = CryptoCapabilities.keyProvider()
+            // Total: it serves every algorithm, resolving each to at least the exportable-software floor.
+            for (alg in ProtectedKeyAlgorithm.entries) {
+                assertTrue(keys.eligible(alg), "the resolver serves $alg (routing to the floor)")
+                assertTrue(
+                    keys.custodyFor(alg).tier >= CustodyTier.ExportableSoftware,
+                    "$alg resolves to at least the software floor",
+                )
+            }
+        }
+
+    @Test
+    fun softwareFloorMintsExportableKeys() =
+        runTest {
+            val floor = ResolvingKeyProvider(strong = null)
+            assertEquals(CustodyTier.ExportableSoftware, floor.custodyFor(ProtectedKeyAlgorithm.AesGcm).tier)
+            floor.generateAesGcm(ProtectedKeySpec()).use { aes ->
+                assertEquals(KeyCustody.ExportableSoftware, aes.custody)
+                assertTrue(aes.custody.exportable, "a software-floor key is exportable")
+            }
+        }
+
+    @Test
+    fun resolverRoutesEachAlgorithmToTheStrongestEligibleTier() =
+        runTest {
+            val resolver = ResolvingKeyProvider(strong = FakeHardware())
+            // Eligible on the strong (hardware) provider → hardware custody.
+            assertEquals(CustodyTier.Hardware, resolver.custodyFor(ProtectedKeyAlgorithm.EcdsaP256).tier)
+            assertEquals(CustodyTier.Hardware, resolver.custodyFor(ProtectedKeyAlgorithm.AesGcm).tier)
+            // Not eligible on the strong provider → falls back to the software floor, no throw.
+            assertEquals(CustodyTier.ExportableSoftware, resolver.custodyFor(ProtectedKeyAlgorithm.EcdsaP521).tier)
+            assertEquals(CustodyTier.ExportableSoftware, resolver.custodyFor(ProtectedKeyAlgorithm.X25519).tier)
+            // A routed AES generation actually produces a hardware key (AES keygen exists on every platform).
+            resolver.generateAesGcm(ProtectedKeySpec()).use { aes ->
+                assertTrue(aes.custody is KeyCustody.NonExportable.Hardware, "AES routed to the secure element")
+            }
+        }
+
+    @Test
+    fun requireTierPassesWhenMetAndIsChainable() {
+        val floor = ResolvingKeyProvider(strong = null)
+        // The software floor meets ExportableSoftware; requireTier returns the same provider to chain.
+        val chained = floor.requireTier(ProtectedKeyAlgorithm.EcdsaP256, CustodyTier.ExportableSoftware)
+        assertSame(floor, chained)
+    }
+
+    @Test
+    fun requireTierThrowsStructuredInsufficientCustody() {
+        val floor = ResolvingKeyProvider(strong = null)
+        val ex =
+            assertFailsWith<InsufficientKeyCustody> {
+                floor.requireTier(ProtectedKeyAlgorithm.EcdsaP256, CustodyTier.Hardware)
+            }
+        // The error names only public tiers — non-secret, branchable.
+        assertEquals(ProtectedKeyAlgorithm.EcdsaP256, ex.alg)
+        assertEquals(CustodyTier.Hardware, ex.required)
+        assertEquals(CustodyTier.ExportableSoftware, ex.available)
+    }
+
+    @Test
+    fun requireTierIsPerAlgorithmAgainstAStrongProvider() {
+        val resolver = ResolvingKeyProvider(strong = FakeHardware())
+        // Hardware-eligible alg meets the Hardware tier; a not-eligible alg only reaches the floor.
+        resolver.requireTier(ProtectedKeyAlgorithm.EcdsaP256, CustodyTier.Hardware)
+        assertFailsWith<InsufficientKeyCustody> {
+            resolver.requireTier(ProtectedKeyAlgorithm.EcdsaP521, CustodyTier.Hardware)
+        }
+    }
+}

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.jsAndWasmJs.kt
@@ -5,4 +5,4 @@ package com.ditchoom.buffer.crypto
  * secure element under this SPI's non-exportable contract), so [CryptoCapabilities.hardware] stays
  * [HardwareSupport.Unavailable].
  */
-internal actual fun platformHardwareKeyProvider(): HardwareKeyProvider? = null
+internal actual fun platformProtectedKeyProvider(): ProtectedKeyProvider? = null

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.jsAndWasmJs.kt
@@ -1,8 +1,279 @@
 package com.ditchoom.buffer.crypto
 
-/**
- * Browser/Node and WASM expose no secure-element key provider (WebCrypto keys are not a hardware
- * secure element under this SPI's non-exportable contract), so [CryptoCapabilities.hardware] stays
- * [HardwareSupport.Unavailable].
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.use
+
+/*
+ * WebCrypto non-exportable **software** key provider (js/wasmJs).
+ *
+ * WebCrypto `subtle.generateKey(..., extractable = false, ...)` mints keys whose private material
+ * never enters the JS heap: the browser/engine holds the `CryptoKey`, and every operation drives it
+ * through `subtle.sign` / `subtle.encrypt` / `subtle.deriveBits`. That is exactly this SPI's
+ * [KeyCustody.NonExportable.Software] tier — non-exportable, but *not* a hardware secure element — so
+ * [platformProtectedKeyProvider] returns a provider here (and [CryptoCapabilities.protectedKeys]
+ * reports [ProtectedKeySupport.Available]), while [CryptoCapabilities.hardware] stays
+ * [HardwareSupport.Unavailable] (this is not a [HardwareKeyProvider]).
+ *
+ * WebCrypto is Promise-based, which maps directly onto the `suspend` gated closures each key carries;
+ * a non-exportable key is async-only anyway (it is not a `SyncCapable*` type), so there is no blocking
+ * path to miss. The keys the engine holds are referenced by an integer token into a per-target JS-side
+ * registry (see `HardwareKeys.js.kt` / `HardwareKeys.wasmJs.kt`); the token — never the key bytes —
+ * crosses the Kotlin↔JS boundary, matching the hex-string marshalling the rest of the web bridge uses.
+ * Each key's `onClose` drops its registry entry so the `CryptoKey` can be collected.
+ *
+ * Eligibility mirrors what WebCrypto reliably backs: ECDSA P-256/384/521 (P-256 primary), AES-GCM,
+ * and ECDH P-256/384/521. X25519 is offered only where the engine exposes it (feature-detected via
+ * [webCryptoSupportsX25519]); otherwise the resolver routes X25519 to the software floor. Ed25519 is
+ * excluded (uneven browser support), mirroring the Android secure-element subset.
+ *
+ * ZEROIZATION NOTE: the non-exportable private material is precisely what never reaches Kotlin, so
+ * there is nothing to wipe on the private side. Public keys, nonces, ciphertext, and derived material
+ * still transit the boundary as hex Strings (the documented, accepted web limitation shared with the
+ * rest of this module).
  */
-internal actual fun platformProtectedKeyProvider(): ProtectedKeyProvider? = null
+internal object WebCryptoProtectedKeyProvider : ProtectedKeyProvider {
+    override val custody: KeyCustody.NonExportable get() = KeyCustody.NonExportable.Software
+
+    override fun eligible(alg: ProtectedKeyAlgorithm): Boolean =
+        when (alg) {
+            ProtectedKeyAlgorithm.AesGcm,
+            ProtectedKeyAlgorithm.EcdsaP256,
+            ProtectedKeyAlgorithm.EcdsaP384,
+            ProtectedKeyAlgorithm.EcdsaP521,
+            ProtectedKeyAlgorithm.EcdhP256,
+            ProtectedKeyAlgorithm.EcdhP384,
+            ProtectedKeyAlgorithm.EcdhP521,
+            -> true
+            // X25519 only where the engine implements it; otherwise the resolver falls to software.
+            ProtectedKeyAlgorithm.X25519 -> webCryptoSupportsX25519
+            // Ed25519 support is uneven across engines; excluded from the non-exportable tier for now.
+            ProtectedKeyAlgorithm.Ed25519 -> false
+        }
+
+    override suspend fun generateSigning(
+        scheme: SignatureScheme,
+        spec: ProtectedKeySpec,
+    ): SigningKey {
+        if (!eligible(scheme.toProtectedKeyAlgorithm())) throw HardwareKeyException.AlgorithmNotEligible()
+        val hashName = ecdsaHashName(scheme)
+        val (token, publicHex) = splitTokenAndHex(webCryptoGenerateNonExportableEcdsa(ecdsaCurveName(scheme)))
+        val verifyKey = verifyKeyOf(scheme, hexBuffer(publicHex, BufferFactory.Default))
+        return ProtectedSigningKey(
+            scheme = scheme,
+            custody = custody,
+            gatedSign = { message, factory ->
+                if (!spec.authorization.authorize()) throw AuthorizationFailed()
+                // WebCrypto ECDSA sign is raw P1363 (r ‖ s) — the pinned web wire form; DER conversion
+                // is a consumer's concern via the existing helpers.
+                hexBuffer(webCryptoEcdsaSign(token, hashName, message.toHexRemaining()), factory)
+            },
+            verifyKey = verifyKey,
+            onClose = { webCryptoReleaseHandle(token) },
+        )
+    }
+
+    override suspend fun generateAesGcm(spec: ProtectedKeySpec): AesGcmKey {
+        val sizeBits = spec.aesKeySizeBits
+        if (sizeBits != AES_128_KEY_BYTES * Byte.SIZE_BITS && sizeBits != AES_256_KEY_BYTES * Byte.SIZE_BITS) {
+            throw HardwareKeyException.UnsupportedHardwareKey()
+        }
+        val token = webCryptoGenerateNonExportableAesGcm(sizeBits).toInt()
+        return ProtectedAesGcmKey(
+            sizeBits = sizeBits,
+            custody = custody,
+            // WebCrypto requires the caller to supply the IV, so — unlike the Android keystore path —
+            // the seal closure mints a fresh 12-byte nonce here and frames nonce ‖ ciphertext ‖ tag so
+            // the standard splitFramed open path is unchanged. A reused (key, nonce) pair is
+            // catastrophic, so the nonce is drawn from the library CSPRNG per seal, never from a caller.
+            gatedSeal = { aad, plaintext, factory ->
+                if (!spec.authorization.authorize()) throw AuthorizationFailed()
+                cryptoRandom(AEAD_NONCE_BYTES).use { nonce ->
+                    val ctTagHex =
+                        webCryptoAesGcmSealHandle(
+                            token = token,
+                            ivHex = nonce.toHexRemaining(),
+                            aadHex = aad?.toHexRemaining() ?: "",
+                            plaintextHex = plaintext.toHexRemaining(),
+                        )
+                    val out = allocateFramed(plaintext.remaining(), factory)
+                    out.write(nonce)
+                    out.writeHex(ctTagHex)
+                    out.resetForRead()
+                    out
+                }
+            },
+            gatedOpen = { nonce, aad, ciphertextAndTag, factory ->
+                if (!spec.authorization.authorize()) throw AuthorizationFailed()
+                val ptHex =
+                    webCryptoAesGcmOpenHandle(
+                        token = token,
+                        ivHex = nonce.toHexRemaining(),
+                        aadHex = aad?.toHexRemaining() ?: "",
+                        ciphertextAndTagHex = ciphertextAndTag.toHexRemaining(),
+                    ) ?: throw VerificationFailed()
+                hexBuffer(ptHex, factory)
+            },
+            onClose = { webCryptoReleaseHandle(token) },
+        )
+    }
+
+    override suspend fun generateKeyAgreement(
+        curve: KeyAgreementCurve,
+        spec: ProtectedKeySpec,
+    ): KeyAgreementKeyPair {
+        if (!eligible(curve.toProtectedKeyAlgorithm())) throw HardwareKeyException.AlgorithmNotEligible()
+        val result = webCryptoGenerateNonExportableEcdh(curve.curveName)
+        if (result == UNSUPPORTED_SENTINEL) throw HardwareKeyException.AlgorithmNotEligible()
+        val (token, publicHex) = splitTokenAndHex(result)
+        val publicKey = KeyAgreementPublicKey.of(curve, hexBuffer(publicHex, BufferFactory.Default))
+        val bits = deriveBitsFor(curve)
+        val privateKey =
+            ProtectedKeyAgreementPrivateKey(
+                curve = curve,
+                custody = custody,
+                // The gated DH is exactly the KEM's DH(sk, peer): deriveBits over the non-exportable
+                // private handle. The common seam ([dhRawSecret] / [deriveFromRawSecret]) applies the
+                // shared all-zero rejection + HKDF above it, so hpke().openBase(...) and
+                // keyAgreement().deriveSharedSecret(...) compose unchanged with this recipient key.
+                gatedDh = { peer ->
+                    if (!spec.authorization.authorize()) throw AuthorizationFailed()
+                    require(peer.curve == curve) { "private/public key curve mismatch" }
+                    val sharedHex =
+                        try {
+                            webCryptoEcdhDeriveBits(token, curve.curveName, peer.encoded.toHexRemaining(), bits)
+                        } catch (_: Throwable) {
+                            // A rejected import / deriveBits means an off-curve / low-order / malformed
+                            // peer point — surfaced uniformly, cause dropped (oracle avoidance).
+                            @Suppress("SwallowedException", "TooGenericExceptionCaught")
+                            throw InvalidPublicKey(curve)
+                        }
+                    hexBuffer(sharedHex, secureScratch)
+                },
+                onClose = { webCryptoReleaseHandle(token) },
+            )
+        return keyAgreementKeyPairOf(curve, privateKey, publicKey)
+    }
+}
+
+/**
+ * Browser/Node and WASM expose non-exportable WebCrypto software keys but no dedicated secure element,
+ * so [platformProtectedKeyProvider] returns the [WebCryptoProtectedKeyProvider] (a
+ * [ProtectedKeyProvider], **not** a [HardwareKeyProvider]) only when `subtle.generateKey` is present;
+ * [CryptoCapabilities.hardware] stays [HardwareSupport.Unavailable].
+ */
+internal actual fun platformProtectedKeyProvider(): ProtectedKeyProvider? =
+    if (subtleGenerateKeyAvailable) WebCryptoProtectedKeyProvider else null
+
+// =============================================================================
+// helpers (shared js/wasmJs)
+// =============================================================================
+
+/** ECDSA WebCrypto `namedCurve` for [scheme]. */
+private fun ecdsaCurveName(scheme: SignatureScheme): String =
+    when (scheme) {
+        SignatureScheme.EcdsaP256 -> "P-256"
+        SignatureScheme.EcdsaP384 -> "P-384"
+        SignatureScheme.EcdsaP521 -> "P-521"
+        SignatureScheme.Ed25519 -> throw HardwareKeyException.AlgorithmNotEligible()
+    }
+
+/** ECDSA WebCrypto `hash` name for [scheme] (each curve is bound to its FIPS 186 hash). */
+private fun ecdsaHashName(scheme: SignatureScheme): String =
+    when (scheme) {
+        SignatureScheme.EcdsaP256 -> "SHA-256"
+        SignatureScheme.EcdsaP384 -> "SHA-384"
+        SignatureScheme.EcdsaP521 -> "SHA-512"
+        SignatureScheme.Ed25519 -> throw HardwareKeyException.AlgorithmNotEligible()
+    }
+
+/** WebCrypto `deriveBits` length for [curve] (P-521 rounds up to 528 bits, matching the KA glue). */
+private fun deriveBitsFor(curve: KeyAgreementCurve): Int =
+    when (curve) {
+        KeyAgreementCurve.X25519, KeyAgreementCurve.P256 -> 256
+        KeyAgreementCurve.P384 -> 384
+        KeyAgreementCurve.P521 -> 528
+    }
+
+/** Splits a `"<token>:<hex>"` marshalling into the integer token and the hex payload. */
+private fun splitTokenAndHex(marshalled: String): Pair<Int, String> {
+    val sep = marshalled.indexOf(':')
+    require(sep > 0) { "malformed non-exportable key marshalling" }
+    return marshalled.substring(0, sep).toInt() to marshalled.substring(sep + 1)
+}
+
+/** Builds a fresh read-ready buffer from a lowercase-hex string via [factory]. */
+private fun hexBuffer(
+    hex: String,
+    factory: BufferFactory,
+): PlatformBuffer {
+    val out = factory.allocate(hex.length / 2)
+    out.writeHex(hex)
+    out.resetForRead()
+    return out
+}
+
+// =============================================================================
+// Per-target WebCrypto seam (dynamic on JS, @JsFun externals on wasmJs)
+// =============================================================================
+//
+// Non-exportable CryptoKeys live in a per-target JS-side registry keyed by an integer token; only the
+// token (and hex-marshalled public/derived material) crosses the boundary, so the same jsAndWasmJs
+// logic drives both backends without typed-array interop leaking in.
+
+/** Whether `crypto.subtle.generateKey` is callable in this engine (gates the provider). */
+internal expect val subtleGenerateKeyAvailable: Boolean
+
+/**
+ * Generates a non-extractable ECDSA key pair for [curveName], stores the private `CryptoKey` in the
+ * registry, and returns `"<token>:<rawPublicHex>"` (the uncompressed SEC1 point).
+ */
+internal expect suspend fun webCryptoGenerateNonExportableEcdsa(curveName: String): String
+
+/** Signs [messageHex] with the registered ECDSA private key [token] under [hashName]; returns P1363 hex. */
+internal expect suspend fun webCryptoEcdsaSign(
+    token: Int,
+    hashName: String,
+    messageHex: String,
+): String
+
+/** Generates a non-extractable AES-GCM key of [lengthBits] bits, stores it, and returns the token as a string. */
+internal expect suspend fun webCryptoGenerateNonExportableAesGcm(lengthBits: Int): String
+
+/** AES-GCM encrypt with the registered key [token]; returns `ciphertext ‖ tag` hex (WebCrypto appends the tag). */
+internal expect suspend fun webCryptoAesGcmSealHandle(
+    token: Int,
+    ivHex: String,
+    aadHex: String,
+    plaintextHex: String,
+): String
+
+/** AES-GCM decrypt with the registered key [token]; returns plaintext hex, or `null` on a bad tag. */
+internal expect suspend fun webCryptoAesGcmOpenHandle(
+    token: Int,
+    ivHex: String,
+    aadHex: String,
+    ciphertextAndTagHex: String,
+): String?
+
+/**
+ * Generates a non-extractable ECDH/X25519 key pair for [curveName], stores the private key, and
+ * returns `"<token>:<rawPublicHex>"` — or [UNSUPPORTED_SENTINEL] if the engine lacks the algorithm.
+ */
+internal expect suspend fun webCryptoGenerateNonExportableEcdh(curveName: String): String
+
+/**
+ * Computes the raw ECDH/X25519 shared secret between the registered private key [token] and
+ * [peerPublicHex] (raw peer point), returning [bits]-worth of raw secret as hex. Rejects an
+ * off-curve / low-order peer point by rejecting the underlying Promise (mapped to [InvalidPublicKey]).
+ */
+internal expect suspend fun webCryptoEcdhDeriveBits(
+    token: Int,
+    curveName: String,
+    peerPublicHex: String,
+    bits: Int,
+): String
+
+/** Drops the registry entry for [token] so its non-exportable `CryptoKey` can be collected. */
+internal expect fun webCryptoReleaseHandle(token: Int)

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/KeyAgreement.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/KeyAgreement.jsAndWasmJs.kt
@@ -196,7 +196,7 @@ internal actual suspend fun deriveSharedSecretAsyncPlatform(
  * secret in a wiped SecureBuffer (no KDF). Same validation contract as [deriveSharedSecretAsync].
  */
 @Suppress("SwallowedException", "TooGenericExceptionCaught")
-internal actual suspend fun dhRawSecret(
+internal actual suspend fun dhRawSecretInMemory(
     privateKey: KeyAgreementPrivateKey,
     peerPublicKey: KeyAgreementPublicKey,
 ): PlatformBuffer {

--- a/buffer-crypto/src/jsAndWasmJsTest/kotlin/com/ditchoom/buffer/crypto/WebCryptoProtectedKeyProviderTest.kt
+++ b/buffer-crypto/src/jsAndWasmJsTest/kotlin/com/ditchoom/buffer/crypto/WebCryptoProtectedKeyProviderTest.kt
@@ -1,0 +1,198 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.crypto.CryptoTestVectors.ascii
+import com.ditchoom.buffer.crypto.CryptoTestVectors.toHex
+import com.ditchoom.buffer.use
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * End-to-end tests for the WebCrypto non-exportable **software** key provider (js/wasmJs). Exercises
+ * the real `subtle.generateKey(..., extractable = false, ...)` path and the gated closures the
+ * generated keys carry: ECDSA sign→verify (P1363), self-framed AES-GCM seal→open, ECDH derive
+ * agreeing with a software peer, and HPKE `openBase` composing with a non-exportable recipient key.
+ * Also pins the custody a consumer sees through [CryptoCapabilities.keyProvider] and that a
+ * hardware-tier requirement fails loudly on the web.
+ *
+ * Uses P-256 throughout (broadly available in every WebCrypto engine); X25519 support is
+ * engine-dependent and covered by the feature-detection path elsewhere.
+ */
+class WebCryptoProtectedKeyProviderTest {
+    private fun provider(): ProtectedKeyProvider =
+        when (val support = CryptoCapabilities.protectedKeys) {
+            is ProtectedKeySupport.Available -> support.provider
+            ProtectedKeySupport.Unavailable -> fail("web exposes a non-exportable WebCrypto key provider")
+        }
+
+    private fun aesGcmOps(): AeadAsyncOps<AesGcmKey, SyncCapableAesGcmKey> =
+        when (val aead = CryptoCapabilities.aesGcm) {
+            is Aead.AsyncOnly -> aead.ops
+            is Aead.Blocking -> aead.ops
+        }
+
+    @Test
+    fun protectedKeysAvailableAsNonExportableSoftwareNotHardware() =
+        runTest {
+            val p = provider()
+            assertEquals(KeyCustody.NonExportable.Software, p.custody)
+            assertFalse(p.custody.exportable, "a WebCrypto key is non-exportable")
+            assertEquals(KeyProvenance.Software, p.custody.provenance, "WebCrypto is software-backed, not a secure element")
+            // The non-exportable-software tier must NOT masquerade as hardware.
+            assertEquals(HardwareSupport.Unavailable, CryptoCapabilities.hardware)
+        }
+
+    @Test
+    fun keyProviderRoutesEligibleAlgsToNonExportableSoftware() =
+        runTest {
+            val keys = CryptoCapabilities.keyProvider()
+            val eligible =
+                listOf(
+                    ProtectedKeyAlgorithm.EcdsaP256,
+                    ProtectedKeyAlgorithm.EcdsaP384,
+                    ProtectedKeyAlgorithm.EcdsaP521,
+                    ProtectedKeyAlgorithm.AesGcm,
+                    ProtectedKeyAlgorithm.EcdhP256,
+                    ProtectedKeyAlgorithm.EcdhP384,
+                    ProtectedKeyAlgorithm.EcdhP521,
+                )
+            for (alg in eligible) {
+                assertEquals(CustodyTier.NonExportableSoftware, keys.custodyFor(alg).tier, "$alg routes to WebCrypto")
+            }
+            // Ed25519 is not offered by the WebCrypto tier → the resolver falls to the software floor.
+            assertEquals(CustodyTier.ExportableSoftware, keys.custodyFor(ProtectedKeyAlgorithm.Ed25519).tier)
+        }
+
+    @Test
+    fun requireHardwareTierThrowsOnWeb() {
+        // No secure element on the web: demanding Hardware fails loudly with a structured, non-secret error.
+        val ex =
+            assertFailsWith<InsufficientKeyCustody> {
+                CryptoCapabilities.keyProvider().requireTier(ProtectedKeyAlgorithm.EcdsaP256, CustodyTier.Hardware)
+            }
+        assertEquals(CustodyTier.Hardware, ex.required)
+        assertEquals(CustodyTier.NonExportableSoftware, ex.available)
+    }
+
+    @Test
+    fun ecdsaNonExportableSignVerifies() =
+        runTest {
+            provider().generateSigning(SignatureScheme.EcdsaP256, ProtectedKeySpec()).use { sk ->
+                assertEquals(KeyCustody.NonExportable.Software, sk.custody)
+                assertEquals(SignatureScheme.EcdsaP256, sk.scheme)
+                val message = ascii("non-exportable ECDSA-P256 message")
+                val signature = signAsync(sk, message)
+                // WebCrypto ECDSA is raw P1363 (r ‖ s, 64 bytes for P-256).
+                assertEquals(64, signature.remaining(), "P-256 P1363 signature length")
+                assertTrue(verifyAsync(sk.verifyKey, message, signature), "the non-exportable key's signature verifies")
+                assertFalse(verifyAsync(sk.verifyKey, ascii("a different message"), signature), "a tampered message is rejected")
+            }
+        }
+
+    @Test
+    fun aesGcmNonExportableSealOpenRoundTrips() =
+        runTest {
+            val ops = aesGcmOps()
+            provider().generateAesGcm(ProtectedKeySpec()).use { key ->
+                assertEquals(KeyCustody.NonExportable.Software, key.custody)
+                assertEquals(AES_256_KEY_BYTES * Byte.SIZE_BITS, key.sizeBits)
+                val plaintext = ascii("the quick brown fox jumps over the lazy dog")
+                val aad = ascii("associated data")
+                // The JS-minted nonce is framed inside the sealed buffer (nonce ‖ ct ‖ tag).
+                val sealed = ops.seal(key, plaintext, Aad.Of(aad), BufferFactory.Default)
+                val opened = ops.open(sealed, key, Aad.Of(aad), BufferFactory.Default)
+                assertEquals(plaintext.toHex(), opened.toHex(), "AES-256-GCM round-trips through the non-exportable key")
+            }
+        }
+
+    @Test
+    fun aesGcmNonExportableRejectsTamperedCiphertext() =
+        runTest {
+            val ops = aesGcmOps()
+            provider().generateAesGcm(ProtectedKeySpec()).use { key ->
+                val sealed = ops.seal(key, ascii("secret payload"), Aad.None, BufferFactory.Default)
+                // Flip the last byte (inside the tag) into a fresh copy → the tag no longer authenticates.
+                val tampered = flipByte(sealed, sealed.remaining() - 1)
+                assertFailsWith<VerificationFailed> { ops.open(tampered, key, Aad.None, BufferFactory.Default) }
+            }
+        }
+
+    @Test
+    fun ecdhNonExportableDeriveMatchesSoftwarePeer() =
+        runTest {
+            val curve = KeyAgreementCurve.P256
+            val protectedPair = provider().generateKeyAgreement(curve, ProtectedKeySpec())
+            val softwarePeer = generateKeyPairAsync(curve)
+            try {
+                assertTrue(protectedPair.privateKey is ProtectedKeyAgreementPrivateKey, "the KA private key is non-exportable")
+                assertEquals(KeyProvenance.Software, protectedPair.privateKey.provenance)
+                val info = ascii("ecdh-p256 derive info")
+                val salt = ascii("derive salt")
+                // Non-exportable side derives via the gated closure; software side via the ordinary path.
+                val fromProtected = deriveSharedSecretAsync(protectedPair.privateKey, softwarePeer.publicKey, info, 32, salt)
+                val fromSoftware = deriveSharedSecretAsync(softwarePeer.privateKey, protectedPair.publicKey, info, 32, salt)
+                assertEquals(
+                    fromProtected.toHex(),
+                    fromSoftware.toHex(),
+                    "the non-exportable key and the software peer derive the same key",
+                )
+                // A non-exportable KA key exposes no scalar.
+                assertFailsWith<UnsupportedOperationException> { protectedPair.privateKey.exportEncoded() }
+            } finally {
+                protectedPair.close()
+                softwarePeer.close()
+            }
+        }
+
+    @Test
+    fun hpkeOpenBaseComposesWithNonExportableRecipient() =
+        runTest {
+            val kem = HpkeKem.DhkemP256HkdfSha256
+            val suite = HpkeSuite(kem, HpkeKdf.HkdfSha256, HpkeAead.Aes128Gcm)
+            val ops =
+                when (val witness = CryptoCapabilities.hpke(suite)) {
+                    is HpkeSupport.Supported -> witness.ops
+                    is HpkeSupport.Unsupported -> fail("DHKEM(P-256) HPKE must be supported on web: ${witness.missing}")
+                }
+            val recipientPair = provider().generateKeyAgreement(kem.curve, ProtectedKeySpec())
+            try {
+                // Anyone can seal to the published recipient public key...
+                val recipientPublic = hpkeImportPublicKey(kem, recipientPair.publicKey.encoded)
+                val info = ascii("hpke non-exportable recipient")
+                val keyToWrap = CryptoTestVectors.repeatedByte(0x2a, 32) // a 32-byte session key
+                val aad = ascii("wrap aad")
+                val sealed = ops.sealBase(recipientPublic, Info.Of(info), keyToWrap, Aad.Of(aad))
+
+                // ...and only the holder of the non-exportable private key opens it — the recipient
+                // scalar never enters the JS heap; the KEM decap DH runs through the gated closure.
+                val recipientPrivate = hpkeRecipientPrivateKey(kem, recipientPair)
+                val recovered = ops.openBase(recipientPrivate, sealed.enc, Info.Of(info), sealed.ciphertext, Aad.Of(aad))
+                assertEquals(keyToWrap.toHex(), recovered.toHex(), "HPKE openBase composes with a non-exportable recipient key")
+            } finally {
+                recipientPair.close()
+            }
+        }
+
+    /** A fresh read-ready copy of [source] with the byte at relative index [i] flipped (no ByteArray). */
+    private fun flipByte(
+        source: ReadBuffer,
+        i: Int,
+    ): ReadBuffer {
+        val start = source.position()
+        val n = source.remaining()
+        val out = BufferFactory.Default.allocate(n)
+        for (k in 0 until n) {
+            val b = source.get(start + k)
+            out.writeByte(if (k == i) (b.toInt() xor 0x01).toByte() else b)
+        }
+        out.resetForRead()
+        return out
+    }
+}

--- a/buffer-crypto/src/jsMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.js.kt
+++ b/buffer-crypto/src/jsMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.js.kt
@@ -1,0 +1,212 @@
+package com.ditchoom.buffer.crypto
+
+import kotlinx.coroutines.await
+import kotlin.js.Promise
+
+/**
+ * JS (browser / Node) WebCrypto glue for the non-exportable software key provider. Non-extractable
+ * `CryptoKey`s live in a global registry (`globalThis.__bcNE`) keyed by an integer token; only the
+ * token and hex-marshalled public/derived material cross the Kotlin/JS boundary. The `js(...)`
+ * literals use `.then()` chains (Kotlin/JS rejects `async`/`await` inside `js("…")`) and reference
+ * Kotlin params directly (no IIFE wrapper — a shadowing param breaks Kotlin's name substitution).
+ */
+
+internal actual val subtleGenerateKeyAvailable: Boolean by lazy(LazyThreadSafetyMode.NONE) {
+    jsSubtleGenerateKeyAvailable()
+}
+
+internal actual suspend fun webCryptoGenerateNonExportableEcdsa(curveName: String): String = jsGenerateEcdsa(curveName).await()
+
+internal actual suspend fun webCryptoEcdsaSign(
+    token: Int,
+    hashName: String,
+    messageHex: String,
+): String = jsEcdsaSign(token, hashName, messageHex).await()
+
+internal actual suspend fun webCryptoGenerateNonExportableAesGcm(lengthBits: Int): String = jsGenerateAesGcm(lengthBits).await()
+
+internal actual suspend fun webCryptoAesGcmSealHandle(
+    token: Int,
+    ivHex: String,
+    aadHex: String,
+    plaintextHex: String,
+): String = jsAesGcmSeal(token, ivHex, aadHex, plaintextHex).await()
+
+internal actual suspend fun webCryptoAesGcmOpenHandle(
+    token: Int,
+    ivHex: String,
+    aadHex: String,
+    ciphertextAndTagHex: String,
+): String? = jsAesGcmOpen(token, ivHex, aadHex, ciphertextAndTagHex).await()
+
+internal actual suspend fun webCryptoGenerateNonExportableEcdh(curveName: String): String = jsGenerateEcdh(curveName).await()
+
+internal actual suspend fun webCryptoEcdhDeriveBits(
+    token: Int,
+    curveName: String,
+    peerPublicHex: String,
+    bits: Int,
+): String = jsEcdhDeriveBits(token, curveName, peerPublicHex, bits).await()
+
+internal actual fun webCryptoReleaseHandle(token: Int) {
+    jsReleaseHandle(token)
+}
+
+// --- raw JS helpers ----------------------------------------------------------
+
+private fun jsSubtleGenerateKeyAvailable(): Boolean =
+    js(
+        "(function(){ try { var s=(globalThis.crypto&&globalThis.crypto.subtle); " +
+            "return !!(s&&typeof s.generateKey==='function'); } catch(e){ return false; } })()",
+    ) as Boolean
+
+// The registry accessor + hex helpers are inlined into each literal (a shared js() function can't be
+// referenced by name from inside another js() template).
+private const val REG =
+    "var g=globalThis; if(!g.__bcNE){ g.__bcNE={m:new Map(),n:1}; } var reg=g.__bcNE;"
+private const val HX =
+    "function hx(b){ var a=new Uint8Array(b); var s=''; for(var i=0;i<a.length;i++){ s+=a[i].toString(16).padStart(2,'0'); } return s; }"
+private const val H2B =
+    "function h2b(h){ var a=new Uint8Array(h.length/2); for(var i=0;i<a.length;i++){ a[i]=parseInt(h.substr(i*2,2),16); } return a; }"
+
+@Suppress("UnusedParameter") // referenced inside the js(...) template
+private fun jsGenerateEcdsa(curveName: String): Promise<String> =
+    js(
+        """
+        (function(){
+          $REG $HX
+          var subtle = globalThis.crypto.subtle;
+          return subtle.generateKey({ name:'ECDSA', namedCurve: curveName }, false, ['sign']).then(function(kp){
+            return subtle.exportKey('raw', kp.publicKey).then(function(rawPub){
+              var t = reg.n++; reg.m.set(t, kp.privateKey);
+              return String(t) + ':' + hx(rawPub);
+            });
+          });
+        })()
+        """,
+    )
+
+@Suppress("UnusedParameter") // referenced inside the js(...) template
+private fun jsEcdsaSign(
+    token: Int,
+    hashName: String,
+    messageHex: String,
+): Promise<String> =
+    js(
+        """
+        (function(){
+          $REG $HX $H2B
+          var subtle = globalThis.crypto.subtle;
+          var pk = reg.m.get(token);
+          return subtle.sign({ name:'ECDSA', hash:{ name: hashName } }, pk, h2b(messageHex)).then(function(sig){ return hx(sig); });
+        })()
+        """,
+    )
+
+@Suppress("UnusedParameter") // referenced inside the js(...) template
+private fun jsGenerateAesGcm(lengthBits: Int): Promise<String> =
+    js(
+        """
+        (function(){
+          $REG
+          var subtle = globalThis.crypto.subtle;
+          return subtle.generateKey({ name:'AES-GCM', length: lengthBits }, false, ['encrypt','decrypt']).then(function(k){
+            var t = reg.n++; reg.m.set(t, k);
+            return String(t);
+          });
+        })()
+        """,
+    )
+
+@Suppress("UnusedParameter") // referenced inside the js(...) template
+private fun jsAesGcmSeal(
+    token: Int,
+    ivHex: String,
+    aadHex: String,
+    ptHex: String,
+): Promise<String> =
+    js(
+        """
+        (function(){
+          $REG $HX $H2B
+          var subtle = globalThis.crypto.subtle;
+          var k = reg.m.get(token);
+          var params = { name:'AES-GCM', iv: h2b(ivHex), tagLength: 128 };
+          if (aadHex.length > 0) params.additionalData = h2b(aadHex);
+          return subtle.encrypt(params, k, h2b(ptHex)).then(function(ct){ return hx(ct); });
+        })()
+        """,
+    )
+
+@Suppress("UnusedParameter") // referenced inside the js(...) template
+private fun jsAesGcmOpen(
+    token: Int,
+    ivHex: String,
+    aadHex: String,
+    ctHex: String,
+): Promise<String?> =
+    js(
+        """
+        (function(){
+          $REG $HX $H2B
+          var subtle = globalThis.crypto.subtle;
+          var k = reg.m.get(token);
+          var params = { name:'AES-GCM', iv: h2b(ivHex), tagLength: 128 };
+          if (aadHex.length > 0) params.additionalData = h2b(aadHex);
+          return subtle.decrypt(params, k, h2b(ctHex)).then(function(pt){ return hx(pt); }).catch(function(e){ return null; });
+        })()
+        """,
+    )
+
+@Suppress("UnusedParameter") // referenced inside the js(...) template
+private fun jsGenerateEcdh(curveName: String): Promise<String> =
+    js(
+        """
+        (function(){
+          $REG $HX
+          var subtle = globalThis.crypto.subtle;
+          var alg = (curveName === 'X25519') ? { name:'X25519' } : { name:'ECDH', namedCurve: curveName };
+          return subtle.generateKey(alg, false, ['deriveBits']).then(function(kp){
+            return subtle.exportKey('raw', kp.publicKey).then(function(rawPub){
+              var t = reg.n++; reg.m.set(t, kp.privateKey);
+              return String(t) + ':' + hx(rawPub);
+            });
+          }).catch(function(e){
+            if (e && (e.name === 'NotSupportedError' || e.name === 'SyntaxError')) return 'UNSUPPORTED';
+            throw e;
+          });
+        })()
+        """,
+    )
+
+@Suppress("UnusedParameter") // referenced inside the js(...) template
+private fun jsEcdhDeriveBits(
+    token: Int,
+    curveName: String,
+    peerPublicHex: String,
+    bits: Int,
+): Promise<String> =
+    js(
+        """
+        (function(){
+          $REG $HX $H2B
+          var subtle = globalThis.crypto.subtle;
+          var priv = reg.m.get(token);
+          var isX = (curveName === 'X25519');
+          var alg = isX ? { name:'X25519' } : { name:'ECDH', namedCurve: curveName };
+          return subtle.importKey('raw', h2b(peerPublicHex), alg, false, []).then(function(pub){
+            var deriveAlg = isX ? { name:'X25519', public: pub } : { name:'ECDH', public: pub };
+            return subtle.deriveBits(deriveAlg, priv, bits).then(function(secret){ return hx(secret); });
+          });
+        })()
+        """,
+    )
+
+@Suppress("UnusedParameter") // referenced inside the js(...) template
+private fun jsReleaseHandle(token: Int) {
+    js(
+        """
+        (function(){ var g=globalThis; if(g.__bcNE){ g.__bcNE.m.delete(token); } })()
+        """,
+    )
+}

--- a/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/KeyAgreement.jvmCommon.kt
+++ b/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/KeyAgreement.jvmCommon.kt
@@ -431,7 +431,7 @@ private fun rawAgree(
  * is caught on purpose so no provider exception type/cause leaks a public-point oracle.
  */
 @Suppress("SwallowedException", "TooGenericExceptionCaught", "ThrowsCount")
-internal actual suspend fun dhRawSecret(
+internal actual suspend fun dhRawSecretInMemory(
     privateKey: KeyAgreementPrivateKey,
     peerPublicKey: KeyAgreementPublicKey,
 ): PlatformBuffer {

--- a/buffer-crypto/src/jvmMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.jvm.kt
+++ b/buffer-crypto/src/jvmMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.jvm.kt
@@ -5,4 +5,4 @@ package com.ditchoom.buffer.crypto
  * Enclave reachable from this runtime, so [CryptoCapabilities.hardware] stays
  * [HardwareSupport.Unavailable]. (The Android target supplies its own actual.)
  */
-internal actual fun platformHardwareKeyProvider(): HardwareKeyProvider? = null
+internal actual fun platformProtectedKeyProvider(): ProtectedKeyProvider? = null

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.linux.kt
@@ -4,4 +4,4 @@ package com.ditchoom.buffer.crypto
  * Linux (BoringSSL-backed) wires no secure-element key provider, so [CryptoCapabilities.hardware]
  * stays [HardwareSupport.Unavailable].
  */
-internal actual fun platformHardwareKeyProvider(): HardwareKeyProvider? = null
+internal actual fun platformProtectedKeyProvider(): ProtectedKeyProvider? = null

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/KeyAgreement.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/KeyAgreement.linux.kt
@@ -124,7 +124,7 @@ internal actual fun deriveSharedSecretPlatform(
     return deriveFromRawSecret(curve, raw, info, length, salt, factory)
 }
 
-internal actual suspend fun dhRawSecret(
+internal actual suspend fun dhRawSecretInMemory(
     privateKey: KeyAgreementPrivateKey,
     peerPublicKey: KeyAgreementPublicKey,
 ): PlatformBuffer = validateRawSecret(privateKey.curve, rawAgree(privateKey, peerPublicKey))

--- a/buffer-crypto/src/wasmJsMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.wasmJs.kt
+++ b/buffer-crypto/src/wasmJsMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.wasmJs.kt
@@ -1,0 +1,208 @@
+@file:OptIn(ExperimentalWasmJsInterop::class)
+
+package com.ditchoom.buffer.crypto
+
+import kotlinx.coroutines.await
+import kotlin.js.ExperimentalWasmJsInterop
+import kotlin.js.Promise
+
+/**
+ * wasmJs WebCrypto glue for the non-exportable software key provider. Mirrors the JS actual but
+ * marshals strings through `JsString` and uses `@JsFun` externals; non-extractable `CryptoKey`s live
+ * in the same `globalThis.__bcNE` registry, referenced by an integer token. Each `@JsFun` body is
+ * self-contained (the annotation value must be a constant), so the registry + hex helpers are inlined.
+ */
+
+internal actual val subtleGenerateKeyAvailable: Boolean by lazy(LazyThreadSafetyMode.NONE) {
+    jsSubtleGenerateKeyAvailable()
+}
+
+internal actual suspend fun webCryptoGenerateNonExportableEcdsa(curveName: String): String =
+    jsGenerateEcdsa(curveName.toJsString()).await<JsString>().toString()
+
+internal actual suspend fun webCryptoEcdsaSign(
+    token: Int,
+    hashName: String,
+    messageHex: String,
+): String = jsEcdsaSign(token, hashName.toJsString(), messageHex.toJsString()).await<JsString>().toString()
+
+internal actual suspend fun webCryptoGenerateNonExportableAesGcm(lengthBits: Int): String =
+    jsGenerateAesGcm(lengthBits).await<JsString>().toString()
+
+internal actual suspend fun webCryptoAesGcmSealHandle(
+    token: Int,
+    ivHex: String,
+    aadHex: String,
+    plaintextHex: String,
+): String =
+    jsAesGcmSeal(token, ivHex.toJsString(), aadHex.toJsString(), plaintextHex.toJsString())
+        .await<JsString>()
+        .toString()
+
+internal actual suspend fun webCryptoAesGcmOpenHandle(
+    token: Int,
+    ivHex: String,
+    aadHex: String,
+    ciphertextAndTagHex: String,
+): String? =
+    jsAesGcmOpen(token, ivHex.toJsString(), aadHex.toJsString(), ciphertextAndTagHex.toJsString())
+        .await<JsString?>()
+        ?.toString()
+
+internal actual suspend fun webCryptoGenerateNonExportableEcdh(curveName: String): String =
+    jsGenerateEcdh(curveName.toJsString()).await<JsString>().toString()
+
+internal actual suspend fun webCryptoEcdhDeriveBits(
+    token: Int,
+    curveName: String,
+    peerPublicHex: String,
+    bits: Int,
+): String =
+    jsEcdhDeriveBits(token, curveName.toJsString(), peerPublicHex.toJsString(), bits)
+        .await<JsString>()
+        .toString()
+
+internal actual fun webCryptoReleaseHandle(token: Int) {
+    jsReleaseHandle(token)
+}
+
+// --- externals ---------------------------------------------------------------
+
+@JsFun(
+    """() => {
+      try {
+        var s = (globalThis.crypto && globalThis.crypto.subtle);
+        return !!(s && typeof s.generateKey === 'function');
+      } catch (e) { return false; }
+    }""",
+)
+private external fun jsSubtleGenerateKeyAvailable(): Boolean
+
+@JsFun(
+    """(curveName) => (async () => {
+      var g = globalThis; if (!g.__bcNE) { g.__bcNE = { m: new Map(), n: 1 }; } var reg = g.__bcNE;
+      function hx(b) { var a = new Uint8Array(b); var s = ''; for (var i = 0; i < a.length; i++) { s += a[i].toString(16).padStart(2, '0'); } return s; }
+      var subtle = globalThis.crypto.subtle;
+      var kp = await subtle.generateKey({ name: 'ECDSA', namedCurve: curveName }, false, ['sign']);
+      var rawPub = await subtle.exportKey('raw', kp.publicKey);
+      var t = reg.n++; reg.m.set(t, kp.privateKey);
+      return String(t) + ':' + hx(rawPub);
+    })()""",
+)
+private external fun jsGenerateEcdsa(curveName: JsString): Promise<JsString>
+
+@JsFun(
+    """(token, hashName, messageHex) => (async () => {
+      var g = globalThis; if (!g.__bcNE) { g.__bcNE = { m: new Map(), n: 1 }; } var reg = g.__bcNE;
+      function h2b(h) { var a = new Uint8Array(h.length / 2); for (var i = 0; i < a.length; i++) { a[i] = parseInt(h.substr(i * 2, 2), 16); } return a; }
+      function hx(b) { var a = new Uint8Array(b); var s = ''; for (var i = 0; i < a.length; i++) { s += a[i].toString(16).padStart(2, '0'); } return s; }
+      var subtle = globalThis.crypto.subtle;
+      var pk = reg.m.get(token);
+      var sig = await subtle.sign({ name: 'ECDSA', hash: { name: hashName } }, pk, h2b(messageHex));
+      return hx(sig);
+    })()""",
+)
+private external fun jsEcdsaSign(
+    token: Int,
+    hashName: JsString,
+    messageHex: JsString,
+): Promise<JsString>
+
+@JsFun(
+    """(lengthBits) => (async () => {
+      var g = globalThis; if (!g.__bcNE) { g.__bcNE = { m: new Map(), n: 1 }; } var reg = g.__bcNE;
+      var subtle = globalThis.crypto.subtle;
+      var k = await subtle.generateKey({ name: 'AES-GCM', length: lengthBits }, false, ['encrypt', 'decrypt']);
+      var t = reg.n++; reg.m.set(t, k);
+      return String(t);
+    })()""",
+)
+private external fun jsGenerateAesGcm(lengthBits: Int): Promise<JsString>
+
+@JsFun(
+    """(token, ivHex, aadHex, ptHex) => (async () => {
+      var g = globalThis; if (!g.__bcNE) { g.__bcNE = { m: new Map(), n: 1 }; } var reg = g.__bcNE;
+      function h2b(h) { var a = new Uint8Array(h.length / 2); for (var i = 0; i < a.length; i++) { a[i] = parseInt(h.substr(i * 2, 2), 16); } return a; }
+      function hx(b) { var a = new Uint8Array(b); var s = ''; for (var i = 0; i < a.length; i++) { s += a[i].toString(16).padStart(2, '0'); } return s; }
+      var subtle = globalThis.crypto.subtle;
+      var k = reg.m.get(token);
+      var params = { name: 'AES-GCM', iv: h2b(ivHex), tagLength: 128 };
+      if (aadHex.length > 0) params.additionalData = h2b(aadHex);
+      var ct = await subtle.encrypt(params, k, h2b(ptHex));
+      return hx(ct);
+    })()""",
+)
+private external fun jsAesGcmSeal(
+    token: Int,
+    ivHex: JsString,
+    aadHex: JsString,
+    ptHex: JsString,
+): Promise<JsString>
+
+@JsFun(
+    """(token, ivHex, aadHex, ctHex) => (async () => {
+      var g = globalThis; if (!g.__bcNE) { g.__bcNE = { m: new Map(), n: 1 }; } var reg = g.__bcNE;
+      function h2b(h) { var a = new Uint8Array(h.length / 2); for (var i = 0; i < a.length; i++) { a[i] = parseInt(h.substr(i * 2, 2), 16); } return a; }
+      function hx(b) { var a = new Uint8Array(b); var s = ''; for (var i = 0; i < a.length; i++) { s += a[i].toString(16).padStart(2, '0'); } return s; }
+      var subtle = globalThis.crypto.subtle;
+      var k = reg.m.get(token);
+      var params = { name: 'AES-GCM', iv: h2b(ivHex), tagLength: 128 };
+      if (aadHex.length > 0) params.additionalData = h2b(aadHex);
+      try {
+        var pt = await subtle.decrypt(params, k, h2b(ctHex));
+        return hx(pt);
+      } catch (e) { return null; }
+    })()""",
+)
+private external fun jsAesGcmOpen(
+    token: Int,
+    ivHex: JsString,
+    aadHex: JsString,
+    ctHex: JsString,
+): Promise<JsString?>
+
+@JsFun(
+    """(curveName) => (async () => {
+      var g = globalThis; if (!g.__bcNE) { g.__bcNE = { m: new Map(), n: 1 }; } var reg = g.__bcNE;
+      function hx(b) { var a = new Uint8Array(b); var s = ''; for (var i = 0; i < a.length; i++) { s += a[i].toString(16).padStart(2, '0'); } return s; }
+      var subtle = globalThis.crypto.subtle;
+      var alg = (curveName === 'X25519') ? { name: 'X25519' } : { name: 'ECDH', namedCurve: curveName };
+      try {
+        var kp = await subtle.generateKey(alg, false, ['deriveBits']);
+        var rawPub = await subtle.exportKey('raw', kp.publicKey);
+        var t = reg.n++; reg.m.set(t, kp.privateKey);
+        return String(t) + ':' + hx(rawPub);
+      } catch (e) {
+        if (e && (e.name === 'NotSupportedError' || e.name === 'SyntaxError')) return 'UNSUPPORTED';
+        throw e;
+      }
+    })()""",
+)
+private external fun jsGenerateEcdh(curveName: JsString): Promise<JsString>
+
+@JsFun(
+    """(token, curveName, peerPublicHex, bits) => (async () => {
+      var g = globalThis; if (!g.__bcNE) { g.__bcNE = { m: new Map(), n: 1 }; } var reg = g.__bcNE;
+      function h2b(h) { var a = new Uint8Array(h.length / 2); for (var i = 0; i < a.length; i++) { a[i] = parseInt(h.substr(i * 2, 2), 16); } return a; }
+      function hx(b) { var a = new Uint8Array(b); var s = ''; for (var i = 0; i < a.length; i++) { s += a[i].toString(16).padStart(2, '0'); } return s; }
+      var subtle = globalThis.crypto.subtle;
+      var priv = reg.m.get(token);
+      var isX = (curveName === 'X25519');
+      var alg = isX ? { name: 'X25519' } : { name: 'ECDH', namedCurve: curveName };
+      var pub = await subtle.importKey('raw', h2b(peerPublicHex), alg, false, []);
+      var deriveAlg = isX ? { name: 'X25519', public: pub } : { name: 'ECDH', public: pub };
+      var secret = await subtle.deriveBits(deriveAlg, priv, bits);
+      return hx(secret);
+    })()""",
+)
+private external fun jsEcdhDeriveBits(
+    token: Int,
+    curveName: JsString,
+    peerPublicHex: JsString,
+    bits: Int,
+): Promise<JsString>
+
+@JsFun(
+    """(token) => { var g = globalThis; if (g.__bcNE) { g.__bcNE.m.delete(token); } }""",
+)
+private external fun jsReleaseHandle(token: Int)


### PR DESCRIPTION
Additive minor on top of the frozen 6.0 hardware-key SPI: a first-class **non-exportable software** key custody tier, and the WebCrypto provider that fills it on the web.

The 6.0 SPI collapsed *exportability* (can the process read the secret?) and *provenance* (where the secret lives) onto one axis, so the only way to say "the process can't read the bytes" was to call a key `Hardware`. That is wrong for WebCrypto `extractable:false` keys — non-exportable, but software-isolated, not a secure element. This introduces one canonical `KeyCustody` and a per-algorithm resolver so the two axes stay orthogonal and impossible states are unrepresentable.

## What's here (by commit)
1. **Rename + typealias** — `HardwareKeySpec`/`HardwareAlgorithm` → `ProtectedKeySpec`/`ProtectedKeyAlgorithm` (+ deprecated typealiases) + key-agreement enum entries.
2. **`KeyCustody` model + provider hierarchy** — one sealed `KeyCustody` (`ExportableSoftware` / `NonExportable.Software` / `NonExportable.Hardware`), derived `exportable`/`provenance`/`dedicatedSecureElement`, `KeyProvider`/`ConcreteKeyProvider`/`ProtectedKeyProvider` over the internal `platformProtectedKeyProvider()` seam.
3. **commonMain software floor + total resolver** — `SoftwareKeyProvider`, `keyProvider()` (never null, per-algorithm routing to the strongest eligible tier), `requireTier` + structured `InsufficientKeyCustody`.
4. **WebCrypto provider (js/wasmJs)** — `WebCryptoProtectedKeyProvider` (`NonExportable.Software`): non-extractable ECDSA P-256/384/521 (P1363), self-framed AES-GCM (JS-minted nonce), ECDH P-256/384/521 (X25519 feature-detected), and a gated-DH closure so `hpke().openBase(...)` decapsulates with the recipient scalar never entering the JS heap (`hpkeRecipientPrivateKey` adapter). Common gated key-agreement infra backs it (`ProtectedKeyAgreementPrivateKey`, `dhRawSecret` dispatcher over the renamed `dhRawSecretInMemory`).
5. **SECURITY.md** — custody tiers, attack-vector table, and the per-platform custody matrix.

## Custody matrix
| Platform | Strongest custody | Backing |
|---|---|---|
| JVM / Linux | `ExportableSoftware` | in-process software (no portable non-exportable store) |
| JS / WASM | `NonExportableSoftware` | WebCrypto `extractable:false` |
| Android | `Hardware` | Keystore (StrongBox/TEE) |
| Apple | `Hardware` | Secure Enclave |

## Verification (local)
- `:buffer-crypto:jvmTest`, `:jsNodeTest` (incl. 8 new WebCrypto provider tests), `:apiCheck`, `:ktlintCheck` — green.
- `:buffer-crypto:connectedDebugAndroidTest` on an API-34 emulator — 286 tests, 0 failed (auth-bound tests self-skip without biometric enrollment).
- **Apple targets not compiled locally (WSL)** — relying on the Apple CI leg to confirm the mechanical `dhRawSecretInMemory` rename + Enclave provider.

ABI: single public addition `hpkeRecipientPrivateKey`; everything else internal. No `KeyProvenance` change (binary + source compatible); renames carry deprecated typealiases.

Draft to see CI (esp. the Apple + Android legs) before marking ready.