### PR TITLE
feat(crypto): add single-block AES-ECB primitive

### DIFF
--- a/buffer-crypto/SECURITY.md
+++ b/buffer-crypto/SECURITY.md
@@ -77,6 +77,8 @@ Run the full suite:
 - Hashes: `Sha256Test`, `Sha384Sha512Test`, `HmacSha256Test`, `HmacSha384Sha512Test`,
   `HkdfTest`, `HkdfSha384Sha512Test`, `Sha512FamilyWycheproofTest`
 - AEAD: `AeadTest`, `AeadWycheproofTest`, `AeadTamperTest`
+- Single-block AES (ECB): `AesEcbTest` (FIPS-197 Appendix C.1/C.3 + NIST SP 800-38A F.1
+  single-block KAT, encrypt/decrypt round-trip, key/block-length validation, capability contract)
 - Signatures: `SignatureKatTest`, `SignatureWycheproofTest`, `SignatureTamperTest`,
   `SignatureCapabilityTest`, `SignatureBackingTest`
 - Key agreement: `KeyAgreementKatTest`, `KeyAgreementWycheproofTest`, `KeyAgreementTest`
@@ -109,6 +111,26 @@ prevented by API/type design · **(e)** out of scope / documented trust assumpti
 | Key-size confusion (128 vs 256) | **(d)** typed sized keys + **(a)** |
 | ChaCha on WebCrypto | **(b)/(d)** throws — never polyfilled |
 | AES/GHASH timing side-channel | **(e)** trust AES-NI/CLMUL |
+
+### Single-block AES / ECB (raw block permutation)
+
+This is a deliberately low-level primitive — the bare keyed AES permutation over one 16-byte block,
+with **no** IV, chaining, padding, or authentication. It is **not** a general-purpose cipher and must
+never be used for bulk confidentiality: equal plaintext blocks map to equal ciphertext blocks under
+the same key, so ECB hides nothing about message content and detects no tampering. Its only intended
+use is keystream/PRF constructions that run AES forward once — e.g. **DTLS 1.3 / TLS 1.3 record
+sequence-number encryption** (RFC 9147 §4.2.3 / RFC 8446 §5.4.1), where the mask is
+`AES-ECB-encrypt(sn_key, ciphertext_sample)` and both peers recover the sequence number by XORing
+that mask (so only the forward direction is used). For confidentiality use the AEAD family above.
+
+| Vector | Defense |
+|---|---|
+| Misuse as a bulk cipher | **(d)/(e)** single-block-only API (multi-block rejected) + documented "not for confidentiality" contract; ECB pattern-leakage is inherent and out of scope by design |
+| Input length ≠ one 16-byte block | **(d)** enforce exactly 16 bytes + **(b)** runtime check + negative test |
+| Key-size confusion (128 vs 256) | **(d)** typed sized key (`AesEcbKey`) + **(b)** length validation + negative test |
+| Block permutation correctness | **(a)** FIPS-197 + NIST SP 800-38A single-block KAT on every native platform |
+| Use on the web | **(b)/(d)** witness is `Unavailable` — no ECB in WebCrypto, never polyfilled (DTLS 1.3 does not run on the web) |
+| AES timing side-channel | **(e)** trust AES-NI (JCA/CommonCrypto) / BoringSSL constant-time AES |
 
 ### Signatures (ECDSA P-256/384/521, Ed25519)
 | Vector | Defense |
