### PR TITLE
feat(codec): @JvmInline value-class-over-String fields under String framings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,6 +346,23 @@ data class MyMessage(
 // MyMessageCodec.encode(buffer, msg) — generated, type-safe, batch-optimized
 ```
 
+#### Value-class (`newtype`) id fields over String
+
+A field typed as a `@JvmInline value class` over a single `String` is a valid codec field under any of the String framings (`@LengthPrefixed`, `@LengthFrom`, `@RemainingBytes`). It encodes **byte-for-byte identically** to the same field typed as a bare `String` — the generated codec just wraps on decode (via the value class constructor) and unwraps on encode (via the inner property). Use this for typed identifiers instead of hand-writing inline-string codecs:
+
+```kotlin
+@JvmInline value class UserId(val value: String)
+@JvmInline value class SessionId(val value: String)
+
+@ProtocolMessage
+data class Session(
+    @LengthPrefixed val user: UserId,          // wire-identical to @LengthPrefixed String
+    @When("resumed") @LengthPrefixed val prior: SessionId? = null,  // composes with @When
+)
+```
+
+The wrapper is wire-insignificant (invisible in the codec schema; a field is interchangeable between `String` and a value class over `String` with no wire change). The value class must **not** itself be `@ProtocolMessage`, and `@WireBytes` / `@WireOrder` on its inner property are unsupported.
+
 ### Sealed Interface Dispatch with `@PacketType` and `@DispatchOn`
 
 For protocols with a type discriminator, use sealed interfaces with `@PacketType`:

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecAnalyzer.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecAnalyzer.kt
@@ -614,10 +614,23 @@ internal fun analyzeField(
                 FieldSpec.RemainingBytesString(name = name, ownerSimpleName = ownerSimpleName),
             )
         }
+        // `@RemainingBytes val: <value class over String>` — wire-identical
+        // to `@RemainingBytes String`, wrapping the trailing UTF-8 bytes in
+        // the value class. Detect before the List gate below.
+        valueClassOverStringWrapperOrNull(type)?.let { wrapper ->
+            return FieldAnalysis.Ok(
+                FieldSpec.RemainingBytesString(
+                    name = name,
+                    ownerSimpleName = ownerSimpleName,
+                    valueClass = wrapper,
+                ),
+            )
+        }
         if (typeQname != "kotlin.collections.List") {
             return FieldAnalysis.Err(
                 Diagnostic(
-                    "@RemainingBytes supports only String, List<@ProtocolMessage>, or @UseCodec val: Payload",
+                    "@RemainingBytes supports only String, a @JvmInline value class over String, " +
+                        "List<@ProtocolMessage>, or @UseCodec val: Payload",
                     param,
                 ),
             )
@@ -668,15 +681,32 @@ internal fun analyzeField(
                     params = params,
                     index = index,
                 )
-            else ->
-                analyzeLengthFromMessageField(
-                    param = param,
-                    type = type,
-                    lengthFromAnn = lengthFromAnn,
-                    ownerSimpleName = ownerSimpleName,
-                    params = params,
-                    index = index,
-                )
+            else -> {
+                // `@LengthFrom("ref") val: <value class over String>` —
+                // wire-identical to `@LengthFrom String`. Detect before the
+                // nested-@ProtocolMessage fallback (value classes over
+                // String are neither String, List, nor @ProtocolMessage).
+                val stringWrapper = valueClassOverStringWrapperOrNull(type)
+                if (stringWrapper != null) {
+                    analyzeLengthFromStringField(
+                        param = param,
+                        lengthFromAnn = lengthFromAnn,
+                        ownerSimpleName = ownerSimpleName,
+                        params = params,
+                        index = index,
+                        valueClass = stringWrapper,
+                    )
+                } else {
+                    analyzeLengthFromMessageField(
+                        param = param,
+                        type = type,
+                        lengthFromAnn = lengthFromAnn,
+                        ownerSimpleName = ownerSimpleName,
+                        params = params,
+                        index = index,
+                    )
+                }
+            }
         }
     }
 
@@ -732,6 +762,23 @@ internal fun analyzeField(
                     ownerSimpleName = ownerSimpleName,
                     prefixWidth = prefixWidth,
                     prefixWireOrder = messageWireOrder,
+                ),
+            )
+        }
+        // `@LengthPrefixed val: <value class over String>` — a
+        // `@JvmInline value class UserId(val value: String)` typed field.
+        // Wire form is byte-identical to `@LengthPrefixed String`; only
+        // the generated wrap/unwrap differs. Not terminal-only (same as
+        // the bare-String case), so detect it ahead of the terminal
+        // `@ProtocolMessage` gate below.
+        valueClassOverStringWrapperOrNull(type)?.let { wrapper ->
+            return FieldAnalysis.Ok(
+                FieldSpec.LengthPrefixedString(
+                    name = name,
+                    ownerSimpleName = ownerSimpleName,
+                    prefixWidth = prefixWidth,
+                    prefixWireOrder = messageWireOrder,
+                    valueClass = wrapper,
                 ),
             )
         }
@@ -1012,6 +1059,63 @@ internal fun analyzeValueClassScalarField(
 }
 
 /**
+ * Detect a `@JvmInline value class` over a single `String`
+ * constructor parameter (e.g. `value class UserId(val value:
+ * String)`). Returns the wire-insignificant [ValueClassStringWrapper]
+ * when [type] matches, or `null` otherwise so callers fall through to
+ * their existing bare-`String` / message handling.
+ *
+ * Mirrors the validity checks applied to [analyzeValueClassScalarField]'s
+ * scalar path: exactly one primary-constructor parameter, over a
+ * non-nullable inner, with no `@WireBytes` / `@WireOrder` on the inner
+ * property (out of scope, same narrowing as the scalar shape). The
+ * only difference is the inner type is `kotlin.String` rather than a
+ * numeric scalar — so a String value class routes to the length-framed
+ * String field logic instead of the inline-scalar logic.
+ */
+@Suppress("ReturnCount") // guard-clause validity checks, consistent with the analyze* family
+internal fun valueClassOverStringWrapperOrNull(type: KSType): ValueClassStringWrapper? {
+    val decl = type.declaration as? KSClassDeclaration ?: return null
+    if (!decl.isValueClassDecl()) return null
+    // A value class that is itself `@ProtocolMessage` has its own generated
+    // codec and keeps routing to the nested-message paths — it is not
+    // treated as a transparent String wrapper. The target of this shape is
+    // the plain id wrapper (`value class UserId(val value: String)`) with no
+    // `@ProtocolMessage`.
+    if (decl.annotations.any { ann ->
+            ann.shortName.asString() == "ProtocolMessage" &&
+                ann.annotationType
+                    .resolve()
+                    .declaration.qualifiedName
+                    ?.asString() == PROTOCOL_MESSAGE_QNAME
+        }
+    ) {
+        return null
+    }
+    val ctor = decl.primaryConstructor ?: return null
+    if (ctor.parameters.size != 1) return null
+    val innerParam = ctor.parameters[0]
+    val innerName = innerParam.name?.asString() ?: return null
+    val innerType = innerParam.type.resolve()
+    if (innerType.isError || innerType.isMarkedNullable) return null
+    if (innerType.declaration.qualifiedName?.asString() != "kotlin.String") return null
+    // @WireBytes / @WireOrder on the inner property widen the wire
+    // shape and are deferred — same narrowing the inline-scalar value
+    // class path applies.
+    if (innerParam.annotations.any { ann ->
+            val n = ann.shortName.asString()
+            n == "WireBytes" || n == "WireOrder"
+        }
+    ) {
+        return null
+    }
+    return ValueClassStringWrapper(
+        valueClassType = classNameOf(decl),
+        innerPropertyName = innerName,
+    )
+}
+
+/**
  * `@LengthFrom("ref") val: String`. Two source-expression forms:
  *   - Simple-name `"sibling"`: sibling is a numeric `Scalar`; body
  *     byte count = `sibling.toInt()`.
@@ -1028,6 +1132,7 @@ internal fun analyzeLengthFromStringField(
     ownerSimpleName: String,
     params: List<KSValueParameter>,
     index: Int,
+    valueClass: ValueClassStringWrapper? = null,
 ): FieldAnalysis {
     val name =
         param.name?.asString() ?: return FieldAnalysis.Err(Diagnostic("field has no name", param))
@@ -1036,7 +1141,10 @@ internal fun analyzeLengthFromStringField(
     if (type.isMarkedNullable) {
         return FieldAnalysis.Err(Diagnostic("@LengthFrom val: String must be non-nullable", param))
     }
-    if (type.declaration.qualifiedName?.asString() != "kotlin.String") {
+    // A non-null [valueClass] means the caller already matched a value
+    // class over `String` (wire-identical to a bare `String`); skip the
+    // bare-`String` type check in that case.
+    if (valueClass == null && type.declaration.qualifiedName?.asString() != "kotlin.String") {
         return FieldAnalysis.Err(Diagnostic("@LengthFrom String analyzer requires a String field", param))
     }
 
@@ -1055,6 +1163,7 @@ internal fun analyzeLengthFromStringField(
             name = name,
             ownerSimpleName = ownerSimpleName,
             source = source,
+            valueClass = valueClass,
         ),
     )
 }
@@ -2250,13 +2359,21 @@ internal fun analyzeConditionalInner(
     }
     if (lengthPrefixedAnn != null) {
         // Widens the inner universe to LengthPrefixed
-        // String only. LengthPrefixed @ProtocolMessage bodies are
-        // doctrine-row-19 valid but defer until a vector requires
-        // them.
-        if (qualified != "kotlin.String") return null
+        // String — either a bare `String?` or a `@JvmInline value class`
+        // over `String` (wire-identical, wraps/unwraps at the boundary).
+        // LengthPrefixed @ProtocolMessage bodies are doctrine-row-19 valid
+        // but defer until a vector requires them.
+        if (qualified == "kotlin.String") {
+            return ConditionalInner.LengthPrefixedString(
+                prefixWidth = readLengthPrefix(lengthPrefixedAnn),
+                prefixWireOrder = messageWireOrder,
+            )
+        }
+        val stringWrapper = valueClassOverStringWrapperOrNull(innerType) ?: return null
         return ConditionalInner.LengthPrefixedString(
             prefixWidth = readLengthPrefix(lengthPrefixedAnn),
             prefixWireOrder = messageWireOrder,
+            valueClass = stringWrapper,
         )
     }
     // Bare `@When val: T?` where T is a
@@ -2462,7 +2579,8 @@ internal fun analyzeConditionalValueClassInner(innerType: KSType): ConditionalIn
 internal fun conditionalInnerNullableTypeName(inner: ConditionalInner): TypeName =
     when (inner) {
         is ConditionalInner.Scalar -> scalarTypeName(inner.kind).copy(nullable = true)
-        is ConditionalInner.LengthPrefixedString -> STRING_NULLABLE_TN
+        is ConditionalInner.LengthPrefixedString ->
+            inner.valueClass?.valueClassType?.copy(nullable = true) ?: STRING_NULLABLE_TN
         is ConditionalInner.ValueClassScalar -> inner.valueClassType.copy(nullable = true)
         is ConditionalInner.LengthPrefixedUseCodecList ->
             ClassName("kotlin.collections", "List")

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
@@ -1797,9 +1797,11 @@ internal class CodecEmitter(
     private fun partialFieldTypeName(field: FieldSpec): TypeName =
         when (field) {
             is FieldSpec.Scalar -> scalarTypeName(field.kind)
-            is FieldSpec.LengthPrefixedString -> ClassName("kotlin", "String")
+            is FieldSpec.LengthPrefixedString ->
+                field.valueClass?.valueClassType ?: ClassName("kotlin", "String")
             is FieldSpec.LengthPrefixedMessage -> field.messageType
-            is FieldSpec.LengthFromString -> ClassName("kotlin", "String")
+            is FieldSpec.LengthFromString ->
+                field.valueClass?.valueClassType ?: ClassName("kotlin", "String")
             is FieldSpec.LengthFromMessage -> field.messageType
             is FieldSpec.LengthFromList ->
                 ClassName("kotlin.collections", "List").parameterizedBy(field.elementClassName)

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterFields.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterFields.kt
@@ -508,7 +508,16 @@ internal fun appendDecodeConditional(
                     prefixWidth = inner.prefixWidth,
                     prefixWireOrder = inner.prefixWireOrder,
                 )
-            body.addStatement("buffer.readString(%L, %T.UTF8)", lengthVar, CHARSET_CN)
+            if (inner.valueClass != null) {
+                body.addStatement(
+                    "%T(buffer.readString(%L, %T.UTF8))",
+                    inner.valueClass.valueClassType,
+                    lengthVar,
+                    CHARSET_CN,
+                )
+            } else {
+                body.addStatement("buffer.readString(%L, %T.UTF8)", lengthVar, CHARSET_CN)
+            }
             body.nextControlFlow("else")
             body.addStatement("null")
             body.endControlFlow()
@@ -678,7 +687,14 @@ internal fun appendEncodeConditional(
                 ownerSimpleName = field.ownerSimpleName,
                 prefixWidth = inner.prefixWidth,
                 prefixWireOrder = inner.prefixWireOrder,
-                accessor = localName,
+                // `localName` is the null-checked non-null value; unwrap the
+                // value class via its inner property when present.
+                accessor =
+                    if (inner.valueClass != null) {
+                        "$localName.${inner.valueClass.innerPropertyName}"
+                    } else {
+                        localName
+                    },
             )
         is ConditionalInner.ValueClassScalar ->
             // Unwrap the value class via the
@@ -1091,12 +1107,14 @@ internal fun appendDecodeLengthPrefixedString(
             prefixWidth = field.prefixWidth,
             prefixWireOrder = field.prefixWireOrder,
         )
-    body.addStatement(
-        "val %L = buffer.readString(%L, %T.UTF8)",
-        field.name,
-        lengthVar,
-        CHARSET_CN,
-    )
+    val read = CodeBlock.of("buffer.readString(%L, %T.UTF8)", lengthVar, CHARSET_CN)
+    // Wrap the decoded String in the value class's primary constructor when
+    // the field is a value class over String (wire-identical to bare String).
+    if (field.valueClass != null) {
+        body.addStatement("val %L = %T(%L)", field.name, field.valueClass.valueClassType, read)
+    } else {
+        body.addStatement("val %L = %L", field.name, read)
+    }
 }
 
 /**
@@ -1139,7 +1157,14 @@ internal fun appendEncodeLengthPrefixedString(
         ownerSimpleName = field.ownerSimpleName,
         prefixWidth = field.prefixWidth,
         prefixWireOrder = field.prefixWireOrder,
-        accessor = "value.${field.name}",
+        // Unwrap the value class via its inner property when present
+        // (`value.id.value`); plain String fields use `value.id`.
+        accessor =
+            if (field.valueClass != null) {
+                "value.${field.name}.${field.valueClass.innerPropertyName}"
+            } else {
+                "value.${field.name}"
+            },
     )
 }
 
@@ -1250,12 +1275,13 @@ internal fun appendDecodeLengthFromString(
     // shadow the sibling local when the user names the carrier
     // `<bound>Length` — a natural Kotlin convention that the
     // generated code must not break.
-    body.addStatement(
-        "val %L = buffer.readString(%L, %T.UTF8)",
-        field.name,
-        field.source.decodeAccessor(),
-        CHARSET_CN,
-    )
+    val read =
+        CodeBlock.of("buffer.readString(%L, %T.UTF8)", field.source.decodeAccessor(), CHARSET_CN)
+    if (field.valueClass != null) {
+        body.addStatement("val %L = %T(%L)", field.name, field.valueClass.valueClassType, read)
+    } else {
+        body.addStatement("val %L = %L", field.name, read)
+    }
 }
 
 /**
@@ -1271,9 +1297,15 @@ internal fun appendEncodeLengthFromString(
     body: CodeBlock.Builder,
     field: FieldSpec.LengthFromString,
 ) {
+    val accessor =
+        if (field.valueClass != null) {
+            "value.${field.name}.${field.valueClass.innerPropertyName}"
+        } else {
+            "value.${field.name}"
+        }
     body.addStatement(
-        "buffer.writeString(value.%L, %T.UTF8)",
-        field.name,
+        "buffer.writeString(%L, %T.UTF8)",
+        accessor,
         CHARSET_CN,
     )
 }
@@ -1479,22 +1511,23 @@ internal fun appendDecodeRemainingBytesString(
     body: CodeBlock.Builder,
     field: FieldSpec.RemainingBytesString,
 ) {
-    if (field.reservedTrailingBytes == 0) {
-        body.addStatement(
-            "val %L = buffer.readString(buffer.remaining(), %T.UTF8)",
-            field.name,
-            CHARSET_CN,
-        )
-        return
+    val read =
+        if (field.reservedTrailingBytes == 0) {
+            CodeBlock.of("buffer.readString(buffer.remaining(), %T.UTF8)", CHARSET_CN)
+        } else {
+            // Read the body byte count minus the reserved trailing
+            // FixedSize bytes; the trailing field emits run normally after.
+            CodeBlock.of(
+                "buffer.readString(buffer.remaining() - %L, %T.UTF8)",
+                field.reservedTrailingBytes,
+                CHARSET_CN,
+            )
+        }
+    if (field.valueClass != null) {
+        body.addStatement("val %L = %T(%L)", field.name, field.valueClass.valueClassType, read)
+    } else {
+        body.addStatement("val %L = %L", field.name, read)
     }
-    // Read the body byte count minus the reserved trailing
-    // FixedSize bytes; the trailing field emits run normally after.
-    body.addStatement(
-        "val %L = buffer.readString(buffer.remaining() - %L, %T.UTF8)",
-        field.name,
-        field.reservedTrailingBytes,
-        CHARSET_CN,
-    )
 }
 
 /**
@@ -1508,9 +1541,15 @@ internal fun appendEncodeRemainingBytesString(
     body: CodeBlock.Builder,
     field: FieldSpec.RemainingBytesString,
 ) {
+    val accessor =
+        if (field.valueClass != null) {
+            "value.${field.name}.${field.valueClass.innerPropertyName}"
+        } else {
+            "value.${field.name}"
+        }
     body.addStatement(
-        "buffer.writeString(value.%L, %T.UTF8)",
-        field.name,
+        "buffer.writeString(%L, %T.UTF8)",
+        accessor,
         CHARSET_CN,
     )
 }

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecIr.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecIr.kt
@@ -549,6 +549,17 @@ internal sealed interface FieldSpec {
         val ownerSimpleName: String,
         val prefixWidth: Int,
         val prefixWireOrder: Endianness,
+        /**
+         * Non-null when the field's declared type is a `@JvmInline value
+         * class` over a single `String` (e.g. `value class UserId(val
+         * value: String)`) rather than a bare `String`. The wire form is
+         * byte-identical to a plain `@LengthPrefixed String` — the wrapper
+         * is wire-insignificant. Decode wraps the decoded `String` via the
+         * value class's primary constructor; encode unwraps via
+         * [ValueClassStringWrapper.innerPropertyName]. See
+         * [ValueClassStringWrapper].
+         */
+        val valueClass: ValueClassStringWrapper? = null,
     ) : FieldSpec
 
     /**
@@ -651,6 +662,13 @@ internal sealed interface FieldSpec {
          * `buffer.limit()` so trailing bytes survive the body read.
          */
         val reservedTrailingBytes: Int = 0,
+        /**
+         * Non-null when the field's declared type is a `@JvmInline value
+         * class` over a single `String` rather than a bare `String`. Wire
+         * form is byte-identical to a plain `@RemainingBytes String`. See
+         * [ValueClassStringWrapper] / [LengthPrefixedString.valueClass].
+         */
+        val valueClass: ValueClassStringWrapper? = null,
     ) : FieldSpec
 
     /**
@@ -894,6 +912,13 @@ internal sealed interface FieldSpec {
         override val name: String,
         val ownerSimpleName: String,
         val source: LengthSource,
+        /**
+         * Non-null when the field's declared type is a `@JvmInline value
+         * class` over a single `String` rather than a bare `String`. Wire
+         * form is byte-identical to a plain `@LengthFrom String`. See
+         * [ValueClassStringWrapper] / [LengthPrefixedString.valueClass].
+         */
+        val valueClass: ValueClassStringWrapper? = null,
     ) : FieldSpec
 
     /**
@@ -948,6 +973,30 @@ internal sealed interface FieldSpec {
 }
 
 /**
+ * A `@JvmInline value class` over a single `String` constructor
+ * parameter (e.g. `value class UserId(val value: String)`) used as
+ * the declared type of a String-framed field (`@LengthPrefixed`,
+ * `@LengthFrom`, `@RemainingBytes`).
+ *
+ * The wrapper is **wire-insignificant**: the value class produces
+ * the exact same bytes on the wire as the bare `String` it wraps, so
+ * a field typed `UserId` is byte-for-byte interchangeable with one
+ * typed `String` under the same framing. Only the generated Kotlin
+ * differs — decode wraps the decoded `String` via [valueClassType]'s
+ * primary constructor, and encode unwraps the field value via
+ * [innerPropertyName].
+ *
+ * Because it changes no bytes, it is deliberately absent from the
+ * codec-schema descriptor (which tracks only wire-significant
+ * attributes): a field's schema line is identical whether it is a
+ * `String` or a value class over `String`.
+ */
+internal data class ValueClassStringWrapper(
+    val valueClassType: ClassName,
+    val innerPropertyName: String,
+)
+
+/**
  * Typed shape of a `@When` field's bound (inner)
  * type. Doctrine row 19 lists the slot's underlying type universe
  * as anything Stages A/B/C/D already emit; the emitter implements
@@ -983,6 +1032,14 @@ internal sealed interface ConditionalInner {
     data class LengthPrefixedString(
         val prefixWidth: Int,
         val prefixWireOrder: Endianness,
+        /**
+         * Non-null when the `@When @LengthPrefixed val: T?` field's inner
+         * (non-null) type is a `@JvmInline value class` over a single
+         * `String`. Presence flag + length-prefixed string of the inner;
+         * wire-identical to the bare-`String?` case. See
+         * [FieldSpec.LengthPrefixedString.valueClass].
+         */
+        val valueClass: ValueClassStringWrapper? = null,
     ) : ConditionalInner
 
     data class ValueClassScalar(

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/ProtocolMessageProcessor.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/ProtocolMessageProcessor.kt
@@ -1069,7 +1069,12 @@ class ProtocolMessageProcessor(
 
             val type = param.type.resolve()
             val typeQname = type.declaration.qualifiedName?.asString()
-            val isStringType = typeQname == STRING_QNAME && !type.isMarkedNullable
+            // A `@JvmInline value class` over `String` is wire-identical to
+            // a bare `String` and accepted the same way (wraps/unwraps at
+            // the decode/encode boundary).
+            val isStringType =
+                !type.isMarkedNullable &&
+                    (typeQname == STRING_QNAME || valueClassOverStringWrapperOrNull(type) != null)
             val isListOfProtocolMessage =
                 !type.isMarkedNullable &&
                     typeQname == LIST_QNAME &&

--- a/buffer-codec-processor/src/test/kotlin/com/ditchoom/buffer/codec/processor/CodecSchemaDescriptorTest.kt
+++ b/buffer-codec-processor/src/test/kotlin/com/ditchoom/buffer/codec/processor/CodecSchemaDescriptorTest.kt
@@ -157,6 +157,65 @@ class CodecSchemaDescriptorTest {
         assertTrue(rendered.startsWith("enum com.acme.Plain\n"), "no default → no default= token:\n$rendered")
     }
 
+    // ---- value-class-over-String is wire-insignificant --------------------
+
+    /**
+     * A `@JvmInline value class` over `String` is byte-for-byte identical on
+     * the wire to the bare `String` it wraps, so the descriptor — which tracks
+     * only wire-significant attributes — must render the two the same. This is
+     * what makes a plain `@LengthPrefixed String` field and a `@LengthPrefixed
+     * UserId` field interchangeable without registering as schema drift.
+     */
+    @Test
+    fun `value-class-over-String descriptor is identical to plain String under every framing`() {
+        val wrapper = ValueClassStringWrapper(ClassName("com.acme", "UserId"), "value")
+
+        assertEquals(
+            CodecSchemaDescriptor.describeField(
+                FieldSpec.LengthPrefixedString("id", "Owner", 2, Endianness.Big),
+            ),
+            CodecSchemaDescriptor.describeField(
+                FieldSpec.LengthPrefixedString("id", "Owner", 2, Endianness.Big, valueClass = wrapper),
+            ),
+            "@LengthPrefixed value-class-over-String must share the plain-String schema line",
+        )
+
+        assertEquals(
+            CodecSchemaDescriptor.describeField(
+                FieldSpec.LengthFromString("id", "Owner", LengthSource.Sibling("len", ScalarKind.UShort)),
+            ),
+            CodecSchemaDescriptor.describeField(
+                FieldSpec.LengthFromString(
+                    "id",
+                    "Owner",
+                    LengthSource.Sibling("len", ScalarKind.UShort),
+                    valueClass = wrapper,
+                ),
+            ),
+            "@LengthFrom value-class-over-String must share the plain-String schema line",
+        )
+
+        assertEquals(
+            CodecSchemaDescriptor.describeField(
+                FieldSpec.RemainingBytesString("id", "Owner", reservedTrailingBytes = 0),
+            ),
+            CodecSchemaDescriptor.describeField(
+                FieldSpec.RemainingBytesString("id", "Owner", reservedTrailingBytes = 0, valueClass = wrapper),
+            ),
+            "@RemainingBytes value-class-over-String must share the plain-String schema line",
+        )
+
+        assertEquals(
+            CodecSchemaDescriptor.describeConditionalInner(
+                ConditionalInner.LengthPrefixedString(2, Endianness.Big),
+            ),
+            CodecSchemaDescriptor.describeConditionalInner(
+                ConditionalInner.LengthPrefixedString(2, Endianness.Big, valueClass = wrapper),
+            ),
+            "@When @LengthPrefixed value-class-over-String must share the plain-String schema line",
+        )
+    }
+
     // ---- helpers ----------------------------------------------------------
 
     private fun assertNonEmptyLine(

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/LengthFromValueClassIdCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/LengthFromValueClassIdCodec.kt
@@ -1,0 +1,58 @@
+package com.ditchoom.buffer.codec.test.protocols.valueclassstring
+
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object LengthFromValueClassIdCodec : Codec<LengthFromValueClassId> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): LengthFromValueClassId {
+    val __batch1 = buffer.readShort().toInt() and 0xFFFF
+    val len: kotlin.UByte
+    val flags: kotlin.Byte
+    if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) {
+      len = (__batch1 ushr 8 and 0xFF).toUByte()
+      flags = (__batch1 and 0xFF).toByte()
+    } else {
+      len = (__batch1 and 0xFF).toUByte()
+      flags = (__batch1 ushr 8 and 0xFF).toByte()
+    }
+    val payload = UserId(buffer.readString(len.toInt(), Charset.UTF8))
+    return LengthFromValueClassId(len = len, flags = flags, payload = payload)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: LengthFromValueClassId,
+    context: EncodeContext,
+  ) {
+    if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) {
+      buffer.writeShort((((value.len.toInt() and 0xFF) shl 8) or (value.flags.toInt() and 0xFF)).toShort())
+    } else {
+      buffer.writeShort(((value.len.toInt() and 0xFF) or ((value.flags.toInt() and 0xFF) shl 8)).toShort())
+    }
+    buffer.writeString(value.payload.value, Charset.UTF8)
+  }
+
+  override fun wireSize(`value`: LengthFromValueClassId, context: EncodeContext): WireSize = WireSize.Exact(2 + value.len.toInt())
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    val len = stream.peekByte(baseOffset + __offset).toUByte()
+    __offset += 1
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    __offset += 1
+    val payloadBytes = len.toInt()
+    if (stream.available() - baseOffset < __offset + payloadBytes) return PeekResult.NeedsMoreData
+    __offset += payloadBytes
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/LpByteValueClassIdCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/LpByteValueClassIdCodec.kt
@@ -1,0 +1,59 @@
+package com.ditchoom.buffer.codec.test.protocols.valueclassstring
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object LpByteValueClassIdCodec : Codec<LpByteValueClassId> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): LpByteValueClassId {
+    val idPrefix = buffer.readUByte().toUInt()
+    if (idPrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "LpByteValueClassId.id", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = idPrefix.toString())
+    }
+    val idLength = idPrefix.toInt()
+    val id = UserId(buffer.readString(idLength, Charset.UTF8))
+    return LpByteValueClassId(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: LpByteValueClassId,
+    context: EncodeContext,
+  ) {
+    val idSizePosition = buffer.position()
+    buffer.position(idSizePosition + 1)
+    val idBodyStart = buffer.position()
+    buffer.writeString(value.id.value, Charset.UTF8)
+    val idEndPosition = buffer.position()
+    val idByteCount = idEndPosition - idBodyStart
+    if (idByteCount > 255) {
+      throw EncodeException(fieldPath = "LpByteValueClassId.id", reason = """UTF-8 byte length ${idByteCount} exceeds @LengthPrefixed(LengthPrefix.Byte) max 255""")
+    }
+    buffer.position(idSizePosition)
+    val idPrefix = idByteCount.toUInt()
+    buffer.writeUByte((idPrefix and 0xFFu).toUByte())
+    buffer.position(idEndPosition)
+  }
+
+  override fun wireSize(`value`: LpByteValueClassId, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    val idPrefix = (stream.peekByte(baseOffset + __offset).toInt() and 0xFF).toUInt()
+    if (idPrefix > (Int.MAX_VALUE - __offset - 1).toUInt()) {
+      throw DecodeException(fieldPath = "LpByteValueClassId.id", bufferPosition = baseOffset + __offset, expected = "__offset + 1 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 1 + idPrefix.toInt()}""")
+    }
+    __offset += 1 + idPrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/LpIntValueClassIdCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/LpIntValueClassIdCodec.kt
@@ -1,0 +1,66 @@
+package com.ditchoom.buffer.codec.test.protocols.valueclassstring
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object LpIntValueClassIdCodec : Codec<LpIntValueClassId> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): LpIntValueClassId {
+    val idPrefixB0 = buffer.readUByte().toUInt()
+    val idPrefixB1 = buffer.readUByte().toUInt()
+    val idPrefixB2 = buffer.readUByte().toUInt()
+    val idPrefixB3 = buffer.readUByte().toUInt()
+    val idPrefix = ((idPrefixB0 shl 24) or (idPrefixB1 shl 16) or (idPrefixB2 shl 8) or idPrefixB3)
+    if (idPrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "LpIntValueClassId.id", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = idPrefix.toString())
+    }
+    val idLength = idPrefix.toInt()
+    val id = TraceId(buffer.readString(idLength, Charset.UTF8))
+    return LpIntValueClassId(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: LpIntValueClassId,
+    context: EncodeContext,
+  ) {
+    val idSizePosition = buffer.position()
+    buffer.position(idSizePosition + 4)
+    val idBodyStart = buffer.position()
+    buffer.writeString(value.id.hex, Charset.UTF8)
+    val idEndPosition = buffer.position()
+    val idByteCount = idEndPosition - idBodyStart
+    buffer.position(idSizePosition)
+    val idPrefix = idByteCount.toUInt()
+    buffer.writeUByte(((idPrefix shr 24) and 0xFFu).toUByte())
+    buffer.writeUByte(((idPrefix shr 16) and 0xFFu).toUByte())
+    buffer.writeUByte(((idPrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((idPrefix and 0xFFu).toUByte())
+    buffer.position(idEndPosition)
+  }
+
+  override fun wireSize(`value`: LpIntValueClassId, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 4) return PeekResult.NeedsMoreData
+    val idPrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val idPrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val idPrefixB2 = stream.peekByte(baseOffset + __offset + 2).toInt() and 0xFF
+    val idPrefixB3 = stream.peekByte(baseOffset + __offset + 3).toInt() and 0xFF
+    val idPrefix = ((idPrefixB0 shl 24) or (idPrefixB1 shl 16) or (idPrefixB2 shl 8) or idPrefixB3).toUInt()
+    if (idPrefix > (Int.MAX_VALUE - __offset - 4).toUInt()) {
+      throw DecodeException(fieldPath = "LpIntValueClassId.id", bufferPosition = baseOffset + __offset, expected = "__offset + 4 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 4 + idPrefix.toInt()}""")
+    }
+    __offset += 4 + idPrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/LpPlainStringIdCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/LpPlainStringIdCodec.kt
@@ -1,0 +1,64 @@
+package com.ditchoom.buffer.codec.test.protocols.valueclassstring
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object LpPlainStringIdCodec : Codec<LpPlainStringId> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): LpPlainStringId {
+    val idPrefixB0 = buffer.readUByte().toUInt()
+    val idPrefixB1 = buffer.readUByte().toUInt()
+    val idPrefix = ((idPrefixB0 shl 8) or idPrefixB1)
+    if (idPrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "LpPlainStringId.id", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = idPrefix.toString())
+    }
+    val idLength = idPrefix.toInt()
+    val id = buffer.readString(idLength, Charset.UTF8)
+    return LpPlainStringId(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: LpPlainStringId,
+    context: EncodeContext,
+  ) {
+    val idSizePosition = buffer.position()
+    buffer.position(idSizePosition + 2)
+    val idBodyStart = buffer.position()
+    buffer.writeString(value.id, Charset.UTF8)
+    val idEndPosition = buffer.position()
+    val idByteCount = idEndPosition - idBodyStart
+    if (idByteCount > 65_535) {
+      throw EncodeException(fieldPath = "LpPlainStringId.id", reason = """UTF-8 byte length ${idByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(idSizePosition)
+    val idPrefix = idByteCount.toUInt()
+    buffer.writeUByte(((idPrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((idPrefix and 0xFFu).toUByte())
+    buffer.position(idEndPosition)
+  }
+
+  override fun wireSize(`value`: LpPlainStringId, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val idPrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val idPrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val idPrefix = ((idPrefixB0 shl 8) or idPrefixB1).toUInt()
+    if (idPrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "LpPlainStringId.id", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + idPrefix.toInt()}""")
+    }
+    __offset += 2 + idPrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/LpValueClassIdCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/LpValueClassIdCodec.kt
@@ -1,0 +1,64 @@
+package com.ditchoom.buffer.codec.test.protocols.valueclassstring
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object LpValueClassIdCodec : Codec<LpValueClassId> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): LpValueClassId {
+    val idPrefixB0 = buffer.readUByte().toUInt()
+    val idPrefixB1 = buffer.readUByte().toUInt()
+    val idPrefix = ((idPrefixB0 shl 8) or idPrefixB1)
+    if (idPrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "LpValueClassId.id", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = idPrefix.toString())
+    }
+    val idLength = idPrefix.toInt()
+    val id = UserId(buffer.readString(idLength, Charset.UTF8))
+    return LpValueClassId(id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: LpValueClassId,
+    context: EncodeContext,
+  ) {
+    val idSizePosition = buffer.position()
+    buffer.position(idSizePosition + 2)
+    val idBodyStart = buffer.position()
+    buffer.writeString(value.id.value, Charset.UTF8)
+    val idEndPosition = buffer.position()
+    val idByteCount = idEndPosition - idBodyStart
+    if (idByteCount > 65_535) {
+      throw EncodeException(fieldPath = "LpValueClassId.id", reason = """UTF-8 byte length ${idByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(idSizePosition)
+    val idPrefix = idByteCount.toUInt()
+    buffer.writeUByte(((idPrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((idPrefix and 0xFFu).toUByte())
+    buffer.position(idEndPosition)
+  }
+
+  override fun wireSize(`value`: LpValueClassId, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val idPrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val idPrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val idPrefix = ((idPrefixB0 shl 8) or idPrefixB1).toUInt()
+    if (idPrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "LpValueClassId.id", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + idPrefix.toInt()}""")
+    }
+    __offset += 2 + idPrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/OptionalValueClassIdCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/OptionalValueClassIdCodec.kt
@@ -1,0 +1,78 @@
+package com.ditchoom.buffer.codec.test.protocols.valueclassstring
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object OptionalValueClassIdCodec : Codec<OptionalValueClassId> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): OptionalValueClassId {
+    val hasId = buffer.readByte() != 0.toByte()
+    val id: UserId? = if (hasId) {
+      val idPrefixB0 = buffer.readUByte().toUInt()
+      val idPrefixB1 = buffer.readUByte().toUInt()
+      val idPrefix = ((idPrefixB0 shl 8) or idPrefixB1)
+      if (idPrefix > Int.MAX_VALUE.toUInt()) {
+        throw DecodeException(fieldPath = "OptionalValueClassId.id", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = idPrefix.toString())
+      }
+      val idLength = idPrefix.toInt()
+      UserId(buffer.readString(idLength, Charset.UTF8))
+    } else {
+      null
+    }
+    return OptionalValueClassId(hasId = hasId, id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: OptionalValueClassId,
+    context: EncodeContext,
+  ) {
+    buffer.writeByte(if (value.hasId) 1.toByte() else 0.toByte())
+    if (value.hasId) {
+      val idValue = value.id ?: throw EncodeException(fieldPath = "OptionalValueClassId.id", reason = "@When(\"hasId\") predicate is true but field is null")
+      val idSizePosition = buffer.position()
+      buffer.position(idSizePosition + 2)
+      val idBodyStart = buffer.position()
+      buffer.writeString(idValue.value, Charset.UTF8)
+      val idEndPosition = buffer.position()
+      val idByteCount = idEndPosition - idBodyStart
+      if (idByteCount > 65_535) {
+        throw EncodeException(fieldPath = "OptionalValueClassId.id", reason = """UTF-8 byte length ${idByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+      }
+      buffer.position(idSizePosition)
+      val idPrefix = idByteCount.toUInt()
+      buffer.writeUByte(((idPrefix shr 8) and 0xFFu).toUByte())
+      buffer.writeUByte((idPrefix and 0xFFu).toUByte())
+      buffer.position(idEndPosition)
+    }
+  }
+
+  override fun wireSize(`value`: OptionalValueClassId, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    val hasId = stream.peekByte(baseOffset + __offset) != 0.toByte()
+    __offset += 1
+    if (hasId) {
+      if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+      val idPrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+      val idPrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+      val idPrefix = ((idPrefixB0 shl 8) or idPrefixB1).toUInt()
+      if (idPrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+        throw DecodeException(fieldPath = "OptionalValueClassId.id", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + idPrefix.toInt()}""")
+      }
+      __offset += 2 + idPrefix.toInt()
+    }
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/RemainingValueClassIdCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/RemainingValueClassIdCodec.kt
@@ -1,0 +1,33 @@
+package com.ditchoom.buffer.codec.test.protocols.valueclassstring
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object RemainingValueClassIdCodec : Codec<RemainingValueClassId> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): RemainingValueClassId {
+    val kind = buffer.readByte()
+    val id = SessionId(buffer.readString(buffer.remaining(), Charset.UTF8))
+    return RemainingValueClassId(kind = kind, id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: RemainingValueClassId,
+    context: EncodeContext,
+  ) {
+    buffer.writeByte(value.kind)
+    buffer.writeString(value.id.value, Charset.UTF8)
+  }
+
+  override fun wireSize(`value`: RemainingValueClassId, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/RemainingValueClassWithTrailerCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/RemainingValueClassWithTrailerCodec.kt
@@ -1,0 +1,35 @@
+package com.ditchoom.buffer.codec.test.protocols.valueclassstring
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object RemainingValueClassWithTrailerCodec : Codec<RemainingValueClassWithTrailer> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): RemainingValueClassWithTrailer {
+    val kind = buffer.readByte()
+    val id = SessionId(buffer.readString(buffer.remaining() - 4, Charset.UTF8))
+    val crc = buffer.readUInt()
+    return RemainingValueClassWithTrailer(kind = kind, id = id, crc = crc)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: RemainingValueClassWithTrailer,
+    context: EncodeContext,
+  ) {
+    buffer.writeByte(value.kind)
+    buffer.writeString(value.id.value, Charset.UTF8)
+    buffer.writeUInt(value.crc)
+  }
+
+  override fun wireSize(`value`: RemainingValueClassWithTrailer, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+}

--- a/buffer-codec-test/src/codecSchema/codec-schema.txt
+++ b/buffer-codec-test/src/codecSchema/codec-schema.txt
@@ -1104,6 +1104,10 @@ message com.ditchoom.buffer.codec.test.protocols.valueclassstring.OptionalValueC
 message com.ditchoom.buffer.codec.test.protocols.valueclassstring.RemainingValueClassId
   0 kind scalar:Byte wire=1B order=Default
   1 id string remaining reserved=0B
+message com.ditchoom.buffer.codec.test.protocols.valueclassstring.RemainingValueClassWithTrailer
+  0 kind scalar:Byte wire=1B order=Default
+  1 id string remaining reserved=4B
+  2 crc scalar:UInt wire=4B order=Default
 message com.ditchoom.buffer.codec.test.protocols.varintfield.VarintLengthFrame
   0 value codec:com.ditchoom.buffer.codec.test.protocols.quic.QuicVarintCodec bounding=false variable=true
   1 tag scalar:UByte wire=1B order=Default

--- a/buffer-codec-test/src/codecSchema/codec-schema.txt
+++ b/buffer-codec-test/src/codecSchema/codec-schema.txt
@@ -1086,6 +1086,24 @@ message com.ditchoom.buffer.codec.test.protocols.usecodecscalar.DispatchVarintUn
 message com.ditchoom.buffer.codec.test.protocols.usecodecscalar.ZigZagFrame
   0 id scalar:Int wire=4B order=Default
   1 value codec:com.ditchoom.buffer.codec.test.protocols.usecodecscalar.ZigZagUIntCodec bounding=false variable=false
+message com.ditchoom.buffer.codec.test.protocols.valueclassstring.LengthFromValueClassId
+  0 len scalar:UByte wire=1B order=Default
+  1 flags scalar:Byte wire=1B order=Default
+  2 payload string len-from=sibling:len
+message com.ditchoom.buffer.codec.test.protocols.valueclassstring.LpByteValueClassId
+  0 id string len-prefix=1B/Default
+message com.ditchoom.buffer.codec.test.protocols.valueclassstring.LpIntValueClassId
+  0 id string len-prefix=4B/Default
+message com.ditchoom.buffer.codec.test.protocols.valueclassstring.LpPlainStringId
+  0 id string len-prefix=2B/Default
+message com.ditchoom.buffer.codec.test.protocols.valueclassstring.LpValueClassId
+  0 id string len-prefix=2B/Default
+message com.ditchoom.buffer.codec.test.protocols.valueclassstring.OptionalValueClassId
+  0 hasId scalar:Boolean wire=1B order=Default
+  1 id? when(sibling:hasId) string len-prefix=2B/Default
+message com.ditchoom.buffer.codec.test.protocols.valueclassstring.RemainingValueClassId
+  0 kind scalar:Byte wire=1B order=Default
+  1 id string remaining reserved=0B
 message com.ditchoom.buffer.codec.test.protocols.varintfield.VarintLengthFrame
   0 value codec:com.ditchoom.buffer.codec.test.protocols.quic.QuicVarintCodec bounding=false variable=true
   1 tag scalar:UByte wire=1B order=Default

--- a/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/valueclassstring/ValueClassStringIds.kt
+++ b/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/valueclassstring/ValueClassStringIds.kt
@@ -1,0 +1,104 @@
+package com.ditchoom.buffer.codec.test.protocols.valueclassstring
+
+import com.ditchoom.buffer.codec.annotations.LengthFrom
+import com.ditchoom.buffer.codec.annotations.LengthPrefix
+import com.ditchoom.buffer.codec.annotations.LengthPrefixed
+import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+import com.ditchoom.buffer.codec.annotations.RemainingBytes
+import com.ditchoom.buffer.codec.annotations.When
+import kotlin.jvm.JvmInline
+
+/**
+ * Vectors for `@JvmInline value class`-over-`String` fields under each
+ * of the three String framings (`@LengthPrefixed`, `@LengthFrom`,
+ * `@RemainingBytes`).
+ *
+ * These id wrappers are the common shape for consumers that give their
+ * string identifiers a distinct type (`UserId`, `SessionId`, …) instead
+ * of passing bare `String`s around. Each is wire-**identical** to the
+ * same field typed as a plain `String` under the same framing — the
+ * value class only changes the generated Kotlin (wrap on decode via the
+ * primary constructor, unwrap on encode via `.value`), never the bytes.
+ * The `*PlainString` twins below exist to prove that byte-identity in a
+ * golden test.
+ *
+ * None of these wrappers is `@ProtocolMessage`: an id wrapper has no
+ * codec of its own, so the field-consumption path must accept the plain
+ * shape directly.
+ */
+@JvmInline
+value class UserId(
+    val value: String,
+)
+
+@JvmInline
+value class SessionId(
+    val value: String,
+)
+
+/**
+ * A value-class inner property named something other than `value`, to
+ * prove the unwrap uses the actual constructor-parameter name rather
+ * than a hard-coded `.value`.
+ */
+@JvmInline
+value class TraceId(
+    val hex: String,
+)
+
+// ---- @LengthPrefixed (default 2-byte big-endian prefix) -----------------
+
+@ProtocolMessage
+data class LpValueClassId(
+    @LengthPrefixed val id: UserId,
+)
+
+/** Byte-identity twin of [LpValueClassId]. */
+@ProtocolMessage
+data class LpPlainStringId(
+    @LengthPrefixed val id: String,
+)
+
+// ---- @LengthPrefixed, explicit prefix widths ----------------------------
+
+@ProtocolMessage
+data class LpByteValueClassId(
+    @LengthPrefixed(LengthPrefix.Byte) val id: UserId,
+)
+
+@ProtocolMessage
+data class LpIntValueClassId(
+    @LengthPrefixed(LengthPrefix.Int) val id: TraceId,
+)
+
+// ---- @When (nullable) + @LengthPrefixed value class ---------------------
+
+@ProtocolMessage
+data class OptionalValueClassId(
+    val hasId: Boolean,
+    @When("hasId") @LengthPrefixed val id: UserId? = null,
+)
+
+// ---- @LengthFrom value class over String --------------------------------
+
+/**
+ * `payload` is sized by the non-adjacent `len` carrier (`@LengthFrom`
+ * is reserved for remote-prefix uses, so a `flags` field sits between
+ * the carrier and the bound field). The author is responsible for
+ * keeping `len` equal to the UTF-8 byte length of `payload.value` (the
+ * same contract a plain `@LengthFrom String` field carries).
+ */
+@ProtocolMessage
+data class LengthFromValueClassId(
+    val len: UByte,
+    val flags: Byte,
+    @LengthFrom("len") val payload: UserId,
+)
+
+// ---- @RemainingBytes value class over String (terminal) -----------------
+
+@ProtocolMessage
+data class RemainingValueClassId(
+    val kind: Byte,
+    @RemainingBytes val id: SessionId,
+)

--- a/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/valueclassstring/ValueClassStringIds.kt
+++ b/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/valueclassstring/ValueClassStringIds.kt
@@ -102,3 +102,16 @@ data class RemainingValueClassId(
     val kind: Byte,
     @RemainingBytes val id: SessionId,
 )
+
+/**
+ * Non-terminal `@RemainingBytes` value class: the body is bounded to
+ * `limit() - 4` so the trailing fixed-size `crc` survives. Exercises the
+ * `reservedTrailingBytes > 0` path in combination with the value-class
+ * wrapper (the terminal [RemainingValueClassId] leaves `reserved = 0`).
+ */
+@ProtocolMessage
+data class RemainingValueClassWithTrailer(
+    val kind: Byte,
+    @RemainingBytes val id: SessionId,
+    val crc: UInt,
+)

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/valueclassstring/ValueClassStringIdsCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/valueclassstring/ValueClassStringIdsCodecTest.kt
@@ -1,0 +1,169 @@
+package com.ditchoom.buffer.codec.test.protocols.valueclassstring
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.WireSize
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Round-trip and wire-golden coverage for `@JvmInline value
+ * class`-over-`String` fields under each String framing, plus the
+ * `@When`-nullable combination. The central guarantee is byte-identity
+ * with a plain `String` field under the same framing — the value class
+ * only wraps/unwraps at the decode/encode boundary and changes no wire
+ * bytes.
+ *
+ * All fixture text is ASCII, so a string's UTF-8 byte length equals its
+ * `.length`.
+ */
+class ValueClassStringIdsCodecTest {
+    // ---- @LengthPrefixed round-trip (default 2-byte prefix) -------------
+
+    @Test
+    fun lengthPrefixedValueClassRoundTrips() {
+        val original = LpValueClassId(UserId("hello"))
+        val buf = encode { LpValueClassIdCodec.encode(it, original, EncodeContext.Empty) }
+        // 2-byte prefix + 5 body bytes.
+        assertEquals(7, buf.position())
+        buf.resetForRead()
+        assertEquals(original, LpValueClassIdCodec.decode(buf, DecodeContext.Empty))
+    }
+
+    @Test
+    fun lengthPrefixedValueClassRoundTripsEmpty() {
+        val original = LpValueClassId(UserId(""))
+        val buf = encode { LpValueClassIdCodec.encode(it, original, EncodeContext.Empty) }
+        assertEquals(2, buf.position())
+        buf.resetForRead()
+        assertEquals(original, LpValueClassIdCodec.decode(buf, DecodeContext.Empty))
+    }
+
+    // ---- byte-identity with a plain @LengthPrefixed String --------------
+
+    @Test
+    fun lengthPrefixedValueClassIsByteIdenticalToPlainString() {
+        val text = "session-42"
+        val fromValueClass =
+            encode { LpValueClassIdCodec.encode(it, LpValueClassId(UserId(text)), EncodeContext.Empty) }
+                .also { it.resetForRead() }
+        val fromPlainString =
+            encode { LpPlainStringIdCodec.encode(it, LpPlainStringId(text), EncodeContext.Empty) }
+                .also { it.resetForRead() }
+        assertTrue(
+            fromValueClass.contentEquals(fromPlainString),
+            "value-class-over-String field must be byte-identical to a plain @LengthPrefixed String",
+        )
+        // Explicit golden: 2-byte BE prefix (0x000A = 10) + "session-42".
+        val expected =
+            encode {
+                it.writeShort(text.length.toShort())
+                it.writeString(text, Charset.UTF8)
+            }.also { it.resetForRead() }
+        assertTrue(fromValueClass.contentEquals(expected), "golden bytes mismatch")
+    }
+
+    @Test
+    fun lengthPrefixedValueClassWireSizeIsBackPatch() {
+        assertEquals(
+            WireSize.BackPatch,
+            LpValueClassIdCodec.wireSize(LpValueClassId(UserId("x")), EncodeContext.Empty),
+        )
+    }
+
+    // ---- @LengthPrefixed, explicit prefix widths ------------------------
+
+    @Test
+    fun bytePrefixValueClassRoundTrips() {
+        val original = LpByteValueClassId(UserId("abc"))
+        val buf = encode { LpByteValueClassIdCodec.encode(it, original, EncodeContext.Empty) }
+        assertEquals(1 + 3, buf.position())
+        buf.resetForRead()
+        assertEquals(0x03.toByte(), buf.readByte(), "1-byte length prefix")
+        buf.position(0) // rewind without re-flipping the limit
+        assertEquals(original, LpByteValueClassIdCodec.decode(buf, DecodeContext.Empty))
+    }
+
+    @Test
+    fun intPrefixValueClassRoundTrips() {
+        val original = LpIntValueClassId(TraceId("deadbeef"))
+        val buf = encode { LpIntValueClassIdCodec.encode(it, original, EncodeContext.Empty) }
+        assertEquals(4 + 8, buf.position())
+        buf.resetForRead()
+        assertEquals(8, buf.readInt(), "4-byte length prefix")
+        buf.position(0) // rewind without re-flipping the limit
+        assertEquals(original, LpIntValueClassIdCodec.decode(buf, DecodeContext.Empty))
+    }
+
+    // ---- @When (nullable) + @LengthPrefixed value class -----------------
+
+    @Test
+    fun optionalValueClassPresentRoundTrips() {
+        val original = OptionalValueClassId(hasId = true, id = UserId("u1"))
+        val buf = encode { OptionalValueClassIdCodec.encode(it, original, EncodeContext.Empty) }
+        // presence flag (1) + prefix (2) + body (2).
+        assertEquals(1 + 2 + 2, buf.position())
+        buf.resetForRead()
+        assertEquals(original, OptionalValueClassIdCodec.decode(buf, DecodeContext.Empty))
+    }
+
+    @Test
+    fun optionalValueClassAbsentRoundTrips() {
+        val original = OptionalValueClassId(hasId = false, id = null)
+        val buf = encode { OptionalValueClassIdCodec.encode(it, original, EncodeContext.Empty) }
+        assertEquals(1, buf.position(), "only the false presence flag")
+        buf.resetForRead()
+        assertEquals(0x00.toByte(), buf.readByte())
+        buf.position(0)
+        assertEquals(original, OptionalValueClassIdCodec.decode(buf, DecodeContext.Empty))
+    }
+
+    // ---- @LengthFrom value class over String ----------------------------
+
+    @Test
+    fun lengthFromValueClassRoundTrips() {
+        val text = "abcd"
+        val original =
+            LengthFromValueClassId(
+                len = text.length.toUByte(),
+                flags = 0x7F,
+                payload = UserId(text),
+            )
+        val buf = encode { LengthFromValueClassIdCodec.encode(it, original, EncodeContext.Empty) }
+        // len (1) + flags (1) + body (4). No inline prefix on the body.
+        assertEquals(1 + 1 + 4, buf.position())
+        buf.resetForRead()
+        assertEquals(original, LengthFromValueClassIdCodec.decode(buf, DecodeContext.Empty))
+    }
+
+    // ---- @RemainingBytes value class over String ------------------------
+
+    @Test
+    fun remainingBytesValueClassRoundTrips() {
+        val text = "trailing-id"
+        val original = RemainingValueClassId(kind = 0x05, id = SessionId(text))
+        val buf = encode { RemainingValueClassIdCodec.encode(it, original, EncodeContext.Empty) }
+        // kind (1) + remaining UTF-8 bytes.
+        assertEquals(1 + text.length, buf.position())
+        buf.resetForRead()
+        assertEquals(original, RemainingValueClassIdCodec.decode(buf, DecodeContext.Empty))
+    }
+
+    @Test
+    fun remainingBytesValueClassEmptyRoundTrips() {
+        val original = RemainingValueClassId(kind = 0x01, id = SessionId(""))
+        val buf = encode { RemainingValueClassIdCodec.encode(it, original, EncodeContext.Empty) }
+        assertEquals(1, buf.position())
+        buf.resetForRead()
+        assertEquals(original, RemainingValueClassIdCodec.decode(buf, DecodeContext.Empty))
+    }
+
+    // ---- helpers --------------------------------------------------------
+
+    private fun encode(block: (PlatformBuffer) -> Unit) = BufferFactory.Default.allocate(256).also(block)
+}

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/valueclassstring/ValueClassStringIdsCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/valueclassstring/ValueClassStringIdsCodecTest.kt
@@ -68,6 +68,37 @@ class ValueClassStringIdsCodecTest {
         assertTrue(fromValueClass.contentEquals(expected), "golden bytes mismatch")
     }
 
+    // ---- multi-byte UTF-8 content (byte-length, not char-length) --------
+
+    @Test
+    fun lengthPrefixedValueClassRoundTripsMultiByteUtf8() {
+        // 6 chars, 9 UTF-8 bytes: é = 2 bytes, ☕ (U+2615) = 3 bytes.
+        val text = "héllo☕"
+        val original = LpValueClassId(UserId(text))
+        val buf = encode { LpValueClassIdCodec.encode(it, original, EncodeContext.Empty) }
+        buf.resetForRead()
+        val prefix = buf.readShort().toInt()
+        assertEquals(9, prefix, "length prefix must count UTF-8 bytes")
+        assertTrue(prefix > text.length, "multi-byte content: byte length exceeds char length")
+        buf.position(0)
+        assertEquals(original, LpValueClassIdCodec.decode(buf, DecodeContext.Empty))
+    }
+
+    @Test
+    fun multiByteUtf8ValueClassIsByteIdenticalToPlainString() {
+        val text = "café-π-☕"
+        val fromValueClass =
+            encode { LpValueClassIdCodec.encode(it, LpValueClassId(UserId(text)), EncodeContext.Empty) }
+                .also { it.resetForRead() }
+        val fromPlainString =
+            encode { LpPlainStringIdCodec.encode(it, LpPlainStringId(text), EncodeContext.Empty) }
+                .also { it.resetForRead() }
+        assertTrue(
+            fromValueClass.contentEquals(fromPlainString),
+            "multi-byte UTF-8 must be byte-identical between value-class and plain-String fields",
+        )
+    }
+
     @Test
     fun lengthPrefixedValueClassWireSizeIsBackPatch() {
         assertEquals(
@@ -161,6 +192,30 @@ class ValueClassStringIdsCodecTest {
         assertEquals(1, buf.position())
         buf.resetForRead()
         assertEquals(original, RemainingValueClassIdCodec.decode(buf, DecodeContext.Empty))
+    }
+
+    // ---- non-terminal @RemainingBytes value class (reserved trailer) ----
+
+    @Test
+    fun remainingBytesValueClassWithTrailerRoundTrips() {
+        val text = "trailing-id"
+        val original = RemainingValueClassWithTrailer(kind = 0x09, id = SessionId(text), crc = 0xDEADBEEFu)
+        val buf = encode { RemainingValueClassWithTrailerCodec.encode(it, original, EncodeContext.Empty) }
+        // kind (1) + body bounded to limit()-4 + crc (4).
+        assertEquals(1 + text.length + 4, buf.position())
+        buf.resetForRead()
+        val decoded = RemainingValueClassWithTrailerCodec.decode(buf, DecodeContext.Empty)
+        assertEquals(original, decoded)
+        assertEquals(0xDEADBEEFu, decoded.crc, "trailing fixed field survives the bounded body read")
+    }
+
+    @Test
+    fun remainingBytesValueClassWithTrailerEmptyBodyRoundTrips() {
+        val original = RemainingValueClassWithTrailer(kind = 0x01, id = SessionId(""), crc = 0x01020304u)
+        val buf = encode { RemainingValueClassWithTrailerCodec.encode(it, original, EncodeContext.Empty) }
+        assertEquals(1 + 0 + 4, buf.position())
+        buf.resetForRead()
+        assertEquals(original, RemainingValueClassWithTrailerCodec.decode(buf, DecodeContext.Empty))
     }
 
     // ---- helpers --------------------------------------------------------

--- a/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/annotations/Annotations.kt
+++ b/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/annotations/Annotations.kt
@@ -93,9 +93,40 @@ enum class LengthPrefix {
  *
  * Accepted on:
  *   - `String` fields — the value is the field's UTF-8 bytes.
+ *   - A `@JvmInline value class` over a single `String` (e.g.
+ *     `value class UserId(val value: String)`) — encoded exactly like the
+ *     `String` it wraps (see "Value class over String" below).
  *   - `@ProtocolMessage` data class fields — the value is the message body's
  *     wire bytes; encode emits the prefix carrying the body's `wireSize`,
  *     decode reads the prefix, bounds inner decode, restores the outer limit.
+ *
+ * ## Value class over String
+ *
+ * A field typed as a `@JvmInline value class` whose single constructor
+ * parameter is a `String` encodes **byte-for-byte identically** to the same
+ * field typed as a bare `String` — the generated codec wraps the decoded
+ * `String` via the value class's primary constructor and unwraps it via that
+ * property on encode. This lets id/newtype wrappers appear directly as codec
+ * fields instead of forcing hand-written codecs:
+ *
+ * ```kotlin
+ * @JvmInline value class UserId(val value: String)
+ *
+ * @ProtocolMessage
+ * data class Session(
+ *     @LengthPrefixed val user: UserId,   // wire-identical to @LengthPrefixed String
+ * )
+ * ```
+ *
+ * The wrapper is wire-insignificant: it is invisible in the codec schema, and
+ * a field is freely interchangeable between `String` and a value class over
+ * `String` without any wire change. All prefix widths and the `@When`-nullable
+ * combination (`@When("flag") @LengthPrefixed val user: UserId?`) are
+ * supported. The value class must **not** itself be `@ProtocolMessage` (such a
+ * type has its own codec and routes to the nested-message path instead), and
+ * `@WireBytes` / `@WireOrder` on its inner property are out of scope. The same
+ * value-class-over-`String` support applies to [LengthFrom] and
+ * [RemainingBytes] fields.
  *
  * For adjacent length carriers, prefer `@LengthPrefixed` over modeling the
  * length as a separate constructor parameter and a `@LengthFrom` reference —
@@ -133,6 +164,9 @@ annotation class LengthPrefixed(
  *
  * Accepted on:
  *   - `String` — UTF-8 body consuming the rest of the buffer.
+ *   - A `@JvmInline value class` over a single `String` — wire-identical to
+ *     the `String` case, wrapping the trailing bytes in the value class. See
+ *     the "Value class over String" section on [LengthPrefixed].
  *   - `List<T>` where `T` is a `@ProtocolMessage` data class — loop
  *     reads nested-message bodies until the bound is reached.
  *   - Typed binary payload via `@RemainingBytes @UseCodec(C::class) val: P`
@@ -206,6 +240,9 @@ annotation class RemainingBytes
  *
  * Accepted on:
  *   - `String` fields — body is a single UTF-8 string sized by the sibling.
+ *   - A `@JvmInline value class` over a single `String` — wire-identical to
+ *     the `String` case. See the "Value class over String" section on
+ *     [LengthPrefixed].
  *   - `List<T>` where `T` is a `@ProtocolMessage` data class — body is a
  *     sequence of nested-message bodies, byte-bounded by the sibling.
  *   - `T` where `T` is a `@ProtocolMessage` data class or sealed parent —


### PR DESCRIPTION
## Summary

A field typed as a `@JvmInline value class` over a single `String` (e.g. `value class UserId(val value: String)`) is now a valid generated-codec field under `@LengthPrefixed`, `@LengthFrom`, and `@RemainingBytes`, and composes with `@When` (nullable). Previously these forced hand-written codecs.

The wire form is **byte-for-byte identical** to the same field typed as a bare `String` under the same framing — the generated codec wraps the decoded `String` via the value class's primary constructor and unwraps it via the inner property on encode. The wrapper is wire-insignificant: it is deliberately **absent from the codec-schema descriptor**, so a field is interchangeable between `String` and a value class over `String` with zero schema drift.

## Not in scope (by design)

- Value classes over **numeric scalars** already work (bare fixed-width `ValueClassScalar` path) and are untouched — their goldens stay byte-identical.
- Value classes over **varint** already work via `@UseCodec`.
- Value classes over `@ProtocolMessage` / `List` / `Payload` under these framings are left for on-demand follow-up; the seam generalizes.
- A value class that is itself `@ProtocolMessage` keeps routing to its own generated codec.
- `@UseCodec`-on-value-class rejection and the numeric path are unchanged.

## Implementation

- **CodecIr** — new `ValueClassStringWrapper`; optional `valueClass` on `LengthPrefixedString` / `LengthFromString` / `RemainingBytesString` and `ConditionalInner.LengthPrefixedString`.
- **CodecAnalyzer** — `valueClassOverStringWrapperOrNull` detector wired into the three framing paths + the `@When @LengthPrefixed` inner path.
- **Emitters** — wrap on decode / unwrap on encode; `partialFieldTypeName` returns the value-class type.
- **ProtocolMessageProcessor** — `validateLengthFrom` accepts the shape.

## Tests / docs

- Round-trip per framing + prefix width, `@When`-nullable, and a golden proving byte-identity with a plain `@LengthPrefixed String`.
- Schema-descriptor identity assertions (value-class line == plain-String line under every framing).
- Docs updated in `Annotations.kt` and `CLAUDE.md`.

## Verification

Processor unit tests, `buffer-codec-test` on JVM / JS / WasmJS / Linux-native, and ktlint — all green. No existing codec snapshot changed (only new fixtures added); `codec-schema.txt` gained SAFE additions only.