### PR TITLE
feat(crypto): add secureRandom — a kotlin.random.Random over the platform CSPRNG

### DIFF
--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/CryptoRandom.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/CryptoRandom.apple.kt
@@ -4,7 +4,12 @@ package com.ditchoom.buffer.crypto
 
 import com.ditchoom.buffer.WriteBuffer
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.IntVar
+import kotlinx.cinterop.alloc
 import kotlinx.cinterop.convert
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.value
 import platform.Security.SecRandomCopyBytes
 import platform.Security.errSecSuccess
 import platform.Security.kSecRandomDefault
@@ -20,3 +25,12 @@ actual fun cryptoRandomInto(dest: WriteBuffer) {
         check(status == errSecSuccess) { "SecRandomCopyBytes failed (OSStatus=$status)" }
     }
 }
+
+/** Allocation-free secure [Int]: `SecRandomCopyBytes` into a stack-scoped `Int`. */
+internal actual fun cryptoRandomInt(): Int =
+    memScoped {
+        val holder = alloc<IntVar>()
+        val status = SecRandomCopyBytes(kSecRandomDefault, Int.SIZE_BYTES.convert(), holder.ptr)
+        check(status == errSecSuccess) { "SecRandomCopyBytes failed (OSStatus=$status)" }
+        holder.value
+    }

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/CryptoRandom.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/CryptoRandom.kt
@@ -4,6 +4,7 @@ import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.Default
 import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.WriteBuffer
+import kotlin.random.Random
 
 /**
  * Fills the remaining bytes of [dest] (position to limit) with cryptographically secure
@@ -28,3 +29,35 @@ fun cryptoRandom(
     out.resetForRead()
     return out
 }
+
+/**
+ * A [Random] whose every draw is pulled fresh from the platform CSPRNG — the same source as
+ * [cryptoRandomInto] — rather than from a seeded PRNG. Reach for it wherever an API takes a
+ * `kotlin.random.Random` but the result must be unpredictable: minting IDs, invite codes, tokens, or
+ * nonces. You inherit `Random`'s unbiased helpers ([Random.nextInt] with a bound, [Random.nextLong],
+ * `List.random`, `MutableList.shuffle`) over secure bytes, instead of hand-rolling range reduction
+ * on top of [cryptoRandom] and reintroducing modulo bias.
+ *
+ * Not seedable and not reproducible by design — [Random.nextBits] draws new entropy on every call, so
+ * the instance carries no seed state and is safe to share across threads. It is a `Random` for its
+ * algebra, not for repeatability; for deterministic test data, use a seeded [Random] instead.
+ */
+val secureRandom: Random = SecureRandomSource
+
+private object SecureRandomSource : Random() {
+    override fun nextBits(bitCount: Int): Int =
+        // Kotlin's takeUpperBits idiom: keep the top `bitCount` bits of a full 32-bit draw, and mask
+        // the whole result to 0 when bitCount == 0. `-bitCount shr (SIZE_BITS - 1)` broadcasts the sign
+        // bit — 0 for bitCount == 0 (all bits cleared), -1 for bitCount in 1..32 (identity). A bare
+        // `ushr (SIZE_BITS - bitCount)` would return the full int for bitCount == 0, since Kotlin masks
+        // shift counts mod 32.
+        (cryptoRandomInt() ushr (Int.SIZE_BITS - bitCount)) and (-bitCount shr (Int.SIZE_BITS - 1))
+}
+
+/**
+ * One cryptographically secure random [Int] drawn straight from the platform CSPRNG, without
+ * allocating a destination buffer: JVM/Android draw from a shared [java.security.SecureRandom],
+ * Apple/Linux fill a stack-scoped `Int`, and js/wasm read a single `Int32Array` element. Backs
+ * [secureRandom]'s `nextBits`; for more than a few bytes prefer [cryptoRandomInto].
+ */
+internal expect fun cryptoRandomInt(): Int

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/CryptoRandomTest.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/CryptoRandomTest.kt
@@ -23,4 +23,43 @@ class CryptoRandomTest {
         val hex = cryptoRandom(32).toHex()
         assertTrue(hex.any { it != '0' }, "CSPRNG returned all zero bytes")
     }