@@ -179,6 +201,7 @@ These are tested error paths, not assumptions — the capability flag drives a `
 | SHA-256/384/512, HMAC, HKDF | ✓ | ✓ | ✓ | ✓ (pure-Kotlin core) |
 | AES-GCM 128/256 | ✓ | ✓ | ✓ | ✓ (WebCrypto, async) |
 | ChaCha20-Poly1305 | ✓ (JDK 11+) | ✓ | ⚠ pending (see §5) | ✗ throws — not in WebCrypto |
+| AES-ECB (single block, raw — unauthenticated) | ✓ | ✓ | ✓ | ✗ throws — no ECB in WebCrypto |
 | ECDSA P-256/384/521 (verify) | ✓ | ✓ | ✓ | ✓ |
 | ECDSA signing | ✓ | ✓ | ⚠ from-scalar gated (see §5) | ✓ |
 | Ed25519 | ✓ (JDK 15+) | ✓ **API 34+** (runtime gate, throws 28–33) | ⚠ pending (see §5) | ✓ newer engines (feature-detected) |

--- a/buffer-crypto/api/android/buffer-crypto.api
+++ b/buffer-crypto/api/android/buffer-crypto.api
@@ -99,6 +99,69 @@ public final class com/ditchoom/buffer/crypto/Aead_jvmCommonKt {
 	public static final fun getChaChaPoly (Lcom/ditchoom/buffer/crypto/CryptoCapabilities;)Lcom/ditchoom/buffer/crypto/OptionalAead;
 }
 
+public abstract interface class com/ditchoom/buffer/crypto/AesEcb {
+}
+
+public final class com/ditchoom/buffer/crypto/AesEcb$Blocking : com/ditchoom/buffer/crypto/AesEcb {
+	public fun <init> (Lcom/ditchoom/buffer/crypto/AesEcbOps;)V
+	public final fun component1 ()Lcom/ditchoom/buffer/crypto/AesEcbOps;
+	public final fun copy (Lcom/ditchoom/buffer/crypto/AesEcbOps;)Lcom/ditchoom/buffer/crypto/AesEcb$Blocking;
+	public static synthetic fun copy$default (Lcom/ditchoom/buffer/crypto/AesEcb$Blocking;Lcom/ditchoom/buffer/crypto/AesEcbOps;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/AesEcb$Blocking;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOps ()Lcom/ditchoom/buffer/crypto/AesEcbOps;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/AesEcb$Unavailable : com/ditchoom/buffer/crypto/AesEcb {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/AesEcb$Unavailable;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/AesEcbKey : java/lang/AutoCloseable {
+	public static final field Companion Lcom/ditchoom/buffer/crypto/AesEcbKey$Companion;
+	public abstract fun getCustody ()Lcom/ditchoom/buffer/crypto/KeyCustody;
+	public fun getProvenance ()Lcom/ditchoom/buffer/crypto/KeyProvenance;
+	public abstract fun getSizeBits ()I
+	public fun getSizeBytes ()I
+}
+
+public final class com/ditchoom/buffer/crypto/AesEcbKey$Companion {
+	public final fun of (Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;)Lcom/ditchoom/buffer/crypto/AesEcbKey;
+	public static synthetic fun of$default (Lcom/ditchoom/buffer/crypto/AesEcbKey$Companion;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/AesEcbKey;
+}
+
+public final class com/ditchoom/buffer/crypto/AesEcbKey$DefaultImpls {
+	public static fun getProvenance (Lcom/ditchoom/buffer/crypto/AesEcbKey;)Lcom/ditchoom/buffer/crypto/KeyProvenance;
+	public static fun getSizeBytes (Lcom/ditchoom/buffer/crypto/AesEcbKey;)I
+}
+
+public final class com/ditchoom/buffer/crypto/AesEcbKt {
+	public static final field AES_ECB_BLOCK_BYTES I
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/AesEcbOps {
+	public fun decryptBlock (Lcom/ditchoom/buffer/crypto/AesEcbKey;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;)Lcom/ditchoom/buffer/PlatformBuffer;
+	public abstract fun decryptBlock (Lcom/ditchoom/buffer/crypto/AesEcbKey;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/WriteBuffer;)V
+	public static synthetic fun decryptBlock$default (Lcom/ditchoom/buffer/crypto/AesEcbOps;Lcom/ditchoom/buffer/crypto/AesEcbKey;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;ILjava/lang/Object;)Lcom/ditchoom/buffer/PlatformBuffer;
+	public fun encryptBlock (Lcom/ditchoom/buffer/crypto/AesEcbKey;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;)Lcom/ditchoom/buffer/PlatformBuffer;
+	public abstract fun encryptBlock (Lcom/ditchoom/buffer/crypto/AesEcbKey;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/WriteBuffer;)V
+	public static synthetic fun encryptBlock$default (Lcom/ditchoom/buffer/crypto/AesEcbOps;Lcom/ditchoom/buffer/crypto/AesEcbKey;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;ILjava/lang/Object;)Lcom/ditchoom/buffer/PlatformBuffer;
+}
+
+public final class com/ditchoom/buffer/crypto/AesEcbOps$DefaultImpls {
+	public static fun decryptBlock (Lcom/ditchoom/buffer/crypto/AesEcbOps;Lcom/ditchoom/buffer/crypto/AesEcbKey;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;)Lcom/ditchoom/buffer/PlatformBuffer;
+	public static synthetic fun decryptBlock$default (Lcom/ditchoom/buffer/crypto/AesEcbOps;Lcom/ditchoom/buffer/crypto/AesEcbKey;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;ILjava/lang/Object;)Lcom/ditchoom/buffer/PlatformBuffer;
+	public static fun encryptBlock (Lcom/ditchoom/buffer/crypto/AesEcbOps;Lcom/ditchoom/buffer/crypto/AesEcbKey;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;)Lcom/ditchoom/buffer/PlatformBuffer;
+	public static synthetic fun encryptBlock$default (Lcom/ditchoom/buffer/crypto/AesEcbOps;Lcom/ditchoom/buffer/crypto/AesEcbKey;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;ILjava/lang/Object;)Lcom/ditchoom/buffer/PlatformBuffer;
+}
+
+public final class com/ditchoom/buffer/crypto/AesEcb_jvmCommonKt {
+	public static final fun getAesEcb (Lcom/ditchoom/buffer/crypto/CryptoCapabilities;)Lcom/ditchoom/buffer/crypto/AesEcb;
+}
+
 public abstract interface class com/ditchoom/buffer/crypto/AesGcmKey : com/ditchoom/buffer/crypto/AeadKey, java/lang/AutoCloseable {
 	public static final field Companion Lcom/ditchoom/buffer/crypto/AesGcmKey$Companion;
 	public abstract fun getCustody ()Lcom/ditchoom/buffer/crypto/KeyCustody;
@@ -175,6 +238,7 @@ public abstract class com/ditchoom/buffer/crypto/CryptoMisuseException : com/dit
 public final class com/ditchoom/buffer/crypto/CryptoRandomKt {
 	public static final fun cryptoRandom (ILcom/ditchoom/buffer/BufferFactory;)Lcom/ditchoom/buffer/PlatformBuffer;
 	public static synthetic fun cryptoRandom$default (ILcom/ditchoom/buffer/BufferFactory;ILjava/lang/Object;)Lcom/ditchoom/buffer/PlatformBuffer;
+	public static final fun getSecureRandom ()Lkotlin/random/Random;
 }
 
 public final class com/ditchoom/buffer/crypto/CryptoRandom_jvmCommonKt {

--- a/buffer-crypto/api/jvm/buffer-crypto.api
+++ b/buffer-crypto/api/jvm/buffer-crypto.api
@@ -99,6 +99,69 @@ public final class com/ditchoom/buffer/crypto/Aead_jvmCommonKt {
 	public static final fun getChaChaPoly (Lcom/ditchoom/buffer/crypto/CryptoCapabilities;)Lcom/ditchoom/buffer/crypto/OptionalAead;
 }
 
+public abstract interface class com/ditchoom/buffer/crypto/AesEcb {
+}
+
+public final class com/ditchoom/buffer/crypto/AesEcb$Blocking : com/ditchoom/buffer/crypto/AesEcb {
+	public fun <init> (Lcom/ditchoom/buffer/crypto/AesEcbOps;)V
+	public final fun component1 ()Lcom/ditchoom/buffer/crypto/AesEcbOps;
+	public final fun copy (Lcom/ditchoom/buffer/crypto/AesEcbOps;)Lcom/ditchoom/buffer/crypto/AesEcb$Blocking;
+	public static synthetic fun copy$default (Lcom/ditchoom/buffer/crypto/AesEcb$Blocking;Lcom/ditchoom/buffer/crypto/AesEcbOps;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/AesEcb$Blocking;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOps ()Lcom/ditchoom/buffer/crypto/AesEcbOps;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/AesEcb$Unavailable : com/ditchoom/buffer/crypto/AesEcb {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/AesEcb$Unavailable;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/AesEcbKey : java/lang/AutoCloseable {
+	public static final field Companion Lcom/ditchoom/buffer/crypto/AesEcbKey$Companion;
+	public abstract fun getCustody ()Lcom/ditchoom/buffer/crypto/KeyCustody;
+	public fun getProvenance ()Lcom/ditchoom/buffer/crypto/KeyProvenance;
+	public abstract fun getSizeBits ()I
+	public fun getSizeBytes ()I
+}
+
+public final class com/ditchoom/buffer/crypto/AesEcbKey$Companion {
+	public final fun of (Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;)Lcom/ditchoom/buffer/crypto/AesEcbKey;
+	public static synthetic fun of$default (Lcom/ditchoom/buffer/crypto/AesEcbKey$Companion;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/AesEcbKey;
+}
+
+public final class com/ditchoom/buffer/crypto/AesEcbKey$DefaultImpls {
+	public static fun getProvenance (Lcom/ditchoom/buffer/crypto/AesEcbKey;)Lcom/ditchoom/buffer/crypto/KeyProvenance;
+	public static fun getSizeBytes (Lcom/ditchoom/buffer/crypto/AesEcbKey;)I
+}
+
+public final class com/ditchoom/buffer/crypto/AesEcbKt {
+	public static final field AES_ECB_BLOCK_BYTES I
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/AesEcbOps {
+	public fun decryptBlock (Lcom/ditchoom/buffer/crypto/AesEcbKey;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;)Lcom/ditchoom/buffer/PlatformBuffer;
+	public abstract fun decryptBlock (Lcom/ditchoom/buffer/crypto/AesEcbKey;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/WriteBuffer;)V
+	public static synthetic fun decryptBlock$default (Lcom/ditchoom/buffer/crypto/AesEcbOps;Lcom/ditchoom/buffer/crypto/AesEcbKey;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;ILjava/lang/Object;)Lcom/ditchoom/buffer/PlatformBuffer;
+	public fun encryptBlock (Lcom/ditchoom/buffer/crypto/AesEcbKey;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;)Lcom/ditchoom/buffer/PlatformBuffer;
+	public abstract fun encryptBlock (Lcom/ditchoom/buffer/crypto/AesEcbKey;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/WriteBuffer;)V
+	public static synthetic fun encryptBlock$default (Lcom/ditchoom/buffer/crypto/AesEcbOps;Lcom/ditchoom/buffer/crypto/AesEcbKey;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;ILjava/lang/Object;)Lcom/ditchoom/buffer/PlatformBuffer;
+}
+
+public final class com/ditchoom/buffer/crypto/AesEcbOps$DefaultImpls {
+	public static fun decryptBlock (Lcom/ditchoom/buffer/crypto/AesEcbOps;Lcom/ditchoom/buffer/crypto/AesEcbKey;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;)Lcom/ditchoom/buffer/PlatformBuffer;
+	public static synthetic fun decryptBlock$default (Lcom/ditchoom/buffer/crypto/AesEcbOps;Lcom/ditchoom/buffer/crypto/AesEcbKey;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;ILjava/lang/Object;)Lcom/ditchoom/buffer/PlatformBuffer;
+	public static fun encryptBlock (Lcom/ditchoom/buffer/crypto/AesEcbOps;Lcom/ditchoom/buffer/crypto/AesEcbKey;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;)Lcom/ditchoom/buffer/PlatformBuffer;
+	public static synthetic fun encryptBlock$default (Lcom/ditchoom/buffer/crypto/AesEcbOps;Lcom/ditchoom/buffer/crypto/AesEcbKey;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;ILjava/lang/Object;)Lcom/ditchoom/buffer/PlatformBuffer;
+}
+
+public final class com/ditchoom/buffer/crypto/AesEcb_jvmCommonKt {
+	public static final fun getAesEcb (Lcom/ditchoom/buffer/crypto/CryptoCapabilities;)Lcom/ditchoom/buffer/crypto/AesEcb;
+}
+
 public abstract interface class com/ditchoom/buffer/crypto/AesGcmKey : com/ditchoom/buffer/crypto/AeadKey, java/lang/AutoCloseable {
 	public static final field Companion Lcom/ditchoom/buffer/crypto/AesGcmKey$Companion;
 	public abstract fun getCustody ()Lcom/ditchoom/buffer/crypto/KeyCustody;
@@ -160,6 +223,7 @@ public abstract class com/ditchoom/buffer/crypto/CryptoMisuseException : com/dit
 public final class com/ditchoom/buffer/crypto/CryptoRandomKt {
 	public static final fun cryptoRandom (ILcom/ditchoom/buffer/BufferFactory;)Lcom/ditchoom/buffer/PlatformBuffer;
 	public static synthetic fun cryptoRandom$default (ILcom/ditchoom/buffer/BufferFactory;ILjava/lang/Object;)Lcom/ditchoom/buffer/PlatformBuffer;
+	public static final fun getSecureRandom ()Lkotlin/random/Random;
 }
 
 public final class com/ditchoom/buffer/crypto/CryptoRandom_jvmCommonKt {

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/AesEcb.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/AesEcb.apple.kt
@@ -1,0 +1,84 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.value
+import platform.CoreCrypto.CCCrypt
+import platform.CoreCrypto.CCOperation
+import platform.CoreCrypto.kCCAlgorithmAES
+import platform.CoreCrypto.kCCDecrypt
+import platform.CoreCrypto.kCCEncrypt
+import platform.CoreCrypto.kCCOptionECBMode
+import platform.CoreCrypto.kCCSuccess
+import platform.posix.size_tVar
+
+/*
+ * Apple single-block AES (ECB) backed by CommonCrypto's public one-shot CCCrypt API.
+ *
+ * Unlike AES-GCM (whose streaming SPI entry points are absent from Kotlin/Native's binding and need
+ * the `commoncryptogcm` cinterop), ECB is one of CommonCrypto's *public* modes and is exposed
+ * directly by platform.CoreCrypto — so no extra cinterop is required. We call CCCrypt with
+ * kCCAlgorithmAES + kCCOptionECBMode and no padding option, over exactly one 16-byte block (the
+ * common witness op validates the length/room first). ECB takes no IV, so it is passed as null.
+ *
+ * This file is verified on macOS CI; the cross-platform KAT suite gates it on Mac.
+ */
+
+/** Single-block AES is synchronous via CommonCrypto's CCCrypt (public ECB mode). */
+actual val CryptoCapabilities.aesEcb: AesEcb get() = AesEcb.Blocking(AesEcbBlockingOps)
+
+internal actual fun aesEcbEncryptBlock(
+    key: AesEcbKey,
+    block: ReadBuffer,
+    dest: WriteBuffer,
+): Unit = ecbCrypt(kCCEncrypt, key, block, dest)
+
+internal actual fun aesEcbDecryptBlock(
+    key: AesEcbKey,
+    block: ReadBuffer,
+    dest: WriteBuffer,
+): Unit = ecbCrypt(kCCDecrypt, key, block, dest)
+
+private fun ecbCrypt(
+    op: CCOperation,
+    key: AesEcbKey,
+    block: ReadBuffer,
+    dest: WriteBuffer,
+) {
+    memScoped {
+        val moved = alloc<size_tVar>()
+        var status = kCCSuccess + 1
+        key.requireInMemoryMaterial().withRemainingBytes { keyPtr, keyLen ->
+            block.withRemainingBytes { inPtr, _ ->
+                // No padding option (kCCOptionECBMode only) — this is the bare block permutation.
+                dest.withWritablePointer(AES_ECB_BLOCK_BYTES) { outPtr ->
+                    status =
+                        CCCrypt(
+                            op,
+                            kCCAlgorithmAES,
+                            kCCOptionECBMode,
+                            keyPtr,
+                            keyLen.convert(),
+                            null, // ECB uses no IV
+                            inPtr,
+                            AES_ECB_BLOCK_BYTES.convert(),
+                            outPtr,
+                            AES_ECB_BLOCK_BYTES.convert(),
+                            moved.ptr,
+                        )
+                }
+            }
+        }
+        check(status == kCCSuccess) { "AES-ECB failed (status=$status)" }
+        check(moved.value.toInt() == AES_ECB_BLOCK_BYTES) {
+            "AES-ECB produced ${moved.value} bytes, expected $AES_ECB_BLOCK_BYTES"
+        }
+    }
+}

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/AesEcb.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/AesEcb.kt
@@ -1,0 +1,260 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+
+/*
+ * Raw single-block AES (ECB) — the bare AES block permutation, not a general-purpose cipher.
+ *
+ * This is a deliberately low-level primitive: it enciphers exactly one 16-byte block under an
+ * AES-128 or AES-256 key, with **no** IV, no chaining, no padding, and no authentication. It exists
+ * so that standard constructions which use AES only as a keyed pseudorandom permutation can be built
+ * inside this module rather than reaching for raw platform crypto.
+ *
+ * WARNING — do NOT use this to encrypt application data. ECB reveals plaintext structure: equal
+ * plaintext blocks produce equal ciphertext blocks under the same key, so it hides nothing about
+ * message content and is unauthenticated (it detects no tampering). For confidentiality use the
+ * AEAD family ([CryptoCapabilities.aesGcm] / [CryptoCapabilities.chaChaPoly]). The only intended
+ * uses of this primitive are keystream/PRF constructions that run AES forward once, e.g. **DTLS 1.3
+ * / TLS 1.3 record sequence-number encryption** (RFC 9147 §4.2.3 / RFC 8446 §5.4.1): the mask is
+ * `AES-ECB-encrypt(sn_key, ciphertext_sample)` and both sender and receiver recover the sequence
+ * number by XORing that mask — so the forward ([encryptBlock]) direction alone suffices there.
+ *
+ * Availability. The primitive is reached through a capability witness ([AesEcb]), like the AEAD
+ * family, so a platform that cannot provide it is a `sealed` [AesEcb.Unavailable] value rather than a
+ * throwing call. AES-ECB is [AesEcb.Blocking] (native, synchronous) on JVM, Android, Apple, and
+ * Linux, and [AesEcb.Unavailable] on js/wasmJs — WebCrypto exposes no ECB mode, and DTLS 1.3 (the
+ * motivating consumer) does not run on the web, so it is deliberately not polyfilled there.
+ */
+
+/** AES block size in bytes — the fixed input/output width of a single [CryptoCapabilities.aesEcb] op. */
+const val AES_ECB_BLOCK_BYTES: Int = 16
+
+// =============================================================================
+// Key type (sealed: only the library-provided in-memory key; impl is internal)
+// =============================================================================
+
+/**
+ * A raw-AES key for the single-block ECB primitive, carrying its [sizeBits] (128 or 256) so a key of
+ * one size cannot be silently used where another was meant. A distinct type from [AesGcmKey] so an
+ * authenticated-encryption key and a raw-block key can never be cross-used.
+ *
+ * `sealed` with a single internal in-memory implementation produced by [of]; downstream cannot supply
+ * an attacker-controlled key. Key material is copied into a buffer from the factory passed to [of] —
+ * by default a secure deterministic one (matching [AesGcmKey] and [SigningKey]), so the copy is zeroed
+ * and freed by [close]. There is no hardware-backed variant: raw single-block AES is a software
+ * construction seam, not a key-custody surface.
+ */
+sealed interface AesEcbKey : AutoCloseable {
+    /** 128 or 256 — the AES key size in bits. */
+    val sizeBits: Int
+
+    /** This key's custody. Always [KeyCustody.ExportableSoftware] for the in-memory key. */
+    val custody: KeyCustody
+
+    /** Whether the key material is in software memory or hardware-backed. Derived from [custody]. */
+    val provenance: KeyProvenance get() = custody.provenance
+
+    /** Key size in bytes (16 for AES-128, 32 for AES-256). */
+    val sizeBytes: Int get() = sizeBits / 8
+
+    companion object {
+        /**
+         * Wraps [key]'s remaining bytes as an in-memory raw-AES key. The length must be exactly 16
+         * (AES-128) or 32 (AES-256) bytes; any other length is rejected. The bytes are copied into a
+         * buffer from [factory] — secure and deterministic by default, so the copy is wiped and freed
+         * by [close] (align with [AesGcmKey]; pass a non-secure factory to opt out).
+         */
+        fun of(
+            key: ReadBuffer,
+            factory: BufferFactory = BufferFactory.deterministicSecure(),
+        ): AesEcbKey {
+            val n = key.remaining()
+            require(n == AES_128_KEY_BYTES || n == AES_256_KEY_BYTES) {
+                "AES-ECB key must be $AES_128_KEY_BYTES or $AES_256_KEY_BYTES bytes, was $n"
+            }
+            return InMemoryAesEcbKey(n * Byte.SIZE_BITS, copyBuffer(key, factory))
+        }
+    }
+}
+
+/** In-memory [AesEcbKey]: holds the raw key bytes, freed (and wiped, on a secure backing) on [close]. */
+internal class InMemoryAesEcbKey(
+    override val sizeBits: Int,
+    private val material: PlatformBuffer,
+) : AesEcbKey {
+    override val custody: KeyCustody get() = KeyCustody.ExportableSoftware
+    private var closed = false
+
+    override fun close() {
+        if (!closed) {
+            closed = true
+            material.freeNativeMemory()
+        }
+    }
+
+    /** The live key material; throws if the key has been [close]d. */
+    fun requireOpen(): PlatformBuffer {
+        check(!closed) { "AesEcbKey already closed" }
+        return material
+    }
+}
+
+/** The in-memory key material for the blocking native primitives; throws if the key has been closed. */
+internal fun AesEcbKey.requireInMemoryMaterial(): PlatformBuffer =
+    when (this) {
+        is InMemoryAesEcbKey -> requireOpen()
+    }
+
+// =============================================================================
+// Capability witness: operations live ON the witness the platform supplies
+// =============================================================================
+
+/**
+ * Single-block AES (ECB) operations. Both directions encipher/decipher exactly one
+ * [AES_ECB_BLOCK_BYTES]-byte block; any other input length is rejected. Synchronous — every platform
+ * that offers the primitive at all offers it natively and blocking.
+ */
+interface AesEcbOps {
+    /**
+     * Enciphers the single [AES_ECB_BLOCK_BYTES]-byte block in [block] under [key], writing the
+     * ciphertext block into [dest] at its current position (advancing it by [AES_ECB_BLOCK_BYTES]).
+     * [block] must have exactly [AES_ECB_BLOCK_BYTES] bytes remaining and [dest] room for that many.
+     * This is the forward AES permutation used by DTLS 1.3 sequence-number masking.
+     */
+    fun encryptBlock(
+        key: AesEcbKey,
+        block: ReadBuffer,
+        dest: WriteBuffer,
+    )
+
+    /**
+     * Deciphers the single [AES_ECB_BLOCK_BYTES]-byte block in [block] under [key], writing the
+     * recovered block into [dest]. The inverse of [encryptBlock]; not needed for keystream/masking
+     * uses (those run AES forward only) but provided for constructions that invert the permutation.
+     */
+    fun decryptBlock(
+        key: AesEcbKey,
+        block: ReadBuffer,
+        dest: WriteBuffer,
+    )
+
+    /** [encryptBlock] into a fresh read-ready [AES_ECB_BLOCK_BYTES]-byte buffer from [factory]. */
+    fun encryptBlock(
+        key: AesEcbKey,
+        block: ReadBuffer,
+        factory: BufferFactory = BufferFactory.Default,
+    ): PlatformBuffer {
+        val out = factory.allocate(AES_ECB_BLOCK_BYTES)
+        encryptBlock(key, block, out)
+        out.resetForRead()
+        return out
+    }
+
+    /** [decryptBlock] into a fresh read-ready [AES_ECB_BLOCK_BYTES]-byte buffer from [factory]. */
+    fun decryptBlock(
+        key: AesEcbKey,
+        block: ReadBuffer,
+        factory: BufferFactory = BufferFactory.Default,
+    ): PlatformBuffer {
+        val out = factory.allocate(AES_ECB_BLOCK_BYTES)
+        decryptBlock(key, block, out)
+        out.resetForRead()
+        return out
+    }
+}
+
+/**
+ * Capability witness for the single-block AES primitive: [Blocking] on JVM/Android/Apple/Linux,
+ * [Unavailable] on js/wasmJs (no ECB in WebCrypto). There is no async variant — a platform either has
+ * a synchronous native block cipher or does not offer the primitive at all.
+ */
+sealed interface AesEcb {
+    /** The primitive is not available on this platform (cannot be reached at all). */
+    data object Unavailable : AesEcb
+
+    /** A synchronous native path is available. */
+    data class Blocking(
+        val ops: AesEcbOps,
+    ) : AesEcb
+}
+
+/**
+ * The single-block AES (ECB) capability on this platform: [AesEcb.Blocking] on JVM/Android/Apple/Linux,
+ * [AesEcb.Unavailable] on js/wasmJs. See the file header for the (narrow) intended uses and the
+ * standing ECB warning.
+ */
+expect val CryptoCapabilities.aesEcb: AesEcb
+
+// =============================================================================
+// Witness op implementation (common — validates, then calls the platform seam)
+// =============================================================================
+
+/** Single-block AES ops over the synchronous native primitives. */
+internal object AesEcbBlockingOps : AesEcbOps {
+    override fun encryptBlock(
+        key: AesEcbKey,
+        block: ReadBuffer,
+        dest: WriteBuffer,
+    ) {
+        requireSingleBlock(block)
+        requireBlockRoom(dest)
+        aesEcbEncryptBlock(key, block, dest)
+    }
+
+    override fun decryptBlock(
+        key: AesEcbKey,
+        block: ReadBuffer,
+        dest: WriteBuffer,
+    ) {
+        requireSingleBlock(block)
+        requireBlockRoom(dest)
+        aesEcbDecryptBlock(key, block, dest)
+    }
+}
+
+/** Whether the single-block AES primitive is reachable here (the witness is [AesEcb.Blocking]). */
+internal val aesEcbBlockingAvailable: Boolean get() = CryptoCapabilities.aesEcb is AesEcb.Blocking
+
+// =============================================================================
+// Low-level one-shot primitives (synchronous, native-or-throw) — internal seam
+// =============================================================================
+
+/**
+ * Enciphers the single [AES_ECB_BLOCK_BYTES]-byte block in [block] under [key], writing the ciphertext
+ * block into [dest] at its current position. The common witness op validates the block/room; this seam
+ * is the raw platform call.
+ */
+internal expect fun aesEcbEncryptBlock(
+    key: AesEcbKey,
+    block: ReadBuffer,
+    dest: WriteBuffer,
+)
+
+/** Inverse of [aesEcbEncryptBlock]. */
+internal expect fun aesEcbDecryptBlock(
+    key: AesEcbKey,
+    block: ReadBuffer,
+    dest: WriteBuffer,
+)
+
+// =============================================================================
+// Internal validation helpers (shared by the witness op)
+// =============================================================================
+
+/** Rejects an input that is not exactly one [AES_ECB_BLOCK_BYTES]-byte block. */
+internal fun requireSingleBlock(block: ReadBuffer) {
+    require(block.remaining() == AES_ECB_BLOCK_BYTES) {
+        "AES-ECB operates on a single $AES_ECB_BLOCK_BYTES-byte block; input had ${block.remaining()} bytes"
+    }
+}
+
+/** Rejects a destination without room for one [AES_ECB_BLOCK_BYTES]-byte block. */
+internal fun requireBlockRoom(dest: WriteBuffer) {
+    require(dest.remaining() >= AES_ECB_BLOCK_BYTES) {
+        "dest needs $AES_ECB_BLOCK_BYTES bytes remaining, has ${dest.remaining()}"
+    }
+}

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/AesEcbTest.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/AesEcbTest.kt
@@ -1,0 +1,168 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.crypto.CryptoTestVectors.hexBuffer
+import com.ditchoom.buffer.crypto.CryptoTestVectors.toHex
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Single-block AES (ECB) known-answer + round-trip + capability tests.
+ *
+ * The KAT vectors are the canonical FIPS-197 (Appendix C.1 / C.3) and NIST SP 800-38A (Appendix F.1)
+ * single-block pairs; they pin the exact ciphertext so a permutation regression on any native
+ * platform fails here. All ops are capability-gated on [aesEcbOpsOrNull] so the suite compiles and
+ * runs on the web too, where the primitive is [AesEcb.Unavailable].
+ */
+class AesEcbTest {
+    // (key, plaintext block, ciphertext block) — one 16-byte AES block.
+    private data class Vec(
+        val key: String,
+        val pt: String,
+        val ct: String,
+    )
+
+    // FIPS-197 Appendix C.1 (AES-128) and C.3 (AES-256): the reference block-cipher vectors.
+    private val fips197Aes128 =
+        Vec(
+            key = "000102030405060708090a0b0c0d0e0f",
+            pt = "00112233445566778899aabbccddeeff",
+            ct = "69c4e0d86a7b0430d8cdb78070b4c55a",
+        )
+    private val fips197Aes256 =
+        Vec(
+            key = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+            pt = "00112233445566778899aabbccddeeff",
+            ct = "8ea2b7ca516745bfeafc49904b496089",
+        )
+
+    // NIST SP 800-38A F.1.1 / F.1.5 first block (ECB-AES128 / ECB-AES256).
+    private val sp80038aAes128 =
+        Vec(
+            key = "2b7e151628aed2a6abf7158809cf4f3c",
+            pt = "6bc1bee22e409f96e93d7e117393172a",
+            ct = "3ad77bb40d7a3660a89ecaf32466ef97",
+        )
+    private val sp80038aAes256 =
+        Vec(
+            key = "603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4",
+            pt = "6bc1bee22e409f96e93d7e117393172a",
+            ct = "f3eed1bdb5d2a03c064b5a7e3db181f8",
+        )
+
+    private val allVectors = listOf(fips197Aes128, fips197Aes256, sp80038aAes128, sp80038aAes256)
+
+    @Test
+    fun encryptBlockKnownAnswer() {
+        val ops = aesEcbOpsOrNull() ?: return
+        for (v in allVectors) {
+            AesEcbKey.of(hexBuffer(v.key)).use { key ->
+                val ct = ops.encryptBlock(key, hexBuffer(v.pt), BufferFactory.Default)
+                assertEquals(v.ct, ct.toHex(), "AES-ECB encrypt (key=${v.key.length * 4}bit)")
+            }
+        }
+    }
+
+    @Test
+    fun decryptBlockKnownAnswer() {
+        val ops = aesEcbOpsOrNull() ?: return
+        for (v in allVectors) {
+            AesEcbKey.of(hexBuffer(v.key)).use { key ->
+                val pt = ops.decryptBlock(key, hexBuffer(v.ct), BufferFactory.Default)
+                assertEquals(v.pt, pt.toHex(), "AES-ECB decrypt (key=${v.key.length * 4}bit)")
+            }
+        }
+    }
+
+    @Test
+    fun encryptThenDecryptRoundTrips() {
+        val ops = aesEcbOpsOrNull() ?: return
+        for (v in allVectors) {
+            AesEcbKey.of(hexBuffer(v.key)).use { key ->
+                val ct = ops.encryptBlock(key, hexBuffer(v.pt), BufferFactory.Default)
+                val pt = ops.decryptBlock(key, ct, BufferFactory.Default)
+                assertEquals(v.pt, pt.toHex(), "AES-ECB round-trip")
+            }
+        }
+    }
+
+    @Test
+    fun encryptIsDeterministic() {
+        // ECB is a pure keyed permutation: the same block under the same key always maps to the same
+        // ciphertext. This determinism is exactly what DTLS 1.3 sequence-number masking relies on and
+        // exactly why ECB must never be used for bulk confidentiality.
+        val ops = aesEcbOpsOrNull() ?: return
+        AesEcbKey.of(hexBuffer(fips197Aes128.key)).use { key ->
+            val a = ops.encryptBlock(key, hexBuffer(fips197Aes128.pt), BufferFactory.Default)
+            val b = ops.encryptBlock(key, hexBuffer(fips197Aes128.pt), BufferFactory.Default)
+            assertEquals(a.toHex(), b.toHex(), "ECB encrypt must be deterministic")
+        }
+    }
+
+    @Test
+    fun dtlsSequenceNumberMaskRoundTrips() {
+        // Models RFC 9147 §4.2.3 sequence-number encryption: mask = AES-ECB-encrypt(sn_key, sample);
+        // both sides XOR the same mask, so only the forward direction is used. Here we mask an 8-byte
+        // sequence number with the leading mask bytes and recover it.
+        val ops = aesEcbOpsOrNull() ?: return
+        AesEcbKey.of(hexBuffer(fips197Aes128.key)).use { key ->
+            val sample = hexBuffer("112233445566778899aabbccddeeff00")
+            val mask = ops.encryptBlock(key, sample, BufferFactory.Default)
+            // Fold the leading 8 mask bytes into a Long and XOR the 8-byte sequence number with it.
+            var maskWord = 0L
+            for (i in 0 until 8) maskWord = (maskWord shl 8) or (mask.get(i).toLong() and 0xFF)
+            val seq = 0x0001020304050607L
+            val masked = seq xor maskWord
+            val recovered = masked xor maskWord
+            assertTrue(masked != seq, "masking must actually change the sequence number")
+            assertEquals(seq, recovered, "re-XOR with the same forward mask must recover the sequence number")
+        }
+    }
+
+    @Test
+    fun keyLengthValidation() {
+        // Non-16/32-byte key lengths are rejected (192-bit is not supported by this wrapper).
+        assertFailsWith<IllegalArgumentException> { AesEcbKey.of(hexBuffer("00112233")) }
+        assertFailsWith<IllegalArgumentException> {
+            AesEcbKey.of(hexBuffer("000102030405060708090a0b0c0d0e0f1011121314151617"))
+        }
+    }
+
+    @Test
+    fun blockLengthValidation() {
+        val ops = aesEcbOpsOrNull() ?: return
+        AesEcbKey.of(hexBuffer(fips197Aes128.key)).use { key ->
+            // Too short and too long (multi-block) are both rejected — this is a single-block primitive.
+            assertFailsWith<IllegalArgumentException> {
+                ops.encryptBlock(key, hexBuffer("00112233"), BufferFactory.Default)
+            }
+            assertFailsWith<IllegalArgumentException> {
+                ops.encryptBlock(key, hexBuffer(fips197Aes128.pt + fips197Aes128.pt), BufferFactory.Default)
+            }
+            assertFailsWith<IllegalArgumentException> {
+                val dst = BufferFactory.Default.allocate(8)
+                ops.encryptBlock(key, hexBuffer(fips197Aes128.pt), dst)
+            }
+        }
+    }
+
+    @Test
+    fun capabilityContract() {
+        when (val w = CryptoCapabilities.aesEcb) {
+            is AesEcb.Blocking -> {
+                // Native: the primitive is reachable and enciphers a block.
+                assertTrue(aesEcbBlockingAvailable)
+                AesEcbKey.of(hexBuffer(fips197Aes128.key)).use { key ->
+                    val ct = w.ops.encryptBlock(key, hexBuffer(fips197Aes128.pt), BufferFactory.Default)
+                    assertEquals(fips197Aes128.ct, ct.toHex())
+                }
+            }
+            // Web: WebCrypto has no ECB, so the witness is Unavailable — there is no op to call
+            // (impossible by construction, not a throw).
+            AesEcb.Unavailable -> assertEquals(false, aesEcbBlockingAvailable)
+        }
+    }
+}

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/AesEcbWitnessSupport.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/AesEcbWitnessSupport.kt
@@ -1,0 +1,13 @@
+package com.ditchoom.buffer.crypto
+
+/*
+ * Test-only accessor that resolves the single-block AES (ECB) capability witness to its ops, so the
+ * suite can drive it uniformly (Blocking on native, Unavailable on the web → null).
+ */
+
+/** The single-block AES ops, or `null` where the primitive is unavailable (web). */
+internal fun aesEcbOpsOrNull(): AesEcbOps? =
+    when (val w = CryptoCapabilities.aesEcb) {
+        is AesEcb.Blocking -> w.ops
+        AesEcb.Unavailable -> null
+    }

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/CryptoCapabilitiesTest.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/CryptoCapabilitiesTest.kt
@@ -33,6 +33,16 @@ class CryptoCapabilitiesTest {
     }
 
     @Test
+    fun aesEcbWitnessResolves() {
+        // Single-block AES resolves to a native Blocking path or Unavailable (web); the witness must
+        // agree with the blocking-availability helper.
+        when (CryptoCapabilities.aesEcb) {
+            is AesEcb.Blocking -> assertTrue(aesEcbBlockingAvailable, "Blocking implies a sync path")
+            AesEcb.Unavailable -> assertFalse(aesEcbBlockingAvailable, "Unavailable implies no sync path")
+        }
+    }
+
+    @Test
     fun signatureWitnessResolvesForEveryScheme() {
         val schemes =
             listOf(

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/AesEcb.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/AesEcb.jsAndWasmJs.kt
@@ -1,0 +1,31 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+
+/*
+ * js/wasmJs single-block AES (ECB): unavailable.
+ *
+ * WebCrypto's SubtleCrypto exposes no ECB mode (only AES-GCM/CBC/CTR/KW), and DTLS 1.3 — the
+ * motivating consumer of this primitive — does not run on the web, so ECB is deliberately not
+ * polyfilled here. The aesEcb witness is Unavailable and both raw seam functions throw; the primitive
+ * is unreachable by construction rather than via a runtime surprise.
+ */
+
+private const val NO_AES_ECB =
+    "single-block AES (ECB) is not part of WebCrypto and is not polyfilled on the web"
+
+/** Single-block AES (ECB) is not available on the web. */
+actual val CryptoCapabilities.aesEcb: AesEcb get() = AesEcb.Unavailable
+
+internal actual fun aesEcbEncryptBlock(
+    key: AesEcbKey,
+    block: ReadBuffer,
+    dest: WriteBuffer,
+): Unit = throw UnsupportedOperationException(NO_AES_ECB)
+
+internal actual fun aesEcbDecryptBlock(
+    key: AesEcbKey,
+    block: ReadBuffer,
+    dest: WriteBuffer,
+): Unit = throw UnsupportedOperationException(NO_AES_ECB)

--- a/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/Aead.jvmCommon.kt
+++ b/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/Aead.jvmCommon.kt
@@ -177,7 +177,7 @@ internal fun requireTagged(ciphertextAndTag: ReadBuffer) {
  * so the wipe cannot affect the spec and the raw key does not linger on the heap. The wipe runs in
  * a `finally` so the staged key is erased even when the spec constructor rejects the material.
  */
-private fun keySpec(
+internal fun keySpec(
     key: ReadBuffer,
     algorithm: String,
 ): SecretKeySpec {

--- a/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/AesEcb.jvmCommon.kt
+++ b/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/AesEcb.jvmCommon.kt
@@ -1,0 +1,40 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import javax.crypto.Cipher
+
+/*
+ * JVM/Android single-block AES (ECB) backed by JCA.
+ *
+ * Uses the `AES/ECB/NoPadding` transform on a single 16-byte block — the bare AES permutation, with
+ * no padding, no chaining, and no authentication (see the common `AesEcb.kt` header for the intended
+ * uses and the ECB warning). The common witness op validates the block length and destination room
+ * before this seam is reached; `finalInto` runs `doFinal` straight into the destination buffer.
+ */
+
+/** Single-block AES is synchronous via JCA. */
+actual val CryptoCapabilities.aesEcb: AesEcb get() = AesEcb.Blocking(AesEcbBlockingOps)
+
+internal actual fun aesEcbEncryptBlock(
+    key: AesEcbKey,
+    block: ReadBuffer,
+    dest: WriteBuffer,
+): Unit = ecbCrypt(Cipher.ENCRYPT_MODE, key, block, dest)
+
+internal actual fun aesEcbDecryptBlock(
+    key: AesEcbKey,
+    block: ReadBuffer,
+    dest: WriteBuffer,
+): Unit = ecbCrypt(Cipher.DECRYPT_MODE, key, block, dest)
+
+private fun ecbCrypt(
+    mode: Int,
+    key: AesEcbKey,
+    block: ReadBuffer,
+    dest: WriteBuffer,
+) {
+    val cipher = Cipher.getInstance("AES/ECB/NoPadding")
+    cipher.init(mode, keySpec(key.requireInMemoryMaterial(), "AES"))
+    finalInto(cipher, block, dest)
+}

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/AesEcb.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/AesEcb.linux.kt
@@ -1,0 +1,71 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.crypto.cinterop.boringssl.BCL_OK
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_aes_ecb_decrypt_block
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_aes_ecb_encrypt_block
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.reinterpret
+
+/*
+ * Linux single-block AES (ECB) backed by BoringSSL's low-level AES_encrypt/AES_decrypt.
+ *
+ * The bare keyed block permutation over one 16-byte block — no IV, no chaining, no padding, no
+ * authentication (see the common AesEcb.kt header for intended uses and the ECB warning). The common
+ * witness op validates block length and destination room before this seam; the C wrappers
+ * (bcl_aes_ecb_*) key the AES schedule and transform the single block straight into dest.
+ */
+
+/** Single-block AES is synchronous via BoringSSL on Linux. */
+actual val CryptoCapabilities.aesEcb: AesEcb get() = AesEcb.Blocking(AesEcbBlockingOps)
+
+internal actual fun aesEcbEncryptBlock(
+    key: AesEcbKey,
+    block: ReadBuffer,
+    dest: WriteBuffer,
+): Unit = ecbCrypt(encrypt = true, key.requireInMemoryMaterial(), block, dest)
+
+internal actual fun aesEcbDecryptBlock(
+    key: AesEcbKey,
+    block: ReadBuffer,
+    dest: WriteBuffer,
+): Unit = ecbCrypt(encrypt = false, key.requireInMemoryMaterial(), block, dest)
+
+private fun ecbCrypt(
+    encrypt: Boolean,
+    keyMaterial: ReadBuffer,
+    block: ReadBuffer,
+    dest: WriteBuffer,
+) {
+    memScoped {
+        var status = BCL_OK - 1
+        keyMaterial.withRemainingBytes { keyPtr, keyLen ->
+            block.withRemainingBytes { inPtr, _ ->
+                dest.withWritablePointer(AES_ECB_BLOCK_BYTES) { outPtr ->
+                    status =
+                        if (encrypt) {
+                            bcl_aes_ecb_encrypt_block(
+                                keyPtr.reinterpret(),
+                                keyLen.convert(),
+                                inPtr.reinterpret(),
+                                outPtr.reinterpret(),
+                            )
+                        } else {
+                            bcl_aes_ecb_decrypt_block(
+                                keyPtr.reinterpret(),
+                                keyLen.convert(),
+                                inPtr.reinterpret(),
+                                outPtr.reinterpret(),
+                            )
+                        }
+                }
+            }
+        }
+        check(status == BCL_OK) { "AES-ECB failed (status=$status)" }
+    }
+}

--- a/buffer-crypto/src/nativeInterop/cinterop/boringsslcrypto.def
+++ b/buffer-crypto/src/nativeInterop/cinterop/boringsslcrypto.def
@@ -14,7 +14,7 @@ package = com.ditchoom.buffer.crypto.cinterop.boringssl
 # (libraryPaths / staticLibraries) are injected by buffer-crypto/build.gradle.kts so the
 # same .def works for both the reused prebuilt (alien dev box) and the CI-built BoringSSL.
 
-headers = openssl/evp.h openssl/sha.h openssl/hmac.h openssl/aead.h openssl/ec.h openssl/ec_key.h openssl/ecdsa.h openssl/ecdh.h openssl/curve25519.h openssl/nid.h openssl/bn.h openssl/rand.h openssl/hkdf.h openssl/mem.h openssl/err.h openssl/crypto.h stdint.h string.h
+headers = openssl/evp.h openssl/sha.h openssl/hmac.h openssl/aead.h openssl/aes.h openssl/ec.h openssl/ec_key.h openssl/ecdsa.h openssl/ecdh.h openssl/curve25519.h openssl/nid.h openssl/bn.h openssl/rand.h openssl/hkdf.h openssl/mem.h openssl/err.h openssl/crypto.h stdint.h string.h
 
 compilerOpts.linux = -D_GNU_SOURCE
 
@@ -194,6 +194,32 @@ static inline int bcl_chacha_open(
     uint8_t *out, size_t out_cap, size_t *out_len) {
     return bcl_aead_open(EVP_aead_chacha20_poly1305(), key, key_len, nonce, nonce_len,
                          aad, aad_len, ct, ct_len, out, out_cap, out_len);
+}
+
+/* ===========================================================================
+ * Single-block AES (ECB): the bare keyed block permutation, one 16-byte block.
+ * Uses BoringSSL's low-level AES_encrypt/AES_decrypt — no IV, no chaining, no padding,
+ * no authentication. Intended only for keystream/PRF constructions (e.g. DTLS 1.3
+ * sequence-number masking), never for bulk confidentiality. key_len is 16 or 32 bytes.
+ * =========================================================================== */
+
+static inline int bcl_aes_ecb_encrypt_block(
+    const uint8_t *key, size_t key_len,
+    const uint8_t *in16, uint8_t *out16) {
+    AES_KEY aeskey;
+    if (AES_set_encrypt_key(key, (unsigned)(key_len * 8), &aeskey) != 0) return BCL_ERR;
+    AES_encrypt(in16, out16, &aeskey);
+    OPENSSL_cleanse(&aeskey, sizeof(aeskey));
+    return BCL_OK;
+}
+static inline int bcl_aes_ecb_decrypt_block(
+    const uint8_t *key, size_t key_len,
+    const uint8_t *in16, uint8_t *out16) {
+    AES_KEY aeskey;
+    if (AES_set_decrypt_key(key, (unsigned)(key_len * 8), &aeskey) != 0) return BCL_ERR;
+    AES_decrypt(in16, out16, &aeskey);
+    OPENSSL_cleanse(&aeskey, sizeof(aeskey));
+    return BCL_OK;
 }
 
 /* ===========================================================================

--- a/docs/docs/recipes/cryptography.md
+++ b/docs/docs/recipes/cryptography.md
@@ -30,6 +30,7 @@ Cryptographic **operations** do not live on free functions. Each family exposes 
 |---|---|---|
 | AES-GCM | `CryptoCapabilities.aesGcm` → `Aead` | `Blocking` (native) · `AsyncOnly` (web) |
 | ChaCha20-Poly1305 | `CryptoCapabilities.chaChaPoly` → `OptionalAead` | `Blocking` · `AsyncOnly` · `Unavailable` |
+| AES-ECB (single block, raw) | `CryptoCapabilities.aesEcb` → `AesEcb` | `Blocking` (native) · `Unavailable` (web) |
 | Signatures | `CryptoCapabilities.signatures(scheme)` → `SignatureSupport` | `Blocking` · `AsyncOnly` · `Unavailable` |
 | Key agreement | `CryptoCapabilities.keyAgreement(curve)` → `KeyAgreementSupport` | `Blocking` · `AsyncOnly` · `Unavailable` |
 | HPKE | `CryptoCapabilities.hpke(suite)` → `HpkeSupport` | `Supported` · `Unsupported` |
@@ -131,6 +132,33 @@ The output is bare `ciphertext ‖ tag`; the receiver reconstructs the same `non
 :::danger You now own nonce uniqueness
 The self-framing ops make `(key, nonce)` reuse impossible by construction; the explicit-nonce ops hand that guarantee to you. **Reusing a `(key, nonce)` pair with AES-GCM or ChaCha20-Poly1305 is catastrophic** — it leaks the XOR of the two plaintexts, and for GCM leaks the authentication key, enabling forgery. Use these ops only with a derivation that provably yields a fresh nonce for every message under a given key (a monotonic counter that never rewinds, a ratchet, etc.). If you're unsure, use the self-framing `seal` / `open` — or, for a managed per-message counter, an [HPKE context](#hpke-rfc-9180), which derives `base_nonce XOR seq` for you and advances it only on success.
 :::
