### PR TITLE
feat(crypto): public deriveTlsPremasterSecret for raw (EC)DHE / TLS premaster

### DIFF
--- a/buffer-crypto/SECURITY.md
+++ b/buffer-crypto/SECURITY.md
@@ -81,7 +81,9 @@ Run the full suite:
   single-block KAT, encrypt/decrypt round-trip, key/block-length validation, capability contract)
 - Signatures: `SignatureKatTest`, `SignatureWycheproofTest`, `SignatureTamperTest`,
   `SignatureCapabilityTest`, `SignatureBackingTest`
-- Key agreement: `KeyAgreementKatTest`, `KeyAgreementWycheproofTest`, `KeyAgreementTest`
+- Key agreement: `KeyAgreementKatTest`, `KeyAgreementWycheproofTest`, `KeyAgreementTest`,
+  `TlsPremasterSecretTest` (RFC 7748 §5.2 + NIST CAVP P-256 raw-secret KATs, premaster↔KDF
+  consistency, low-order / off-curve rejection)
 - HPKE / DHKEM (RFC 9180): `HpkeKatTest` (RFC 9180 Appendix A vectors, all four modes),
   `HpkeRoundTripTest`, `HpkeTamperTest`, `HpkeBackingTests`, `HpkeCapabilityTest`
 - Non-exportable / hardware-backed keys & custody: `HardwareKeyConformanceTest` (SPI +
@@ -151,9 +153,24 @@ that mask (so only the forward direction is used). For confidentiality use the A
 | X25519 all-zero shared secret | **(b)** constant-time all-zero rejection → `InvalidPublicKey` + **(a)** |
 | Low-order / small-subgroup public point | **(a)** + **(b)**/**(c)** |
 | ECDH invalid-curve / off-curve / infinity point | **(a)** + **(c)** provider rejects; checked & unchecked provider exceptions map uniformly to `InvalidPublicKey` (no exception-type oracle) |
-| Raw shared secret used without a KDF | **(b)/(d)** the API forces HKDF over the shared secret; the raw DH output is never returned |
+| Raw shared secret used without a KDF | **(b)/(d)** the default `deriveSharedSecret` forces HKDF over the shared secret and never returns the raw output; the sole raw path, `deriveTlsPremasterSecret`, is narrowly named for protocol key schedules, carries a standing "not a key" warning, and returns a wiped caller-owned `SecureBuffer` (see the premaster note below) |
 | Compressed/SPKI vs raw-point confusion | **(a)** + **(d)** per-platform encoding pinned |
 | Scalar-mult timing | **(e)** |
+
+#### `deriveTlsPremasterSecret` — the one raw-secret path
+
+`KeyAgreementAsyncOps.deriveTlsPremasterSecret(privateKey, peerPublicKey)` is the **only** public
+API that returns the raw (EC)DHE shared secret (the internal `dhRawSecret` seam otherwise stays
+`internal`, used only by HPKE/DHKEM). It exists so an out-of-module TLS/DTLS stack can obtain the
+material its own key schedule requires — the TLS 1.2/DTLS 1.2 `premaster_secret`, or the TLS
+1.3/DTLS 1.3 (EC)DHE input to `HKDF-Extract`. It is deliberately narrow, and misuse-sensitive:
+
+| Vector | Defense |
+|---|---|
+| Raw DH output used directly as a key | **(d)** named for its single legitimate use (TLS/DTLS premaster / HKDF IKM) with a standing "this is NOT a key — run it through the protocol KDF" warning in the KDoc + this note; `deriveSharedSecret` remains the recommended default |
+| All-zero / low-order / off-curve peer point | **(b)/(c)** identical validation to `deriveSharedSecret` — the shared `dhRawSecret` seam applies the constant-time X25519 all-zero rejection and the uniform provider `InvalidPublicKey` mapping *before* any secret is returned (`TlsPremasterSecretTest`) |
+| Raw secret lingering in memory | **(d)** returned in a wiped `SecureBuffer` the caller owns and MUST free (`use {}` / `freeNativeMemory()`); never logged |
+| Wrong-curve key confusion | **(a)** the ops are curve-bound; a private key off the ops' curve is rejected with `IllegalArgumentException` |
 
 ### KDF / MAC (HKDF, HMAC-SHA-2)
 | Vector | Defense |

--- a/buffer-crypto/api/android/buffer-crypto.api
+++ b/buffer-crypto/api/android/buffer-crypto.api
@@ -844,12 +844,14 @@ public final class com/ditchoom/buffer/crypto/Kex {
 public abstract interface class com/ditchoom/buffer/crypto/KeyAgreementAsyncOps {
 	public abstract fun deriveSharedSecret (Lcom/ditchoom/buffer/crypto/KeyAgreementPrivateKey;Lcom/ditchoom/buffer/crypto/KeyAgreementPublicKey;Lcom/ditchoom/buffer/crypto/Info;ILcom/ditchoom/buffer/crypto/Salt;Lcom/ditchoom/buffer/BufferFactory;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun deriveSharedSecret$default (Lcom/ditchoom/buffer/crypto/KeyAgreementAsyncOps;Lcom/ditchoom/buffer/crypto/KeyAgreementPrivateKey;Lcom/ditchoom/buffer/crypto/KeyAgreementPublicKey;Lcom/ditchoom/buffer/crypto/Info;ILcom/ditchoom/buffer/crypto/Salt;Lcom/ditchoom/buffer/BufferFactory;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public fun deriveTlsPremasterSecret (Lcom/ditchoom/buffer/crypto/KeyAgreementPrivateKey;Lcom/ditchoom/buffer/crypto/KeyAgreementPublicKey;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun generateKeyPair (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getCurve ()Lcom/ditchoom/buffer/crypto/KeyAgreementCurve;
 }
 
 public final class com/ditchoom/buffer/crypto/KeyAgreementAsyncOps$DefaultImpls {
 	public static synthetic fun deriveSharedSecret$default (Lcom/ditchoom/buffer/crypto/KeyAgreementAsyncOps;Lcom/ditchoom/buffer/crypto/KeyAgreementPrivateKey;Lcom/ditchoom/buffer/crypto/KeyAgreementPublicKey;Lcom/ditchoom/buffer/crypto/Info;ILcom/ditchoom/buffer/crypto/Salt;Lcom/ditchoom/buffer/BufferFactory;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static fun deriveTlsPremasterSecret (Lcom/ditchoom/buffer/crypto/KeyAgreementAsyncOps;Lcom/ditchoom/buffer/crypto/KeyAgreementPrivateKey;Lcom/ditchoom/buffer/crypto/KeyAgreementPublicKey;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class com/ditchoom/buffer/crypto/KeyAgreementBlockingOps : com/ditchoom/buffer/crypto/KeyAgreementAsyncOps {
@@ -860,6 +862,7 @@ public abstract interface class com/ditchoom/buffer/crypto/KeyAgreementBlockingO
 
 public final class com/ditchoom/buffer/crypto/KeyAgreementBlockingOps$DefaultImpls {
 	public static synthetic fun deriveSharedSecretBlocking$default (Lcom/ditchoom/buffer/crypto/KeyAgreementBlockingOps;Lcom/ditchoom/buffer/crypto/KeyAgreementPrivateKey;Lcom/ditchoom/buffer/crypto/KeyAgreementPublicKey;Lcom/ditchoom/buffer/crypto/Info;ILcom/ditchoom/buffer/crypto/Salt;Lcom/ditchoom/buffer/BufferFactory;ILjava/lang/Object;)Lcom/ditchoom/buffer/ReadBuffer;
+	public static fun deriveTlsPremasterSecret (Lcom/ditchoom/buffer/crypto/KeyAgreementBlockingOps;Lcom/ditchoom/buffer/crypto/KeyAgreementPrivateKey;Lcom/ditchoom/buffer/crypto/KeyAgreementPublicKey;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class com/ditchoom/buffer/crypto/KeyAgreementCurve {

--- a/buffer-crypto/api/jvm/buffer-crypto.api
+++ b/buffer-crypto/api/jvm/buffer-crypto.api
@@ -829,12 +829,14 @@ public final class com/ditchoom/buffer/crypto/Kex {
 public abstract interface class com/ditchoom/buffer/crypto/KeyAgreementAsyncOps {
 	public abstract fun deriveSharedSecret (Lcom/ditchoom/buffer/crypto/KeyAgreementPrivateKey;Lcom/ditchoom/buffer/crypto/KeyAgreementPublicKey;Lcom/ditchoom/buffer/crypto/Info;ILcom/ditchoom/buffer/crypto/Salt;Lcom/ditchoom/buffer/BufferFactory;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun deriveSharedSecret$default (Lcom/ditchoom/buffer/crypto/KeyAgreementAsyncOps;Lcom/ditchoom/buffer/crypto/KeyAgreementPrivateKey;Lcom/ditchoom/buffer/crypto/KeyAgreementPublicKey;Lcom/ditchoom/buffer/crypto/Info;ILcom/ditchoom/buffer/crypto/Salt;Lcom/ditchoom/buffer/BufferFactory;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public fun deriveTlsPremasterSecret (Lcom/ditchoom/buffer/crypto/KeyAgreementPrivateKey;Lcom/ditchoom/buffer/crypto/KeyAgreementPublicKey;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun generateKeyPair (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getCurve ()Lcom/ditchoom/buffer/crypto/KeyAgreementCurve;
 }
 
 public final class com/ditchoom/buffer/crypto/KeyAgreementAsyncOps$DefaultImpls {
 	public static synthetic fun deriveSharedSecret$default (Lcom/ditchoom/buffer/crypto/KeyAgreementAsyncOps;Lcom/ditchoom/buffer/crypto/KeyAgreementPrivateKey;Lcom/ditchoom/buffer/crypto/KeyAgreementPublicKey;Lcom/ditchoom/buffer/crypto/Info;ILcom/ditchoom/buffer/crypto/Salt;Lcom/ditchoom/buffer/BufferFactory;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static fun deriveTlsPremasterSecret (Lcom/ditchoom/buffer/crypto/KeyAgreementAsyncOps;Lcom/ditchoom/buffer/crypto/KeyAgreementPrivateKey;Lcom/ditchoom/buffer/crypto/KeyAgreementPublicKey;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class com/ditchoom/buffer/crypto/KeyAgreementBlockingOps : com/ditchoom/buffer/crypto/KeyAgreementAsyncOps {
@@ -845,6 +847,7 @@ public abstract interface class com/ditchoom/buffer/crypto/KeyAgreementBlockingO
 
 public final class com/ditchoom/buffer/crypto/KeyAgreementBlockingOps$DefaultImpls {
 	public static synthetic fun deriveSharedSecretBlocking$default (Lcom/ditchoom/buffer/crypto/KeyAgreementBlockingOps;Lcom/ditchoom/buffer/crypto/KeyAgreementPrivateKey;Lcom/ditchoom/buffer/crypto/KeyAgreementPublicKey;Lcom/ditchoom/buffer/crypto/Info;ILcom/ditchoom/buffer/crypto/Salt;Lcom/ditchoom/buffer/BufferFactory;ILjava/lang/Object;)Lcom/ditchoom/buffer/ReadBuffer;
+	public static fun deriveTlsPremasterSecret (Lcom/ditchoom/buffer/crypto/KeyAgreementBlockingOps;Lcom/ditchoom/buffer/crypto/KeyAgreementPrivateKey;Lcom/ditchoom/buffer/crypto/KeyAgreementPublicKey;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class com/ditchoom/buffer/crypto/KeyAgreementCurve {

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/KeyAgreement.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/KeyAgreement.kt
@@ -13,12 +13,15 @@ import com.ditchoom.buffer.ReadBuffer
  *
  * # Security contract
  *
- * **Raw Diffie–Hellman output is never handed back as a key.** A raw X25519/ECDH shared secret
- * is not a uniformly random key (it lives in a structured subset of the field), so every public
- * entry point here runs the raw secret through HKDF-Extract-then-Expand ([Hkdf]) with a
- * caller-supplied [Info] (and optional [Salt]) for domain separation, and returns the *derived*
- * key material. The raw secret is allocated in a wiped [SecureBuffer] and zeroed before return,
- * even on the failure path. The library exposes no API that returns the raw secret.
+ * **Raw Diffie–Hellman output is not a key.** A raw X25519/ECDH shared secret is not a uniformly
+ * random key (it lives in a structured subset of the field), so the default entry point
+ * [KeyAgreementAsyncOps.deriveSharedSecret] runs the raw secret through HKDF-Extract-then-Expand
+ * ([Hkdf]) with a caller-supplied [Info] (and optional [Salt]) for domain separation, and returns the
+ * *derived* key material; the raw secret is allocated in a wiped [SecureBuffer] and zeroed before
+ * return, even on the failure path. The **only** API that returns the raw secret is the narrowly
+ * scoped [KeyAgreementAsyncOps.deriveTlsPremasterSecret], provided so an out-of-module TLS/DTLS stack
+ * can obtain the (EC)DHE premaster / HKDF-Extract IKM its own key schedule requires; it carries a
+ * standing "this is not a key" warning and callers MUST run it through the protocol's KDF.
  *
  * **Public-key validation.** Peer public keys are validated before use:
  *  - X25519: low-order / small-subgroup points produce an all-zero shared secret; this is the
@@ -362,6 +365,48 @@ interface KeyAgreementAsyncOps {
         salt: Salt = Salt.None,
         factory: BufferFactory = BufferFactory.Default,
     ): ReadBuffer
+
+    /**
+     * Computes the **raw** Diffie–Hellman shared secret of [privateKey] and [peerPublicKey] (both on
+     * this [curve]) — the TLS/DTLS *(EC)DHE premaster secret* — and returns it **without** a KDF. For
+     * the NIST curves this is the big-endian X-coordinate of the shared point
+     * ([KeyAgreementCurve.sharedSecretBytes] bytes: 32 for P-256, 48 for P-384, 66 for P-521); for
+     * [KeyAgreementCurve.X25519] it is the 32-byte RFC 7748 output.
+     *
+     * ## This is NOT a key — read before using
+     *
+     * A raw Diffie–Hellman secret is **not** uniformly random (it lives in a structured subset of the
+     * field), so it MUST NOT be used directly as an encryption or MAC key. It is returned here for
+     * exactly one purpose: to seed a **protocol key schedule that runs its own KDF over it**, where the
+     * KDF is defined by the protocol and lives outside this module. The intended callers are:
+     *  - **TLS 1.2 / DTLS 1.2** — this *is* the ECDHE `premaster_secret`; the caller runs the TLS PRF
+     *    over it (RFC 5246 §8.1 / RFC 6347).
+     *  - **TLS 1.3 / DTLS 1.3** — this is the (EC)DHE input handed to `HKDF-Extract` as the IKM in the
+     *    key schedule (RFC 8446 §7.1 / RFC 9147).
+     *
+     * For **every other use**, call [deriveSharedSecret], which runs HKDF over the secret for you and
+     * is the recommended default. See `buffer-crypto/SECURITY.md`.
+     *
+     * The result is a wiped [SecureBuffer] holding [KeyAgreementCurve.sharedSecretBytes] bytes,
+     * read-ready. **The caller owns it and MUST free it** (`use {}` / `freeNativeMemory()`) once the
+     * key schedule has consumed it. Peer-key validation is identical to [deriveSharedSecret]: an
+     * off-curve / low-order / identity point (or, for X25519, an all-zero secret per RFC 7748 §6.1) is
+     * rejected with [InvalidPublicKey] before any secret is returned.
+     *
+     * @throws InvalidPublicKey for a rejected peer point (or an X25519 all-zero secret).
+     * @throws IllegalArgumentException if [privateKey] is not on this ops' [curve].
+     */
+    suspend fun deriveTlsPremasterSecret(
+        privateKey: KeyAgreementPrivateKey,
+        peerPublicKey: KeyAgreementPublicKey,
+    ): PlatformBuffer {
+        require(privateKey.curve == curve) {
+            "private key is for ${privateKey.curve.curveName}, not this ops' ${curve.curveName}"
+        }
+        // Delegates to the single audited raw-DH seam (still internal): same native provider
+        // validation + X25519 all-zero rejection as deriveSharedSecret, minus the KDF step.
+        return dhRawSecret(privateKey, peerPublicKey)
+    }
 }
 
 /** Key agreement with a synchronous (non-`suspend`) path, in addition to the inherited async one. */

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/KeyAgreementWitnessSupport.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/KeyAgreementWitnessSupport.kt
@@ -2,6 +2,7 @@ package com.ditchoom.buffer.crypto
 
 import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.ReadBuffer
 
 /*
@@ -81,4 +82,17 @@ internal suspend fun deriveSharedSecretAsync(
                 "${privateKey.curve.curveName} key agreement is unavailable on this platform",
             )
     return ops.deriveSharedSecret(privateKey, peerPublicKey, infoOf(info), length, saltOf(salt), factory)
+}
+
+/** Async raw TLS premaster secret through the witness; throws if the curve is unavailable here. */
+internal suspend fun deriveTlsPremasterSecret(
+    privateKey: KeyAgreementPrivateKey,
+    peerPublicKey: KeyAgreementPublicKey,
+): PlatformBuffer {
+    val ops =
+        keyAgreementAsyncOrNull(privateKey.curve)
+            ?: throw UnsupportedOperationException(
+                "${privateKey.curve.curveName} key agreement is unavailable on this platform",
+            )
+    return ops.deriveTlsPremasterSecret(privateKey, peerPublicKey)
 }

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/TlsPremasterSecretTest.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/TlsPremasterSecretTest.kt
@@ -1,0 +1,156 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.crypto.CryptoTestVectors.hexBuffer
+import com.ditchoom.buffer.crypto.CryptoTestVectors.toHex
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * Known-answer tests for [KeyAgreementAsyncOps.deriveTlsPremasterSecret], the one public API that
+ * returns the **raw** (EC)DHE shared secret (the TLS/DTLS premaster / HKDF-Extract IKM). Unlike
+ * [KeyAgreementKatTest] — which can only oracle-check the raw DH *indirectly* through the KDF, since
+ * [deriveSharedSecret] never returns it — these vectors assert the raw output byte-for-byte:
+ *
+ *  - RFC 7748 §5.2 X25519: the returned secret equals the vector's 32-byte shared value.
+ *  - NIST CAVP ECDH P-256: the returned secret equals the big-endian X-coordinate of the shared point.
+ *
+ * The vectors are raw private scalars, so the KATs are gated on [supportsRawScalarKat] exactly as
+ * [KeyAgreementKatTest] is; the rejection tests run wherever the curve's async path is available.
+ */
+class TlsPremasterSecretTest {
+    /** Reads the premaster to hex and frees the caller-owned wiped [SecureBuffer]. */
+    private fun PlatformBuffer.consumeHex(): String =
+        try {
+            toHex()
+        } finally {
+            freeNativeMemory()
+        }
+
+    private fun runPremasterKat(
+        curve: KeyAgreementCurve,
+        privScalarHex: String,
+        peerPublicHex: String,
+        rawSecretHex: String,
+    ) = runTest {
+        if (!supportsRawScalarKat(curve)) return@runTest
+        val priv = importPrivateKey(curve, hexBuffer(privScalarHex))
+        try {
+            val pub = KeyAgreementPublicKey.of(curve, hexBuffer(peerPublicHex))
+            val premaster = deriveTlsPremasterSecret(priv, pub)
+            assertEquals(rawSecretHex, premaster.consumeHex(), "${curve.curveName} premaster")
+        } finally {
+            priv.close()
+        }
+    }
+
+    @Test
+    fun x25519Rfc7748Section5_2() {
+        // RFC 7748 §5.2 first test vector — the raw X25519 output IS the returned premaster secret.
+        runPremasterKat(
+            curve = KeyAgreementCurve.X25519,
+            privScalarHex = "a546e36bf0527c9d3b16154b82465edd62144c0ac1fc5a18506a2244ba449ac4",
+            peerPublicHex = "e6db6867583030db3594c1a424b15f7c726624ec26b3353b10a903a6d0ab1c4c",
+            rawSecretHex = "c3da55379de9c6908e94ea4df28d084f32eccf03491c71f754b4075577a28552",
+        )
+    }
+
+    @Test
+    fun ecdhP256NistVectorReturnsSharedXCoordinate() {
+        // NIST CAVP ECDH (P-256): the TLS 1.2 premaster is exactly the shared point's X-coordinate.
+        val d = "7d7dc5f71eb29ddaf80d6214632eeae03d9058af1fb6d22ed80badb62bc1a534"
+        val x = "700c48f77f56584c5cc632ca65640db91b6bacce3a4df6b42ce7cc838833d287"
+        val y = "db71e509e3fd9b060ddb20ba5c51dcc5948d46fbf640dfe0441782cab85fa4ac"
+        val sharedX = "46fc62106420ff012e54a434fbdd2d25ccc5852060561e68040dd7778997bd7b"
+        runPremasterKat(
+            curve = KeyAgreementCurve.P256,
+            privScalarHex = d,
+            peerPublicHex = "04$x$y",
+            rawSecretHex = sharedX,
+        )
+    }
+
+    @Test
+    fun premasterAndKdfPathAgreeOnTheSameRawSecret() {
+        // The raw premaster and the KDF path must be consistent: HKDF over the returned premaster
+        // equals what deriveSharedSecret produces for the same keys. Proves the narrow raw path and
+        // the default derived path share one DH computation.
+        val curve = KeyAgreementCurve.P256
+        runTest {
+            if (!supportsRawScalarKat(curve) || !supportsSync(curve)) return@runTest
+            val d = "7d7dc5f71eb29ddaf80d6214632eeae03d9058af1fb6d22ed80badb62bc1a534"
+            val x = "700c48f77f56584c5cc632ca65640db91b6bacce3a4df6b42ce7cc838833d287"
+            val y = "db71e509e3fd9b060ddb20ba5c51dcc5948d46fbf640dfe0441782cab85fa4ac"
+            val priv = importPrivateKey(curve, hexBuffer(d))
+            try {
+                val pub = KeyAgreementPublicKey.of(curve, hexBuffer("04$x$y"))
+                val info = CryptoTestVectors.ascii("tls13 premaster")
+                val premaster = deriveTlsPremasterSecret(priv, pub)
+                val fromRaw =
+                    Hkdf
+                        .derive(
+                            salt = Salt.None,
+                            ikm = premaster,
+                            info = Info.Of(info),
+                            length = 32,
+                            factory = BufferFactory.Default,
+                        ).toHex()
+                        .also { premaster.freeNativeMemory() }
+                val fromApi = deriveSharedSecret(priv, pub, info, 32).toHex()
+                assertEquals(fromApi, fromRaw, "premaster→HKDF must equal deriveSharedSecret")
+            } finally {
+                priv.close()
+            }
+        }
+    }
+
+    @Test
+    fun x25519LowOrderPeerKeyRejected() {
+        // An all-zero X25519 peer point is a low-order point: the raw output is all-zero and must be
+        // rejected with InvalidPublicKey (RFC 7748 §6.1) — the raw path enforces the same check as
+        // the KDF path, so no all-zero secret is ever returned.
+        val curve = KeyAgreementCurve.X25519
+        runTest {
+            if (!asyncAgreementSupported(curve)) return@runTest
+            val a = generateKeyPairAsync(curve)
+            try {
+                val lowOrder = KeyAgreementPublicKey.of(curve, hexBuffer("00".repeat(32)))
+                assertFailsWith<InvalidPublicKey>("all-zero X25519 secret must be rejected") {
+                    deriveTlsPremasterSecret(a.privateKey, lowOrder)
+                }
+            } finally {
+                a.close()
+            }
+        }
+    }
+
+    @Test
+    fun offCurveP256PeerKeyRejected() {
+        // A full-length but off-curve P-256 point (0x04 ‖ X=0 ‖ Y=1) reaches provider validation on
+        // the raw path and must be rejected uniformly with InvalidPublicKey — no premaster leaks.
+        val curve = KeyAgreementCurve.P256
+        runTest {
+            if (!asyncAgreementSupported(curve)) return@runTest
+            val a = generateKeyPairAsync(curve)
+            try {
+                val coord = curve.privateKeyBytes
+                val pt = BufferFactory.Default.allocate(curve.publicKeyBytes)
+                pt.writeByte(0x04)
+                repeat(coord) { pt.writeByte(0) } // X = 0
+                repeat(coord - 1) { pt.writeByte(0) }
+                pt.writeByte(1) // Y = 1 → off curve
+                pt.resetForRead()
+                val offCurve = KeyAgreementPublicKey.of(curve, pt)
+                assertFailsWith<InvalidPublicKey>("off-curve P-256 point must be rejected") {
+                    deriveTlsPremasterSecret(a.privateKey, offCurve)
+                }
+            } finally {
+                a.close()
+            }
+        }
+    }
+}