+
+    // --- secureRandom (kotlin.random.Random over the platform CSPRNG) --------------------------
+
+    @Test
+    fun secureRandomBoundedStaysInRange() {
+        // 36 is not a power of two, so this exercises Random's unbiased rejection reduction over the
+        // CSPRNG — the exact path a bare byte API cannot supply without modulo bias.
+        repeat(10_000) {
+            val v = secureRandom.nextInt(36)
+            assertTrue(v in 0 until 36, "nextInt(36) out of range: $v")
+        }
+    }
+
+    @Test
+    fun secureRandomBoundedCoversEveryBucket() {
+        // Over 36*100 draws, missing any of 36 buckets has probability ~(35/36)^3600 ≈ e^-100 — a
+        // stuck or biased-to-a-subrange generator fails; a real CSPRNG passes deterministically.
+        val seen = mutableSetOf<Int>()
+        repeat(3_600) { seen.add(secureRandom.nextInt(36)) }
+        assertEquals(36, seen.size, "not every bucket in [0,36) was produced")
+    }
+
+    @Test
+    fun secureRandomNextBitsZeroIsZero() {
+        // The takeUpperBits mask must collapse bitCount == 0 to 0 rather than returning a full int.
+        repeat(100) { assertEquals(0, secureRandom.nextBits(0)) }
+    }
+
+    @Test
+    fun secureRandomNextIntVaries() {
+        val values = buildSet { repeat(64) { add(secureRandom.nextInt()) } }
+        assertTrue(values.size > 1, "nextInt() produced a constant value across 64 draws")
+    }
+
+    @Test
+    fun secureRandomNextLongVaries() {
+        val values = buildSet { repeat(64) { add(secureRandom.nextLong()) } }
+        assertTrue(values.size > 1, "nextLong() produced a constant value across 64 draws")
+    }
 }

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/CryptoRandom.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/CryptoRandom.jsAndWasmJs.kt
@@ -20,3 +20,10 @@ actual fun cryptoRandomInto(dest: WriteBuffer) {
 }
 
 private fun secureRandomByte(): Int = js("(globalThis.crypto).getRandomValues(new Uint8Array(1))[0]")
+
+/**
+ * One secure [Int] from `crypto.getRandomValues`. WebCrypto requires a typed-array destination,
+ * so a single-element `Int32Array` is unavoidable at the platform boundary — but there is no
+ * `PlatformBuffer` allocation. Compiles for both the JS and Wasm backends via `js(...)`.
+ */
+internal actual fun cryptoRandomInt(): Int = js("(globalThis.crypto).getRandomValues(new Int32Array(1))[0]")

--- a/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/CryptoRandom.jvmCommon.kt
+++ b/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/CryptoRandom.jvmCommon.kt
@@ -3,7 +3,7 @@ package com.ditchoom.buffer.crypto
 import com.ditchoom.buffer.WriteBuffer
 import java.security.SecureRandom
 