+
+## Single-block AES (ECB)
+
+:::danger ECB is not a general-purpose cipher
+`CryptoCapabilities.aesEcb` is the **bare keyed AES permutation over one 16-byte block** — no IV, no chaining, no padding, no authentication. Equal plaintext blocks map to equal ciphertext blocks under the same key, so **ECB hides nothing about message content and detects no tampering. Never use it to encrypt application data** — use the [AEAD](#seal--open-aead) family for confidentiality. This primitive exists only for standard constructions that use AES as a keyed pseudorandom permutation and run it forward once.
+:::
+
+The motivating use is **DTLS 1.3 / TLS 1.3 record sequence-number encryption** (RFC 9147 §4.2.3 / RFC 8446 §5.4.1): the mask is `AES-ECB-encrypt(sn_key, ciphertext_sample)`, and both peers recover the sequence number by XORing that mask — so only the forward (`encryptBlock`) direction is needed.
+
+The witness is `AesEcb.Blocking` on JVM/Android/Apple/Linux and `AesEcb.Unavailable` on JS/WASM (WebCrypto has no ECB mode, and DTLS 1.3 does not run on the web):
+
+```kotlin
+import com.ditchoom.buffer.crypto.*
+
+val block = when (val ecb = CryptoCapabilities.aesEcb) {
+    is AesEcb.Blocking -> {
+        // 16-byte (AES-128) or 32-byte (AES-256) key; here from a KDF/key schedule.
+        AesEcbKey.of(cryptoRandom(AES_128_KEY_BYTES)).use { key ->
+            // block must be exactly AES_ECB_BLOCK_BYTES (16); any other length is rejected.
+            ecb.ops.encryptBlock(key, sample) // → fresh read-ready 16-byte ciphertext block
+        }
+    }
+    AesEcb.Unavailable -> error("single-block AES is unavailable on this platform (web)")
+}
+```
+
+`encryptBlock` / `decryptBlock` also have a `(key, block, dest: WriteBuffer)` overload that writes straight into a destination buffer. `decryptBlock` inverts the permutation; it is unnecessary for keystream/masking uses (those run AES forward only) but is provided for constructions that invert a block. Keys are typed and sized (`AesEcbKey`), so an AES-128 and an AES-256 key can't be confused, and the material is wiped on `close()` (use `use { }`).
 
 ## Sign / Verify
 
@@ -639,6 +667,7 @@ Capability flags are tested error paths, not assumptions — the witness drives 
 | SHA-256/384/512, HMAC, HKDF | ✅ | ✅ | ✅ | ✅ | ✅ (pure-Kotlin core) |
 | AES-GCM 128/256 | ✅ | ✅ | ✅ | ✅ | ✅ (WebCrypto, async only) |
 | ChaCha20-Poly1305 | ✅ (JDK 11+) | ✅ | ✅ | ✅ | ❌ unavailable — not in WebCrypto |
+| AES-ECB (single block, raw — unauthenticated) | ✅ | ✅ | ✅ | ✅ | ❌ unavailable — no ECB in WebCrypto |
 | ECDSA P-256/384/521 (verify) | ✅ | ✅ | ✅ | ✅ | ✅ |
 | ECDSA signing | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Ed25519 | ✅ (JDK 15+) | ❌ **all API levels** | ✅ | ✅ | ✅ newer engines (feature-detected) |


### PR DESCRIPTION
## What

Adds `CryptoCapabilities.aesEcb` — the **bare keyed AES block permutation over one 16-byte block**: no IV, chaining, padding, or authentication. It follows the existing AEAD capability-witness pattern but is standalone (unauthenticated, so it does not touch `AeadKey`).

## Why

It is the primitive needed for **DTLS 1.3 / TLS 1.3 record sequence-number encryption** (RFC 9147 §4.2.3 / RFC 8446 §5.4.1), where the sequence-number mask is `AES-ECB-encrypt(sn_key, ciphertext_sample)` and both peers recover the sequence number by XORing that mask — so only the forward direction is used. More generally it unlocks standard constructions that use AES as a keyed PRP (CMAC, KW, CTR building blocks) inside the module instead of reaching for raw platform crypto.

**ECB is not a general-purpose cipher.** Equal plaintext blocks map to equal ciphertext blocks under the same key, so it hides nothing about content and detects no tampering. The docs and `SECURITY.md` carry a prominent "never for bulk confidentiality — use AEAD" warning, and the API is deliberately single-block / no-padding to keep it a pure block primitive.

## API (additive → `minor`)

- `AesEcbKey.of(key, factory)` — typed/sized (AES-128/256), secure-wiped on `close()`, no hardware variant.
- `CryptoCapabilities.aesEcb` → `AesEcb.Blocking(ops)` on native, `AesEcb.Unavailable` on web.
- `AesEcbOps.encryptBlock` / `decryptBlock` — single 16-byte block into a `WriteBuffer` or a fresh buffer. Multi-block and non-16-byte inputs are rejected.

## Backends

| Platform | Backend |
|---|---|
| JVM/Android | JCA `AES/ECB/NoPadding` (reuses `keySpec`, widened to `internal`) |
| Linux | BoringSSL `AES_encrypt`/`AES_decrypt` via new `bcl_aes_ecb_*` wrappers (+ `openssl/aes.h`) |
| Apple | public CommonCrypto `CCCrypt` + `kCCOptionECBMode` (no new cinterop) |
| JS/WASM | `Unavailable` — WebCrypto has no ECB, and DTLS 1.3 does not run on the web |

## Tests

`AesEcbTest`: FIPS-197 Appendix C.1/C.3 **and** NIST SP 800-38A F.1 single-block KAT (AES-128/256), encrypt/decrypt round-trip, determinism, a DTLS-1.3 sequence-number-mask round-trip, key/block-length + capability-contract negatives; wired into `CryptoCapabilitiesTest`.

Verified green on **JVM, JS, WASM, Linux (BoringSSL, against the NIST vectors), and a real Android emulator (API 34, `connectedDebugAndroidTest` on ART/Conscrypt)**. The Apple actual is written to the documented CommonCrypto pattern and is CI-gated on macOS, matching the module convention.

## Also

- Regenerated `api/jvm` + `api/android` BCV dumps. (These also pick up a pre-existing `secureRandom` line that was missing from the checked-in dump on `main`; regenerating correctly includes it and `apiCheck` requires it.)
- Updated `SECURITY.md` (test inventory, platform matrix, dedicated ECB attack-vector table) and the cryptography recipe docs (witness table, capability matrix, usage section with the ECB warning).
- `apiCheck`, `ktlintCheck`, and JVM/JS/WASM/Linux suites all pass.