### PR TITLE
perf(crypto): reuse a scratch Int32Array in secureRandom's js/wasm draw + honest alloc docs

### DIFF
--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/CryptoRandom.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/CryptoRandom.kt
@@ -41,6 +41,10 @@ fun cryptoRandom(
  * Not seedable and not reproducible by design — [Random.nextBits] draws new entropy on every call, so
  * the instance carries no seed state and is safe to share across threads. It is a `Random` for its
  * algebra, not for repeatability; for deterministic test data, use a seeded [Random] instead.
+ *
+ * Each draw is one platform CSPRNG call, so this is sized for occasional secret minting, not a hot
+ * loop. Being a thread-safe shared value, it cannot buffer draws behind a lock-free path; for
+ * high-throughput secure random, fill a buffer once with [cryptoRandomInto] and consume it.
  */
 val secureRandom: Random = SecureRandomSource
 
@@ -55,9 +59,9 @@ private object SecureRandomSource : Random() {
 }
 
 /**
- * One cryptographically secure random [Int] drawn straight from the platform CSPRNG, without
- * allocating a destination buffer: JVM/Android draw from a shared [java.security.SecureRandom],
- * Apple/Linux fill a stack-scoped `Int`, and js/wasm read a single `Int32Array` element. Backs
- * [secureRandom]'s `nextBits`; for more than a few bytes prefer [cryptoRandomInto].
+ * One cryptographically secure random [Int] from the platform CSPRNG, without a [PlatformBuffer]
+ * round-trip. JVM/Android draw from a shared [java.security.SecureRandom] (no allocation); Apple/Linux
+ * fill an `Int` through a small `memScoped` arena; js/wasm read from a reused module-level `Int32Array`
+ * scratch. Backs [secureRandom]'s `nextBits`; for more than a few bytes prefer [cryptoRandomInto].
  */
 internal expect fun cryptoRandomInt(): Int

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/CryptoRandom.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/CryptoRandom.jsAndWasmJs.kt
@@ -21,9 +21,7 @@ actual fun cryptoRandomInto(dest: WriteBuffer) {
 
 private fun secureRandomByte(): Int = js("(globalThis.crypto).getRandomValues(new Uint8Array(1))[0]")
 
-/**
- * One secure [Int] from `crypto.getRandomValues`. WebCrypto requires a typed-array destination,
- * so a single-element `Int32Array` is unavoidable at the platform boundary — but there is no
- * `PlatformBuffer` allocation. Compiles for both the JS and Wasm backends via `js(...)`.
- */
-internal actual fun cryptoRandomInt(): Int = js("(globalThis.crypto).getRandomValues(new Int32Array(1))[0]")
+// cryptoRandomInt() is implemented per-leaf (jsMain / wasmJsMain) rather than here: each reuses a
+// module-level Int32Array scratch to avoid a per-call typed-array allocation, and a properly-typed
+// reused array can't be expressed in the shared jsAndWasmJs source set (the JS and Wasm typed-array
+// bindings differ).

--- a/buffer-crypto/src/jsMain/kotlin/com/ditchoom/buffer/crypto/CryptoRandom.js.kt
+++ b/buffer-crypto/src/jsMain/kotlin/com/ditchoom/buffer/crypto/CryptoRandom.js.kt
@@ -1,0 +1,15 @@
+package com.ditchoom.buffer.crypto
+
+/**
+ * A module-level `Int32Array(1)` reused across every [cryptoRandomInt] call so no typed array is
+ * allocated per draw. Safe because JS is single-threaded — there is no concurrent access to race on.
+ */
+private val randomScratch: dynamic = newInt32Scratch()
+
+private fun newInt32Scratch(): dynamic = js("new Int32Array(1)")
+
+/** One secure [Int] from `crypto.getRandomValues`, filling the reused [randomScratch]. */
+internal actual fun cryptoRandomInt(): Int = fillRandomInt(randomScratch)
+
+@Suppress("UnusedParameter") // referenced inside the js(...) template
+private fun fillRandomInt(scratch: dynamic): Int = js("(globalThis.crypto.getRandomValues(scratch), scratch[0])")

--- a/buffer-crypto/src/wasmJsMain/kotlin/com/ditchoom/buffer/crypto/CryptoRandom.wasmJs.kt
+++ b/buffer-crypto/src/wasmJsMain/kotlin/com/ditchoom/buffer/crypto/CryptoRandom.wasmJs.kt
@@ -1,0 +1,21 @@
+@file:OptIn(ExperimentalWasmJsInterop::class)
+
+package com.ditchoom.buffer.crypto
+
+import kotlin.js.ExperimentalWasmJsInterop
+import kotlin.js.JsAny
+
+/**
+ * A module-level `Int32Array(1)` reused across every [cryptoRandomInt] call so no typed array is
+ * allocated per draw. Safe because the Wasm/JS backend is single-threaded — no concurrent access to
+ * race on. (`js(...)` may only be a function body on Wasm, so the array is created via a helper.)
+ */
+private val randomScratch: JsAny = newInt32Scratch()
+
+private fun newInt32Scratch(): JsAny = js("new Int32Array(1)")
+
+/** One secure [Int] from `crypto.getRandomValues`, filling the reused [randomScratch]. */
+internal actual fun cryptoRandomInt(): Int = fillRandomInt(randomScratch)
+
+@Suppress("UnusedParameter") // referenced inside the js(...) template
+private fun fillRandomInt(scratch: JsAny): Int = js("(globalThis.crypto.getRandomValues(scratch), scratch[0])")


### PR DESCRIPTION
Follow-up to #294 (secureRandom).

## Change 1 — remove the per-call `Int32Array` allocation on js/wasm

`cryptoRandomInt()` (which backs `secureRandom.nextBits`) allocated a fresh `new Int32Array(1)` on **every** call on the web backends. This splits the shared `jsAndWasmJs` actual into per-leaf **`jsMain`** and **`wasmJsMain`** actuals, each reusing a **module-level scratch `Int32Array`** — zero typed-array allocation per draw after init.

Why a source-set split rather than a one-liner: a *properly-typed* reused array can't be expressed in the shared `jsAndWasmJs` source set — the JS (`dynamic`) and Wasm (`JsAny`) typed-array bindings differ, and `js(...)` may only be a function body on Wasm. Reuse is safe because both backends are single-threaded (no concurrent access to race on).

JVM/Android was already zero-alloc (shared `SecureRandom`); Apple/Linux keep their small `memScoped` arena (inherent to a thread-safe, unbuffered draw).

## Change 2 — honest allocation docs + hot-path guidance

The earlier KDoc called the draw "allocation-free," which was only true on JVM. Corrected to state the real per-platform cost, and added explicit guidance to `secureRandom`: it is **one CSPRNG call per draw**, sized for occasional secret minting; being a thread-safe shared value it can't buffer behind a lock-free path, so **high-throughput secure random should go through `cryptoRandomInto`** (fill a buffer once, consume it).

## Notes

- **No public API or behavior change** (`cryptoRandomInt` is `internal`) → patch.
- Green on JVM, JS, wasmJs locally; detekt clean (the `js(...)`-template params carry the repo's standard `@Suppress("UnusedParameter")`). Apple/Linux unchanged, validated on CI.