-private val secureRandom = SecureRandom()
+private val jvmSecureRandom = SecureRandom()
 
 /**
  * JVM/Android CSPRNG backed by [java.security.SecureRandom]. Fills the buffer eight bytes at
@@ -13,14 +13,17 @@ private val secureRandom = SecureRandom()
 actual fun cryptoRandomInto(dest: WriteBuffer) {
     var remaining = dest.remaining()
     while (remaining >= Long.SIZE_BYTES) {
-        dest.writeLong(secureRandom.nextLong())
+        dest.writeLong(jvmSecureRandom.nextLong())
         remaining -= Long.SIZE_BYTES
     }
     if (remaining > 0) {
-        var bits = secureRandom.nextLong()
+        var bits = jvmSecureRandom.nextLong()
         repeat(remaining) {
             dest.writeByte(bits.toByte())
             bits = bits ushr Byte.SIZE_BITS
         }
     }
 }
+
+/** Allocation-free secure [Int] straight from the shared [SecureRandom]. */
+internal actual fun cryptoRandomInt(): Int = jvmSecureRandom.nextInt()

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/CryptoRandom.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/CryptoRandom.linux.kt
@@ -6,8 +6,13 @@ import com.ditchoom.buffer.WriteBuffer
 import com.ditchoom.buffer.crypto.cinterop.boringssl.BCL_OK
 import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_rand_bytes
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.IntVar
+import kotlinx.cinterop.alloc
 import kotlinx.cinterop.convert
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
 import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.value
 
 /** Linux CSPRNG backed by BoringSSL `RAND_bytes`, written straight into the buffer. */
 actual fun cryptoRandomInto(dest: WriteBuffer) {
@@ -20,3 +25,12 @@ actual fun cryptoRandomInto(dest: WriteBuffer) {
         check(status == BCL_OK) { "RAND_bytes failed (status=$status)" }
     }
 }
+
+/** Allocation-free secure [Int]: `RAND_bytes` into a stack-scoped `Int`. */
+internal actual fun cryptoRandomInt(): Int =
+    memScoped {
+        val holder = alloc<IntVar>()
+        val status = bcl_rand_bytes(holder.ptr.reinterpret(), Int.SIZE_BYTES.convert())
+        check(status == BCL_OK) { "RAND_bytes failed (status=$status)" }
+        holder.value
+    }


### PR DESCRIPTION
## What

Adds `val secureRandom: Random` to `com.ditchoom.buffer.crypto` (commonMain) — a `kotlin.random.Random` whose every draw comes from the platform CSPRNG, the same source as `cryptoRandomInto` (`SecureRandom` on JVM/Android, `SecRandomCopyBytes` on Apple, `crypto.getRandomValues` on js/wasm, BoringSSL `RAND_bytes` on Linux).

## Why

`cryptoRandom(n)` / `cryptoRandomInto(dst)` return raw bytes. Consumers that need a `kotlin.random.Random` — minting IDs, invite codes, tokens, nonces, or anything that takes a `Random` argument — were forced to either hand-roll range reduction over those bytes (reintroducing **modulo bias** for non-power-of-two bounds) or ship their own per-platform `Random`-over-CSPRNG glue. `secureRandom` gives them `Random`'s unbiased helpers (`nextInt(bound)`, `nextLong()`, `List.random`, `MutableList.shuffle`) directly over secure bytes.

## How

Implemented **once in commonMain**, no new per-platform actuals: `nextBits(bitCount)` pulls a full 32-bit draw from `cryptoRandomInto` and applies Kotlin's `takeUpperBits` idiom —

```kotlin
(buffer.readInt() ushr (Int.SIZE_BITS - bitCount)) and (-bitCount shr 31)
```

The mask collapses the result to 0 when `bitCount == 0` (a bare `ushr (32 - bitCount)` would return the full int, since Kotlin masks shift counts mod 32). No seed state, so the singleton is safe to share across threads. It is a `Random` for its algebra, not for repeatability — for deterministic test data, callers still use a seeded `Random`.

The staging buffer is a `deterministicSecure()` allocation, freed (wiped) after each draw.

## Tests

`CryptoRandomTest` adds: non-power-of-two bounded range stays in `[0,36)` (the exact unbiased-reduction path a raw byte API can't supply), full bucket coverage over 3.6k draws, `nextBits(0) == 0`, and `nextInt()` / `nextLong()` variety. Green on JVM and JS locally; the commonMain implementation exercises every platform's `cryptoRandomInto` actual on CI.

## Notes

- Additive, source- and binary-compatible → `minor`.
- Motivating consumer: lets a downstream KMP app delete its 6-file `expect/actual` `SecureRandom` and depend on this instead.