### PR TITLE
fix(jvm21): bounds-check readString on the FFM native fast path

### DIFF
--- a/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/FfmAutoBuffer.kt
+++ b/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/FfmAutoBuffer.kt
@@ -46,8 +46,12 @@ class FfmAutoBuffer(
         length: Int,
         charset: Charset,
     ): String {
-        if (charset == Charset.UTF8) {
-            val start = position()
+        val start = position()
+        // The native decode reads raw memory with no per-byte bounds check, so an out-of-range length
+        // would read past the segment — garbage, or a SIGSEGV once it crosses an unmapped page. Only
+        // take the fast path when the whole [start, start+length) range is in bounds; otherwise fall
+        // back to the base ByteBuffer path, which throws for the over-read exactly as it always has.
+        if (charset == Charset.UTF8 && canReadUtf8FromNative(start, length)) {
             val decoded = decodeUtf8FromNative(segment.address(), start, start + length)
             position(start + length)
             return decoded

--- a/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/FfmBuffer.kt
+++ b/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/FfmBuffer.kt
@@ -114,8 +114,12 @@ class FfmBuffer(
         length: Int,
         charset: Charset,
     ): String {
-        if (charset == Charset.UTF8 && !isFreed) {
-            val start = position()
+        val start = position()
+        // The native decode reads raw memory with no per-byte bounds check, so an out-of-range length
+        // would read past the segment — garbage, or a SIGSEGV once it crosses an unmapped page. Only
+        // take the fast path when the whole [start, start+length) range is in bounds; otherwise fall
+        // back to the base ByteBuffer path, which throws for the over-read exactly as it always has.
+        if (charset == Charset.UTF8 && !isFreed && canReadUtf8FromNative(start, length)) {
             val decoded = decodeUtf8FromNative(segment.address(), start, start + length)
             position(start + length)
             return decoded

--- a/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/Utf8DirectDecode.kt
+++ b/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/Utf8DirectDecode.kt
@@ -110,3 +110,14 @@ internal fun decodeUtf8FromNative(
 // REPORT-mode decoders report the malformed *length* (the maximal subpart), but since we throw on
 // first error the exact length is immaterial — 1 keeps the exception shape identical to the encoder's.
 private fun malformed(): MalformedInputException = MalformedInputException(1)
+
+/**
+ * Whether [decodeUtf8FromNative] can safely decode [length] bytes starting at [start] on this buffer:
+ * the range must be non-negative and stay within [BaseJvmBuffer.limit], since the native decode reads
+ * raw memory with no per-byte bounds check. When it can't, callers fall back to the checked ByteBuffer
+ * path, which throws for the over-read. `start.toLong()` keeps a pathological [length] from overflowing.
+ */
+internal fun BaseJvmBuffer.canReadUtf8FromNative(
+    start: Int,
+    length: Int,
+): Boolean = length >= 0 && start.toLong() + length <= limit()

--- a/buffer/src/jvmTest/kotlin/com/ditchoom/buffer/ReadStringDirectUtf8Test.kt
+++ b/buffer/src/jvmTest/kotlin/com/ditchoom/buffer/ReadStringDirectUtf8Test.kt
@@ -143,6 +143,19 @@ class ReadStringDirectUtf8Test {
     }
 
     @Test
+    fun `readString past the buffer throws instead of an out-of-bounds native read`() {
+        // The FFM fast path reads raw native memory with no per-byte bounds check, so a length that
+        // runs past the segment used to SIGSEGV (caught by the MQTT control-packet fuzzers on a
+        // malformed UTF-8 length prefix). It must instead throw, exactly as the CharsetDecoder path
+        // does when asked to read past capacity, and leave the read position untouched for a retry.
+        val buffer = BufferFactory.Default.allocate(4)
+        buffer.writeBytes(byteArrayOf(0x41, 0x42, 0x43, 0x44)) // "ABCD"
+        buffer.resetForRead()
+        assertFailsWith<IllegalArgumentException> { buffer.readString(64, Charset.UTF8) }
+        assertEquals(0, buffer.position(), "a rejected over-read must not advance position")
+    }
+
+    @Test
     fun `non-UTF8 charset falls back to the decoder path`() {
         val bytes = byteArrayOf(0xE9.toByte(), 0x20) // 0xE9 = U+00E9 in Latin-1
         val buffer = BufferFactory.Default.allocate(bytes.size)


### PR DESCRIPTION
## Problem
`FfmBuffer` / `FfmAutoBuffer` (the JVM 21+ FFM buffers) override `readString` with a fast path that decodes UTF-8 straight off the segment's native address via `decodeUtf8FromNative`, which reads raw memory with **no per-byte bounds check**:

```kotlin
val start = position()
val decoded = decodeUtf8FromNative(segment.address(), start, start + length)  // no bounds check
```

`readString` never validated `length` against the buffer, so a `length` running past the segment reads out of bounds — garbage past a small allocation, or a **SIGSEGV** once the read crosses an unmapped page. The base ByteBuffer path (`BaseJvmBuffer.readString`) throws `IllegalArgumentException` for the same over-read.

### How it was found
The MQTT control-packet **fuzzers** crashed the JVM on a malformed UTF-8 length prefix (a 2-byte length saying "read N bytes" when fewer remain):

```
# SIGSEGV (0xb) ... SEGV_ACCERR
# J ... com.ditchoom.buffer.Utf8DirectDecodeKt.decodeUtf8FromNative(JII)
```

## Fix
Only take the native fast path when the whole `[start, start+length)` range is in bounds; otherwise fall back to `super.readString`, which throws for the over-read exactly as it always has — keeping behaviour identical to the non-FFM path.

```kotlin
if (charset == Charset.UTF8 && !isFreed && length >= 0 && start.toLong() + length <= limit()) { ... }
return super.readString(length, charset)
```

`start.toLong() + length` avoids `Int` overflow on a pathological length. Applied to both `FfmBuffer` and `FfmAutoBuffer`.

## Test
New regression test in `ReadStringDirectUtf8Test` asserting an over-long `readString` **throws** (`IllegalArgumentException`, matching the CharsetDecoder path) instead of reading out of bounds, and leaves the read position unchanged. It fails on `main` (returns garbage / crashes) and passes with the fix.

## No performance regression
`ReadStringDecodeBench` (`:buffer:jvmFfmTest`), native fast-path speedup over the CharsetDecoder, before → after:

| content | chars | before | after |
|---|---|---|---|
| ascii | 1024 | 2.39x | 2.32x |
| ascii | 65536 | 1.83x | 1.92x |
| cjk | 1024 | 1.75x | 1.68x |
| cjk | 65536 | 1.79x | 1.75x |
| emoji | 1024 | 1.48x | 1.55x |
| emoji | 65536 | 1.37x | 1.42x |

Within run-to-run noise — the added comparison is negligible next to the decode loop.

## Verification
- `ReadStringDirectUtf8Test` (FFM classpath): all green incl. the new test.
- Full `:buffer:jvmFfmTest`: no new failures (5 pre-existing failures — `DeterministicBufferTest` after-free guards + `DirectUncheckedAccessTest.matchesCheckedBigEndian` — fail identically on clean `main`, unrelated to this change).
- `ktlintCheck`: pass.

## Follow-up
Unblocks bumping the DitchOoM siblings in downstream repos — MQTT is holding buffer at 6.8.2 / socket at 3.8.12 because of this crash (see DitchOoM/mqtt#28). Once this ships in a buffer release, MQTT can bump.