### PR TITLE
feat(buffer-flow): datagram trichotomy (DatagramSource/Sink/Channel + SocketAddress + DatagramMux) under @ExperimentalDatagramApi

### DIFF
--- a/buffer-flow/api/android/buffer-flow.api
+++ b/buffer-flow/api/android/buffer-flow.api
@@ -79,6 +79,9 @@ public abstract interface class com/ditchoom/buffer/flow/Connection : com/ditcho
 	public abstract fun getId ()J
 }
 
+public abstract interface annotation class com/ditchoom/buffer/flow/ExperimentalDatagramApi : java/lang/annotation/Annotation {
+}
+
 public final class com/ditchoom/buffer/flow/FlowExtensionsKt {
 	public static final fun asStringFlow (Lkotlinx/coroutines/flow/Flow;Lcom/ditchoom/buffer/Charset;)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun asStringFlow$default (Lkotlinx/coroutines/flow/Flow;Lcom/ditchoom/buffer/Charset;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;

--- a/buffer-flow/api/jvm/buffer-flow.api
+++ b/buffer-flow/api/jvm/buffer-flow.api
@@ -79,6 +79,9 @@ public abstract interface class com/ditchoom/buffer/flow/Connection : com/ditcho
 	public abstract fun getId ()J
 }
 
+public abstract interface annotation class com/ditchoom/buffer/flow/ExperimentalDatagramApi : java/lang/annotation/Annotation {
+}
+
 public final class com/ditchoom/buffer/flow/FlowExtensionsKt {
 	public static final fun asStringFlow (Lkotlinx/coroutines/flow/Flow;Lcom/ditchoom/buffer/Charset;)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun asStringFlow$default (Lkotlinx/coroutines/flow/Flow;Lcom/ditchoom/buffer/Charset;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;

--- a/buffer-flow/build.gradle.kts
+++ b/buffer-flow/build.gradle.kts
@@ -23,6 +23,11 @@ plugins {
 // the JVM ABI only: it is host-independent and the common public surface is wholly contained in
 // the JVM dump; klib validation would diverge between partial-target dev hosts and CI runners.
 apiValidation {
+    // The datagram trichotomy is incubating under @ExperimentalDatagramApi: exclude it from the
+    // locked ABI so changing an opt-in-experimental signature during conformance is not flagged as a
+    // breaking change (RFC §11.2). The marker is dropped — and the surface enters the dump — only
+    // once conformance is green across every witness and platform.
+    nonPublicMarkers.add("com.ditchoom.buffer.flow.ExperimentalDatagramApi")
     klib {
         enabled = false
     }

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/Datagram.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/Datagram.kt
@@ -1,0 +1,142 @@
+package com.ditchoom.buffer.flow
+
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+
+/**
+ * The ECN (Explicit Congestion Notification) codepoint of a datagram — RFC 3168 / RFC 9331 (L4S).
+ *
+ * The two low bits of the IP TOS / Traffic Class octet. On the read side [Unknown] is the sentinel
+ * for a platform that cannot report the received codepoint (per the §7.2 degradation policy); it is
+ * never a valid *send* value.
+ */
+@ExperimentalDatagramApi
+enum class Ecn(
+    val codepoint: Int,
+) {
+    /** Not ECN-Capable Transport (00). */
+    NotEct(0),
+
+    /** ECN-Capable Transport, ECT(1) (01). */
+    Ect1(1),
+
+    /** ECN-Capable Transport, ECT(0) (10). */
+    Ect0(2),
+
+    /** Congestion Experienced (11). */
+    Ce(3),
+
+    /** The received codepoint is unavailable on this platform (read-side sentinel only). */
+    Unknown(-1),
+    ;
+
+    @ExperimentalDatagramApi
+    companion object {
+        /** Map the low 2 bits of a TOS/TClass octet to an [Ecn]; [Unknown] for out-of-range input. */
+        fun fromCodepoint(value: Int): Ecn =
+            when (value and 0x3) {
+                0 -> NotEct
+                1 -> Ect1
+                2 -> Ect0
+                3 -> Ce
+                else -> Unknown
+            }
+    }
+}
+
+/**
+ * One received datagram: a zero-copy [payload] plus who sent it plus the read-side control plane.
+ *
+ * **Ownership:** [payload] transfers to the caller exactly like a [ReadResult.Data] buffer — release
+ * or pool it as usual. Each [DatagramSource.receive] returns exactly one whole message; datagram
+ * boundaries are never dissolved (contrast the byte-stream shape, where reads are an unframed river).
+ *
+ * Control-plane read fields ([ecn], [localAddress], [hopLimit]) carry the §7.2 **sentinels** when the
+ * platform cannot report them ([Ecn.Unknown], `null`, `-1`) — consumers query, never assume. Whether a
+ * field is *ever* populated is advertised by [DatagramSource.capabilities].
+ */
+@ExperimentalDatagramApi
+class Datagram(
+    /** The message bytes; ownership transfers to the caller. */
+    val payload: PlatformBuffer,
+    /** The source endpoint. For a connected source this is the fixed peer. */
+    val peer: SocketAddress,
+    /** Received ECN codepoint, or [Ecn.Unknown] if the platform cannot report it. */
+    val ecn: Ecn = Ecn.Unknown,
+    /** Which local IP received this datagram (IP_PKTINFO), or `null` if unavailable. */
+    val localAddress: SocketAddress? = null,
+    /** Received TTL / hop limit, or `-1` if unavailable. */
+    val hopLimit: Int = -1,
+)
+
+/**
+ * The send-side control plane. Every field defaults to "unset / OS default". A field's real effect
+ * is bounded by [DatagramSink.capabilities]: an **advisory** cap the platform lacks ([dscp],
+ * [hopLimit]) is a documented no-op; a **correctness-critical** cap it lacks ([dontFragment]) is
+ * advertised absent and never silently no-op'd (see §7.2). Reuse a single instance across sends to
+ * stay zero-alloc; [Default] is the shared "everything unset" value.
+ */
+@ExperimentalDatagramApi
+class DatagramSendOptions(
+    /** ECN codepoint to stamp on the outgoing datagram. [Ecn.Unknown] means "leave OS default". */
+    val ecn: Ecn = Ecn.Unknown,
+    /** DiffServ codepoint (0..63, the upper 6 TOS bits); `-1` leaves the OS default. Advisory. */
+    val dscp: Int = -1,
+    /** Set the IP Don't-Fragment bit (quiche sets this for PMTU). Correctness-critical. */
+    val dontFragment: Boolean = false,
+    /** TTL / hop limit; `-1` leaves the OS default. Advisory. */
+    val hopLimit: Int = -1,
+    /** Pin the source local IP (IP_PKTINFO) for a multi-homed reply, or `null` for OS routing. */
+    val fromLocal: SocketAddress? = null,
+) {
+    @ExperimentalDatagramApi
+    companion object {
+        /** The shared "everything unset / OS default" options — the zero-alloc default send path. */
+        val Default: DatagramSendOptions = DatagramSendOptions()
+    }
+}
+
+/**
+ * The unified result of a datagram read — the §2.1 datagram analogue of [ReadResult].
+ *
+ * [Received] carries the whole [Datagram]; [Closed] signals the source will yield no more datagrams
+ * (the socket/connection ended), optionally with a structured [Closed.reason] the consumer can
+ * downcast (e.g. a QUIC error). This is the one result type that replaces both raw UDP's ad-hoc
+ * signalling and QUIC's hand-rolled `DatagramReceiveResult (Received | ConnectionClosed)`.
+ */
+@ExperimentalDatagramApi
+sealed interface DatagramReadResult {
+    /** A datagram was received. */
+    @ExperimentalDatagramApi
+    class Received(
+        val datagram: Datagram,
+    ) : DatagramReadResult
+
+    /** The source is closed and will produce no further datagrams. [reason] is optional structured detail. */
+    @ExperimentalDatagramApi
+    class Closed(
+        val reason: Any? = null,
+    ) : DatagramReadResult
+}
+
+/**
+ * An outbound datagram for [DatagramSink.sendBatch]: payload, optional destination (`null` on a
+ * connected sink), and its control plane. Mirrors the arguments of [DatagramSink.send].
+ */
+@ExperimentalDatagramApi
+class OutboundDatagram(
+    val payload: ReadBuffer,
+    val to: SocketAddress? = null,
+    val options: DatagramSendOptions = DatagramSendOptions.Default,
+)
+
+/**
+ * A decoded message tagged with the peer that sent it — the result element of
+ * [DatagramSource.typedAddressed]. Exactly what an SFU/ICE stack wants: `Addressed<StunMessage>`,
+ * `Addressed<RtpPacket>`.
+ */
+@ExperimentalDatagramApi
+class Addressed<out T>(
+    val value: T,
+    val peer: SocketAddress,
+)

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/Datagram.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/Datagram.kt
@@ -3,6 +3,18 @@ package com.ditchoom.buffer.flow
 import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.ReadBuffer
 
+// File-level so the [Ecn] entry constructors can reference them (an enum's entries are initialized
+// before its companion object, so companion consts are off-limits in entry arguments).
+
+/** Congestion Experienced (11) — the only in-range ECN codepoint above the ignore-listed 0/1/2. */
+private const val CE_CODEPOINT = 3
+
+/** Read-side sentinel codepoint for an unreported ECN value. */
+private const val UNKNOWN_CODEPOINT = -1
+
+/** Mask selecting the ECN field — the low 2 bits — of a TOS / Traffic-Class octet. */
+private const val ECN_FIELD_MASK = 0x3
+
 /**
  * The ECN (Explicit Congestion Notification) codepoint of a datagram — RFC 3168 / RFC 9331 (L4S).
  *
@@ -24,23 +36,19 @@ enum class Ecn(
     Ect0(2),
 
     /** Congestion Experienced (11). */
-    Ce(3),
+    Ce(CE_CODEPOINT),
 
     /** The received codepoint is unavailable on this platform (read-side sentinel only). */
-    Unknown(-1),
+    Unknown(UNKNOWN_CODEPOINT),
     ;
 
     @ExperimentalDatagramApi
     companion object {
         /** Map the low 2 bits of a TOS/TClass octet to an [Ecn]; [Unknown] for out-of-range input. */
-        fun fromCodepoint(value: Int): Ecn =
-            when (value and 0x3) {
-                0 -> NotEct
-                1 -> Ect1
-                2 -> Ect0
-                3 -> Ce
-                else -> Unknown
-            }
+        fun fromCodepoint(value: Int): Ecn {
+            val field = value and ECN_FIELD_MASK
+            return entries.firstOrNull { it.codepoint == field } ?: Unknown
+        }
     }
 }
 

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/DatagramCapabilities.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/DatagramCapabilities.kt
@@ -1,0 +1,72 @@
+package com.ditchoom.buffer.flow
+
+/**
+ * The control-plane capabilities a datagram endpoint actually supports on its platform.
+ *
+ * Decision §10.2: the full control-plane **surface** ships everywhere ([Datagram] read fields,
+ * [DatagramSendOptions] send fields), but each field is implemented to the platform's real ceiling
+ * and the ceiling is advertised here. Consumers (quiche, ICE) read this **once in commonMain and
+ * branch once** — the same code auto-optimizes per platform because the actual's capability set
+ * differs. There is no per-platform consumer code.
+ *
+ * Each flag's absence degrades to a **correct** mode (§7.2):
+ * - **Advisory** ([dscpSend], [hopLimitSend]) absent → the send field is a documented no-op
+ *   (unmarked traffic), never wrong bytes.
+ * - **Correctness-critical** ([dontFragment]) absent → advertised absent here, **never silently
+ *   no-op'd**; quiche only grows datagram size past the 1200-byte floor when DF is truly present.
+ * - **Read fields** ([ecnReceive], [hopLimitReceive], [localAddressReceive]) absent → the
+ *   [Datagram] carries the sentinel ([Ecn.Unknown] / `-1` / `null`).
+ * - [localAddressReceive] / [sourceAddressSelect] (IP_PKTINFO) absence is the only *functional*
+ *   limit, and only for a multi-homed single-socket server; single-homed servers and ICE
+ *   (socket-per-candidate) don't need it, and high-scale relays deploy where it exists.
+ *
+ * The empirically-measured platform values (used to seed platform actuals in `:socket-udp`) are:
+ *
+ * | Feature | Linux native | JVM/Android NIO | Apple POSIX srv | Apple NW client | Node dgram |
+ * |---|---|---|---|---|---|
+ * | ecnSend | ✅ | ✅ (IP_TOS, unmasked) | ✅ | ❌ | ❌ |
+ * | ecnReceive | ✅ | ❌ | ✅ | ❌ | ❌ |
+ * | dscpSend | ✅ | ✅ | ✅ | ⚠️ svc-class | ❌ |
+ * | dontFragment | ✅ (IP_MTU_DISCOVER v4 / IPV6_DONTFRAG v6) | ✅ (JDK 19+) | ✅ | ❌ | ❌ |
+ * | hopLimitSend | ✅ | ❌ (only multicast TTL) | ✅ | ⚠️ | ✅ (setTTL) |
+ * | hopLimitReceive | ✅ | ❌ | ✅ | ❌ | ❌ |
+ * | localAddressReceive | ✅ | ❌ | ⚠️/✅ | ❌ | ❌ |
+ * | sourceAddressSelect | ✅ | ❌ | ⚠️ | ❌ | ❌ |
+ */
+@ExperimentalDatagramApi
+class DatagramCapabilities(
+    /** Can stamp an ECN codepoint on outgoing datagrams ([DatagramSendOptions.ecn]). */
+    val ecnSend: Boolean = false,
+    /** Can report the received ECN codepoint ([Datagram.ecn]). */
+    val ecnReceive: Boolean = false,
+    /** Can set the DiffServ codepoint on outgoing datagrams ([DatagramSendOptions.dscp]). Advisory. */
+    val dscpSend: Boolean = false,
+    /**
+     * Can set the IP Don't-Fragment bit ([DatagramSendOptions.dontFragment]). **Correctness-critical:**
+     * when `false`, a consumer must assume DF is unavailable and hold a conservative MTU floor.
+     */
+    val dontFragment: Boolean = false,
+    /** Can set the outgoing TTL / hop limit ([DatagramSendOptions.hopLimit]). Advisory. */
+    val hopLimitSend: Boolean = false,
+    /** Can report the received TTL / hop limit ([Datagram.hopLimit]). */
+    val hopLimitReceive: Boolean = false,
+    /** Can report which local IP received a datagram ([Datagram.localAddress], IP_PKTINFO). */
+    val localAddressReceive: Boolean = false,
+    /** Can pin the source local IP per send ([DatagramSendOptions.fromLocal], IP_PKTINFO). */
+    val sourceAddressSelect: Boolean = false,
+    /**
+     * Multicast join/leave is available. Decision §10.3 is **design-for, defer impl** — no signature
+     * precludes multicast, but the shipped default is `false` until a later additive minor.
+     */
+    val multicast: Boolean = false,
+) {
+    @ExperimentalDatagramApi
+    companion object {
+        /**
+         * No control-plane capabilities — the conservative default. A minimal or in-memory endpoint
+         * advertises this; every control-plane read yields a sentinel and every advisory send field
+         * is a no-op. Correct on every platform.
+         */
+        val None: DatagramCapabilities = DatagramCapabilities()
+    }
+}

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/DatagramChannel.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/DatagramChannel.kt
@@ -1,0 +1,115 @@
+package com.ditchoom.buffer.flow
+
+import com.ditchoom.buffer.ReadBuffer
+
+/**
+ * The receive half of a datagram endpoint — the unreliable, pre-framed, **addressed** analogue of
+ * [ByteSource].
+ *
+ * There is **no framing driver** here (no `StreamProcessor`, no `peekFrameSize`): the kernel already
+ * delivers one whole message per [receive], so a datagram source never dissolves message boundaries
+ * the way the byte-stream shape does. [receive] returns exactly one [Datagram] (with its source
+ * [Datagram.peer]) or a [DatagramReadResult.Closed].
+ *
+ * - **Connected** (single peer): every [Datagram.peer] is the fixed peer — the QUIC/WebTransport
+ *   datagram case and a `connect()`ed UDP socket.
+ * - **Unconnected** (many peers): [Datagram.peer] is the per-packet source — raw UDP for SFU/TURN/ICE.
+ *
+ * **Thread safety:** implementations are NOT assumed thread-safe; confine [receive] to one coroutine.
+ */
+@ExperimentalDatagramApi
+interface DatagramSource {
+    /** Whether the source is open. Once closed, [receive] yields [DatagramReadResult.Closed]. */
+    val isOpen: Boolean
+
+    /** The local endpoint this source is bound to, for ICE local-candidate gathering, or `null`. */
+    val localAddress: SocketAddress?
+
+    /** The read-side control-plane capabilities of this source (§7.2). Consult, never assume. */
+    val capabilities: DatagramCapabilities
+
+    /** Receives the next datagram, or [DatagramReadResult.Closed] once the source ends. */
+    suspend fun receive(): DatagramReadResult
+
+    /**
+     * Batching hook: receive up to [max] datagrams (recvmmsg / GRO where the platform offers it).
+     * The default fans out to [receive], blocking until [max] datagrams have arrived or the source
+     * closes; the returned list ends at the first [DatagramReadResult.Closed]. Real actuals override
+     * with a single syscall.
+     */
+    suspend fun receiveBatch(max: Int): List<DatagramReadResult> {
+        require(max > 0) { "max must be positive: $max" }
+        val out = ArrayList<DatagramReadResult>(max)
+        repeat(max) {
+            val r = receive()
+            out.add(r)
+            if (r is DatagramReadResult.Closed) return out
+        }
+        return out
+    }
+}
+
+/**
+ * The send half of a datagram endpoint — the analogue of [ByteSink].
+ *
+ * The 2-arg send is deliberate (§4): [to] is a pre-resolved [SocketAddress] that owns its platform
+ * representation, so sending to many distinct peers is zero-alloc — no per-packet resolve, no address
+ * reconstruction.
+ *
+ * **Thread safety:** implementations are NOT assumed thread-safe; confine sends to one coroutine.
+ */
+@ExperimentalDatagramApi
+interface DatagramSink {
+    /** Whether the sink is open. */
+    val isOpen: Boolean
+
+    /**
+     * The largest payload a single [send] can carry — the link MTU for raw UDP, or the negotiated
+     * `max_datagram_size` for QUIC/WebTransport datagrams. A payload larger than this may be rejected
+     * or dropped.
+     */
+    val maxWritableSize: Int
+
+    /** The send-side control-plane capabilities of this sink (§7.2). Consult, never assume. */
+    val capabilities: DatagramCapabilities
+
+    /**
+     * Sends [payload] to [to] (or the fixed peer when [to] is `null` on a connected sink) with the
+     * control plane [options].
+     *
+     * [payload] is consumed as a [ReadBuffer]; ownership is not transferred (the caller may pool it).
+     * [options] defaults to the shared [DatagramSendOptions.Default] to keep the hot path allocation-free.
+     */
+    suspend fun send(
+        payload: ReadBuffer,
+        to: SocketAddress? = null,
+        options: DatagramSendOptions = DatagramSendOptions.Default,
+    )
+
+    /**
+     * Batching hook: send many datagrams at once (sendmmsg / GSO where the platform offers it). The
+     * default fans out to [send]; real actuals override with a single syscall.
+     */
+    suspend fun sendBatch(datagrams: List<OutboundDatagram>) {
+        for (d in datagrams) send(d.payload, d.to, d.options)
+    }
+
+    /** Close the send side. Idempotent. Defaults to a no-op (a simple sink needs nothing). */
+    fun close() {}
+}
+
+/**
+ * A bidirectional datagram endpoint — the common case (a bound UDP socket, a QUIC/WebTransport
+ * datagram flow). Mirrors [ByteStream] over the byte trichotomy.
+ *
+ * A receive-only source is a [DatagramSource], a send-only sink is a [DatagramSink]; a duplex endpoint
+ * is a [DatagramChannel]. No fake capabilities — the tightest type per direction, exactly as the byte
+ * trichotomy.
+ */
+@ExperimentalDatagramApi
+interface DatagramChannel :
+    DatagramSource,
+    DatagramSink {
+    /** Close the whole channel (re-abstracts [DatagramSink.close], which is send-side-only). */
+    override fun close()
+}

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/DatagramMux.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/DatagramMux.kt
@@ -1,0 +1,28 @@
+package com.ditchoom.buffer.flow
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * A multiplexed datagram connection: many independent logical datagram flows over one underlying
+ * datagram channel, demuxed by a leading flow id.
+ *
+ * This is the **unreliable-transport analogue of [ByteStreamMux]**. Where [ByteStreamMux] multiplexes
+ * reliable byte streams (QUIC streams), [DatagramMux] multiplexes unreliable datagram flows — exactly
+ * what WebTransport does today by hand, prefixing each datagram with a session/flow id and routing it
+ * to a per-session channel. Datagrams **bypass the reliable stream mux** ([ByteStreamMux] only does
+ * `openBidirectional`/`openUnidirectional`), so there is no conflict: this is the parallel primitive.
+ *
+ * The flow-id *semantics* (how the id is encoded on the wire, session lifecycle) live in the consumer
+ * (`:socket-quic` / `socket-webtransport`); this interface is only the shared shape (decision §10.4).
+ *
+ * **Thread safety:** implementations are NOT assumed thread-safe; external synchronization is required
+ * for concurrent [open] / [accept] unless an implementation documents otherwise.
+ */
+@ExperimentalDatagramApi
+interface DatagramMux {
+    /** Open a logical datagram flow identified by [flowId] over the underlying datagram channel. */
+    fun open(flowId: Long): DatagramChannel
+
+    /** Peer-initiated datagram flows, demuxed by their leading id. */
+    fun accept(): Flow<DatagramChannel>
+}

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/ExperimentalDatagramApi.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/ExperimentalDatagramApi.kt
@@ -1,0 +1,32 @@
+package com.ditchoom.buffer.flow
+
+/**
+ * Marks the datagram trichotomy ([SocketAddress] / [Datagram] / [DatagramSource] / [DatagramSink] /
+ * [DatagramChannel] / [DatagramMux] and their value types) as **experimental and opt-in**.
+ *
+ * The datagram surface is the unreliable, pre-framed, addressed analogue of the byte trichotomy
+ * ([ByteSource] / [ByteSink] / [ByteStream]). Unlike the byte surface, it is *incubating*: it lands
+ * ahead of its platform socket actuals (`:socket-udp`) and its conformance witnesses (quiche, ICE,
+ * SFU/TURN, mDNS, DNS/STUN) so those can adversarially exercise it. Changing an opt-in-experimental
+ * API is not a semver-major break — that is exactly what this marker buys. The marker is dropped
+ * only once conformance is green across every witness and platform, at which point the surface
+ * becomes stable public API.
+ *
+ * Opt in with `@OptIn(ExperimentalDatagramApi::class)` at the call site, or propagate by annotating
+ * your own declaration `@ExperimentalDatagramApi`.
+ */
+@RequiresOptIn(
+    level = RequiresOptIn.Level.WARNING,
+    message =
+        "The datagram trichotomy is experimental and may change until conformance is proven " +
+            "across all witnesses and platforms. Opt in with @OptIn(ExperimentalDatagramApi::class).",
+)
+@Retention(AnnotationRetention.BINARY)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.CONSTRUCTOR,
+    AnnotationTarget.TYPEALIAS,
+)
+annotation class ExperimentalDatagramApi

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/SocketAddress.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/SocketAddress.kt
@@ -69,19 +69,30 @@ interface SocketAddress {
         ): SocketAddress = resolver.resolve(host, port)
 
         /**
+         * Install the platform hostname [resolver] that backs [resolve]. `:socket-udp` calls this once
+         * with a DNS resolver for its platform; until then [resolve] handles numeric literals only and
+         * throws for hostnames (buffer-flow performs no I/O). Last install wins; idempotent to re-install
+         * the same resolver.
+         */
+        fun installResolver(resolver: SocketAddressResolver) {
+            this.resolver = resolver
+        }
+
+        /**
          * Pluggable hostname resolver. Defaults to a literal-only resolver; `:socket-udp` installs a
-         * platform DNS resolver. Internal so it is not part of the locked public/ABI surface.
+         * platform DNS resolver via [installResolver]. The backing field is internal so it is not part of
+         * the locked public/ABI surface — [installResolver] is the only public mutator.
          */
         internal var resolver: SocketAddressResolver = LiteralOnlyResolver
     }
 }
 
 /**
- * Resolves a host/port to a [SocketAddress]. Installed by the platform socket module (`:socket-udp`);
- * buffer-flow ships only [LiteralOnlyResolver].
+ * Resolves a host/port to a [SocketAddress]. Implemented and installed by the platform socket module
+ * (`:socket-udp`) via [SocketAddress.installResolver]; buffer-flow ships only [LiteralOnlyResolver].
  */
 @ExperimentalDatagramApi
-internal fun interface SocketAddressResolver {
+fun interface SocketAddressResolver {
     suspend fun resolve(
         host: String,
         port: Int,

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/SocketAddress.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/SocketAddress.kt
@@ -160,116 +160,169 @@ internal class LiteralSocketAddress private constructor(
             ip: String,
             port: Int,
         ): SocketAddress? {
-            if (port < 0 || port > 65535) throw IllegalArgumentException("port out of range: $port")
-            parseIpv4(ip)?.let { return LiteralSocketAddress(ip, port, AddressFamily.IPv4, 0L, packLo(it, 0)) }
-            parseIpv6(ip)?.let {
-                return LiteralSocketAddress(ip, port, AddressFamily.IPv6, packLo(it, 0), packLo(it, 8))
+            require(port in 0..PORT_MAX) { "port out of range: $port" }
+            parseIpv4(ip)?.let { return LiteralSocketAddress(ip, port, AddressFamily.IPv4, 0L, packBytes(it, 0)) }
+            return parseIpv6(ip)?.let {
+                val hi = packBytes(it, 0)
+                val lo = packBytes(it, IPV6_LOW_HALF_OFFSET)
+                LiteralSocketAddress(ip, port, AddressFamily.IPv6, hi, lo)
             }
-            return null
-        }
-
-        /** Pack 8 bytes starting at [offset] (big-endian) into a long; IPv4 uses only 4 bytes. */
-        private fun packLo(
-            bytes: ByteArray,
-            offset: Int,
-        ): Long {
-            var v = 0L
-            val n = if (bytes.size == 4) 4 else 8
-            for (i in 0 until n) v = (v shl 8) or (bytes[offset + i].toLong() and 0xff)
-            return v
-        }
-
-        /** Parse dotted-quad IPv4 into 4 bytes, or null if not a valid IPv4 literal. */
-        private fun parseIpv4(s: String): ByteArray? {
-            val parts = s.split('.')
-            if (parts.size != 4) return null
-            val out = ByteArray(4)
-            for (i in 0 until 4) {
-                val p = parts[i]
-                if (p.isEmpty() || p.length > 3) return null
-                if (!p.all { it in '0'..'9' }) return null
-                val v = p.toIntOrNull() ?: return null
-                if (v > 255) return null
-                out[i] = v.toByte()
-            }
-            return out
-        }
-
-        /**
-         * Parse an IPv6 literal (with `::` compression and optional embedded IPv4 tail) into 16
-         * bytes, or null if not a valid IPv6 literal. Zone ids (`%eth0`) are stripped.
-         */
-        private fun parseIpv6(raw: String): ByteArray? {
-            val s = raw.substringBefore('%')
-            if (!s.contains(':')) return null
-            val doubleColon = s.indexOf("::")
-            if (s.indexOf("::", doubleColon + 1) >= 0) return null // at most one "::"
-
-            val head: String
-            val tail: String
-            if (doubleColon >= 0) {
-                head = s.substring(0, doubleColon)
-                tail = s.substring(doubleColon + 2)
-            } else {
-                head = s
-                tail = ""
-            }
-
-            fun groups(part: String): List<String>? {
-                if (part.isEmpty()) return emptyList()
-                val g = part.split(':')
-                return if (g.any { it.isEmpty() }) null else g
-            }
-
-            val headGroups = groups(head) ?: return null
-            val tailGroupsRaw = groups(tail) ?: return null
-
-            // An embedded IPv4 tail (e.g. ::ffff:1.2.3.4) counts as two 16-bit groups.
-            val out = ByteArray(16)
-            val words = ArrayList<Int>()
-
-            fun appendGroups(gs: List<String>): Boolean {
-                for ((idx, g) in gs.withIndex()) {
-                    val isLast = idx == gs.size - 1
-                    if (isLast && g.contains('.')) {
-                        val v4 = parseIpv4(g) ?: return false
-                        words.add(((v4[0].toInt() and 0xff) shl 8) or (v4[1].toInt() and 0xff))
-                        words.add(((v4[2].toInt() and 0xff) shl 8) or (v4[3].toInt() and 0xff))
-                    } else {
-                        if (g.length > 4 || !g.all { it in "0123456789abcdefABCDEF" }) return false
-                        words.add(g.toInt(16))
-                    }
-                }
-                return true
-            }
-
-            val headWordsStart = words.size
-            if (!appendGroups(headGroups)) return null
-            val headWordCount = words.size - headWordsStart
-            if (!appendGroups(tailGroupsRaw)) return null
-            val tailWordCount = words.size - headWordsStart - headWordCount
-
-            if (doubleColon >= 0) {
-                val zeros = 8 - (headWordCount + tailWordCount)
-                if (zeros < 0) return null
-                // words currently = head... tail...; splice `zeros` zero-words between them.
-                val final = ArrayList<Int>(8)
-                for (i in 0 until headWordCount) final.add(words[i])
-                repeat(zeros) { final.add(0) }
-                for (i in 0 until tailWordCount) final.add(words[headWordCount + i])
-                if (final.size != 8) return null
-                for (i in 0 until 8) {
-                    out[i * 2] = (final[i] ushr 8).toByte()
-                    out[i * 2 + 1] = final[i].toByte()
-                }
-            } else {
-                if (words.size != 8) return null
-                for (i in 0 until 8) {
-                    out[i * 2] = (words[i] ushr 8).toByte()
-                    out[i * 2 + 1] = words[i].toByte()
-                }
-            }
-            return out
         }
     }
+}
+
+// ── IP-literal parsing (file-private) ─────────────────────────────────────────────────────────────
+// Pure String→bytes helpers, kept at file scope so each is its own small, independently analyzable
+// function (the parser was one 26-branch method before). No I/O, no experimental types.
+
+/** Highest valid UDP port. */
+private const val PORT_MAX = 65535
+
+/** Bytes in an IPv4 address / a dotted-quad's group count. */
+private const val IPV4_BYTE_COUNT = 4
+
+/** Bytes in an IPv6 address. */
+private const val IPV6_BYTE_COUNT = 16
+
+/** 16-bit groups (hextets) in an IPv6 address. */
+private const val IPV6_WORD_COUNT = 8
+
+/** Byte offset of an IPv6 address's low 8 bytes (packed into the `lo` long). */
+private const val IPV6_LOW_HALF_OFFSET = 8
+
+/** Bytes packed into a single long by [packBytes]. */
+private const val LONG_PACK_BYTES = 8
+
+/** Bits in a byte — the shift between a byte and its place in a word/long. */
+private const val BITS_PER_BYTE = 8
+
+/** Bytes per 16-bit IPv6 word. */
+private const val BYTES_PER_WORD = 2
+
+/** Low-8-bits mask. */
+private const val BYTE_MASK = 0xff
+
+/** Largest value of an IPv4 octet. */
+private const val OCTET_MAX = 255
+
+/** Maximum decimal digits in an IPv4 octet. */
+private const val MAX_OCTET_DIGITS = 3
+
+/** Maximum hex digits in an IPv6 group. */
+private const val MAX_HEX_GROUP_DIGITS = 4
+
+/** Radix of an IPv6 hex group. */
+private const val HEX_RADIX = 16
+
+/** The valid characters of an IPv6 hex group. */
+private const val HEX_DIGITS = "0123456789abcdefABCDEF"
+
+/** Pack up to [LONG_PACK_BYTES] bytes starting at [offset] (big-endian) into a long; IPv4 uses 4. */
+private fun packBytes(
+    bytes: ByteArray,
+    offset: Int,
+): Long {
+    val n = if (bytes.size == IPV4_BYTE_COUNT) IPV4_BYTE_COUNT else LONG_PACK_BYTES
+    var v = 0L
+    for (i in 0 until n) {
+        v = (v shl BITS_PER_BYTE) or (bytes[offset + i].toLong() and BYTE_MASK.toLong())
+    }
+    return v
+}
+
+/** Parse dotted-quad IPv4 into 4 bytes, or null if not a valid IPv4 literal. */
+private fun parseIpv4(s: String): ByteArray? {
+    val parts = s.split('.')
+    if (parts.size != IPV4_BYTE_COUNT) return null
+    val octets = parts.mapNotNull { parseOctet(it) }
+    return if (octets.size == IPV4_BYTE_COUNT) ByteArray(IPV4_BYTE_COUNT) { octets[it].toByte() } else null
+}
+
+/** Parse a single decimal IPv4 octet (0..255, no more than 3 digits), or null if invalid. */
+private fun parseOctet(p: String): Int? {
+    if (p.isEmpty() || p.length > MAX_OCTET_DIGITS || p.any { it !in '0'..'9' }) return null
+    val v = p.toIntOrNull()
+    return if (v == null || v > OCTET_MAX) null else v
+}
+
+/**
+ * Parse an IPv6 literal (with `::` compression and optional embedded IPv4 tail) into 16 bytes, or
+ * null if not a valid IPv6 literal. Zone ids (`%eth0`) are stripped.
+ */
+private fun parseIpv6(raw: String): ByteArray? {
+    val s = raw.substringBefore('%')
+    val doubleColon = s.indexOf("::")
+    // Must contain ':' and at most one "::".
+    val malformed = !s.contains(':') || (doubleColon >= 0 && s.indexOf("::", doubleColon + 1) >= 0)
+    if (malformed) return null
+    val head = if (doubleColon >= 0) s.substring(0, doubleColon) else s
+    val tail = if (doubleColon >= 0) s.substring(doubleColon + BYTES_PER_WORD) else ""
+    val words =
+        parseHexGroups(head)?.let { headWords ->
+            parseHexGroups(tail)?.let { tailWords -> combineIpv6Words(headWords, tailWords, doubleColon >= 0) }
+        }
+    return words?.toIpv6Bytes()
+}
+
+/**
+ * Parse the colon-separated groups of one IPv6 half (before/after `::`) into 16-bit words. An empty
+ * part yields no words; an empty group (e.g. a stray `:`) or any invalid group yields null.
+ */
+private fun parseHexGroups(part: String): List<Int>? {
+    if (part.isEmpty()) return emptyList()
+    val groups = part.split(':')
+    return if (groups.any { it.isEmpty() }) {
+        null
+    } else {
+        val parsed = groups.mapIndexed { idx, g -> parseIpv6Group(g, isLast = idx == groups.size - 1) }
+        if (parsed.any { it == null }) null else parsed.filterNotNull().flatten()
+    }
+}
+
+/**
+ * Parse one IPv6 group into its 16-bit word(s): a hex group is one word; a dotted-quad in the last
+ * group (e.g. `::ffff:1.2.3.4`) is two words. Null if the group is invalid.
+ */
+private fun parseIpv6Group(
+    g: String,
+    isLast: Boolean,
+): List<Int>? =
+    when {
+        isLast && g.contains('.') ->
+            parseIpv4(g)?.toList()?.chunked(BYTES_PER_WORD)?.map { bytesToWord(it[0], it[1]) }
+        g.length > MAX_HEX_GROUP_DIGITS || g.any { it !in HEX_DIGITS } -> null
+        else -> listOf(g.toInt(HEX_RADIX))
+    }
+
+/** Combine a big-endian byte pair into a 16-bit word. */
+private fun bytesToWord(
+    hi: Byte,
+    lo: Byte,
+): Int = ((hi.toInt() and BYTE_MASK) shl BITS_PER_BYTE) or (lo.toInt() and BYTE_MASK)
+
+/**
+ * Assemble the final 8 IPv6 words from the head/tail halves. When [compressed] (a `::` was present),
+ * splice the missing zero-words between them; otherwise require exactly 8 words and no tail. Null if
+ * the group count can't form a valid address.
+ */
+private fun combineIpv6Words(
+    head: List<Int>,
+    tail: List<Int>,
+    compressed: Boolean,
+): List<Int>? {
+    if (!compressed) {
+        return if (head.size == IPV6_WORD_COUNT && tail.isEmpty()) head else null
+    }
+    val zeros = IPV6_WORD_COUNT - head.size - tail.size
+    return if (zeros < 0) null else head + List(zeros) { 0 } + tail
+}
+
+/** Serialize exactly [IPV6_WORD_COUNT] words (big-endian) into 16 bytes. */
+private fun List<Int>.toIpv6Bytes(): ByteArray {
+    val out = ByteArray(IPV6_BYTE_COUNT)
+    for (i in indices) {
+        out[i * BYTES_PER_WORD] = (this[i] ushr BITS_PER_BYTE).toByte()
+        out[i * BYTES_PER_WORD + 1] = this[i].toByte()
+    }
+    return out
 }

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/SocketAddress.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/SocketAddress.kt
@@ -1,0 +1,264 @@
+package com.ditchoom.buffer.flow
+
+/** The IP address family of a [SocketAddress]. */
+@ExperimentalDatagramApi
+enum class AddressFamily {
+    IPv4,
+    IPv6,
+}
+
+/**
+ * A **resolved** network endpoint that **owns its platform representation** from construction.
+ *
+ * This is the make-or-break type of the datagram substrate. Three pulls must hold at once:
+ *
+ * 1. **Inspectable** — [host] / [port] / [family] are readable for ICE candidate gathering and
+ *    logging.
+ * 2. **Zero-alloc handoff to a native engine** — a platform actual (quiche's `send_info.to` /
+ *    `recv_info.from` FFI) reads the backing `sockaddr` pointer without re-resolving, via a
+ *    platform SPI extension (e.g. `internal fun SocketAddress.nativeSockAddr()`), not part of this
+ *    common surface.
+ * 3. **Zero-alloc reuse as a send target across MANY distinct peers** — `send(payload, to)` on a
+ *    relay fanning out to N peers must not allocate, even when `to` differs every call. Because a
+ *    [SocketAddress] carries its resolved form (a pinned `sockaddr` on native, an interned
+ *    `InetSocketAddress` on JVM) from construction, the send path is a pointer/field read, never a
+ *    resolve-and-pin. This deletes the `PathKey → InetSocketAddress` reconstruction that today's
+ *    1-entry `lastDest` cache exists to amortize.
+ *
+ * **Resolved-only (decision §10.1):** DNS happens once, out of band, via [Companion.resolve] — the
+ * sole suspending entry point — or [Companion.ofLiteral] for numeric IPs. A [send][DatagramSink.send]
+ * therefore never suspends on resolution and stays zero-alloc; ICE gathers pre-resolved candidates.
+ *
+ * **Value semantics:** implementations must be usable as a map key (a demux routing table keys by
+ * peer), so [equals] / [hashCode] compare the resolved endpoint, not object identity.
+ */
+@ExperimentalDatagramApi
+interface SocketAddress {
+    /** The address as text — an IP literal (numeric), inspectable for ICE and logging. */
+    val host: String
+
+    /** The UDP port. */
+    val port: Int
+
+    /** The IP address family. */
+    val family: AddressFamily
+
+    @ExperimentalDatagramApi
+    companion object {
+        /**
+         * Wrap an already-numeric [ip]:[port] with **no DNS** — the ICE / literal-IP fast path.
+         *
+         * @throws IllegalArgumentException if [ip] is not a valid IPv4 or IPv6 literal, or [port]
+         *   is out of range.
+         */
+        fun ofLiteral(
+            ip: String,
+            port: Int,
+        ): SocketAddress = LiteralSocketAddress.parse(ip, port)
+
+        /**
+         * Resolve [host]:[port] to a [SocketAddress]. The **only** suspending / DNS entry point.
+         *
+         * Numeric literals resolve synchronously here (delegating to [ofLiteral]); real hostname
+         * resolution is provided by a platform resolver installed by `:socket-udp`. Until one is
+         * installed, resolving a non-literal host throws — buffer-flow itself performs no I/O.
+         */
+        suspend fun resolve(
+            host: String,
+            port: Int,
+        ): SocketAddress = resolver.resolve(host, port)
+
+        /**
+         * Pluggable hostname resolver. Defaults to a literal-only resolver; `:socket-udp` installs a
+         * platform DNS resolver. Internal so it is not part of the locked public/ABI surface.
+         */
+        internal var resolver: SocketAddressResolver = LiteralOnlyResolver
+    }
+}
+
+/**
+ * Resolves a host/port to a [SocketAddress]. Installed by the platform socket module (`:socket-udp`);
+ * buffer-flow ships only [LiteralOnlyResolver].
+ */
+@ExperimentalDatagramApi
+internal fun interface SocketAddressResolver {
+    suspend fun resolve(
+        host: String,
+        port: Int,
+    ): SocketAddress
+}
+
+/** The default resolver: numeric literals only. Real DNS arrives with `:socket-udp`. */
+@ExperimentalDatagramApi
+internal object LiteralOnlyResolver : SocketAddressResolver {
+    override suspend fun resolve(
+        host: String,
+        port: Int,
+    ): SocketAddress =
+        LiteralSocketAddress.parseOrNull(host, port)
+            ?: throw UnsupportedOperationException(
+                "buffer-flow resolves only numeric IP literals; install a DNS resolver via :socket-udp to " +
+                    "resolve host '$host'.",
+            )
+}
+
+/**
+ * The common, platform-independent [SocketAddress]: a normalized IP literal that owns its resolved
+ * byte form. Reusing it as a send target is a field read (zero-alloc). Platform actuals (`:socket-udp`)
+ * supply subtypes that additionally carry a pinned `sockaddr` / interned `InetSocketAddress` exposed
+ * through a platform SPI; this one is sufficient for the in-memory channel, the conformance suite, and
+ * [DatagramMux] routing.
+ */
+@ExperimentalDatagramApi
+internal class LiteralSocketAddress private constructor(
+    override val host: String,
+    override val port: Int,
+    override val family: AddressFamily,
+    /**
+     * Normalized address, packed into two longs (IPv4 → low 32 bits of [lo], [hi]=0; IPv6 → 16
+     * bytes across [hi]+[lo]) — the equality/hash basis. Primitive storage keeps reuse as a send
+     * target zero-alloc and mirrors the existing quiche `PathKey` (family, hi, lo) encoding.
+     */
+    private val hi: Long,
+    private val lo: Long,
+) : SocketAddress {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is LiteralSocketAddress) return false
+        return port == other.port && family == other.family && hi == other.hi && lo == other.lo
+    }
+
+    override fun hashCode(): Int {
+        var h = (hi xor lo).hashCode()
+        h = 31 * h + port
+        h = 31 * h + family.ordinal
+        return h
+    }
+
+    override fun toString(): String = if (family == AddressFamily.IPv6) "[$host]:$port" else "$host:$port"
+
+    companion object {
+        fun parse(
+            ip: String,
+            port: Int,
+        ): SocketAddress =
+            parseOrNull(ip, port)
+                ?: throw IllegalArgumentException("Not a valid IP literal: '$ip'")
+
+        fun parseOrNull(
+            ip: String,
+            port: Int,
+        ): SocketAddress? {
+            if (port < 0 || port > 65535) throw IllegalArgumentException("port out of range: $port")
+            parseIpv4(ip)?.let { return LiteralSocketAddress(ip, port, AddressFamily.IPv4, 0L, packLo(it, 0)) }
+            parseIpv6(ip)?.let {
+                return LiteralSocketAddress(ip, port, AddressFamily.IPv6, packLo(it, 0), packLo(it, 8))
+            }
+            return null
+        }
+
+        /** Pack 8 bytes starting at [offset] (big-endian) into a long; IPv4 uses only 4 bytes. */
+        private fun packLo(
+            bytes: ByteArray,
+            offset: Int,
+        ): Long {
+            var v = 0L
+            val n = if (bytes.size == 4) 4 else 8
+            for (i in 0 until n) v = (v shl 8) or (bytes[offset + i].toLong() and 0xff)
+            return v
+        }
+
+        /** Parse dotted-quad IPv4 into 4 bytes, or null if not a valid IPv4 literal. */
+        private fun parseIpv4(s: String): ByteArray? {
+            val parts = s.split('.')
+            if (parts.size != 4) return null
+            val out = ByteArray(4)
+            for (i in 0 until 4) {
+                val p = parts[i]
+                if (p.isEmpty() || p.length > 3) return null
+                if (!p.all { it in '0'..'9' }) return null
+                val v = p.toIntOrNull() ?: return null
+                if (v > 255) return null
+                out[i] = v.toByte()
+            }
+            return out
+        }
+
+        /**
+         * Parse an IPv6 literal (with `::` compression and optional embedded IPv4 tail) into 16
+         * bytes, or null if not a valid IPv6 literal. Zone ids (`%eth0`) are stripped.
+         */
+        private fun parseIpv6(raw: String): ByteArray? {
+            val s = raw.substringBefore('%')
+            if (!s.contains(':')) return null
+            val doubleColon = s.indexOf("::")
+            if (s.indexOf("::", doubleColon + 1) >= 0) return null // at most one "::"
+
+            val head: String
+            val tail: String
+            if (doubleColon >= 0) {
+                head = s.substring(0, doubleColon)
+                tail = s.substring(doubleColon + 2)
+            } else {
+                head = s
+                tail = ""
+            }
+
+            fun groups(part: String): List<String>? {
+                if (part.isEmpty()) return emptyList()
+                val g = part.split(':')
+                return if (g.any { it.isEmpty() }) null else g
+            }
+
+            val headGroups = groups(head) ?: return null
+            val tailGroupsRaw = groups(tail) ?: return null
+
+            // An embedded IPv4 tail (e.g. ::ffff:1.2.3.4) counts as two 16-bit groups.
+            val out = ByteArray(16)
+            val words = ArrayList<Int>()
+
+            fun appendGroups(gs: List<String>): Boolean {
+                for ((idx, g) in gs.withIndex()) {
+                    val isLast = idx == gs.size - 1
+                    if (isLast && g.contains('.')) {
+                        val v4 = parseIpv4(g) ?: return false
+                        words.add(((v4[0].toInt() and 0xff) shl 8) or (v4[1].toInt() and 0xff))
+                        words.add(((v4[2].toInt() and 0xff) shl 8) or (v4[3].toInt() and 0xff))
+                    } else {
+                        if (g.length > 4 || !g.all { it in "0123456789abcdefABCDEF" }) return false
+                        words.add(g.toInt(16))
+                    }
+                }
+                return true
+            }
+
+            val headWordsStart = words.size
+            if (!appendGroups(headGroups)) return null
+            val headWordCount = words.size - headWordsStart
+            if (!appendGroups(tailGroupsRaw)) return null
+            val tailWordCount = words.size - headWordsStart - headWordCount
+
+            if (doubleColon >= 0) {
+                val zeros = 8 - (headWordCount + tailWordCount)
+                if (zeros < 0) return null
+                // words currently = head... tail...; splice `zeros` zero-words between them.
+                val final = ArrayList<Int>(8)
+                for (i in 0 until headWordCount) final.add(words[i])
+                repeat(zeros) { final.add(0) }
+                for (i in 0 until tailWordCount) final.add(words[headWordCount + i])
+                if (final.size != 8) return null
+                for (i in 0 until 8) {
+                    out[i * 2] = (final[i] ushr 8).toByte()
+                    out[i * 2 + 1] = final[i].toByte()
+                }
+            } else {
+                if (words.size != 8) return null
+                for (i in 0 until 8) {
+                    out[i * 2] = (words[i] ushr 8).toByte()
+                    out[i * 2 + 1] = words[i].toByte()
+                }
+            }
+            return out
+        }
+    }
+}

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/TypedDatagram.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/TypedDatagram.kt
@@ -1,0 +1,155 @@
+package com.ditchoom.buffer.flow
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.encodeToPlatformBuffer
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+/*
+ * Datagram-native typed views.
+ *
+ * A Codec plugs in UNCHANGED — each datagram is already one whole message, so the codec's whole-buffer
+ * encode/decode is called directly. What does not carry over from the byte trichotomy is the stream
+ * framing driver (StreamProcessor / peekFrameSize): feeding pre-framed datagrams through it would
+ * concatenate them and dissolve kernel boundaries. These adapters are therefore much simpler than
+ * ByteSource.typed — no processor, no pool.
+ */
+
+/**
+ * Views this **connected** datagram [DatagramSource] as a typed [Receiver] of [T]: each received
+ * datagram's payload is decoded with [codec] and emitted; the source peer is dropped (connected case).
+ * A [DatagramReadResult.Closed] completes the flow. Each payload buffer is freed after decode.
+ */
+@ExperimentalDatagramApi
+public fun <T> DatagramSource.typed(
+    codec: Codec<T>,
+    context: DecodeContext = DecodeContext.Empty,
+): Receiver<T> =
+    Receiver {
+        flow {
+            while (true) {
+                when (val r = receive()) {
+                    is DatagramReadResult.Received -> {
+                        val payload = r.datagram.payload
+                        val value =
+                            try {
+                                codec.decode(payload, context)
+                            } finally {
+                                payload.freeNativeMemory()
+                            }
+                        emit(value)
+                    }
+                    is DatagramReadResult.Closed -> break
+                }
+            }
+        }
+    }
+
+/**
+ * Views this **unconnected** datagram [DatagramSource] as a typed [Receiver] of [Addressed] messages:
+ * each received datagram is decoded with [codec] and tagged with its source peer — exactly what an
+ * SFU/ICE stack wants (`Receiver<Addressed<StunMessage>>`, `Receiver<Addressed<RtpPacket>>`). A
+ * [DatagramReadResult.Closed] completes the flow. Each payload buffer is freed after decode.
+ */
+@ExperimentalDatagramApi
+public fun <T> DatagramSource.typedAddressed(
+    codec: Codec<T>,
+    context: DecodeContext = DecodeContext.Empty,
+): Receiver<Addressed<T>> =
+    Receiver {
+        flow {
+            while (true) {
+                when (val r = receive()) {
+                    is DatagramReadResult.Received -> {
+                        val payload = r.datagram.payload
+                        val value =
+                            try {
+                                codec.decode(payload, context)
+                            } finally {
+                                payload.freeNativeMemory()
+                            }
+                        emit(Addressed(value, r.datagram.peer))
+                    }
+                    is DatagramReadResult.Closed -> break
+                }
+            }
+        }
+    }
+
+/**
+ * Views this **connected** datagram [DatagramSink] as a typed [Sender] of [T]: each message is encoded
+ * with [codec] into a fresh buffer and sent to the fixed peer (`to = null`). The encode buffer is freed
+ * after each send. [Sender.close] delegates to [DatagramSink.close].
+ */
+@ExperimentalDatagramApi
+public fun <T> DatagramSink.typed(
+    codec: Codec<T>,
+    factory: BufferFactory = BufferFactory.Default,
+    context: EncodeContext = EncodeContext.Empty,
+    options: DatagramSendOptions = DatagramSendOptions.Default,
+): Sender<T> =
+    object : Sender<T> {
+        override suspend fun send(message: T) {
+            val buffer = codec.encodeToPlatformBuffer(message, factory, context)
+            try {
+                this@typed.send(buffer, to = null, options = options)
+            } finally {
+                buffer.freeNativeMemory()
+            }
+        }
+
+        override suspend fun close() = this@typed.close()
+    }
+
+/**
+ * Encodes [message] with [codec] and sends it to [to] (the unconnected, many-dest case) with the
+ * control plane [options]. The encode buffer is freed after the send. Mirrors [DatagramSink.typed] for
+ * the case where the destination varies per message (SFU/TURN egress).
+ */
+@ExperimentalDatagramApi
+public suspend fun <T> DatagramSink.typedSend(
+    message: T,
+    codec: Codec<T>,
+    to: SocketAddress? = null,
+    options: DatagramSendOptions = DatagramSendOptions.Default,
+    factory: BufferFactory = BufferFactory.Default,
+    context: EncodeContext = EncodeContext.Empty,
+) {
+    val buffer = codec.encodeToPlatformBuffer(message, factory, context)
+    try {
+        send(buffer, to, options)
+    } finally {
+        buffer.freeNativeMemory()
+    }
+}
+
+/**
+ * Views this **connected** duplex [DatagramChannel] as a typed [Connection] of [T]: the receive half
+ * decodes inbound datagrams (see [typed] on [DatagramSource]) and the send half encodes outbound
+ * messages to the fixed peer (see [typed] on [DatagramSink]). [Connection.close] closes the channel.
+ */
+@ExperimentalDatagramApi
+public fun <T> DatagramChannel.typed(
+    codec: Codec<T>,
+    factory: BufferFactory = BufferFactory.Default,
+    decodeContext: DecodeContext = DecodeContext.Empty,
+    encodeContext: EncodeContext = EncodeContext.Empty,
+    options: DatagramSendOptions = DatagramSendOptions.Default,
+): Connection<T> {
+    val channel = this
+    val receiver = (channel as DatagramSource).typed(codec, decodeContext)
+    val sender = (channel as DatagramSink).typed(codec, factory, encodeContext, options)
+    return object : Connection<T> {
+        override val id: Long get() = 0L
+
+        override suspend fun send(message: T) = sender.send(message)
+
+        override fun receive(): Flow<T> = receiver.receive()
+
+        override suspend fun close() = channel.close()
+    }
+}

--- a/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/DatagramChannelConformanceTests.kt
+++ b/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/DatagramChannelConformanceTests.kt
@@ -1,0 +1,309 @@
+package com.ditchoom.buffer.flow
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.WireSize
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * The datagram trichotomy **conformance contract** — the datagram analogue of the read/write-timeout
+ * RFC contract suites. Every property here is what a real `:socket-udp` platform actual must satisfy;
+ * against the in-memory [MemoryDatagramNetwork] the suite is green, so it is the *baseline* the (not
+ * yet written) socket actuals are measured against — "red" until they exist and pass it. Control-plane
+ * assertions are **capability-gated**: they run only when the endpoint advertises the capability, and
+ * the absent-capability cases assert honest degradation to sentinels (§7.2).
+ */
+@OptIn(ExperimentalDatagramApi::class)
+class DatagramChannelConformanceTests {
+    private val addrA = SocketAddress.ofLiteral("10.0.0.1", 1111)
+    private val addrB = SocketAddress.ofLiteral("10.0.0.2", 2222)
+    private val addrC = SocketAddress.ofLiteral("10.0.0.3", 3333)
+
+    private fun payload(text: String): ReadBuffer = BufferFactory.Default.wrap(text.encodeToByteArray())
+
+    private fun DatagramReadResult.text(): String {
+        val d = assertIs<DatagramReadResult.Received>(this).datagram
+        return d.payload.readByteArray(d.payload.remaining()).decodeToString()
+    }
+
+    // ---- shape: pre-framed, addressed, unreliable ----
+
+    @Test
+    fun receivePreservesDatagramBoundaries() =
+        runTest {
+            val net = MemoryDatagramNetwork()
+            val a = net.bind(addrA)
+            val b = net.bind(addrB)
+            b.send(payload("one"), to = addrA)
+            b.send(payload("two"), to = addrA)
+            // Two sends → two whole datagrams, never concatenated into "onetwo".
+            assertEquals("one", a.receive().text())
+            assertEquals("two", a.receive().text())
+        }
+
+    @Test
+    fun unconnectedReceiveCarriesPerPacketPeer() =
+        runTest {
+            val net = MemoryDatagramNetwork()
+            val a = net.bind(addrA)
+            net.bind(addrB).send(payload("hi"), to = addrA)
+            val d = assertIs<DatagramReadResult.Received>(a.receive()).datagram
+            assertEquals(addrB, d.peer)
+        }
+
+    @Test
+    fun unconnectedSendRoutesByDestination() =
+        runTest {
+            val net = MemoryDatagramNetwork()
+            val a = net.bind(addrA)
+            val b = net.bind(addrB)
+            val c = net.bind(addrC)
+            a.send(payload("toB"), to = addrB)
+            a.send(payload("toC"), to = addrC)
+            assertEquals("toB", b.receive().text())
+            assertEquals("toC", c.receive().text())
+        }
+
+    @Test
+    fun datagramToUnboundDestinationIsDropped() =
+        runTest {
+            val net = MemoryDatagramNetwork()
+            val a = net.bind(addrA)
+            // Nothing bound at addrC — unreliable drop, must not throw.
+            a.send(payload("void"), to = addrC)
+        }
+
+    @Test
+    fun connectedSendUsesFixedPeerBothDirections() =
+        runTest {
+            val net = MemoryDatagramNetwork()
+            val (a, b) = net.connectedPair(addrA, addrB)
+            a.send(payload("ping")) // to = null → fixed peer addrB
+            val atB = assertIs<DatagramReadResult.Received>(b.receive()).datagram
+            assertEquals("ping", atB.payload.readByteArray(atB.payload.remaining()).decodeToString())
+            assertEquals(addrA, atB.peer)
+
+            b.send(payload("pong"))
+            val atA = assertIs<DatagramReadResult.Received>(a.receive()).datagram
+            assertEquals(addrB, atA.peer)
+        }
+
+    // ---- lifecycle ----
+
+    @Test
+    fun closeMakesReceiveReturnClosedAndIsOpenFalse() =
+        runTest {
+            val net = MemoryDatagramNetwork()
+            val a = net.bind(addrA)
+            assertTrue(a.isOpen)
+            a.close()
+            assertFalse(a.isOpen)
+            assertIs<DatagramReadResult.Closed>(a.receive())
+        }
+
+    @Test
+    fun sendAfterCloseThrows() =
+        runTest {
+            val net = MemoryDatagramNetwork()
+            val a = net.bind(addrA)
+            a.close()
+            assertFailsWith<IllegalStateException> { a.send(payload("x"), to = addrB) }
+        }
+
+    @Test
+    fun sendDoesNotConsumeCallerBuffer() =
+        runTest {
+            val net = MemoryDatagramNetwork()
+            val a = net.bind(addrA)
+            val b = net.bind(addrB)
+            val buf = payload("keep")
+            val before = buf.remaining()
+            a.send(buf, to = addrB)
+            assertEquals(before, buf.remaining(), "send must not consume the caller's payload buffer")
+            assertEquals("keep", b.receive().text())
+        }
+
+    @Test
+    fun maxWritableSizeIsPositive() =
+        runTest {
+            val net = MemoryDatagramNetwork()
+            assertTrue(net.bind(addrA).maxWritableSize > 0)
+        }
+
+    // ---- control plane (capability-gated §7.2) ----
+
+    @Test
+    fun controlPlaneRoundTripsWhenAdvertised() =
+        runTest {
+            val net = MemoryDatagramNetwork(FullMemoryCapabilities)
+            val a = net.bind(addrA)
+            val b = net.bind(addrB)
+            val opts =
+                DatagramSendOptions(
+                    ecn = Ecn.Ect0,
+                    hopLimit = 55,
+                    fromLocal = addrB,
+                )
+            b.send(payload("cp"), to = addrA, options = opts)
+            val d = assertIs<DatagramReadResult.Received>(a.receive()).datagram
+
+            if (net.capabilities.ecnSend && net.capabilities.ecnReceive) {
+                assertEquals(Ecn.Ect0, d.ecn)
+            }
+            if (net.capabilities.hopLimitSend && net.capabilities.hopLimitReceive) {
+                assertEquals(55, d.hopLimit)
+            }
+            if (net.capabilities.localAddressReceive) {
+                assertEquals(addrB, d.localAddress)
+            }
+        }
+
+    @Test
+    fun controlPlaneDegradesToSentinelsWhenAbsent() =
+        runTest {
+            val net = MemoryDatagramNetwork(DatagramCapabilities.None)
+            val a = net.bind(addrA)
+            val b = net.bind(addrB)
+            b.send(
+                payload("cp"),
+                to = addrA,
+                options = DatagramSendOptions(ecn = Ecn.Ect0, hopLimit = 55, fromLocal = addrB),
+            )
+            val d = assertIs<DatagramReadResult.Received>(a.receive()).datagram
+            // Absent read capabilities → sentinels, never fabricated values.
+            assertEquals(Ecn.Unknown, d.ecn)
+            assertEquals(-1, d.hopLimit)
+            assertEquals(null, d.localAddress)
+        }
+
+    @Test
+    fun dontFragmentIsNeverSilentlyClaimedWhenAbsent() =
+        runTest {
+            // Correctness-critical: an endpoint that can't set DF must advertise it absent, so a
+            // consumer (quiche) holds its MTU floor instead of mis-fragmenting.
+            assertFalse(MemoryDatagramNetwork(DatagramCapabilities.None).capabilities.dontFragment)
+            assertTrue(MemoryDatagramNetwork(FullMemoryCapabilities).capabilities.dontFragment)
+        }
+
+    // ---- typed views (§5) ----
+
+    @Test
+    fun typedAddressedDecodesAndTagsPeer() =
+        runTest {
+            val net = MemoryDatagramNetwork()
+            val a = net.bind(addrA)
+            val b = net.bind(addrB)
+            b.typedSend("hello", WholeStringCodec, to = addrA)
+            val first =
+                a
+                    .typedAddressed(WholeStringCodec)
+                    .receive()
+                    .take(1)
+                    .toList()
+                    .single()
+            assertEquals("hello", first.value)
+            assertEquals(addrB, first.peer)
+        }
+
+    @Test
+    fun typedConnectedRoundTrips() =
+        runTest {
+            val net = MemoryDatagramNetwork()
+            val (a, b) = net.connectedPair(addrA, addrB)
+            val connA = a.typed(WholeStringCodec)
+            connA.send("ping")
+            val received =
+                b
+                    .typed(WholeStringCodec)
+                    .receive()
+                    .take(1)
+                    .toList()
+                    .single()
+            assertEquals("ping", received)
+        }
+
+    // ---- batching hooks (§10.5) ----
+
+    @Test
+    fun sendBatchDefaultFansOut() =
+        runTest {
+            val net = MemoryDatagramNetwork()
+            val a = net.bind(addrA)
+            val b = net.bind(addrB)
+            a.sendBatch(
+                listOf(
+                    OutboundDatagram(payload("1"), to = addrB),
+                    OutboundDatagram(payload("2"), to = addrB),
+                    OutboundDatagram(payload("3"), to = addrB),
+                ),
+            )
+            assertEquals("1", b.receive().text())
+            assertEquals("2", b.receive().text())
+            assertEquals("3", b.receive().text())
+        }
+
+    @Test
+    fun receiveBatchDefaultLoops() =
+        runTest {
+            val net = MemoryDatagramNetwork()
+            val a = net.bind(addrA)
+            val b = net.bind(addrB)
+            repeat(3) { b.send(payload("m$it"), to = addrA) }
+            val batch = a.receiveBatch(3)
+            assertEquals(3, batch.size)
+            assertEquals(listOf("m0", "m1", "m2"), batch.map { it.text() })
+        }
+
+    @Test
+    fun receiveBatchStopsAtClose() =
+        runTest {
+            val net = MemoryDatagramNetwork()
+            val a = net.bind(addrA)
+            net.bind(addrB).send(payload("only"), to = addrA)
+            a.close()
+            val batch = a.receiveBatch(5)
+            // First the buffered datagram, then Closed terminates the batch early.
+            assertEquals("only", batch.first().text())
+            assertIs<DatagramReadResult.Closed>(batch.last())
+            assertTrue(batch.size <= 2)
+        }
+}
+
+/**
+ * A whole-buffer [Codec] where the datagram boundary *is* the frame: encode writes the UTF-8 bytes,
+ * decode reads all remaining bytes. No length prefix, no [com.ditchoom.buffer.codec.FrameDetector]
+ * participation — exactly the pre-framed shape datagrams have.
+ */
+@OptIn(ExperimentalDatagramApi::class)
+private object WholeStringCodec : Codec<String> {
+    override fun encode(
+        buffer: WriteBuffer,
+        value: String,
+        context: EncodeContext,
+    ) {
+        buffer.writeString(value)
+    }
+
+    override fun decode(
+        buffer: ReadBuffer,
+        context: DecodeContext,
+    ): String = buffer.readString(buffer.remaining())
+
+    override fun wireSize(
+        value: String,
+        context: EncodeContext,
+    ): WireSize = WireSize.BackPatch
+}

--- a/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/MemoryDatagram.kt
+++ b/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/MemoryDatagram.kt
@@ -1,0 +1,145 @@
+package com.ditchoom.buffer.flow
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import kotlinx.coroutines.channels.Channel
+
+/**
+ * An in-memory datagram "network": a routing hub keyed by destination [SocketAddress], the datagram
+ * analogue of [memoryByteStreamPair]. It exists to exercise the datagram trichotomy contract with **no
+ * sockets** — the same role `StubUdpChannel` plays for QUIC, and the sans-I/O seam the RFC §6
+ * deterministic-simulation story stands on.
+ *
+ * Datagram semantics are honored faithfully:
+ * - **Boundaries preserved** — each [DatagramSink.send] delivers exactly one [Datagram]; nothing is
+ *   concatenated.
+ * - **Per-packet source** — the delivered [Datagram.peer] is the *sender's* local address.
+ * - **Copy on send** — the payload is copied into a fresh buffer the receiver owns, so the caller may
+ *   keep/pool its buffer (a real socket copies into the kernel).
+ * - **Unreliable** — a datagram addressed to an unbound endpoint is silently dropped.
+ * - **Capability-honest** — a read-side control-plane field is carried only when [capabilities]
+ *   advertises it; otherwise the receiver sees the §7.2 sentinel.
+ */
+@OptIn(ExperimentalDatagramApi::class)
+internal class MemoryDatagramNetwork(
+    val capabilities: DatagramCapabilities = FullMemoryCapabilities,
+) {
+    private val endpoints = HashMap<SocketAddress, Channel<Datagram>>()
+
+    /** Bind an **unconnected** endpoint at [local]; sends addressed to [local] arrive here. */
+    fun bind(local: SocketAddress): DatagramChannel {
+        val inbound = Channel<Datagram>(Channel.UNLIMITED)
+        endpoints[local] = inbound
+        return MemoryDatagramChannel(local, inbound, this, capabilities, connectedPeer = null)
+    }
+
+    /** A **connected** pair: each channel's `to = null` sends reach the other; peers are fixed. */
+    fun connectedPair(
+        addrA: SocketAddress,
+        addrB: SocketAddress,
+    ): Pair<DatagramChannel, DatagramChannel> {
+        val inA = Channel<Datagram>(Channel.UNLIMITED)
+        val inB = Channel<Datagram>(Channel.UNLIMITED)
+        endpoints[addrA] = inA
+        endpoints[addrB] = inB
+        val a = MemoryDatagramChannel(addrA, inA, this, capabilities, connectedPeer = addrB)
+        val b = MemoryDatagramChannel(addrB, inB, this, capabilities, connectedPeer = addrA)
+        return a to b
+    }
+
+    fun deliver(
+        to: SocketAddress,
+        datagram: Datagram,
+    ) {
+        // Unreliable: no endpoint bound at `to` → dropped, like a UDP packet into the void.
+        endpoints[to]?.trySend(datagram)
+    }
+}
+
+@OptIn(ExperimentalDatagramApi::class)
+internal class MemoryDatagramChannel(
+    override val localAddress: SocketAddress,
+    private val inbound: Channel<Datagram>,
+    private val network: MemoryDatagramNetwork,
+    override val capabilities: DatagramCapabilities,
+    private val connectedPeer: SocketAddress?,
+) : DatagramChannel {
+    private var closed = false
+
+    override val isOpen: Boolean get() = !closed && !inbound.isClosedForReceive
+
+    /** The classic UDP payload ceiling (65535 − 8 UDP − 20 IP). */
+    override val maxWritableSize: Int = 65507
+
+    override suspend fun receive(): DatagramReadResult {
+        val result = inbound.receiveCatching()
+        val datagram = result.getOrNull()
+        return when {
+            datagram != null -> DatagramReadResult.Received(datagram)
+            else -> DatagramReadResult.Closed()
+        }
+    }
+
+    override suspend fun send(
+        payload: ReadBuffer,
+        to: SocketAddress?,
+        options: DatagramSendOptions,
+    ) {
+        check(!closed) { "sink is closed" }
+        val dest = to ?: connectedPeer ?: error("no destination on an unconnected sink")
+
+        // Copy the payload so the caller keeps ownership of its buffer.
+        val slice = payload.slice()
+        val bytes = slice.readByteArray(slice.remaining())
+        val delivered: PlatformBuffer = BufferFactory.Default.wrap(bytes)
+
+        // Carry each control-plane field only if the capability set advertises both ends of it.
+        val ecn =
+            if (capabilities.ecnSend && capabilities.ecnReceive && options.ecn != Ecn.Unknown) {
+                options.ecn
+            } else {
+                Ecn.Unknown
+            }
+        val hopLimit =
+            if (capabilities.hopLimitSend && capabilities.hopLimitReceive && options.hopLimit >= 0) {
+                options.hopLimit
+            } else {
+                -1
+            }
+        val localAddr =
+            if (capabilities.localAddressReceive) options.fromLocal ?: localAddress else null
+
+        network.deliver(
+            dest,
+            Datagram(
+                payload = delivered,
+                peer = localAddress,
+                ecn = ecn,
+                localAddress = localAddr,
+                hopLimit = hopLimit,
+            ),
+        )
+    }
+
+    override fun close() {
+        closed = true
+        inbound.close()
+    }
+}
+
+/** A full-capability in-memory endpoint: every control-plane field round-trips through memory. */
+@OptIn(ExperimentalDatagramApi::class)
+internal val FullMemoryCapabilities =
+    DatagramCapabilities(
+        ecnSend = true,
+        ecnReceive = true,
+        dscpSend = true,
+        dontFragment = true,
+        hopLimitSend = true,
+        hopLimitReceive = true,
+        localAddressReceive = true,
+        sourceAddressSelect = true,
+        multicast = false,
+    )

--- a/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/SocketAddressTests.kt
+++ b/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/SocketAddressTests.kt
@@ -1,0 +1,104 @@
+package com.ditchoom.buffer.flow
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * The address-model contract (§4 / decision §10.1): [SocketAddress] is resolved-only, inspectable,
+ * and has value semantics so it can key a demux routing table. The zero-alloc-many-dest property
+ * itself is proven in the JVM allocation test (`SocketAddressAllocationTest`), which can measure
+ * bytes allocated; here we pin the observable behavior.
+ */
+@OptIn(ExperimentalDatagramApi::class)
+class SocketAddressTests {
+    @Test
+    fun ofLiteralParsesIpv4() {
+        val a = SocketAddress.ofLiteral("192.168.1.10", 4433)
+        assertEquals("192.168.1.10", a.host)
+        assertEquals(4433, a.port)
+        assertEquals(AddressFamily.IPv4, a.family)
+    }
+
+    @Test
+    fun ofLiteralParsesIpv6() {
+        val a = SocketAddress.ofLiteral("::1", 443)
+        assertEquals(443, a.port)
+        assertEquals(AddressFamily.IPv6, a.family)
+    }
+
+    @Test
+    fun ofLiteralParsesFullAndCompressedIpv6Equal() {
+        val compressed = SocketAddress.ofLiteral("::1", 443)
+        val full = SocketAddress.ofLiteral("0:0:0:0:0:0:0:1", 443)
+        assertEquals(compressed, full)
+        assertEquals(compressed.hashCode(), full.hashCode())
+    }
+
+    @Test
+    fun ofLiteralParsesEmbeddedV4Ipv6() {
+        val mapped = SocketAddress.ofLiteral("::ffff:1.2.3.4", 80)
+        assertEquals(AddressFamily.IPv6, mapped.family)
+        // ::ffff:0102:0304 — same 16 bytes whichever spelling.
+        assertEquals(SocketAddress.ofLiteral("::ffff:102:304", 80), mapped)
+    }
+
+    @Test
+    fun equalAddressesShareHashForMapKeying() {
+        val x = SocketAddress.ofLiteral("10.0.0.1", 9000)
+        val y = SocketAddress.ofLiteral("10.0.0.1", 9000)
+        assertEquals(x, y)
+        assertEquals(x.hashCode(), y.hashCode())
+        val map = HashMap<SocketAddress, String>()
+        map[x] = "peer"
+        assertEquals("peer", map[y])
+    }
+
+    @Test
+    fun differentPortsAreDistinct() {
+        assertNotEquals(
+            SocketAddress.ofLiteral("10.0.0.1", 9000),
+            SocketAddress.ofLiteral("10.0.0.1", 9001),
+        )
+    }
+
+    @Test
+    fun invalidLiteralsThrow() {
+        assertFailsWith<IllegalArgumentException> { SocketAddress.ofLiteral("not-an-ip", 80) }
+        assertFailsWith<IllegalArgumentException> { SocketAddress.ofLiteral("256.1.1.1", 80) }
+        assertFailsWith<IllegalArgumentException> { SocketAddress.ofLiteral("1.2.3", 80) }
+        assertFailsWith<IllegalArgumentException> { SocketAddress.ofLiteral("::1::2", 80) }
+    }
+
+    @Test
+    fun portRangeIsValidated() {
+        assertFailsWith<IllegalArgumentException> { SocketAddress.ofLiteral("1.2.3.4", -1) }
+        assertFailsWith<IllegalArgumentException> { SocketAddress.ofLiteral("1.2.3.4", 65536) }
+    }
+
+    @Test
+    fun resolveHandlesLiteralsSynchronously() =
+        runTest {
+            val a = SocketAddress.resolve("127.0.0.1", 53)
+            assertEquals(AddressFamily.IPv4, a.family)
+            assertEquals(53, a.port)
+        }
+
+    @Test
+    fun resolveRejectsHostnamesWithoutInstalledResolver() =
+        runTest {
+            // buffer-flow performs no I/O; hostname DNS arrives with :socket-udp.
+            assertFailsWith<UnsupportedOperationException> {
+                SocketAddress.resolve("example.com", 443)
+            }
+        }
+
+    @Test
+    fun toStringBracketsIpv6() {
+        assertTrue(SocketAddress.ofLiteral("::1", 443).toString().startsWith("["))
+        assertEquals("1.2.3.4:80", SocketAddress.ofLiteral("1.2.3.4", 80).toString())
+    }
+}

--- a/buffer-flow/src/jvmTest/kotlin/com/ditchoom/buffer/flow/SocketAddressAllocationTest.kt
+++ b/buffer-flow/src/jvmTest/kotlin/com/ditchoom/buffer/flow/SocketAddressAllocationTest.kt
@@ -1,0 +1,143 @@
+package com.ditchoom.buffer.flow
+
+import com.sun.management.ThreadMXBean
+import java.lang.management.ManagementFactory
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * The **make-or-break** (§4): sending to MANY distinct destinations must be zero-alloc.
+ *
+ * `send(payload, to)` on a relay fanning out to N peers must not allocate per packet. The design's
+ * answer is that a [SocketAddress] *owns* its resolved platform representation from construction — on
+ * JVM, an interned `InetSocketAddress` — so a platform sink extracts the send target with a field
+ * read, never a resolve-and-pin. This is exactly what deletes the `PathKey → InetSocketAddress`
+ * reconstruction the current quiche `NioUdpChannel` 1-entry `lastDest` cache exists to amortize.
+ *
+ * This test measures per-thread bytes allocated (HotSpot `ThreadMXBean`) while extracting the send
+ * target across 1000 DISTINCT destinations, two ways:
+ *  - **owned** (the design): read the interned `InetSocketAddress` off each [SocketAddress] — must be
+ *    essentially zero regardless of destination count.
+ *  - **reconstructed** (today's cache-defeating path): rebuild `InetSocketAddress` from packed address
+ *    bits every time, as a relay with a 1-entry cache is forced to — allocates real memory per packet.
+ *
+ * If the owned path does NOT hold zero-alloc, the address model — and the whole substrate design —
+ * re-opens.
+ */
+class SocketAddressAllocationTest {
+    private val bean = ManagementFactory.getThreadMXBean() as ThreadMXBean
+
+    private inline fun allocatedBytes(block: () -> Unit): Long {
+        val tid = Thread.currentThread().threadId()
+        val before = bean.getThreadAllocatedBytes(tid)
+        block()
+        val after = bean.getThreadAllocatedBytes(tid)
+        return after - before
+    }
+
+    /** Take the minimum over several trials to squeeze out measurement/JIT noise. */
+    private inline fun minAllocatedBytes(
+        trials: Int,
+        block: () -> Unit,
+    ): Long {
+        var min = Long.MAX_VALUE
+        repeat(trials) {
+            val b = allocatedBytes(block)
+            if (b < min) min = b
+        }
+        return min
+    }
+
+    @OptIn(ExperimentalDatagramApi::class)
+    @Test
+    fun sendToManyDistinctDestinationsIsZeroAlloc() {
+        if (!bean.isThreadAllocatedMemorySupported) return // HotSpot only; skip elsewhere.
+        bean.isThreadAllocatedMemoryEnabled = true
+
+        val n = 1000
+
+        // Pre-resolve N distinct destinations ONCE (out of band, per §10.1). Each owns its interned
+        // InetSocketAddress. A numeric-literal InetSocketAddress performs no DNS lookup.
+        val destinations =
+            Array(n) { i ->
+                InternedJvmSocketAddress(
+                    InetSocketAddress(
+                        InetAddress.getByAddress(byteArrayOf(10, (i / 256).toByte(), (i % 256).toByte(), 1)),
+                        4000 + (i % 1000),
+                    ),
+                ) as SocketAddress
+            }
+
+        // The packed (family/hi/lo)-style bits a demux table would carry, forcing reconstruction.
+        val packedPort = IntArray(n) { 4000 + (it % 1000) }
+        val packedIp = Array(n) { i -> byteArrayOf(10, (i / 256).toByte(), (i % 256).toByte(), 1) }
+
+        var blackhole = 0L
+
+        // The design's send-target extraction: a field read off the owned address.
+        val ownedExtract: () -> Unit = {
+            for (i in 0 until n) {
+                val inet = (destinations[i] as InternedJvmSocketAddress).inet
+                blackhole += inet.port.toLong()
+            }
+        }
+
+        // The reconstruction a 1-entry cache is defeated into on every distinct destination.
+        val reconstructExtract: () -> Unit = {
+            for (i in 0 until n) {
+                val inet = InetSocketAddress(InetAddress.getByAddress(packedIp[i]), packedPort[i])
+                blackhole += inet.port.toLong()
+            }
+        }
+
+        // Warm up both paths (JIT, class init, first ThreadMXBean call).
+        repeat(20) {
+            ownedExtract()
+            reconstructExtract()
+        }
+
+        val ownedBytes = minAllocatedBytes(10, ownedExtract)
+        val reconstructBytes = minAllocatedBytes(10, reconstructExtract)
+
+        // Keep blackhole observable so the loops can't be optimized away.
+        assertTrue(blackhole != Long.MIN_VALUE)
+
+        // 1. The owned path is essentially zero-alloc for 1000 distinct destinations. Allow a tiny
+        //    absolute slack for measurement jitter; the design demands O(1), not O(n).
+        assertTrue(
+            ownedBytes < 1024,
+            "owned send-target extraction must be ~zero-alloc across $n distinct destinations, " +
+                "measured $ownedBytes bytes",
+        )
+
+        // 2. The reconstruction path allocates real memory per destination — proving the owned model
+        //    is what buys the zero-alloc, not the measurement being blind.
+        assertTrue(
+            reconstructBytes > n.toLong() * 16,
+            "reconstruction should allocate per-destination (sanity floor); measured $reconstructBytes bytes",
+        )
+
+        // 3. The owned path allocates at least 50x less than reconstruction — the make-or-break margin.
+        assertTrue(
+            ownedBytes * 50 < reconstructBytes,
+            "owned=$ownedBytes must be <1/50th of reconstruct=$reconstructBytes",
+        )
+    }
+}
+
+/**
+ * A JVM [SocketAddress] that owns an interned `InetSocketAddress` — the platform-representation-owning
+ * shape `:socket-udp`'s JVM actual will use (and quiche reads via a platform SPI). Constructed once;
+ * reuse as a send target is a field read.
+ */
+@OptIn(ExperimentalDatagramApi::class)
+private class InternedJvmSocketAddress(
+    val inet: InetSocketAddress,
+) : SocketAddress {
+    override val host: String get() = inet.address.hostAddress
+    override val port: Int get() = inet.port
+    override val family: AddressFamily
+        get() = if (inet.address is java.net.Inet6Address) AddressFamily.IPv6 else AddressFamily.IPv4
+}


### PR DESCRIPTION
## Datagram trichotomy for `buffer-flow` (RFC Phases 0+1)

Adds the **unreliable, pre-framed, _addressed_ datagram** shape that `buffer-flow` lacked — the third shape alongside `ByteSource/Sink/Stream` (unframed reliable) and `Sender/Receiver/Connection` (typed-over-framed-stream). It is the shared datagram vocabulary for `:socket-udp`, Cloudflare-quiche QUIC/WebTransport app-datagrams, and a future sans-I/O `webrtc` (P2P client + SFU/TURN relay).

All new API lives in `com.ditchoom.buffer.flow` under **`@ExperimentalDatagramApi`** (a `@RequiresOptIn` WARNING marker), so this is **source- and binary-additive → `minor`**. A bug found during incubation is an experimental tweak, never a breaking change.

### What's added
- **`SocketAddress`** (+ `AddressFamily`) — resolved-only (DNS is out-of-band via `resolve()` / `ofLiteral()`), **owns its platform representation** so reuse as a send target across many distinct peers is zero-alloc (SFU/TURN fanout), value-equality for demux keys. `installResolver()` is the public SPI a platform module (`:socket-udp`) installs a real DNS resolver through; the default is literal-only (buffer-flow does no I/O).
- **`DatagramSource` / `DatagramSink` / `DatagramChannel`** — no framing driver (the kernel delivers one whole message per `receive`); 2-arg zero-alloc `send(payload, to)`; batching hooks.
- **`Datagram`** (payload + `peer` + read-side control plane) / **`Ecn`** / **`DatagramSendOptions`** / **`DatagramReadResult`** (`Received | Closed`, `Closed.reason` carries e.g. a QUIC error) / `Addressed` / `OutboundDatagram`.
- **`DatagramCapabilities`** — the §7.1 per-platform control-plane matrix (query-never-assume; each capability implemented to the platform's real ceiling).
- **`DatagramMux`** — the unreliable analogue of `ByteStreamMux` (flow-id-keyed demux; WebTransport's per-session datagram routing).
- **`TypedDatagram`** — whole-buffer codec helpers (`typed` / `typedAddressed` / `typedSend` / `Connection`).

### Make-or-break proven (§4 address model)
`SocketAddressAllocationTest` (jvmTest, `ThreadMXBean.getThreadAllocatedBytes`): extracting an owned, interned address's send-target is ~0 bytes across 1000 distinct destinations, >50× less than reconstruction — the zero-alloc-many-dest requirement the relay case needs.

### Testing
- `DatagramChannelConformanceTests` (17) + `SocketAddressTests` (11) over a `MemoryDatagramNetwork`, green on **jvmTest / jsNodeTest / linuxX64Test**.
- `apiCheck` (BCV) green — only the marker annotation enters the api dump (companions/nested subclasses individually annotated so BCV's per-decl marker exclusion covers them).
- Local CI-parity (`build-linux.yaml`) reproduced green.

Apple targets are validated by `build-apple` CI (this branch was developed on Linux).