--- a/docs/docs/recipes/cryptography.md
+++ b/docs/docs/recipes/cryptography.md
@@ -265,6 +265,25 @@ suspend fun agree(): Boolean {
 
 Peer public keys are validated before use: X25519 all-zero shared secrets (low-order points, RFC 7748 §6.1) and ECDH off-curve / infinity / small-subgroup points are rejected with `InvalidPublicKey`. To exchange or persist a **public** key, use its encoding (`KeyAgreementCurve.publicKeyBytes` long) and rebuild it with `KeyAgreementPublicKey.of(curve, encoded)`.
 
+### Raw premaster secret for TLS / DTLS
+
+`deriveSharedSecret` runs HKDF for you and is the right call for almost everything. The exception is a **TLS/DTLS handshake**, whose own key schedule must consume the *raw* (EC)DHE secret directly — the TLS 1.2 `premaster_secret`, or the TLS 1.3 `HKDF-Extract` IKM. For that one case, `deriveTlsPremasterSecret` returns the raw secret:
+
+```kotlin
+// Inside a TLS/DTLS key schedule — the caller runs the protocol KDF (TLS PRF or HKDF-Extract).
+val ops = (CryptoCapabilities.keyAgreement(KeyAgreementCurve.P256) as KeyAgreementSupport.Blocking).ops
+val premaster = ops.deriveTlsPremasterSecret(myEphemeral.privateKey, peerPublicKey)
+premaster.use { secret ->
+    // TLS 1.2: PRF(secret, "master secret", ...); TLS 1.3: HKDF-Extract(salt, ikm = secret)
+}
+// `premaster` is a wiped SecureBuffer you own — `use {}` frees it. For P-256 it is the 32-byte
+// big-endian X-coordinate of the shared point; for X25519 it is the 32-byte RFC 7748 output.
+```
+
+:::danger A raw DH secret is not a key
+`deriveTlsPremasterSecret` returns structured, non-uniform field output — **never** use it directly as an encryption or MAC key. It is safe only as the input to a protocol key schedule that runs its own KDF over it. For every other use, call `deriveSharedSecret`, which does the KDF for you.
+:::
+
 :::note Private-key serialization is the raw scalar on every platform
 `importPrivateKey(curve, encoded)` and `KeyAgreementPrivateKey.exportEncoded()` use the **curve's raw big-endian scalar** (32/48/66 bytes for P-256/384/521, 32 bytes for X25519) on **every** platform, so a serialized private key is byte-portable across JVM/Android/Apple/Linux/JS/WASM. The platforms whose native stack needs a wrapped form reconstruct it just-in-time for the exchange and never surface it — Apple rebuilds the Security-framework X9.63 representation via CryptoKit, and JS/WASM wrap the scalar in PKCS#8 for WebCrypto. Public keys, shared secrets, signatures, and AEAD outputs are byte-identical across all platforms too.
 :::


### PR DESCRIPTION
## Summary

Adds **`KeyAgreementAsyncOps.deriveTlsPremasterSecret(privateKey, peerPublicKey)`** — the one public buffer-crypto API that returns the **raw** (EC)DHE shared secret, so an external, pure-Kotlin TLS/DTLS-over-buffer-crypto stack can do ECDHE key exchange without bridging to JCA.

Today the only public key-agreement API, `deriveSharedSecret`, unconditionally runs HKDF-Extract+Expand and never returns the raw value; the raw path (`dhRawSecret`) is `internal`, reserved for in-module HPKE/DHKEM. But **TLS 1.2's premaster secret *is* the raw ECDH output** (P-256 X-coordinate), and **TLS 1.3 ECDHE feeds the raw secret to `HKDF-Extract` as IKM** — so out-of-module ECDHE was impossible without JCA.

Per review discussion, rather than a general `deriveRawSharedSecret`, this exposes a **narrower, harder-to-misuse, TLS-named helper** and keeps `dhRawSecret` internal.

## Design (additive / minor)

- **Keeps `dhRawSecret` internal** (still HPKE/DHKEM-only); the new helper delegates to it, inheriting the same native-provider peer-key validation + constant-time X25519 all-zero rejection (RFC 7748 §6.1), minus the KDF step.
- **Default method on `KeyAgreementAsyncOps`** (inherited by the `Blocking` witness): binary-compatible, availability-gated (you must resolve the witness to call it), and curve-bound (a private key off the ops' curve → `IllegalArgumentException`). `suspend`-only, so one surface covers the async-only web (WebCrypto `deriveBits`).
- Returns the raw secret in a **wiped, caller-owned `SecureBuffer`** (`curve.sharedSecretBytes` — 32-byte P-256 X-coordinate / 32-byte X25519). Documented throughout as **"NOT a key — run it through the protocol KDF"**; `deriveSharedSecret` remains the recommended default.
- **No behavior change** to `deriveSharedSecret`, signing, or the AES-ECB primitive (#301).

## Note on Task B (signature SPKI export)

The companion ask — public `VerifyKey.exportSpki()` / `exportEncoded()` — is **already implemented and tested** (landed in #292; `PublicKeyExportTest` asserts the exact 91-byte P-256 SPKI, Ed25519, and KeyAgreement round-trips). They return `ReadBuffer` per the repo's buffer conventions, not `ByteArray`. No code change needed there; this PR is the raw-ECDH half only.

## Tests

`TlsPremasterSecretTest` (commonMain → all platforms):
- RFC 7748 §5.2 X25519 and NIST CAVP P-256 **raw-secret KATs** — the raw DH output is now oracle-checked **directly**, not just through the KDF.
- premaster↔`deriveSharedSecret` consistency (both share one DH computation).
- X25519 low-order + P-256 off-curve peer-key rejection on the raw path.

Verified green on **JVM**, **JS/Node** (the WebCrypto async path — the load-bearing target for out-of-module TLS/DTLS), full JVM crypto suite, and JS/Linux test compiles. Apple actual is CI-gated on macOS.

## Housekeeping

- `./gradlew apiDump` — api/jvm + api/android BCV dumps updated (additive).
- ktlint/detekt clean.
- SECURITY.md: test inventory, revised raw-secret row, new `deriveTlsPremasterSecret` attack-vector note.
- Cryptography recipe docs: raw-premaster section + "a raw DH secret is not a key" warning.