### PR TITLE
fix(codec): make generated wireSize total and prefix reservation growth-safe

### DIFF
--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecAnalyzer.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecAnalyzer.kt
@@ -1943,13 +1943,32 @@ internal fun analyzeLengthPrefixedListSpec(
  *
  * Mirrors the message-wide BackPatch short-circuits in
  * [classifyVariantWireSize] / `buildWireSizeFun`. Any of these
- * annotations on a primary-constructor parameter forces BackPatch:
+ * on a primary-constructor parameter forces BackPatch:
  *  - `@When` (`Conditional` field shape, row 19),
  *  - `@RemainingBytes` (variable-bounded body),
  *  - `@UseCodec` (user codec wireSize is opaque, conservatively
  *    BackPatch — covers `UseCodecScalar`, `RemainingBytesPayload`,
  *    `LengthPrefixedUseCodecList`),
- *  - `@LengthPrefixed val: String` (`LengthPrefixedString`, row 15).
+ *  - `@Count` (the nested list's own elements may probe to BackPatch
+ *    at runtime, so the enclosing element can't be assumed Exact),
+ *  - `@LengthPrefixed val: String` or `@LengthPrefixed` on a
+ *    `@JvmInline value class`-over-String (`LengthPrefixedString`,
+ *    row 15 — the value-class wrapper is wire-identical to a bare
+ *    String and shares its BackPatch wireSize),
+ *  - a bare param typed as a `@ProtocolMessage` class
+ *    (`ProtocolMessageScalar`, which collapses the element codec's
+ *    wireSize to BackPatch regardless of the inner shape — it
+ *    carries no annotation for a purely annotation-driven scan to
+ *    see). `@LengthPrefixed`/`@LengthFrom` message params are
+ *    excluded: those field shapes stay runtime-Exact.
+ *
+ * This scan stays deliberately conservative: a miss no longer CCEs
+ * (the generated wireSize probes element sizes and degrades to
+ * BackPatch at runtime — see `appendElementWireSizeProbeLoop`), but
+ * the encode-path pre-measure selection for `@LengthPrefixed
+ * @UseCodec` lists still keys off it, so over-detecting only costs
+ * the scratch-buffer path, while under-detecting risks an encode
+ * ClassCastException.
  *
  * Sealed parents stay conservatively BackPatch — promoting to
  * Exact-when-all-variants-are-Exact is a follow-on refactor; no
@@ -1959,18 +1978,37 @@ internal fun detectElementBackPatch(elementDecl: KSClassDeclaration): Boolean {
     if (Modifier.SEALED in elementDecl.modifiers) return true
     val ctor = elementDecl.primaryConstructor ?: return false
     return ctor.parameters.any { param ->
-        val paramTypeQname =
-            param.type
-                .resolve()
-                .declaration.qualifiedName
-                ?.asString()
-        param.annotations.any { ann ->
-            when (ann.shortName.asString()) {
-                "When", "RemainingBytes", "UseCodec" -> true
-                "LengthPrefixed" -> paramTypeQname == "kotlin.String"
-                else -> false
+        val paramType = param.type.resolve()
+        val paramTypeQname = paramType.declaration.qualifiedName?.asString()
+        val paramTypeDecl = paramType.declaration as? KSClassDeclaration
+        val annotationForcesBackPatch =
+            param.annotations.any { ann ->
+                when (ann.shortName.asString()) {
+                    "When", "RemainingBytes", "UseCodec", "Count" -> true
+                    "LengthPrefixed" ->
+                        paramTypeQname == "kotlin.String" ||
+                            paramTypeDecl?.modifiers?.contains(Modifier.VALUE) == true
+                    else -> false
+                }
             }
-        }
+        if (annotationForcesBackPatch) return@any true
+        // Bare nested-message param → ProtocolMessageScalar collapse.
+        // Skip when a framing annotation reshapes the field into one of
+        // the runtime-Exact message shapes (LengthPrefixedMessage /
+        // LengthFromMessage).
+        val reframed =
+            param.annotations.any { ann ->
+                ann.shortName.asString() == "LengthPrefixed" || ann.shortName.asString() == "LengthFrom"
+            }
+        !reframed &&
+            paramTypeDecl != null &&
+            paramTypeDecl.annotations.any { ann ->
+                ann.shortName.asString() == "ProtocolMessage" &&
+                    ann.annotationType
+                        .resolve()
+                        .declaration.qualifiedName
+                        ?.asString() == PROTOCOL_MESSAGE_QNAME
+            }
     }
 }
 

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterDispatch.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterDispatch.kt
@@ -380,13 +380,19 @@ internal fun buildDispatchWireSizeFun(shape: DispatchShape): FunSpec {
                             WIRE_SIZE_CN,
                         )
                     is VariantWireSize.RuntimeExact -> {
+                        // The variant's wireSize is Exact in the common case,
+                        // but a runtime-probed shape (e.g. a `@Count` list
+                        // whose elements turn out BackPatch) may degrade —
+                        // forward BackPatch instead of casting (a cast threw
+                        // ClassCastException on every encode).
                         body.beginControlFlow("is %T ->", branchType)
-                        body.addStatement(
-                            "val inner = (%L.wireSize(value, context) as %T.Exact).bytes",
+                        body.beginControlFlow(
+                            "when (val inner = %L.wireSize(value, context))",
                             variant.codecReceiver(),
-                            WIRE_SIZE_CN,
                         )
-                        body.addStatement("%T.Exact(1 + inner)", WIRE_SIZE_CN)
+                        body.addStatement("is %T.Exact -> %T.Exact(1 + inner.bytes)", WIRE_SIZE_CN, WIRE_SIZE_CN)
+                        body.addStatement("%T.BackPatch -> %T.BackPatch", WIRE_SIZE_CN, WIRE_SIZE_CN)
+                        body.endControlFlow()
                         body.endControlFlow()
                     }
                     // Delegated is produced only by the @DispatchOn adapter

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterFields.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterFields.kt
@@ -957,7 +957,7 @@ internal fun appendEncodeConditionalLengthPrefixedUseCodecPayload(
     val endPosVar = "${field.name}EndPosition"
     val byteCountVar = "${field.name}ByteCount"
     body.addStatement("val %L = buffer.position()", sizePosVar)
-    body.addStatement("buffer.position(%L + %L)", sizePosVar, inner.prefixWidth)
+    appendPrefixSlotReservation(body, inner.prefixWidth)
     body.addStatement("val %L = buffer.position()", bodyStartVar)
     body.addStatement("%T.encode(buffer, %L, context)", inner.payloadCodecType, accessor)
     body.addStatement("val %L = buffer.position()", endPosVar)
@@ -1079,20 +1079,91 @@ internal fun appendBufferPrefixDecode(
     body.addStatement("val %L = (%L)", targetVar, parts.joinToString(" or "))
 }
 
+/**
+ * Encode a terminal `@LengthPrefixed val: @ProtocolMessage` body. Forks at
+ * runtime on the nested codec's wireSize:
+ *
+ * - **Exact** — write the prefix from the measured size, then the body
+ *   (the historical fast path, now with the same prefix-range guard the
+ *   String emit carries — the unguarded path silently mask-truncated an
+ *   oversized body into a corrupt prefix).
+ * - **BackPatch** — a nested body carrying its own variable-length field
+ *   reports BackPatch; reserve the prefix slot with placeholder writes,
+ *   encode the body, measure the position delta, guard, and back-patch
+ *   (the same shape as the `@LengthPrefixed val: String` emit). This path
+ *   used to throw ClassCastException on every encode.
+ */
 internal fun appendEncodeLengthPrefixed(
     body: CodeBlock.Builder,
     field: FieldSpec.LengthPrefixedMessage,
 ) {
-    val prefixVar = "${field.name}Prefix"
-    body.addStatement(
-        "val %L = (%T.wireSize(value.%L, context) as %T.Exact).bytes.toUInt()",
-        prefixVar,
+    val fieldPath = "${field.ownerSimpleName}.${field.name}"
+    val sizeVar = "${field.name}WireSize"
+    body.beginControlFlow(
+        "when (val %L = %T.wireSize(value.%L, context))",
+        sizeVar,
         field.codecType,
         field.name,
-        WIRE_SIZE_CN,
     )
+    body.beginControlFlow("is %T.Exact ->", WIRE_SIZE_CN)
+    val byteCountVar = "${field.name}ByteCount"
+    body.addStatement("val %L = %L.bytes", byteCountVar, sizeVar)
+    appendPrefixWidthGuard(body, byteCountVar, field.prefixWidth, fieldPath)
+    val prefixVar = "${field.name}Prefix"
+    body.addStatement("val %L = %L.toUInt()", prefixVar, byteCountVar)
     appendBufferPrefixEncode(body, prefixVar, field.prefixWidth, field.prefixWireOrder)
     body.addStatement("%T.encode(buffer, value.%L, context)", field.codecType, field.name)
+    body.endControlFlow()
+    body.beginControlFlow("%T.BackPatch ->", WIRE_SIZE_CN)
+    val sizePosVar = "${field.name}SizePosition"
+    val bodyStartVar = "${field.name}BodyStart"
+    val endPosVar = "${field.name}EndPosition"
+    val patchCountVar = "${field.name}PatchByteCount"
+    body.addStatement("val %L = buffer.position()", sizePosVar)
+    appendPrefixSlotReservation(body, field.prefixWidth)
+    body.addStatement("val %L = buffer.position()", bodyStartVar)
+    body.addStatement("%T.encode(buffer, value.%L, context)", field.codecType, field.name)
+    body.addStatement("val %L = buffer.position()", endPosVar)
+    body.addStatement("val %L = %L - %L", patchCountVar, endPosVar, bodyStartVar)
+    appendPrefixWidthGuard(body, patchCountVar, field.prefixWidth, fieldPath)
+    body.addStatement("buffer.position(%L)", sizePosVar)
+    val patchPrefixVar = "${field.name}PatchPrefix"
+    body.addStatement("val %L = %L.toUInt()", patchPrefixVar, patchCountVar)
+    appendBufferPrefixEncode(body, patchPrefixVar, field.prefixWidth, field.prefixWireOrder)
+    body.addStatement("buffer.position(%L)", endPosVar)
+    body.endControlFlow()
+    body.endControlFlow()
+}
+
+/**
+ * Emit the prefix-range guard shared by the length-prefix encode paths: for
+ * 1/2-byte prefixes, throw `EncodeException` when the measured body byte
+ * count exceeds the prefix's value range. 4-byte prefixes skip the guard —
+ * an Int-typed position delta can never exceed the UInt range.
+ */
+internal fun appendPrefixWidthGuard(
+    body: CodeBlock.Builder,
+    byteCountVar: String,
+    prefixWidth: Int,
+    fieldPath: String,
+) {
+    if (prefixWidth >= Int.SIZE_BYTES) return
+    val maxValue = (1L shl (prefixWidth * Byte.SIZE_BITS)) - 1
+    val widthName =
+        when (prefixWidth) {
+            1 -> "Byte"
+            2 -> "Short"
+            else -> error("unreachable: prefixWidth must be 1, 2, or 4")
+        }
+    body.beginControlFlow("if (%L > %L)", byteCountVar, maxValue)
+    body.addStatement(
+        "throw %T(fieldPath = %S, reason = %P)",
+        ENCODE_EXCEPTION_CN,
+        fieldPath,
+        "encoded message byte length \${$byteCountVar} exceeds " +
+            "@LengthPrefixed(LengthPrefix.$widthName) max $maxValue",
+    )
+    body.endControlFlow()
 }
 
 internal fun appendDecodeLengthPrefixedString(
@@ -1200,7 +1271,7 @@ internal fun appendLengthPrefixedStringEncode(
     val endPosVar = "${name}EndPosition"
     val byteCountVar = "${name}ByteCount"
     body.addStatement("val %L = buffer.position()", sizePosVar)
-    body.addStatement("buffer.position(%L + %L)", sizePosVar, prefixWidth)
+    appendPrefixSlotReservation(body, prefixWidth)
     body.addStatement("val %L = buffer.position()", bodyStartVar)
     body.addStatement(
         "buffer.writeString(%L, %T.UTF8)",
@@ -1882,22 +1953,11 @@ internal fun appendDecodeLengthPrefixedListBody(
 /**
  * Emit encode for `@LengthPrefixed
  * @UseCodec(C::class) val xs: List<E>`. Pre-measures the body byte
- * count via the element codec's `wireSize` (cast to `Exact`), writes
- * the prefix via the user codec's `encode`, then iterates and encodes
- * elements. BackPatch element codecs throw `ClassCastException` —
- * same fixture-design contract as `RemainingBytesProtocolMessageList`
- * and `LengthPrefixedMessage`.
- *
- * Generated shape:
- * ```
- * val __<name>BodyBytes = value.<name>.sumOf {
- *     (ElementCodec.wireSize(it, context) as WireSize.Exact).bytes
- * }
- * <codecType>.encode(buffer, __<name>BodyBytes.toUInt(), context)
- * for (__elem in value.<name>) {
- *     ElementCodec.encode(buffer, __elem, context)
- * }
- * ```
+ * count by probing each element codec's `wireSize`, writes the prefix
+ * via the user codec's `encode`, then iterates and encodes elements.
+ * A BackPatch element wireSize at runtime falls back to the
+ * scratch-staging `LengthPrefixedListEncoder` — see
+ * [appendEncodeLengthPrefixedListBody] for the emitted shape.
  */
 internal fun appendEncodeLengthPrefixedUseCodecList(
     body: CodeBlock.Builder,
@@ -1928,7 +1988,7 @@ internal fun appendEncodeLengthPrefixedUseCodecPayload(
     val endPosVar = "${field.name}EndPosition"
     val byteCountVar = "${field.name}ByteCount"
     body.addStatement("val %L = buffer.position()", sizePosVar)
-    body.addStatement("buffer.position(%L + %L)", sizePosVar, field.prefixWidth)
+    appendPrefixSlotReservation(body, field.prefixWidth)
     body.addStatement("val %L = buffer.position()", bodyStartVar)
     body.addStatement(
         "%T.encode(buffer, value.%L, context)",
@@ -1991,14 +2051,11 @@ internal fun appendEncodeLengthPrefixedUseCodecPayload(
  * correctly. An earlier emit used a fixed 64-byte scratch that silently
  * truncated sections over 64 bytes.
  *
- * **Data-class elements** — pre-measure body bytes via the element
- * codec's `wireSize as Exact`, write VBI prefix, iterate. BackPatch
- * elements throw `ClassCastException` — same fixture-design contract
- * as `RemainingBytesProtocolMessageList` and `LengthPrefixedMessage`.
- * Audit 2b notes the latent risk: a data-class element with a
- * `@LengthPrefixed val: String` field has BackPatch wireSize and
- * would CCE; no current fixture trips it because all sealed-parent
- * cases are routed through the scratch path.
+ * **Data-class elements** — probe each element's `wireSize`; when all
+ * report Exact, write the VBI prefix from the sum and iterate. If any
+ * element reports BackPatch at runtime (an element shape the analyze-time
+ * scan under-detects), fall back to the scratch path above instead of
+ * crashing — closing the latent ClassCastException Audit 2b flagged.
  */
 internal fun appendEncodeLengthPrefixedListBody(
     body: CodeBlock.Builder,
@@ -2020,14 +2077,25 @@ internal fun appendEncodeLengthPrefixedListBody(
             spec.elementCodecClassName,
         )
     } else {
+        // Pre-measure path for elements the analyzer classified Exact.
+        // Probe each element's wireSize rather than casting: if a shape the
+        // analyze-time scan under-detects reports BackPatch at runtime,
+        // fall back to the scratch-staging LengthPrefixedListEncoder (the
+        // same path always-BackPatch elements take) instead of throwing
+        // ClassCastException mid-encode.
         val bodyBytesVar = "__${namespacePrefix}BodyBytes"
-        body.addStatement(
-            "val %L = %L.sumOf { (%T.wireSize(it, context) as %T.Exact).bytes }",
-            bodyBytesVar,
-            accessor,
-            spec.elementCodecClassName,
-            WIRE_SIZE_CN,
-        )
+        val allExactVar = "__${namespacePrefix}AllExact"
+        body.addStatement("var %L = 0", bodyBytesVar)
+        body.addStatement("var %L = true", allExactVar)
+        body.beginControlFlow("for (__elem in %L)", accessor)
+        body.addStatement("val __elemSize = %T.wireSize(__elem, context)", spec.elementCodecClassName)
+        body.beginControlFlow("if (__elemSize !is %T.Exact)", WIRE_SIZE_CN)
+        body.addStatement("%L = false", allExactVar)
+        body.addStatement("break")
+        body.endControlFlow()
+        body.addStatement("%L += __elemSize.bytes", bodyBytesVar)
+        body.endControlFlow()
+        body.beginControlFlow("if (%L)", allExactVar)
         body.addStatement(
             "%T.encode(buffer, %L.toUInt(), context)",
             spec.codecType,
@@ -2036,7 +2104,36 @@ internal fun appendEncodeLengthPrefixedListBody(
         body.beginControlFlow("for (__elem in %L)", accessor)
         body.addStatement("%T.encode(buffer, __elem, context)", spec.elementCodecClassName)
         body.endControlFlow()
+        body.nextControlFlow("else")
+        body.addStatement(
+            "%T.encode(buffer, %T.%M, %T, %L, %T, context)",
+            LENGTH_PREFIXED_LIST_ENCODER_CN,
+            BUFFER_FACTORY_CN,
+            BUFFER_FACTORY_DEFAULT_MN,
+            spec.codecType,
+            accessor,
+            spec.elementCodecClassName,
+        )
+        body.endControlFlow()
     }
+}
+
+/**
+ * Reserve a length-prefix slot by writing `prefixWidth` placeholder bytes.
+ * MUST be a write, not a forward `buffer.position(pos + width)` seek: at a
+ * capacity boundary a seek past the limit throws a platform-dependent,
+ * non-retryable exception (java.nio signals `IllegalArgumentException`),
+ * which escapes `encodeToPlatformBuffer`'s grow-and-retry loop. A
+ * placeholder write overflows with the retryable [BufferOverflowException]
+ * — and on a growable scratch buffer it triggers growth, which a bare seek
+ * would not. The real prefix is back-patched over the placeholders once the
+ * body's byte count is known.
+ */
+internal fun appendPrefixSlotReservation(
+    body: CodeBlock.Builder,
+    prefixWidth: Int,
+) {
+    body.addStatement("repeat(%L) { buffer.writeUByte(0u) }", prefixWidth)
 }
 
 internal fun appendBufferPrefixEncode(

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterWireSize.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterWireSize.kt
@@ -150,14 +150,21 @@ internal fun buildWireSizeFun(
         val fixedBytes = shape.fields.sumOfFixedWireBytes().requireFixed("runtimeExactWireSize")
         for (f in runtimeExactVarFields) {
             when (f) {
-                is FieldSpec.UseCodecScalar ->
-                    builder.addStatement(
-                        "val %L = (%T.wireSize(value.%L, context) as %T.Exact).bytes",
+                is FieldSpec.UseCodecScalar -> {
+                    // The VariableLengthCodec contract fills wireSize in as
+                    // `Exact(encodedLength(value))`, but a user codec may
+                    // override it — degrade to BackPatch instead of casting
+                    // (a cast would CCE on a contract violation).
+                    builder.beginControlFlow(
+                        "val %L = when (val __s = %T.wireSize(value.%L, context))",
                         "__${f.name}Size",
                         f.codecType,
                         f.name,
-                        WIRE_SIZE_CN,
                     )
+                    builder.addStatement("is %T.Exact -> __s.bytes", WIRE_SIZE_CN)
+                    builder.addStatement("%T.BackPatch -> return %T.BackPatch", WIRE_SIZE_CN, WIRE_SIZE_CN)
+                    builder.endControlFlow()
+                }
                 is FieldSpec.EnumScalar ->
                     builder.addStatement(
                         "val %L = (%T.wireSize(value.%L.ordinal.toUInt(), context) as %T.Exact).bytes",
@@ -178,20 +185,27 @@ internal fun buildWireSizeFun(
     }
     when (val terminal = shape.fields.lastOrNull()) {
         is FieldSpec.LengthPrefixedMessage -> {
+            // The nested message's wireSize is Exact for fixed/runtime-Exact
+            // bodies, but a BackPatch-shaped body (e.g. one carrying a
+            // `@LengthPrefixed val: String`) must degrade the parent to
+            // BackPatch instead of casting (a cast threw ClassCastException
+            // on every encode).
             val headerBytes = shape.scalarHeaderBytes() + terminal.prefixWidth
-            builder.addStatement(
-                "val %L = (%T.wireSize(value.%L, context) as %T.Exact).bytes",
+            builder.beginControlFlow(
+                "return when (val %L = %T.wireSize(value.%L, context))",
                 "${terminal.name}Size",
                 terminal.codecType,
                 terminal.name,
-                WIRE_SIZE_CN,
             )
             builder.addStatement(
-                "return %T.Exact(%L + %L)",
+                "is %T.Exact -> %T.Exact(%L + %L.bytes)",
+                WIRE_SIZE_CN,
                 WIRE_SIZE_CN,
                 headerBytes,
                 "${terminal.name}Size",
             )
+            builder.addStatement("%T.BackPatch -> %T.BackPatch", WIRE_SIZE_CN, WIRE_SIZE_CN)
+            builder.endControlFlow()
         }
         is FieldSpec.LengthFromString -> {
             // Body byte count comes from the resolved LengthSource
@@ -231,19 +245,25 @@ internal fun buildWireSizeFun(
             )
         }
         is FieldSpec.RemainingBytesProtocolMessageList -> {
-            // Body byte count = sum of element wireSizes.
-            // Each element codec's wireSize is cast to Exact at runtime —
-            // same convention as LengthPrefixedMessage's `as Exact` cast
-            // above; BackPatch element codecs throw ClassCastException
-            // (fixture-design contract for this slice).
+            // Body byte count = sum of element wireSizes. Probe each
+            // element's wireSize and short-circuit to BackPatch on the
+            // first non-Exact result — the analyze-time `elementIsBackPatch`
+            // guard diverts always-BackPatch element types upfront, but an
+            // element shape the scan under-detects must degrade instead of
+            // throwing ClassCastException.
             val prefixBytes = shape.scalarHeaderBytes()
+            val bodySizeVar = "__${terminal.name}BodySize"
+            appendElementWireSizeProbeLoop(
+                builder = builder,
+                listAccessor = "value.${terminal.name}",
+                elementCodec = terminal.elementCodecClassName,
+                sumVar = bodySizeVar,
+            )
             builder.addStatement(
-                "return %T.Exact(%L + value.%L.sumOf { (%T.wireSize(it, context) as %T.Exact).bytes })",
+                "return %T.Exact(%L + %L)",
                 WIRE_SIZE_CN,
                 prefixBytes,
-                terminal.name,
-                terminal.elementCodecClassName,
-                WIRE_SIZE_CN,
+                bodySizeVar,
             )
         }
         is FieldSpec.RemainingBytesPayload ->
@@ -273,10 +293,12 @@ internal fun buildWireSizeFun(
 /**
  * Emit the `__<name>Size` local for a `@Count` element-count list inside the
  * runtime-Exact wireSize sum: the varint width of the element count plus the
- * sum of element wireSizes (each cast `as Exact`, the same convention the other
- * runtime-Exact summations use). A BackPatch element variant CCEs on the cast —
- * such shapes are diverted to BackPatch by the upfront `elementIsBackPatch`
- * guard, so this branch only runs for Exact-measured elements.
+ * sum of element wireSizes. Element sizes are probed with a short-circuit —
+ * the first non-Exact element wireSize makes the whole message report
+ * BackPatch. Always-BackPatch element types are diverted upfront by the
+ * `elementIsBackPatch` guard; the probe is the runtime backstop for element
+ * shapes the analyze-time scan under-detects (previously those threw
+ * ClassCastException on the `as Exact` cast).
  */
 internal fun appendCountListWireSizeLocal(
     builder: FunSpec.Builder,
@@ -290,14 +312,49 @@ internal fun appendCountListWireSizeLocal(
         field.name,
         WIRE_SIZE_CN,
     )
+    val elementsSizeVar = "__${field.name}ElementsSize"
+    appendElementWireSizeProbeLoop(
+        builder = builder,
+        listAccessor = "value.${field.name}",
+        elementCodec = field.elementCodecClassName,
+        sumVar = elementsSizeVar,
+    )
     builder.addStatement(
-        "val %L = %L + value.%L.sumOf { (%T.wireSize(it, context) as %T.Exact).bytes }",
+        "val %L = %L + %L",
         "__${field.name}Size",
         countSizeVar,
-        field.name,
-        field.elementCodecClassName,
-        WIRE_SIZE_CN,
+        elementsSizeVar,
     )
+}
+
+/**
+ * Emit the element-size probe loop shared by the `@Count` and terminal
+ * `@RemainingBytes List<E>` wireSize sums:
+ * ```
+ * var <sumVar> = 0
+ * for (__elem in <listAccessor>) {
+ *     when (val __elemSize = ElementCodec.wireSize(__elem, context)) {
+ *         is WireSize.Exact -> <sumVar> += __elemSize.bytes
+ *         WireSize.BackPatch -> return WireSize.BackPatch
+ *     }
+ * }
+ * ```
+ * The short-circuit is what keeps a mixed-shape element type safe: only when
+ * EVERY element reports Exact may the message stay on the precompute path.
+ */
+private fun appendElementWireSizeProbeLoop(
+    builder: FunSpec.Builder,
+    listAccessor: String,
+    elementCodec: TypeName,
+    sumVar: String,
+) {
+    builder.addStatement("var %L = 0", sumVar)
+    builder.beginControlFlow("for (__elem in %L)", listAccessor)
+    builder.beginControlFlow("when (val __elemSize = %T.wireSize(__elem, context))", elementCodec)
+    builder.addStatement("is %T.Exact -> %L += __elemSize.bytes", WIRE_SIZE_CN, sumVar)
+    builder.addStatement("%T.BackPatch -> return %T.BackPatch", WIRE_SIZE_CN, WIRE_SIZE_CN)
+    builder.endControlFlow()
+    builder.endControlFlow()
 }
 
 /**

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/asciistring/AsciiGreetingCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/asciistring/AsciiGreetingCodec.kt
@@ -38,7 +38,7 @@ public object AsciiGreetingCodec : Codec<AsciiGreeting> {
     context: EncodeContext,
   ) {
     val commandSizePosition = buffer.position()
-    buffer.position(commandSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val commandBodyStart = buffer.position()
     AsciiStringCodec.encode(buffer, value.command, context)
     val commandEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/BigTailCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/BigTailCodec.kt
@@ -1,0 +1,97 @@
+package com.ditchoom.buffer.codec.test.protocols.boundary
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object BigTailCodec : Codec<BigTail> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): BigTail {
+    val aPrefixB0 = buffer.readUByte().toUInt()
+    val aPrefixB1 = buffer.readUByte().toUInt()
+    val aPrefix = ((aPrefixB0 shl 8) or aPrefixB1)
+    if (aPrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "BigTail.a", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = aPrefix.toString())
+    }
+    val aLength = aPrefix.toInt()
+    val a = buffer.readString(aLength, Charset.UTF8)
+    val bPrefixB0 = buffer.readUByte().toUInt()
+    val bPrefixB1 = buffer.readUByte().toUInt()
+    val bPrefixB2 = buffer.readUByte().toUInt()
+    val bPrefixB3 = buffer.readUByte().toUInt()
+    val bPrefix = ((bPrefixB0 shl 24) or (bPrefixB1 shl 16) or (bPrefixB2 shl 8) or bPrefixB3)
+    if (bPrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "BigTail.b", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = bPrefix.toString())
+    }
+    val bLength = bPrefix.toInt()
+    val b = buffer.readString(bLength, Charset.UTF8)
+    return BigTail(a = a, b = b)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: BigTail,
+    context: EncodeContext,
+  ) {
+    val aSizePosition = buffer.position()
+    repeat(2) { buffer.writeUByte(0u) }
+    val aBodyStart = buffer.position()
+    buffer.writeString(value.a, Charset.UTF8)
+    val aEndPosition = buffer.position()
+    val aByteCount = aEndPosition - aBodyStart
+    if (aByteCount > 65_535) {
+      throw EncodeException(fieldPath = "BigTail.a", reason = """UTF-8 byte length ${aByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(aSizePosition)
+    val aPrefix = aByteCount.toUInt()
+    buffer.writeUByte(((aPrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((aPrefix and 0xFFu).toUByte())
+    buffer.position(aEndPosition)
+    val bSizePosition = buffer.position()
+    repeat(4) { buffer.writeUByte(0u) }
+    val bBodyStart = buffer.position()
+    buffer.writeString(value.b, Charset.UTF8)
+    val bEndPosition = buffer.position()
+    val bByteCount = bEndPosition - bBodyStart
+    buffer.position(bSizePosition)
+    val bPrefix = bByteCount.toUInt()
+    buffer.writeUByte(((bPrefix shr 24) and 0xFFu).toUByte())
+    buffer.writeUByte(((bPrefix shr 16) and 0xFFu).toUByte())
+    buffer.writeUByte(((bPrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((bPrefix and 0xFFu).toUByte())
+    buffer.position(bEndPosition)
+  }
+
+  override fun wireSize(`value`: BigTail, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val aPrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val aPrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val aPrefix = ((aPrefixB0 shl 8) or aPrefixB1).toUInt()
+    if (aPrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "BigTail.a", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + aPrefix.toInt()}""")
+    }
+    __offset += 2 + aPrefix.toInt()
+    if (stream.available() - baseOffset < __offset + 4) return PeekResult.NeedsMoreData
+    val bPrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val bPrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val bPrefixB2 = stream.peekByte(baseOffset + __offset + 2).toInt() and 0xFF
+    val bPrefixB3 = stream.peekByte(baseOffset + __offset + 3).toInt() and 0xFF
+    val bPrefix = ((bPrefixB0 shl 24) or (bPrefixB1 shl 16) or (bPrefixB2 shl 8) or bPrefixB3).toUInt()
+    if (bPrefix > (Int.MAX_VALUE - __offset - 4).toUInt()) {
+      throw DecodeException(fieldPath = "BigTail.b", bufferPosition = baseOffset + __offset, expected = "__offset + 4 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 4 + bPrefix.toInt()}""")
+    }
+    __offset += 4 + bPrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/BoundaryDispCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/BoundaryDispCodec.kt
@@ -1,0 +1,70 @@
+package com.ditchoom.buffer.codec.test.protocols.boundary
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object BoundaryDispCodec : Codec<BoundaryDisp> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): BoundaryDisp {
+    val discriminatorPosition = buffer.position()
+    val discriminator = buffer.readUByte().toInt()
+    return when (discriminator) {
+      0x00 -> BoundaryDispNamedCodec.decode(buffer, context)
+      0x01 -> BoundaryDispInheritsCodec.decode(buffer, context)
+      else -> {
+        throw DecodeException(fieldPath = "BoundaryDisp.discriminator", bufferPosition = discriminatorPosition, expected = "one of {0x00, 0x01}", actual = """0x${discriminator.toString(16).padStart(2, '0').uppercase()}""")
+      }
+    }
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: BoundaryDisp,
+    context: EncodeContext,
+  ) {
+    when (value) {
+      is BoundaryDisp.Named -> {
+        buffer.writeUByte(0x00.toUByte())
+        BoundaryDispNamedCodec.encode(buffer, value, context)
+      }
+      is BoundaryDisp.Inherits -> {
+        buffer.writeUByte(0x01.toUByte())
+        BoundaryDispInheritsCodec.encode(buffer, value, context)
+      }
+    }
+  }
+
+  override fun wireSize(`value`: BoundaryDisp, context: EncodeContext): WireSize = when (value) {
+    is BoundaryDisp.Named -> WireSize.BackPatch
+    is BoundaryDisp.Inherits -> WireSize.Exact(1)
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
+    val discriminator = stream.peekByte(baseOffset).toInt() and 0xFF
+    return when (discriminator) {
+      0x00 -> {
+        when (val inner = BoundaryDispNamedCodec.peekFrameSize(stream, baseOffset + 1)) {
+          is PeekResult.Complete -> PeekResult.Complete(1 + inner.bytes)
+          else -> inner
+        }
+      }
+      0x01 -> {
+        when (val inner = BoundaryDispInheritsCodec.peekFrameSize(stream, baseOffset + 1)) {
+          is PeekResult.Complete -> PeekResult.Complete(1 + inner.bytes)
+          else -> inner
+        }
+      }
+      else -> {
+        throw DecodeException(fieldPath = "BoundaryDisp.discriminator", bufferPosition = baseOffset, expected = "one of {0x00, 0x01}", actual = """0x${discriminator.toString(16).padStart(2, '0').uppercase()}""")
+      }
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/BoundaryDispInheritsCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/BoundaryDispInheritsCodec.kt
@@ -1,0 +1,26 @@
+package com.ditchoom.buffer.codec.test.protocols.boundary
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object BoundaryDispInheritsCodec : Codec<BoundaryDisp.Inherits> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): BoundaryDisp.Inherits = BoundaryDisp.Inherits
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: BoundaryDisp.Inherits,
+    context: EncodeContext,
+  ) {
+  }
+
+  override fun wireSize(`value`: BoundaryDisp.Inherits, context: EncodeContext): WireSize = WireSize.Exact(0)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 0) PeekResult.Complete(0) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/BoundaryDispNamedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/BoundaryDispNamedCodec.kt
@@ -1,0 +1,64 @@
+package com.ditchoom.buffer.codec.test.protocols.boundary
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object BoundaryDispNamedCodec : Codec<BoundaryDisp.Named> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): BoundaryDisp.Named {
+    val namePrefixB0 = buffer.readUByte().toUInt()
+    val namePrefixB1 = buffer.readUByte().toUInt()
+    val namePrefix = ((namePrefixB0 shl 8) or namePrefixB1)
+    if (namePrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "Named.name", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = namePrefix.toString())
+    }
+    val nameLength = namePrefix.toInt()
+    val name = buffer.readString(nameLength, Charset.UTF8)
+    return BoundaryDisp.Named(name = name)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: BoundaryDisp.Named,
+    context: EncodeContext,
+  ) {
+    val nameSizePosition = buffer.position()
+    repeat(2) { buffer.writeUByte(0u) }
+    val nameBodyStart = buffer.position()
+    buffer.writeString(value.name, Charset.UTF8)
+    val nameEndPosition = buffer.position()
+    val nameByteCount = nameEndPosition - nameBodyStart
+    if (nameByteCount > 65_535) {
+      throw EncodeException(fieldPath = "Named.name", reason = """UTF-8 byte length ${nameByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(nameSizePosition)
+    val namePrefix = nameByteCount.toUInt()
+    buffer.writeUByte(((namePrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((namePrefix and 0xFFu).toUByte())
+    buffer.position(nameEndPosition)
+  }
+
+  override fun wireSize(`value`: BoundaryDisp.Named, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val namePrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val namePrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val namePrefix = ((namePrefixB0 shl 8) or namePrefixB1).toUInt()
+    if (namePrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "Named.name", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + namePrefix.toInt()}""")
+    }
+    __offset += 2 + namePrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/BoundaryHostCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/BoundaryHostCodec.kt
@@ -1,0 +1,55 @@
+package com.ditchoom.buffer.codec.test.protocols.boundary
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object BoundaryHostCodec : Codec<BoundaryHost> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): BoundaryHost {
+    val hostPrefixB0 = buffer.readUByte().toUInt()
+    val hostPrefixB1 = buffer.readUByte().toUInt()
+    val hostPrefix = ((hostPrefixB0 shl 8) or hostPrefixB1)
+    if (hostPrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "BoundaryHost.host", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = hostPrefix.toString())
+    }
+    val hostLength = hostPrefix.toInt()
+    val host = buffer.readString(hostLength, Charset.UTF8)
+    val disp = BoundaryDispCodec.decode(buffer, context)
+    return BoundaryHost(host = host, disp = disp)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: BoundaryHost,
+    context: EncodeContext,
+  ) {
+    val hostSizePosition = buffer.position()
+    repeat(2) { buffer.writeUByte(0u) }
+    val hostBodyStart = buffer.position()
+    buffer.writeString(value.host, Charset.UTF8)
+    val hostEndPosition = buffer.position()
+    val hostByteCount = hostEndPosition - hostBodyStart
+    if (hostByteCount > 65_535) {
+      throw EncodeException(fieldPath = "BoundaryHost.host", reason = """UTF-8 byte length ${hostByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(hostSizePosition)
+    val hostPrefix = hostByteCount.toUInt()
+    buffer.writeUByte(((hostPrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((hostPrefix and 0xFFu).toUByte())
+    buffer.position(hostEndPosition)
+    BoundaryDispCodec.encode(buffer, value.disp, context)
+  }
+
+  override fun wireSize(`value`: BoundaryHost, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/LpByteWrappedTailCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/LpByteWrappedTailCodec.kt
@@ -1,0 +1,80 @@
+package com.ditchoom.buffer.codec.test.protocols.boundary
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object LpByteWrappedTailCodec : Codec<LpByteWrappedTail> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): LpByteWrappedTail {
+    val bodyPrefix = buffer.readUByte().toUInt()
+    if (bodyPrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "LpByteWrappedTail.body", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = bodyPrefix.toString())
+    }
+    val bodyLength = bodyPrefix.toInt()
+    val bodyOuterLimit = buffer.limit()
+    buffer.setLimit(buffer.position() + bodyLength)
+    val body = try {
+      WrappedLabelCodec.decode(buffer, context)
+    } finally {
+      buffer.setLimit(bodyOuterLimit)
+    }
+    return LpByteWrappedTail(body = body)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: LpByteWrappedTail,
+    context: EncodeContext,
+  ) {
+    when (val bodyWireSize = WrappedLabelCodec.wireSize(value.body, context)) {
+      is WireSize.Exact -> {
+        val bodyByteCount = bodyWireSize.bytes
+        if (bodyByteCount > 255) {
+          throw EncodeException(fieldPath = "LpByteWrappedTail.body", reason = """encoded message byte length ${bodyByteCount} exceeds @LengthPrefixed(LengthPrefix.Byte) max 255""")
+        }
+        val bodyPrefix = bodyByteCount.toUInt()
+        buffer.writeUByte((bodyPrefix and 0xFFu).toUByte())
+        WrappedLabelCodec.encode(buffer, value.body, context)
+      }
+      WireSize.BackPatch -> {
+        val bodySizePosition = buffer.position()
+        repeat(1) { buffer.writeUByte(0u) }
+        val bodyBodyStart = buffer.position()
+        WrappedLabelCodec.encode(buffer, value.body, context)
+        val bodyEndPosition = buffer.position()
+        val bodyPatchByteCount = bodyEndPosition - bodyBodyStart
+        if (bodyPatchByteCount > 255) {
+          throw EncodeException(fieldPath = "LpByteWrappedTail.body", reason = """encoded message byte length ${bodyPatchByteCount} exceeds @LengthPrefixed(LengthPrefix.Byte) max 255""")
+        }
+        buffer.position(bodySizePosition)
+        val bodyPatchPrefix = bodyPatchByteCount.toUInt()
+        buffer.writeUByte((bodyPatchPrefix and 0xFFu).toUByte())
+        buffer.position(bodyEndPosition)
+      }
+    }
+  }
+
+  override fun wireSize(`value`: LpByteWrappedTail, context: EncodeContext): WireSize = when (val bodySize = WrappedLabelCodec.wireSize(value.body, context)) {
+    is WireSize.Exact -> WireSize.Exact(1 + bodySize.bytes)
+    WireSize.BackPatch -> WireSize.BackPatch
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    val bodyPrefix = (stream.peekByte(baseOffset + __offset).toInt() and 0xFF).toUInt()
+    if (bodyPrefix > (Int.MAX_VALUE - __offset - 1).toUInt()) {
+      throw DecodeException(fieldPath = "LpByteWrappedTail.body", bufferPosition = baseOffset + __offset, expected = "__offset + 1 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 1 + bodyPrefix.toInt()}""")
+    }
+    __offset += 1 + bodyPrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/LpWrappedTailCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/LpWrappedTailCodec.kt
@@ -1,0 +1,90 @@
+package com.ditchoom.buffer.codec.test.protocols.boundary
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object LpWrappedTailCodec : Codec<LpWrappedTail> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): LpWrappedTail {
+    val kind = buffer.readByte()
+    val bodyPrefixB0 = buffer.readUByte().toUInt()
+    val bodyPrefixB1 = buffer.readUByte().toUInt()
+    val bodyPrefix = ((bodyPrefixB0 shl 8) or bodyPrefixB1)
+    if (bodyPrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "LpWrappedTail.body", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = bodyPrefix.toString())
+    }
+    val bodyLength = bodyPrefix.toInt()
+    val bodyOuterLimit = buffer.limit()
+    buffer.setLimit(buffer.position() + bodyLength)
+    val body = try {
+      WrappedLabelCodec.decode(buffer, context)
+    } finally {
+      buffer.setLimit(bodyOuterLimit)
+    }
+    return LpWrappedTail(kind = kind, body = body)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: LpWrappedTail,
+    context: EncodeContext,
+  ) {
+    buffer.writeByte(value.kind)
+    when (val bodyWireSize = WrappedLabelCodec.wireSize(value.body, context)) {
+      is WireSize.Exact -> {
+        val bodyByteCount = bodyWireSize.bytes
+        if (bodyByteCount > 65_535) {
+          throw EncodeException(fieldPath = "LpWrappedTail.body", reason = """encoded message byte length ${bodyByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+        }
+        val bodyPrefix = bodyByteCount.toUInt()
+        buffer.writeUByte(((bodyPrefix shr 8) and 0xFFu).toUByte())
+        buffer.writeUByte((bodyPrefix and 0xFFu).toUByte())
+        WrappedLabelCodec.encode(buffer, value.body, context)
+      }
+      WireSize.BackPatch -> {
+        val bodySizePosition = buffer.position()
+        repeat(2) { buffer.writeUByte(0u) }
+        val bodyBodyStart = buffer.position()
+        WrappedLabelCodec.encode(buffer, value.body, context)
+        val bodyEndPosition = buffer.position()
+        val bodyPatchByteCount = bodyEndPosition - bodyBodyStart
+        if (bodyPatchByteCount > 65_535) {
+          throw EncodeException(fieldPath = "LpWrappedTail.body", reason = """encoded message byte length ${bodyPatchByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+        }
+        buffer.position(bodySizePosition)
+        val bodyPatchPrefix = bodyPatchByteCount.toUInt()
+        buffer.writeUByte(((bodyPatchPrefix shr 8) and 0xFFu).toUByte())
+        buffer.writeUByte((bodyPatchPrefix and 0xFFu).toUByte())
+        buffer.position(bodyEndPosition)
+      }
+    }
+  }
+
+  override fun wireSize(`value`: LpWrappedTail, context: EncodeContext): WireSize = when (val bodySize = WrappedLabelCodec.wireSize(value.body, context)) {
+    is WireSize.Exact -> WireSize.Exact(3 + bodySize.bytes)
+    WireSize.BackPatch -> WireSize.BackPatch
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    __offset += 1
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val bodyPrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val bodyPrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val bodyPrefix = ((bodyPrefixB0 shl 8) or bodyPrefixB1).toUInt()
+    if (bodyPrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "LpWrappedTail.body", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + bodyPrefix.toInt()}""")
+    }
+    __offset += 2 + bodyPrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/WithVidCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/WithVidCodec.kt
@@ -1,0 +1,94 @@
+package com.ditchoom.buffer.codec.test.protocols.boundary
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object WithVidCodec : Codec<WithVid> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): WithVid {
+    val padPrefixB0 = buffer.readUByte().toUInt()
+    val padPrefixB1 = buffer.readUByte().toUInt()
+    val padPrefix = ((padPrefixB0 shl 8) or padPrefixB1)
+    if (padPrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "WithVid.pad", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = padPrefix.toString())
+    }
+    val padLength = padPrefix.toInt()
+    val pad = buffer.readString(padLength, Charset.UTF8)
+    val idPrefixB0 = buffer.readUByte().toUInt()
+    val idPrefixB1 = buffer.readUByte().toUInt()
+    val idPrefix = ((idPrefixB0 shl 8) or idPrefixB1)
+    if (idPrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "WithVid.id", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = idPrefix.toString())
+    }
+    val idLength = idPrefix.toInt()
+    val id = BoundaryVid(buffer.readString(idLength, Charset.UTF8))
+    return WithVid(pad = pad, id = id)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: WithVid,
+    context: EncodeContext,
+  ) {
+    val padSizePosition = buffer.position()
+    repeat(2) { buffer.writeUByte(0u) }
+    val padBodyStart = buffer.position()
+    buffer.writeString(value.pad, Charset.UTF8)
+    val padEndPosition = buffer.position()
+    val padByteCount = padEndPosition - padBodyStart
+    if (padByteCount > 65_535) {
+      throw EncodeException(fieldPath = "WithVid.pad", reason = """UTF-8 byte length ${padByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(padSizePosition)
+    val padPrefix = padByteCount.toUInt()
+    buffer.writeUByte(((padPrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((padPrefix and 0xFFu).toUByte())
+    buffer.position(padEndPosition)
+    val idSizePosition = buffer.position()
+    repeat(2) { buffer.writeUByte(0u) }
+    val idBodyStart = buffer.position()
+    buffer.writeString(value.id.value, Charset.UTF8)
+    val idEndPosition = buffer.position()
+    val idByteCount = idEndPosition - idBodyStart
+    if (idByteCount > 65_535) {
+      throw EncodeException(fieldPath = "WithVid.id", reason = """UTF-8 byte length ${idByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(idSizePosition)
+    val idPrefix = idByteCount.toUInt()
+    buffer.writeUByte(((idPrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((idPrefix and 0xFFu).toUByte())
+    buffer.position(idEndPosition)
+  }
+
+  override fun wireSize(`value`: WithVid, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val padPrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val padPrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val padPrefix = ((padPrefixB0 shl 8) or padPrefixB1).toUInt()
+    if (padPrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "WithVid.pad", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + padPrefix.toInt()}""")
+    }
+    __offset += 2 + padPrefix.toInt()
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val idPrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val idPrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val idPrefix = ((idPrefixB0 shl 8) or idPrefixB1).toUInt()
+    if (idPrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "WithVid.id", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + idPrefix.toInt()}""")
+    }
+    __offset += 2 + idPrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/WrappedLabelCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/WrappedLabelCodec.kt
@@ -1,0 +1,64 @@
+package com.ditchoom.buffer.codec.test.protocols.boundary
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object WrappedLabelCodec : Codec<WrappedLabel> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): WrappedLabel {
+    val labelPrefixB0 = buffer.readUByte().toUInt()
+    val labelPrefixB1 = buffer.readUByte().toUInt()
+    val labelPrefix = ((labelPrefixB0 shl 8) or labelPrefixB1)
+    if (labelPrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "WrappedLabel.label", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = labelPrefix.toString())
+    }
+    val labelLength = labelPrefix.toInt()
+    val label = buffer.readString(labelLength, Charset.UTF8)
+    return WrappedLabel(label = label)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: WrappedLabel,
+    context: EncodeContext,
+  ) {
+    val labelSizePosition = buffer.position()
+    repeat(2) { buffer.writeUByte(0u) }
+    val labelBodyStart = buffer.position()
+    buffer.writeString(value.label, Charset.UTF8)
+    val labelEndPosition = buffer.position()
+    val labelByteCount = labelEndPosition - labelBodyStart
+    if (labelByteCount > 65_535) {
+      throw EncodeException(fieldPath = "WrappedLabel.label", reason = """UTF-8 byte length ${labelByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(labelSizePosition)
+    val labelPrefix = labelByteCount.toUInt()
+    buffer.writeUByte(((labelPrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((labelPrefix and 0xFFu).toUByte())
+    buffer.position(labelEndPosition)
+  }
+
+  override fun wireSize(`value`: WrappedLabel, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val labelPrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val labelPrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val labelPrefix = ((labelPrefixB0 shl 8) or labelPrefixB1).toUInt()
+    if (labelPrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "WrappedLabel.label", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + labelPrefix.toInt()}""")
+    }
+    __offset += 2 + labelPrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountBadgeAnonymousCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountBadgeAnonymousCodec.kt
@@ -1,0 +1,26 @@
+package com.ditchoom.buffer.codec.test.protocols.count
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object CountBadgeAnonymousCodec : Codec<CountBadge.Anonymous> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): CountBadge.Anonymous = CountBadge.Anonymous
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: CountBadge.Anonymous,
+    context: EncodeContext,
+  ) {
+  }
+
+  override fun wireSize(`value`: CountBadge.Anonymous, context: EncodeContext): WireSize = WireSize.Exact(0)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 0) PeekResult.Complete(0) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountBadgeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountBadgeCodec.kt
@@ -1,0 +1,70 @@
+package com.ditchoom.buffer.codec.test.protocols.count
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object CountBadgeCodec : Codec<CountBadge> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): CountBadge {
+    val discriminatorPosition = buffer.position()
+    val discriminator = buffer.readUByte().toInt()
+    return when (discriminator) {
+      0x00 -> CountBadgeNamedCodec.decode(buffer, context)
+      0x01 -> CountBadgeAnonymousCodec.decode(buffer, context)
+      else -> {
+        throw DecodeException(fieldPath = "CountBadge.discriminator", bufferPosition = discriminatorPosition, expected = "one of {0x00, 0x01}", actual = """0x${discriminator.toString(16).padStart(2, '0').uppercase()}""")
+      }
+    }
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: CountBadge,
+    context: EncodeContext,
+  ) {
+    when (value) {
+      is CountBadge.Named -> {
+        buffer.writeUByte(0x00.toUByte())
+        CountBadgeNamedCodec.encode(buffer, value, context)
+      }
+      is CountBadge.Anonymous -> {
+        buffer.writeUByte(0x01.toUByte())
+        CountBadgeAnonymousCodec.encode(buffer, value, context)
+      }
+    }
+  }
+
+  override fun wireSize(`value`: CountBadge, context: EncodeContext): WireSize = when (value) {
+    is CountBadge.Named -> WireSize.BackPatch
+    is CountBadge.Anonymous -> WireSize.Exact(1)
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
+    val discriminator = stream.peekByte(baseOffset).toInt() and 0xFF
+    return when (discriminator) {
+      0x00 -> {
+        when (val inner = CountBadgeNamedCodec.peekFrameSize(stream, baseOffset + 1)) {
+          is PeekResult.Complete -> PeekResult.Complete(1 + inner.bytes)
+          else -> inner
+        }
+      }
+      0x01 -> {
+        when (val inner = CountBadgeAnonymousCodec.peekFrameSize(stream, baseOffset + 1)) {
+          is PeekResult.Complete -> PeekResult.Complete(1 + inner.bytes)
+          else -> inner
+        }
+      }
+      else -> {
+        throw DecodeException(fieldPath = "CountBadge.discriminator", bufferPosition = baseOffset, expected = "one of {0x00, 0x01}", actual = """0x${discriminator.toString(16).padStart(2, '0').uppercase()}""")
+      }
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountBadgeNamedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountBadgeNamedCodec.kt
@@ -1,0 +1,64 @@
+package com.ditchoom.buffer.codec.test.protocols.count
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object CountBadgeNamedCodec : Codec<CountBadge.Named> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): CountBadge.Named {
+    val namePrefixB0 = buffer.readUByte().toUInt()
+    val namePrefixB1 = buffer.readUByte().toUInt()
+    val namePrefix = ((namePrefixB0 shl 8) or namePrefixB1)
+    if (namePrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "Named.name", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = namePrefix.toString())
+    }
+    val nameLength = namePrefix.toInt()
+    val name = buffer.readString(nameLength, Charset.UTF8)
+    return CountBadge.Named(name = name)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: CountBadge.Named,
+    context: EncodeContext,
+  ) {
+    val nameSizePosition = buffer.position()
+    repeat(2) { buffer.writeUByte(0u) }
+    val nameBodyStart = buffer.position()
+    buffer.writeString(value.name, Charset.UTF8)
+    val nameEndPosition = buffer.position()
+    val nameByteCount = nameEndPosition - nameBodyStart
+    if (nameByteCount > 65_535) {
+      throw EncodeException(fieldPath = "Named.name", reason = """UTF-8 byte length ${nameByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(nameSizePosition)
+    val namePrefix = nameByteCount.toUInt()
+    buffer.writeUByte(((namePrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((namePrefix and 0xFFu).toUByte())
+    buffer.position(nameEndPosition)
+  }
+
+  override fun wireSize(`value`: CountBadge.Named, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val namePrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val namePrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val namePrefix = ((namePrefixB0 shl 8) or namePrefixB1).toUInt()
+    if (namePrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "Named.name", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + namePrefix.toInt()}""")
+    }
+    __offset += 2 + namePrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountFixedListCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountFixedListCodec.kt
@@ -36,7 +36,14 @@ public object CountFixedListCodec : Codec<CountFixedList> {
 
   override fun wireSize(`value`: CountFixedList, context: EncodeContext): WireSize {
     val __pointsCountSize = (UnsignedVarIntCodec.wireSize(value.points.size.toUInt(), context) as WireSize.Exact).bytes
-    val __pointsSize = __pointsCountSize + value.points.sumOf { (CountPointCodec.wireSize(it, context) as WireSize.Exact).bytes }
+    var __pointsElementsSize = 0
+    for (__elem in value.points) {
+      when (val __elemSize = CountPointCodec.wireSize(__elem, context)) {
+        is WireSize.Exact -> __pointsElementsSize += __elemSize.bytes
+        WireSize.BackPatch -> return WireSize.BackPatch
+      }
+    }
+    val __pointsSize = __pointsCountSize + __pointsElementsSize
     return WireSize.Exact(1 + __pointsSize)
   }
 

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountInnerFixedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountInnerFixedCodec.kt
@@ -1,0 +1,34 @@
+package com.ditchoom.buffer.codec.test.protocols.count
+
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import com.ditchoom.buffer.swapBytes
+import kotlin.Int
+
+public object CountInnerFixedCodec : Codec<CountInnerFixed> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): CountInnerFixed {
+    val aRaw = buffer.readShort()
+    val a = if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) aRaw else swapBytes(aRaw)
+    return CountInnerFixed(a = a)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: CountInnerFixed,
+    context: EncodeContext,
+  ) {
+    val aRaw = value.a
+    buffer.writeShort(if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) aRaw else swapBytes(aRaw))
+  }
+
+  override fun wireSize(`value`: CountInnerFixed, context: EncodeContext): WireSize = WireSize.Exact(2)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountNamedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountNamedCodec.kt
@@ -32,7 +32,7 @@ public object CountNamedCodec : Codec<CountNamed> {
     context: EncodeContext,
   ) {
     val nameSizePosition = buffer.position()
-    buffer.position(nameSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val nameBodyStart = buffer.position()
     buffer.writeString(value.name, Charset.UTF8)
     val nameEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountNestedEntryCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountNestedEntryCodec.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.buffer.codec.test.protocols.count
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object CountNestedEntryCodec : Codec<CountNestedEntry> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): CountNestedEntry {
+    val inner = CountInnerFixedCodec.decode(buffer, context)
+    return CountNestedEntry(inner = inner)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: CountNestedEntry,
+    context: EncodeContext,
+  ) {
+    CountInnerFixedCodec.encode(buffer, value.inner, context)
+  }
+
+  override fun wireSize(`value`: CountNestedEntry, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountNestedEntryListCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountNestedEntryListCodec.kt
@@ -1,0 +1,38 @@
+package com.ditchoom.buffer.codec.test.protocols.count
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.UnsignedVarIntCodec
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object CountNestedEntryListCodec : Codec<CountNestedEntryList> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): CountNestedEntryList {
+    val __entriesCount = UnsignedVarIntCodec.decode(buffer, context).toInt()
+    val entries = ArrayList<CountNestedEntry>(__entriesCount.coerceIn(0, 1_024))
+    repeat(__entriesCount) {
+      entries += CountNestedEntryCodec.decode(buffer, context)
+    }
+    return CountNestedEntryList(entries = entries)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: CountNestedEntryList,
+    context: EncodeContext,
+  ) {
+    UnsignedVarIntCodec.encode(buffer, value.entries.size.toUInt(), context)
+    for (__elem in value.entries) {
+      CountNestedEntryCodec.encode(buffer, __elem, context)
+    }
+  }
+
+  override fun wireSize(`value`: CountNestedEntryList, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountSealedEntryCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountSealedEntryCodec.kt
@@ -1,0 +1,36 @@
+package com.ditchoom.buffer.codec.test.protocols.count
+
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import com.ditchoom.buffer.swapBytes
+import kotlin.Int
+
+public object CountSealedEntryCodec : Codec<CountSealedEntry> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): CountSealedEntry {
+    val idRaw = buffer.readShort()
+    val id = (if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) idRaw else swapBytes(idRaw)).toUShort()
+    val badge = CountBadgeCodec.decode(buffer, context)
+    return CountSealedEntry(id = id, badge = badge)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: CountSealedEntry,
+    context: EncodeContext,
+  ) {
+    val idRaw = value.id.toShort()
+    buffer.writeShort(if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) idRaw else swapBytes(idRaw))
+    CountBadgeCodec.encode(buffer, value.badge, context)
+  }
+
+  override fun wireSize(`value`: CountSealedEntry, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountSealedEntryListCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountSealedEntryListCodec.kt
@@ -1,0 +1,38 @@
+package com.ditchoom.buffer.codec.test.protocols.count
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.UnsignedVarIntCodec
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object CountSealedEntryListCodec : Codec<CountSealedEntryList> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): CountSealedEntryList {
+    val __entriesCount = UnsignedVarIntCodec.decode(buffer, context).toInt()
+    val entries = ArrayList<CountSealedEntry>(__entriesCount.coerceIn(0, 1_024))
+    repeat(__entriesCount) {
+      entries += CountSealedEntryCodec.decode(buffer, context)
+    }
+    return CountSealedEntryList(entries = entries)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: CountSealedEntryList,
+    context: EncodeContext,
+  ) {
+    UnsignedVarIntCodec.encode(buffer, value.entries.size.toUInt(), context)
+    for (__elem in value.entries) {
+      CountSealedEntryCodec.encode(buffer, __elem, context)
+    }
+  }
+
+  override fun wireSize(`value`: CountSealedEntryList, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountTaggedEntryCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountTaggedEntryCodec.kt
@@ -1,0 +1,64 @@
+package com.ditchoom.buffer.codec.test.protocols.count
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object CountTaggedEntryCodec : Codec<CountTaggedEntry> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): CountTaggedEntry {
+    val tagPrefixB0 = buffer.readUByte().toUInt()
+    val tagPrefixB1 = buffer.readUByte().toUInt()
+    val tagPrefix = ((tagPrefixB0 shl 8) or tagPrefixB1)
+    if (tagPrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "CountTaggedEntry.tag", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = tagPrefix.toString())
+    }
+    val tagLength = tagPrefix.toInt()
+    val tag = CountTag(buffer.readString(tagLength, Charset.UTF8))
+    return CountTaggedEntry(tag = tag)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: CountTaggedEntry,
+    context: EncodeContext,
+  ) {
+    val tagSizePosition = buffer.position()
+    repeat(2) { buffer.writeUByte(0u) }
+    val tagBodyStart = buffer.position()
+    buffer.writeString(value.tag.value, Charset.UTF8)
+    val tagEndPosition = buffer.position()
+    val tagByteCount = tagEndPosition - tagBodyStart
+    if (tagByteCount > 65_535) {
+      throw EncodeException(fieldPath = "CountTaggedEntry.tag", reason = """UTF-8 byte length ${tagByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(tagSizePosition)
+    val tagPrefix = tagByteCount.toUInt()
+    buffer.writeUByte(((tagPrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((tagPrefix and 0xFFu).toUByte())
+    buffer.position(tagEndPosition)
+  }
+
+  override fun wireSize(`value`: CountTaggedEntry, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val tagPrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val tagPrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val tagPrefix = ((tagPrefixB0 shl 8) or tagPrefixB1).toUInt()
+    if (tagPrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "CountTaggedEntry.tag", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + tagPrefix.toInt()}""")
+    }
+    __offset += 2 + tagPrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountTaggedListCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountTaggedListCodec.kt
@@ -1,0 +1,38 @@
+package com.ditchoom.buffer.codec.test.protocols.count
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.UnsignedVarIntCodec
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object CountTaggedListCodec : Codec<CountTaggedList> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): CountTaggedList {
+    val __tagsCount = UnsignedVarIntCodec.decode(buffer, context).toInt()
+    val tags = ArrayList<CountTaggedEntry>(__tagsCount.coerceIn(0, 1_024))
+    repeat(__tagsCount) {
+      tags += CountTaggedEntryCodec.decode(buffer, context)
+    }
+    return CountTaggedList(tags = tags)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: CountTaggedList,
+    context: EncodeContext,
+  ) {
+    UnsignedVarIntCodec.encode(buffer, value.tags.size.toUInt(), context)
+    for (__elem in value.tags) {
+      CountTaggedEntryCodec.encode(buffer, __elem, context)
+    }
+  }
+
+  override fun wireSize(`value`: CountTaggedList, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountThenTrailerCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountThenTrailerCodec.kt
@@ -40,7 +40,14 @@ public object CountThenTrailerCodec : Codec<CountThenTrailer> {
 
   override fun wireSize(`value`: CountThenTrailer, context: EncodeContext): WireSize {
     val __pointsCountSize = (UnsignedVarIntCodec.wireSize(value.points.size.toUInt(), context) as WireSize.Exact).bytes
-    val __pointsSize = __pointsCountSize + value.points.sumOf { (CountPointCodec.wireSize(it, context) as WireSize.Exact).bytes }
+    var __pointsElementsSize = 0
+    for (__elem in value.points) {
+      when (val __elemSize = CountPointCodec.wireSize(__elem, context)) {
+        is WireSize.Exact -> __pointsElementsSize += __elemSize.bytes
+        WireSize.BackPatch -> return WireSize.BackPatch
+      }
+    }
+    val __pointsSize = __pointsCountSize + __pointsElementsSize
     return WireSize.Exact(4 + __pointsSize)
   }
 

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/forwardcompat/ForwardCompatibleOpSetTitleCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/forwardcompat/ForwardCompatibleOpSetTitleCodec.kt
@@ -68,7 +68,7 @@ public object ForwardCompatibleOpSetTitleCodec {
     },
   ) { buffer ->
     val titleSizePosition = buffer.position()
-    buffer.position(titleSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val titleBodyStart = buffer.position()
     buffer.writeString(value.title, Charset.UTF8)
     val titleEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/grpc/GrpcLengthPrefixedMessageCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/grpc/GrpcLengthPrefixedMessageCodec.kt
@@ -41,7 +41,7 @@ public object GrpcLengthPrefixedMessageCodec : Codec<GrpcLengthPrefixedMessage> 
   ) {
     buffer.writeUByte(value.compressedFlag)
     val messageSizePosition = buffer.position()
-    buffer.position(messageSizePosition + 4)
+    repeat(4) { buffer.writeUByte(0u) }
     val messageBodyStart = buffer.position()
     BinaryDataCodec.encode(buffer, value.message, context)
     val messageEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameTypeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameTypeCodec.kt
@@ -26,7 +26,10 @@ public object Http3FrameTypeCodec : Codec<Http3FrameType> {
   }
 
   override fun wireSize(`value`: Http3FrameType, context: EncodeContext): WireSize {
-    val __rawSize = (QuicVarintCodec.wireSize(value.raw, context) as WireSize.Exact).bytes
+    val __rawSize = when (val __s = QuicVarintCodec.wireSize(value.raw, context)) {
+      is WireSize.Exact -> __s.bytes
+      WireSize.BackPatch -> return WireSize.BackPatch
+    }
     return WireSize.Exact(0 + __rawSize)
   }
 

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcFrameTypeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcFrameTypeCodec.kt
@@ -26,7 +26,10 @@ public object Http3FcFrameTypeCodec : Codec<Http3FcFrameType> {
   }
 
   override fun wireSize(`value`: Http3FcFrameType, context: EncodeContext): WireSize {
-    val __rawSize = (QuicVarintCodec.wireSize(value.raw, context) as WireSize.Exact).bytes
+    val __rawSize = when (val __s = QuicVarintCodec.wireSize(value.raw, context)) {
+      is WireSize.Exact -> __s.bytes
+      WireSize.BackPatch -> return WireSize.BackPatch
+    }
     return WireSize.Exact(0 + __rawSize)
   }
 

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcSettingCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcSettingCodec.kt
@@ -28,8 +28,14 @@ public object Http3FcSettingCodec : Codec<Http3FcSetting> {
   }
 
   override fun wireSize(`value`: Http3FcSetting, context: EncodeContext): WireSize {
-    val __identifierSize = (QuicVarintCodec.wireSize(value.identifier, context) as WireSize.Exact).bytes
-    val __valueSize = (QuicVarintCodec.wireSize(value.value, context) as WireSize.Exact).bytes
+    val __identifierSize = when (val __s = QuicVarintCodec.wireSize(value.identifier, context)) {
+      is WireSize.Exact -> __s.bytes
+      WireSize.BackPatch -> return WireSize.BackPatch
+    }
+    val __valueSize = when (val __s = QuicVarintCodec.wireSize(value.value, context)) {
+      is WireSize.Exact -> __s.bytes
+      WireSize.BackPatch -> return WireSize.BackPatch
+    }
     return WireSize.Exact(0 + __identifierSize + __valueSize)
   }
 

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/PropertyBagFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/PropertyBagFrameCodec.kt
@@ -1,11 +1,14 @@
 package com.ditchoom.buffer.codec.test.protocols.lengthprefixedusecodec
 
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
 import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.WriteBuffer
 import com.ditchoom.buffer.codec.Codec
 import com.ditchoom.buffer.codec.DecodeContext
 import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.LengthPrefixedListEncoder
 import com.ditchoom.buffer.codec.PeekResult
 import com.ditchoom.buffer.codec.WireSize
 import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttRemainingLengthCodec
@@ -34,10 +37,23 @@ public object PropertyBagFrameCodec : Codec<PropertyBagFrame> {
     `value`: PropertyBagFrame,
     context: EncodeContext,
   ) {
-    val __propertiesBodyBytes = value.properties.sumOf { (PropertyEntryCodec.wireSize(it, context) as WireSize.Exact).bytes }
-    MqttRemainingLengthCodec.encode(buffer, __propertiesBodyBytes.toUInt(), context)
+    var __propertiesBodyBytes = 0
+    var __propertiesAllExact = true
     for (__elem in value.properties) {
-      PropertyEntryCodec.encode(buffer, __elem, context)
+      val __elemSize = PropertyEntryCodec.wireSize(__elem, context)
+      if (__elemSize !is WireSize.Exact) {
+        __propertiesAllExact = false
+        break
+      }
+      __propertiesBodyBytes += __elemSize.bytes
+    }
+    if (__propertiesAllExact) {
+      MqttRemainingLengthCodec.encode(buffer, __propertiesBodyBytes.toUInt(), context)
+      for (__elem in value.properties) {
+        PropertyEntryCodec.encode(buffer, __elem, context)
+      }
+    } else {
+      LengthPrefixedListEncoder.encode(buffer, BufferFactory.Default, MqttRemainingLengthCodec, value.properties, PropertyEntryCodec, context)
     }
   }
 

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/StringTaggedPropertyCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/StringTaggedPropertyCodec.kt
@@ -33,7 +33,7 @@ public object StringTaggedPropertyCodec : Codec<StringTaggedProperty> {
     context: EncodeContext,
   ) {
     val tagSizePosition = buffer.position()
-    buffer.position(tagSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val tagBodyStart = buffer.position()
     buffer.writeString(value.tag, Charset.UTF8)
     val tagEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/TaggedPropertyBagCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/TaggedPropertyBagCodec.kt
@@ -1,11 +1,14 @@
 package com.ditchoom.buffer.codec.test.protocols.lengthprefixedusecodec
 
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
 import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.WriteBuffer
 import com.ditchoom.buffer.codec.Codec
 import com.ditchoom.buffer.codec.DecodeContext
 import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.LengthPrefixedListEncoder
 import com.ditchoom.buffer.codec.PeekResult
 import com.ditchoom.buffer.codec.WireSize
 import com.ditchoom.buffer.codec.test.protocols.mqtt.MqttRemainingLengthCodec
@@ -36,10 +39,23 @@ public object TaggedPropertyBagCodec : Codec<TaggedPropertyBag> {
     context: EncodeContext,
   ) {
     buffer.writeUByte(value.tag)
-    val __propertiesBodyBytes = value.properties.sumOf { (PropertyEntryCodec.wireSize(it, context) as WireSize.Exact).bytes }
-    MqttRemainingLengthCodec.encode(buffer, __propertiesBodyBytes.toUInt(), context)
+    var __propertiesBodyBytes = 0
+    var __propertiesAllExact = true
     for (__elem in value.properties) {
-      PropertyEntryCodec.encode(buffer, __elem, context)
+      val __elemSize = PropertyEntryCodec.wireSize(__elem, context)
+      if (__elemSize !is WireSize.Exact) {
+        __propertiesAllExact = false
+        break
+      }
+      __propertiesBodyBytes += __elemSize.bytes
+    }
+    if (__propertiesAllExact) {
+      MqttRemainingLengthCodec.encode(buffer, __propertiesBodyBytes.toUInt(), context)
+      for (__elem in value.properties) {
+        PropertyEntryCodec.encode(buffer, __elem, context)
+      }
+    } else {
+      LengthPrefixedListEncoder.encode(buffer, BufferFactory.Default, MqttRemainingLengthCodec, value.properties, PropertyEntryCodec, context)
     }
   }
 

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttConnectProtocolNameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttConnectProtocolNameCodec.kt
@@ -32,7 +32,7 @@ public object MqttConnectProtocolNameCodec : Codec<MqttConnectProtocolName> {
     context: EncodeContext,
   ) {
     val nameSizePosition = buffer.position()
-    buffer.position(nameSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val nameBodyStart = buffer.position()
     buffer.writeString(value.name, Charset.UTF8)
     val nameEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketConnectCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketConnectCodec.kt
@@ -152,7 +152,7 @@ public object MqttPacketConnectCodec {
     },
   ) { buffer ->
     val protocolNameSizePosition = buffer.position()
-    buffer.position(protocolNameSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val protocolNameBodyStart = buffer.position()
     buffer.writeString(value.protocolName, Charset.UTF8)
     val protocolNameEndPosition = buffer.position()
@@ -171,7 +171,7 @@ public object MqttPacketConnectCodec {
       buffer.writeInt((value.protocolLevel.toInt() and 0xFF) or ((value.connectFlags.raw.toInt() and 0xFF) shl 8) or ((value.keepAliveSeconds.toInt() and 0xFFFF) shl 16))
     }
     val clientIdSizePosition = buffer.position()
-    buffer.position(clientIdSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val clientIdBodyStart = buffer.position()
     buffer.writeString(value.clientId, Charset.UTF8)
     val clientIdEndPosition = buffer.position()
@@ -187,7 +187,7 @@ public object MqttPacketConnectCodec {
     if (value.connectFlags.willPresent) {
       val willTopicValue = value.willTopic ?: throw EncodeException(fieldPath = "Connect.willTopic", reason = "@When(\"connectFlags.willPresent\") predicate is true but field is null")
       val willTopicSizePosition = buffer.position()
-      buffer.position(willTopicSizePosition + 2)
+      repeat(2) { buffer.writeUByte(0u) }
       val willTopicBodyStart = buffer.position()
       buffer.writeString(willTopicValue, Charset.UTF8)
       val willTopicEndPosition = buffer.position()
@@ -204,7 +204,7 @@ public object MqttPacketConnectCodec {
     if (value.connectFlags.willPresent) {
       val willPayloadValue = value.willPayload ?: throw EncodeException(fieldPath = "Connect.willPayload", reason = "@When(\"connectFlags.willPresent\") predicate is true but field is null")
       val willPayloadSizePosition = buffer.position()
-      buffer.position(willPayloadSizePosition + 2)
+      repeat(2) { buffer.writeUByte(0u) }
       val willPayloadBodyStart = buffer.position()
       BinaryDataCodec.encode(buffer, willPayloadValue, context)
       val willPayloadEndPosition = buffer.position()
@@ -221,7 +221,7 @@ public object MqttPacketConnectCodec {
     if (value.connectFlags.usernamePresent) {
       val usernameValue = value.username ?: throw EncodeException(fieldPath = "Connect.username", reason = "@When(\"connectFlags.usernamePresent\") predicate is true but field is null")
       val usernameSizePosition = buffer.position()
-      buffer.position(usernameSizePosition + 2)
+      repeat(2) { buffer.writeUByte(0u) }
       val usernameBodyStart = buffer.position()
       buffer.writeString(usernameValue, Charset.UTF8)
       val usernameEndPosition = buffer.position()
@@ -238,7 +238,7 @@ public object MqttPacketConnectCodec {
     if (value.connectFlags.passwordPresent) {
       val passwordValue = value.password ?: throw EncodeException(fieldPath = "Connect.password", reason = "@When(\"connectFlags.passwordPresent\") predicate is true but field is null")
       val passwordSizePosition = buffer.position()
-      buffer.position(passwordSizePosition + 2)
+      repeat(2) { buffer.writeUByte(0u) }
       val passwordBodyStart = buffer.position()
       BinaryDataCodec.encode(buffer, passwordValue, context)
       val passwordEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketPublishCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketPublishCodec.kt
@@ -76,7 +76,7 @@ public class MqttPacketPublishCodec<P : Payload>(
     },
   ) { buffer ->
     val topicSizePosition = buffer.position()
-    buffer.position(topicSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val topicBodyStart = buffer.position()
     buffer.writeString(value.topic, Charset.UTF8)
     val topicEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttTopicFilterCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttTopicFilterCodec.kt
@@ -33,7 +33,7 @@ public object MqttTopicFilterCodec : Codec<MqttTopicFilter> {
     context: EncodeContext,
   ) {
     val filterSizePosition = buffer.position()
-    buffer.position(filterSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val filterBodyStart = buffer.position()
     buffer.writeString(value.filter, Charset.UTF8)
     val filterEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttUnsubscribeTopicCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttUnsubscribeTopicCodec.kt
@@ -32,7 +32,7 @@ public object MqttUnsubscribeTopicCodec : Codec<MqttUnsubscribeTopic> {
     context: EncodeContext,
   ) {
     val nameSizePosition = buffer.position()
-    buffer.position(nameSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val nameBodyStart = buffer.position()
     buffer.writeString(value.name, Charset.UTF8)
     val nameEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketConnectCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketConnectCodec.kt
@@ -149,7 +149,7 @@ public object MqttV5PacketConnectCodec {
     },
   ) { buffer ->
     val protocolNameSizePosition = buffer.position()
-    buffer.position(protocolNameSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val protocolNameBodyStart = buffer.position()
     buffer.writeString(value.protocolName, Charset.UTF8)
     val protocolNameEndPosition = buffer.position()
@@ -168,7 +168,7 @@ public object MqttV5PacketConnectCodec {
     buffer.writeShort(if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) keepAliveSecondsRaw else swapBytes(keepAliveSecondsRaw))
     V5PropertyBagCodec.encode(buffer, value.properties, context)
     val clientIdSizePosition = buffer.position()
-    buffer.position(clientIdSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val clientIdBodyStart = buffer.position()
     buffer.writeString(value.clientId, Charset.UTF8)
     val clientIdEndPosition = buffer.position()
@@ -188,7 +188,7 @@ public object MqttV5PacketConnectCodec {
     if (value.connectFlags.willPresent) {
       val willTopicValue = value.willTopic ?: throw EncodeException(fieldPath = "Connect.willTopic", reason = "@When(\"connectFlags.willPresent\") predicate is true but field is null")
       val willTopicSizePosition = buffer.position()
-      buffer.position(willTopicSizePosition + 2)
+      repeat(2) { buffer.writeUByte(0u) }
       val willTopicBodyStart = buffer.position()
       buffer.writeString(willTopicValue, Charset.UTF8)
       val willTopicEndPosition = buffer.position()
@@ -205,7 +205,7 @@ public object MqttV5PacketConnectCodec {
     if (value.connectFlags.willPresent) {
       val willPayloadValue = value.willPayload ?: throw EncodeException(fieldPath = "Connect.willPayload", reason = "@When(\"connectFlags.willPresent\") predicate is true but field is null")
       val willPayloadSizePosition = buffer.position()
-      buffer.position(willPayloadSizePosition + 2)
+      repeat(2) { buffer.writeUByte(0u) }
       val willPayloadBodyStart = buffer.position()
       BinaryDataCodec.encode(buffer, willPayloadValue, context)
       val willPayloadEndPosition = buffer.position()
@@ -222,7 +222,7 @@ public object MqttV5PacketConnectCodec {
     if (value.connectFlags.usernamePresent) {
       val usernameValue = value.username ?: throw EncodeException(fieldPath = "Connect.username", reason = "@When(\"connectFlags.usernamePresent\") predicate is true but field is null")
       val usernameSizePosition = buffer.position()
-      buffer.position(usernameSizePosition + 2)
+      repeat(2) { buffer.writeUByte(0u) }
       val usernameBodyStart = buffer.position()
       buffer.writeString(usernameValue, Charset.UTF8)
       val usernameEndPosition = buffer.position()
@@ -239,7 +239,7 @@ public object MqttV5PacketConnectCodec {
     if (value.connectFlags.passwordPresent) {
       val passwordValue = value.password ?: throw EncodeException(fieldPath = "Connect.password", reason = "@When(\"connectFlags.passwordPresent\") predicate is true but field is null")
       val passwordSizePosition = buffer.position()
-      buffer.position(passwordSizePosition + 2)
+      repeat(2) { buffer.writeUByte(0u) }
       val passwordBodyStart = buffer.position()
       BinaryDataCodec.encode(buffer, passwordValue, context)
       val passwordEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketPublishCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketPublishCodec.kt
@@ -79,7 +79,7 @@ public class MqttV5PacketPublishCodec<P : Payload>(
     },
   ) { buffer ->
     val topicSizePosition = buffer.position()
-    buffer.position(topicSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val topicBodyStart = buffer.position()
     buffer.writeString(value.topic, Charset.UTF8)
     val topicEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyAssignedClientIdentifierCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyAssignedClientIdentifierCodec.kt
@@ -34,7 +34,7 @@ public object MqttV5PropertyAssignedClientIdentifierCodec : Codec<MqttV5Property
   ) {
     buffer.writeUByte(value.id.raw)
     val valueSizePosition = buffer.position()
-    buffer.position(valueSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val valueBodyStart = buffer.position()
     buffer.writeString(value.value, Charset.UTF8)
     val valueEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyAuthenticationDataCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyAuthenticationDataCodec.kt
@@ -40,7 +40,7 @@ public object MqttV5PropertyAuthenticationDataCodec : Codec<MqttV5Property.Authe
   ) {
     buffer.writeUByte(value.id.raw)
     val dataSizePosition = buffer.position()
-    buffer.position(dataSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val dataBodyStart = buffer.position()
     BinaryDataCodec.encode(buffer, value.data, context)
     val dataEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyAuthenticationMethodCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyAuthenticationMethodCodec.kt
@@ -34,7 +34,7 @@ public object MqttV5PropertyAuthenticationMethodCodec : Codec<MqttV5Property.Aut
   ) {
     buffer.writeUByte(value.id.raw)
     val valueSizePosition = buffer.position()
-    buffer.position(valueSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val valueBodyStart = buffer.position()
     buffer.writeString(value.value, Charset.UTF8)
     val valueEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyContentTypeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyContentTypeCodec.kt
@@ -34,7 +34,7 @@ public object MqttV5PropertyContentTypeCodec : Codec<MqttV5Property.ContentType>
   ) {
     buffer.writeUByte(value.id.raw)
     val valueSizePosition = buffer.position()
-    buffer.position(valueSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val valueBodyStart = buffer.position()
     buffer.writeString(value.value, Charset.UTF8)
     val valueEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyCorrelationDataCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyCorrelationDataCodec.kt
@@ -40,7 +40,7 @@ public object MqttV5PropertyCorrelationDataCodec : Codec<MqttV5Property.Correlat
   ) {
     buffer.writeUByte(value.id.raw)
     val dataSizePosition = buffer.position()
-    buffer.position(dataSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val dataBodyStart = buffer.position()
     BinaryDataCodec.encode(buffer, value.data, context)
     val dataEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyReasonStringCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyReasonStringCodec.kt
@@ -34,7 +34,7 @@ public object MqttV5PropertyReasonStringCodec : Codec<MqttV5Property.ReasonStrin
   ) {
     buffer.writeUByte(value.id.raw)
     val valueSizePosition = buffer.position()
-    buffer.position(valueSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val valueBodyStart = buffer.position()
     buffer.writeString(value.value, Charset.UTF8)
     val valueEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyResponseInformationCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyResponseInformationCodec.kt
@@ -34,7 +34,7 @@ public object MqttV5PropertyResponseInformationCodec : Codec<MqttV5Property.Resp
   ) {
     buffer.writeUByte(value.id.raw)
     val valueSizePosition = buffer.position()
-    buffer.position(valueSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val valueBodyStart = buffer.position()
     buffer.writeString(value.value, Charset.UTF8)
     val valueEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyResponseTopicCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyResponseTopicCodec.kt
@@ -34,7 +34,7 @@ public object MqttV5PropertyResponseTopicCodec : Codec<MqttV5Property.ResponseTo
   ) {
     buffer.writeUByte(value.id.raw)
     val valueSizePosition = buffer.position()
-    buffer.position(valueSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val valueBodyStart = buffer.position()
     buffer.writeString(value.value, Charset.UTF8)
     val valueEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyServerReferenceCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyServerReferenceCodec.kt
@@ -34,7 +34,7 @@ public object MqttV5PropertyServerReferenceCodec : Codec<MqttV5Property.ServerRe
   ) {
     buffer.writeUByte(value.id.raw)
     val valueSizePosition = buffer.position()
-    buffer.position(valueSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val valueBodyStart = buffer.position()
     buffer.writeString(value.value, Charset.UTF8)
     val valueEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyUserPropertyCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyUserPropertyCodec.kt
@@ -42,7 +42,7 @@ public object MqttV5PropertyUserPropertyCodec : Codec<MqttV5Property.UserPropert
   ) {
     buffer.writeUByte(value.id.raw)
     val keySizePosition = buffer.position()
-    buffer.position(keySizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val keyBodyStart = buffer.position()
     buffer.writeString(value.key, Charset.UTF8)
     val keyEndPosition = buffer.position()
@@ -56,7 +56,7 @@ public object MqttV5PropertyUserPropertyCodec : Codec<MqttV5Property.UserPropert
     buffer.writeUByte((keyPrefix and 0xFFu).toUByte())
     buffer.position(keyEndPosition)
     val valueSizePosition = buffer.position()
-    buffer.position(valueSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val valueBodyStart = buffer.position()
     buffer.writeString(value.value, Charset.UTF8)
     val valueEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/V5SubscriptionCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/V5SubscriptionCodec.kt
@@ -33,7 +33,7 @@ public object V5SubscriptionCodec : Codec<V5Subscription> {
     context: EncodeContext,
   ) {
     val topicFilterSizePosition = buffer.position()
-    buffer.position(topicFilterSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val topicFilterBodyStart = buffer.position()
     buffer.writeString(value.topicFilter, Charset.UTF8)
     val topicFilterEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/payload/MqttPublishV3Codec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/payload/MqttPublishV3Codec.kt
@@ -42,7 +42,7 @@ public class MqttPublishV3Codec<P : Payload>(
   ) {
     buffer.writeUByte(value.header.raw)
     val topicSizePosition = buffer.position()
-    buffer.position(topicSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val topicBodyStart = buffer.position()
     buffer.writeString(value.topic, Charset.UTF8)
     val topicEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/payload/MqttPublishV3ConcreteCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/payload/MqttPublishV3ConcreteCodec.kt
@@ -38,7 +38,7 @@ public object MqttPublishV3ConcreteCodec : Codec<MqttPublishV3Concrete> {
   ) {
     buffer.writeUByte(value.header.raw)
     val topicSizePosition = buffer.position()
-    buffer.position(topicSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val topicBodyStart = buffer.position()
     buffer.writeString(value.topic, Charset.UTF8)
     val topicEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/riff/WavFmtChunkCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/riff/WavFmtChunkCodec.kt
@@ -43,17 +43,37 @@ public object WavFmtChunkCodec : Codec<WavFmtChunk> {
   ) {
     val fourCCRaw = value.fourCC.toInt()
     buffer.writeInt(if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) fourCCRaw else swapBytes(fourCCRaw))
-    val bodyPrefix = (WavFmtBodyCodec.wireSize(value.body, context) as WireSize.Exact).bytes.toUInt()
-    buffer.writeUByte((bodyPrefix and 0xFFu).toUByte())
-    buffer.writeUByte(((bodyPrefix shr 8) and 0xFFu).toUByte())
-    buffer.writeUByte(((bodyPrefix shr 16) and 0xFFu).toUByte())
-    buffer.writeUByte(((bodyPrefix shr 24) and 0xFFu).toUByte())
-    WavFmtBodyCodec.encode(buffer, value.body, context)
+    when (val bodyWireSize = WavFmtBodyCodec.wireSize(value.body, context)) {
+      is WireSize.Exact -> {
+        val bodyByteCount = bodyWireSize.bytes
+        val bodyPrefix = bodyByteCount.toUInt()
+        buffer.writeUByte((bodyPrefix and 0xFFu).toUByte())
+        buffer.writeUByte(((bodyPrefix shr 8) and 0xFFu).toUByte())
+        buffer.writeUByte(((bodyPrefix shr 16) and 0xFFu).toUByte())
+        buffer.writeUByte(((bodyPrefix shr 24) and 0xFFu).toUByte())
+        WavFmtBodyCodec.encode(buffer, value.body, context)
+      }
+      WireSize.BackPatch -> {
+        val bodySizePosition = buffer.position()
+        repeat(4) { buffer.writeUByte(0u) }
+        val bodyBodyStart = buffer.position()
+        WavFmtBodyCodec.encode(buffer, value.body, context)
+        val bodyEndPosition = buffer.position()
+        val bodyPatchByteCount = bodyEndPosition - bodyBodyStart
+        buffer.position(bodySizePosition)
+        val bodyPatchPrefix = bodyPatchByteCount.toUInt()
+        buffer.writeUByte((bodyPatchPrefix and 0xFFu).toUByte())
+        buffer.writeUByte(((bodyPatchPrefix shr 8) and 0xFFu).toUByte())
+        buffer.writeUByte(((bodyPatchPrefix shr 16) and 0xFFu).toUByte())
+        buffer.writeUByte(((bodyPatchPrefix shr 24) and 0xFFu).toUByte())
+        buffer.position(bodyEndPosition)
+      }
+    }
   }
 
-  override fun wireSize(`value`: WavFmtChunk, context: EncodeContext): WireSize {
-    val bodySize = (WavFmtBodyCodec.wireSize(value.body, context) as WireSize.Exact).bytes
-    return WireSize.Exact(8 + bodySize)
+  override fun wireSize(`value`: WavFmtChunk, context: EncodeContext): WireSize = when (val bodySize = WavFmtBodyCodec.wireSize(value.body, context)) {
+    is WireSize.Exact -> WireSize.Exact(8 + bodySize.bytes)
+    WireSize.BackPatch -> WireSize.BackPatch
   }
 
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/BytePrefixedStringCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/BytePrefixedStringCodec.kt
@@ -30,7 +30,7 @@ public object BytePrefixedStringCodec : Codec<BytePrefixedString> {
     context: EncodeContext,
   ) {
     val nameSizePosition = buffer.position()
-    buffer.position(nameSizePosition + 1)
+    repeat(1) { buffer.writeUByte(0u) }
     val nameBodyStart = buffer.position()
     buffer.writeString(value.name, Charset.UTF8)
     val nameEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/CommandEchoCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/CommandEchoCodec.kt
@@ -32,7 +32,7 @@ public object CommandEchoCodec : Codec<Command.Echo> {
     context: EncodeContext,
   ) {
     val msgSizePosition = buffer.position()
-    buffer.position(msgSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val msgBodyStart = buffer.position()
     buffer.writeString(value.msg, Charset.UTF8)
     val msgEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/IntPrefixedStringCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/IntPrefixedStringCodec.kt
@@ -33,7 +33,7 @@ public object IntPrefixedStringCodec : Codec<IntPrefixedString> {
     context: EncodeContext,
   ) {
     val nameSizePosition = buffer.position()
-    buffer.position(nameSizePosition + 4)
+    repeat(4) { buffer.writeUByte(0u) }
     val nameBodyStart = buffer.position()
     buffer.writeString(value.name, Charset.UTF8)
     val nameEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/SimpleHeaderCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/SimpleHeaderCodec.kt
@@ -34,7 +34,7 @@ public object SimpleHeaderCodec : Codec<SimpleHeader> {
   ) {
     buffer.writeInt(value.id)
     val nameSizePosition = buffer.position()
-    buffer.position(nameSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val nameBodyStart = buffer.position()
     buffer.writeString(value.name, Charset.UTF8)
     val nameEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/TwoStringsCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/TwoStringsCodec.kt
@@ -40,7 +40,7 @@ public object TwoStringsCodec : Codec<TwoStrings> {
     context: EncodeContext,
   ) {
     val firstSizePosition = buffer.position()
-    buffer.position(firstSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val firstBodyStart = buffer.position()
     buffer.writeString(value.first, Charset.UTF8)
     val firstEndPosition = buffer.position()
@@ -54,7 +54,7 @@ public object TwoStringsCodec : Codec<TwoStrings> {
     buffer.writeUByte((firstPrefix and 0xFFu).toUByte())
     buffer.position(firstEndPosition)
     val secondSizePosition = buffer.position()
-    buffer.position(secondSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val secondBodyStart = buffer.position()
     buffer.writeString(value.second, Charset.UTF8)
     val secondEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/WithFlagPayloadCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/WithFlagPayloadCodec.kt
@@ -41,7 +41,7 @@ public object WithFlagPayloadCodec : Codec<WithFlagPayload> {
     if (value.flags.want) {
       val payloadValue = value.payload ?: throw EncodeException(fieldPath = "WithFlagPayload.payload", reason = "@When(\"flags.want\") predicate is true but field is null")
       val payloadSizePosition = buffer.position()
-      buffer.position(payloadSizePosition + 2)
+      repeat(2) { buffer.writeUByte(0u) }
       val payloadBodyStart = buffer.position()
       buffer.writeString(payloadValue, Charset.UTF8)
       val payloadEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice10e/RemoteCommandCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice10e/RemoteCommandCodec.kt
@@ -34,7 +34,7 @@ public object RemoteCommandCodec : Codec<RemoteCommand> {
     context: EncodeContext,
   ) {
     val idSizePosition = buffer.position()
-    buffer.position(idSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val idBodyStart = buffer.position()
     buffer.writeString(value.id, Charset.UTF8)
     val idEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice11a/ProbeSealedTag2Codec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice11a/ProbeSealedTag2Codec.kt
@@ -32,7 +32,7 @@ public object ProbeSealedTag2Codec : Codec<ProbeSealed.Tag2> {
     context: EncodeContext,
   ) {
     val msgSizePosition = buffer.position()
-    buffer.position(msgSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val msgBodyStart = buffer.position()
     buffer.writeString(value.msg, Charset.UTF8)
     val msgEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14b/Slice14bFramedFrameVariableCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14b/Slice14bFramedFrameVariableCodec.kt
@@ -63,7 +63,7 @@ public object Slice14bFramedFrameVariableCodec {
     context = context,
   ) { buffer ->
     val messageSizePosition = buffer.position()
-    buffer.position(messageSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val messageBodyStart = buffer.position()
     buffer.writeString(value.message, Charset.UTF8)
     val messageEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14c/Slice14cFramedDispatchBCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14c/Slice14cFramedDispatchBCodec.kt
@@ -68,7 +68,7 @@ public object Slice14cFramedDispatchBCodec {
     },
   ) { buffer ->
     val messageSizePosition = buffer.position()
-    buffer.position(messageSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val messageBodyStart = buffer.position()
     buffer.writeString(value.message, Charset.UTF8)
     val messageEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14cgeneric/Slice14cGenericFramedDispatchWithPayloadCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14cgeneric/Slice14cGenericFramedDispatchWithPayloadCodec.kt
@@ -76,7 +76,7 @@ public class Slice14cGenericFramedDispatchWithPayloadCodec<P : Payload>(
     },
   ) { buffer ->
     val topicSizePosition = buffer.position()
-    buffer.position(topicSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val topicBodyStart = buffer.position()
     buffer.writeString(value.topic, Charset.UTF8)
     val topicEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice15a/Slice15aLengthPrefixedPayloadCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice15a/Slice15aLengthPrefixedPayloadCodec.kt
@@ -38,7 +38,7 @@ public object Slice15aLengthPrefixedPayloadCodec : Codec<Slice15aLengthPrefixedP
     context: EncodeContext,
   ) {
     val dataSizePosition = buffer.position()
-    buffer.position(dataSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val dataBodyStart = buffer.position()
     BinaryDataCodec.encode(buffer, value.data, context)
     val dataEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice7c/RepeatedBlocksCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice7c/RepeatedBlocksCodec.kt
@@ -35,7 +35,16 @@ public object RepeatedBlocksCodec : Codec<RepeatedBlocks> {
     }
   }
 
-  override fun wireSize(`value`: RepeatedBlocks, context: EncodeContext): WireSize = WireSize.Exact(2 + value.blocks.sumOf { (RepeatedBlockCodec.wireSize(it, context) as WireSize.Exact).bytes })
+  override fun wireSize(`value`: RepeatedBlocks, context: EncodeContext): WireSize {
+    var __blocksBodySize = 0
+    for (__elem in value.blocks) {
+      when (val __elemSize = RepeatedBlockCodec.wireSize(__elem, context)) {
+        is WireSize.Exact -> __blocksBodySize += __elemSize.bytes
+        WireSize.BackPatch -> return WireSize.BackPatch
+      }
+    }
+    return WireSize.Exact(2 + __blocksBodySize)
+  }
 
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/DispatchVarintUnionCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/DispatchVarintUnionCodec.kt
@@ -53,12 +53,16 @@ public object DispatchVarintUnionCodec : Codec<DispatchVarintUnion> {
 
   override fun wireSize(`value`: DispatchVarintUnion, context: EncodeContext): WireSize = when (value) {
     is DispatchVarintUnion.Single -> {
-      val inner = (DispatchVarintUnionSingleCodec.wireSize(value, context) as WireSize.Exact).bytes
-      WireSize.Exact(1 + inner)
+      when (val inner = DispatchVarintUnionSingleCodec.wireSize(value, context)) {
+        is WireSize.Exact -> WireSize.Exact(1 + inner.bytes)
+        WireSize.BackPatch -> WireSize.BackPatch
+      }
     }
     is DispatchVarintUnion.Mixed -> {
-      val inner = (DispatchVarintUnionMixedCodec.wireSize(value, context) as WireSize.Exact).bytes
-      WireSize.Exact(1 + inner)
+      when (val inner = DispatchVarintUnionMixedCodec.wireSize(value, context)) {
+        is WireSize.Exact -> WireSize.Exact(1 + inner.bytes)
+        WireSize.BackPatch -> WireSize.BackPatch
+      }
     }
     is DispatchVarintUnion.Marker -> WireSize.Exact(1)
     is DispatchVarintUnion.Plain -> WireSize.BackPatch

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/DispatchVarintUnionMixedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/DispatchVarintUnionMixedCodec.kt
@@ -28,7 +28,10 @@ public object DispatchVarintUnionMixedCodec : Codec<DispatchVarintUnion.Mixed> {
   }
 
   override fun wireSize(`value`: DispatchVarintUnion.Mixed, context: EncodeContext): WireSize {
-    val __vSize = (QuicVarintCodec.wireSize(value.v, context) as WireSize.Exact).bytes
+    val __vSize = when (val __s = QuicVarintCodec.wireSize(value.v, context)) {
+      is WireSize.Exact -> __s.bytes
+      WireSize.BackPatch -> return WireSize.BackPatch
+    }
     return WireSize.Exact(1 + __vSize)
   }
 

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/DispatchVarintUnionSingleCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/DispatchVarintUnionSingleCodec.kt
@@ -26,7 +26,10 @@ public object DispatchVarintUnionSingleCodec : Codec<DispatchVarintUnion.Single>
   }
 
   override fun wireSize(`value`: DispatchVarintUnion.Single, context: EncodeContext): WireSize {
-    val __vSize = (QuicVarintCodec.wireSize(value.v, context) as WireSize.Exact).bytes
+    val __vSize = when (val __s = QuicVarintCodec.wireSize(value.v, context)) {
+      is WireSize.Exact -> __s.bytes
+      WireSize.BackPatch -> return WireSize.BackPatch
+    }
     return WireSize.Exact(0 + __vSize)
   }
 

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/LpByteValueClassIdCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/LpByteValueClassIdCodec.kt
@@ -30,7 +30,7 @@ public object LpByteValueClassIdCodec : Codec<LpByteValueClassId> {
     context: EncodeContext,
   ) {
     val idSizePosition = buffer.position()
-    buffer.position(idSizePosition + 1)
+    repeat(1) { buffer.writeUByte(0u) }
     val idBodyStart = buffer.position()
     buffer.writeString(value.id.value, Charset.UTF8)
     val idEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/LpIntValueClassIdCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/LpIntValueClassIdCodec.kt
@@ -33,7 +33,7 @@ public object LpIntValueClassIdCodec : Codec<LpIntValueClassId> {
     context: EncodeContext,
   ) {
     val idSizePosition = buffer.position()
-    buffer.position(idSizePosition + 4)
+    repeat(4) { buffer.writeUByte(0u) }
     val idBodyStart = buffer.position()
     buffer.writeString(value.id.hex, Charset.UTF8)
     val idEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/LpPlainStringIdCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/LpPlainStringIdCodec.kt
@@ -32,7 +32,7 @@ public object LpPlainStringIdCodec : Codec<LpPlainStringId> {
     context: EncodeContext,
   ) {
     val idSizePosition = buffer.position()
-    buffer.position(idSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val idBodyStart = buffer.position()
     buffer.writeString(value.id, Charset.UTF8)
     val idEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/LpValueClassIdCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/LpValueClassIdCodec.kt
@@ -32,7 +32,7 @@ public object LpValueClassIdCodec : Codec<LpValueClassId> {
     context: EncodeContext,
   ) {
     val idSizePosition = buffer.position()
-    buffer.position(idSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val idBodyStart = buffer.position()
     buffer.writeString(value.id.value, Charset.UTF8)
     val idEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/OptionalValueClassIdCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/OptionalValueClassIdCodec.kt
@@ -40,7 +40,7 @@ public object OptionalValueClassIdCodec : Codec<OptionalValueClassId> {
     if (value.hasId) {
       val idValue = value.id ?: throw EncodeException(fieldPath = "OptionalValueClassId.id", reason = "@When(\"hasId\") predicate is true but field is null")
       val idSizePosition = buffer.position()
-      buffer.position(idSizePosition + 2)
+      repeat(2) { buffer.writeUByte(0u) }
       val idBodyStart = buffer.position()
       buffer.writeString(idValue.value, Charset.UTF8)
       val idEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/varintfield/VarintLengthFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/varintfield/VarintLengthFrameCodec.kt
@@ -28,7 +28,10 @@ public object VarintLengthFrameCodec : Codec<VarintLengthFrame> {
   }
 
   override fun wireSize(`value`: VarintLengthFrame, context: EncodeContext): WireSize {
-    val __valueSize = (QuicVarintCodec.wireSize(value.value, context) as WireSize.Exact).bytes
+    val __valueSize = when (val __s = QuicVarintCodec.wireSize(value.value, context)) {
+      is WireSize.Exact -> __s.bytes
+      WireSize.BackPatch -> return WireSize.BackPatch
+    }
     return WireSize.Exact(1 + __valueSize)
   }
 

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/visibility/InternalCommandEchoCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/visibility/InternalCommandEchoCodec.kt
@@ -32,7 +32,7 @@ internal object InternalCommandEchoCodec : Codec<InternalCommand.Echo> {
     context: EncodeContext,
   ) {
     val msgSizePosition = buffer.position()
-    buffer.position(msgSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val msgBodyStart = buffer.position()
     buffer.writeString(value.msg, Charset.UTF8)
     val msgEndPosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/visibility/InternalPacketCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/visibility/InternalPacketCodec.kt
@@ -34,7 +34,7 @@ internal object InternalPacketCodec : Codec<InternalPacket> {
   ) {
     buffer.writeInt(value.id)
     val nameSizePosition = buffer.position()
-    buffer.position(nameSizePosition + 2)
+    repeat(2) { buffer.writeUByte(0u) }
     val nameBodyStart = buffer.position()
     buffer.writeString(value.name, Charset.UTF8)
     val nameEndPosition = buffer.position()

--- a/buffer-codec-test/src/codecSchema/codec-schema.txt
+++ b/buffer-codec-test/src/codecSchema/codec-schema.txt
@@ -114,14 +114,57 @@ message com.ditchoom.buffer.codec.test.protocols.batch.SignedAndUnsignedMix
 message com.ditchoom.buffer.codec.test.protocols.batch.ValueClassBatch
   0 header valueclass:com.ditchoom.buffer.codec.test.protocols.batch.HeaderByte scalar:UByte wire=1B order=Default
   1 tail valueclass:com.ditchoom.buffer.codec.test.protocols.batch.HeaderByte scalar:UByte wire=1B order=Default
+message com.ditchoom.buffer.codec.test.protocols.boundary.BigTail
+  0 a string len-prefix=2B/Default
+  1 b string len-prefix=4B/Default
+sealed com.ditchoom.buffer.codec.test.protocols.boundary.BoundaryDisp dispatch=fixed-byte/1B
+  0x00 Named
+  0x01 Inherits
+message com.ditchoom.buffer.codec.test.protocols.boundary.BoundaryDisp.Inherits
+message com.ditchoom.buffer.codec.test.protocols.boundary.BoundaryDisp.Named
+  0 name string len-prefix=2B/Default
+message com.ditchoom.buffer.codec.test.protocols.boundary.BoundaryHost
+  0 host string len-prefix=2B/Default
+  1 disp msg:com.ditchoom.buffer.codec.test.protocols.boundary.BoundaryDisp
+message com.ditchoom.buffer.codec.test.protocols.boundary.LpByteWrappedTail
+  0 body msg:com.ditchoom.buffer.codec.test.protocols.boundary.WrappedLabel len-prefix=1B/Default
+message com.ditchoom.buffer.codec.test.protocols.boundary.LpWrappedTail
+  0 kind scalar:Byte wire=1B order=Default
+  1 body msg:com.ditchoom.buffer.codec.test.protocols.boundary.WrappedLabel len-prefix=2B/Default
+message com.ditchoom.buffer.codec.test.protocols.boundary.WithVid
+  0 pad string len-prefix=2B/Default
+  1 id string len-prefix=2B/Default
+message com.ditchoom.buffer.codec.test.protocols.boundary.WrappedLabel
+  0 label string len-prefix=2B/Default
+sealed com.ditchoom.buffer.codec.test.protocols.count.CountBadge dispatch=fixed-byte/1B
+  0x00 Named
+  0x01 Anonymous
+message com.ditchoom.buffer.codec.test.protocols.count.CountBadge.Anonymous
+message com.ditchoom.buffer.codec.test.protocols.count.CountBadge.Named
+  0 name string len-prefix=2B/Default
 message com.ditchoom.buffer.codec.test.protocols.count.CountFixedList
   0 id scalar:UByte wire=1B order=Big
   1 points list:com.ditchoom.buffer.codec.test.protocols.count.CountPoint count-prefixed
+message com.ditchoom.buffer.codec.test.protocols.count.CountInnerFixed
+  0 a scalar:Short wire=2B order=Big
 message com.ditchoom.buffer.codec.test.protocols.count.CountNamed
   0 name string len-prefix=2B/Big
+message com.ditchoom.buffer.codec.test.protocols.count.CountNestedEntry
+  0 inner msg:com.ditchoom.buffer.codec.test.protocols.count.CountInnerFixed
+message com.ditchoom.buffer.codec.test.protocols.count.CountNestedEntryList
+  0 entries list:com.ditchoom.buffer.codec.test.protocols.count.CountNestedEntry count-prefixed
 message com.ditchoom.buffer.codec.test.protocols.count.CountPoint
   0 x scalar:UShort wire=2B order=Big
   1 y scalar:UByte wire=1B order=Big
+message com.ditchoom.buffer.codec.test.protocols.count.CountSealedEntry
+  0 id scalar:UShort wire=2B order=Big
+  1 badge msg:com.ditchoom.buffer.codec.test.protocols.count.CountBadge
+message com.ditchoom.buffer.codec.test.protocols.count.CountSealedEntryList
+  0 entries list:com.ditchoom.buffer.codec.test.protocols.count.CountSealedEntry count-prefixed
+message com.ditchoom.buffer.codec.test.protocols.count.CountTaggedEntry
+  0 tag string len-prefix=2B/Big
+message com.ditchoom.buffer.codec.test.protocols.count.CountTaggedList
+  0 tags list:com.ditchoom.buffer.codec.test.protocols.count.CountTaggedEntry count-prefixed
 message com.ditchoom.buffer.codec.test.protocols.count.CountThenTrailer
   0 points list:com.ditchoom.buffer.codec.test.protocols.count.CountPoint count-prefixed
   1 trailer scalar:UInt wire=4B order=Big

--- a/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/boundary/BoundaryFixtures.kt
+++ b/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/boundary/BoundaryFixtures.kt
@@ -1,0 +1,89 @@
+package com.ditchoom.buffer.codec.test.protocols.boundary
+
+import com.ditchoom.buffer.codec.annotations.LengthPrefix
+import com.ditchoom.buffer.codec.annotations.LengthPrefixed
+import com.ditchoom.buffer.codec.annotations.PacketType
+import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+import kotlin.jvm.JvmInline
+
+/*
+ * Capacity-boundary fixtures for `encodeToPlatformBuffer`'s grow-and-retry
+ * loop. BackPatch-shaped messages start from a 64-byte estimate and double
+ * on overflow; a `@LengthPrefixed` field whose PREFIX slot straddles the
+ * current capacity (position 63/64, 127/128, …) historically failed with a
+ * non-retryable exception because the prefix was reserved with a forward
+ * `buffer.position(pos + width)` seek instead of placeholder writes.
+ *
+ * Sweeping the leading field's length walks the second field's prefix
+ * across both sides of the 64- and 128-byte boundaries; every point in the
+ * sweep must round-trip. (`TwoStrings` in `protocols.simple` covers the
+ * default 2-byte-prefix pair; the shapes here cover the 4-byte prefix,
+ * the value-class prefix, and the nested-sealed-host composition.)
+ */
+
+/** 2-byte-prefixed leader, 4-byte-prefixed tail. */
+@ProtocolMessage
+data class BigTail(
+    @LengthPrefixed val a: String,
+    @LengthPrefixed(LengthPrefix.Int) val b: String,
+)
+
+@JvmInline
+value class BoundaryVid(
+    val value: String,
+)
+
+/** Value-class-over-String prefix landing at the boundary. */
+@ProtocolMessage
+data class WithVid(
+    @LengthPrefixed val pad: String,
+    @LengthPrefixed val id: BoundaryVid,
+)
+
+/** Sealed field whose Named variant carries a `@LengthPrefixed String`. */
+@ProtocolMessage
+sealed interface BoundaryDisp {
+    @ProtocolMessage
+    @PacketType(0x00)
+    data class Named(
+        @LengthPrefixed val name: String,
+    ) : BoundaryDisp
+
+    @ProtocolMessage
+    @PacketType(0x01)
+    data object Inherits : BoundaryDisp
+}
+
+/** LP string followed by a bare nested sealed field carrying its own LP string. */
+@ProtocolMessage
+data class BoundaryHost(
+    @LengthPrefixed val host: String,
+    val disp: BoundaryDisp,
+)
+
+/** Nested data-class body whose own field is variable-length → BackPatch wireSize. */
+@ProtocolMessage
+data class WrappedLabel(
+    @LengthPrefixed val label: String,
+)
+
+/**
+ * Terminal `@LengthPrefixed` nested message with a BackPatch-shaped body.
+ * The parent's wireSize must degrade to BackPatch (it used to throw
+ * ClassCastException), and encode must reserve-and-back-patch the prefix.
+ */
+@ProtocolMessage
+data class LpWrappedTail(
+    val kind: Byte,
+    @LengthPrefixed val body: WrappedLabel,
+)
+
+/**
+ * 1-byte prefix over a nested BackPatch body — exercises the prefix-range
+ * guard: a body over 255 bytes must throw `EncodeException`, not silently
+ * mask-truncate the prefix.
+ */
+@ProtocolMessage
+data class LpByteWrappedTail(
+    @LengthPrefixed(LengthPrefix.Byte) val body: WrappedLabel,
+)

--- a/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/count/CountBackPatchGaps.kt
+++ b/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/count/CountBackPatchGaps.kt
@@ -1,0 +1,94 @@
+package com.ditchoom.buffer.codec.test.protocols.count
+
+import com.ditchoom.buffer.codec.annotations.Count
+import com.ditchoom.buffer.codec.annotations.Endianness
+import com.ditchoom.buffer.codec.annotations.LengthPrefixed
+import com.ditchoom.buffer.codec.annotations.PacketType
+import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+import kotlin.jvm.JvmInline
+
+/*
+ * `@Count` fixtures whose ELEMENT wireSize is BackPatch for a reason the
+ * one-level annotation scan (`detectElementBackPatch`) historically missed.
+ * Each shape here used to generate a `wireSize()` that cast the element
+ * codec's `WireSize` `as WireSize.Exact` and threw `ClassCastException` on
+ * every `encodeToPlatformBuffer` call — even a 1-element list.
+ *
+ * The contract under test: a `@Count` list whose element wireSize is
+ * BackPatch must collapse the containing message's wireSize to BackPatch
+ * (never throw); a `@Count` list of Exact-sized elements must keep an
+ * Exact wireSize (see `CountFixedList`).
+ */
+
+/** Sealed field carried by a list element — variants mix BackPatch (LP string) and Exact (data object). */
+@ProtocolMessage
+sealed interface CountBadge {
+    @ProtocolMessage
+    @PacketType(0x00)
+    data class Named(
+        @LengthPrefixed val name: String,
+    ) : CountBadge
+
+    @ProtocolMessage
+    @PacketType(0x01)
+    data object Anonymous : CountBadge
+}
+
+/**
+ * Element holding a bare nested sealed `@ProtocolMessage` field. The bare
+ * nested field is a `ProtocolMessageScalar`, which collapses the element
+ * codec's wireSize to BackPatch — but carries no annotation for the
+ * element-level scan to see.
+ */
+@ProtocolMessage(wireOrder = Endianness.Big)
+data class CountSealedEntry(
+    val id: UShort,
+    val badge: CountBadge,
+)
+
+@ProtocolMessage(wireOrder = Endianness.Big)
+data class CountSealedEntryList(
+    @Count val entries: List<CountSealedEntry>,
+)
+
+/** Value-class-over-String id — wire-identical to a bare `@LengthPrefixed String`. */
+@JvmInline
+value class CountTag(
+    val value: String,
+)
+
+/**
+ * Element whose only field is a `@LengthPrefixed` value-class-over-String.
+ * The element codec's wireSize is BackPatch (same as a bare LP String), but
+ * the parameter's declared type is the value class, not `kotlin.String`.
+ */
+@ProtocolMessage(wireOrder = Endianness.Big)
+data class CountTaggedEntry(
+    @LengthPrefixed val tag: CountTag,
+)
+
+@ProtocolMessage(wireOrder = Endianness.Big)
+data class CountTaggedList(
+    @Count val tags: List<CountTaggedEntry>,
+)
+
+/** All-fixed nested message — 2 bytes on the wire. */
+@ProtocolMessage(wireOrder = Endianness.Big)
+data class CountInnerFixed(
+    val a: Short,
+)
+
+/**
+ * Element holding a bare nested data-class `@ProtocolMessage` field. Even
+ * though the inner message is all-fixed, a bare `ProtocolMessageScalar`
+ * field conservatively collapses the element's wireSize to BackPatch.
+ */
+@ProtocolMessage(wireOrder = Endianness.Big)
+data class CountNestedEntry(
+    val inner: CountInnerFixed,
+)
+
+@ProtocolMessage(wireOrder = Endianness.Big)
+data class CountNestedEntryList(
+    @Count val entries: List<CountNestedEntry>,
+)

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/boundary/LengthPrefixBoundarySweepTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/boundary/LengthPrefixBoundarySweepTest.kt
@@ -1,0 +1,74 @@
+package com.ditchoom.buffer.codec.test.protocols.boundary
+
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.encodeToPlatformBuffer
+import com.ditchoom.buffer.codec.test.protocols.count.CountNamed
+import com.ditchoom.buffer.codec.test.protocols.count.CountVariableList
+import com.ditchoom.buffer.codec.test.protocols.count.CountVariableListCodec
+import com.ditchoom.buffer.codec.test.protocols.simple.TwoStrings
+import com.ditchoom.buffer.codec.test.protocols.simple.TwoStringsCodec
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Regression sweeps for the length-prefix reservation at a capacity
+ * boundary. `encodeToPlatformBuffer` starts BackPatch shapes at a 64-byte
+ * estimate and doubles on `BufferOverflowException`; a prefix reservation
+ * that forward-seeks (`buffer.position(pos + width)`) past the current
+ * limit instead threw `IllegalArgumentException`, which escaped the
+ * grow-and-retry loop. Sweeping the leading field's length walks the next
+ * prefix across both sides of the 64- and 128-byte boundaries — every
+ * point must round-trip.
+ */
+class LengthPrefixBoundarySweepTest {
+    private fun <T> assertRoundTrips(
+        codec: Codec<T>,
+        value: T,
+    ) {
+        val buf = codec.encodeToPlatformBuffer(value)
+        assertEquals(value, codec.decode(buf, DecodeContext.Empty), "round-trip for $value")
+    }
+
+    @Test
+    fun twoStringsSecondPrefixAcross64And128() {
+        // 2 (prefix a) + padLen (body a) puts b's 2-byte prefix at padLen+2:
+        // padLen 55..75 walks it across 64, 119..135 across 128.
+        for (padLen in 55..75) assertRoundTrips(TwoStringsCodec, TwoStrings("x".repeat(padLen), "y"))
+        for (padLen in 119..135) assertRoundTrips(TwoStringsCodec, TwoStrings("x".repeat(padLen), "y"))
+    }
+
+    @Test
+    fun fourBytePrefixAcross64And128() {
+        for (padLen in 55..75) assertRoundTrips(BigTailCodec, BigTail("x".repeat(padLen), "y"))
+        for (padLen in 119..135) assertRoundTrips(BigTailCodec, BigTail("x".repeat(padLen), "y"))
+    }
+
+    @Test
+    fun valueClassPrefixAcross64And128() {
+        for (padLen in 55..75) assertRoundTrips(WithVidCodec, WithVid("x".repeat(padLen), BoundaryVid("id")))
+        for (padLen in 119..135) assertRoundTrips(WithVidCodec, WithVid("x".repeat(padLen), BoundaryVid("id")))
+    }
+
+    @Test
+    fun nestedSealedPrefixAcross64And128() {
+        for (len in 40..140) {
+            assertRoundTrips(BoundaryHostCodec, BoundaryHost("h".repeat(len), BoundaryDisp.Named("x")))
+        }
+        // Singleton variant: only the host string and the discriminator byte.
+        for (len in 55..70) {
+            assertRoundTrips(BoundaryHostCodec, BoundaryHost("h".repeat(len), BoundaryDisp.Inherits))
+        }
+    }
+
+    @Test
+    fun countListElementPrefixCrossesBoundary() {
+        // Composes both bugs: a @Count list of BackPatch elements whose
+        // second/third element prefix crosses the 64-byte boundary.
+        assertRoundTrips(CountVariableListCodec, CountVariableList(List(3) { CountNamed("z".repeat(30)) }))
+        // Sweep the element size so the crossing lands at many offsets.
+        for (elemLen in 18..34) {
+            assertRoundTrips(CountVariableListCodec, CountVariableList(List(3) { CountNamed("z".repeat(elemLen)) }))
+        }
+    }
+}

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/boundary/LpNestedMessageBackPatchTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/boundary/LpNestedMessageBackPatchTest.kt
@@ -1,0 +1,57 @@
+package com.ditchoom.buffer.codec.test.protocols.boundary
+
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.codec.encodeToPlatformBuffer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * Regression coverage for a terminal `@LengthPrefixed val: @ProtocolMessage`
+ * whose nested body has a BackPatch wireSize (it carries its own
+ * `@LengthPrefixed String`). The parent's wireSize used to cast the nested
+ * codec's result `as WireSize.Exact` (ClassCastException on every encode);
+ * it must degrade to BackPatch, and encode must reserve-and-back-patch the
+ * prefix slot.
+ *
+ * Also pins the prefix-range guard: an oversized body under a 1-byte prefix
+ * must throw `EncodeException`, never silently mask-truncate the prefix
+ * into corrupt framing.
+ */
+class LpNestedMessageBackPatchTest {
+    @Test
+    fun wireSizeDegradesToBackPatchNotThrow() {
+        val msg = LpWrappedTail(kind = 1, body = WrappedLabel("hello"))
+        assertEquals(WireSize.BackPatch, LpWrappedTailCodec.wireSize(msg, EncodeContext.Empty))
+    }
+
+    @Test
+    fun roundTripsAcrossCapacityBoundary() {
+        // The nested body's own string sweep walks both the inner string's
+        // prefix and the outer body's back-patched prefix across the 64- and
+        // 128-byte estimate boundaries.
+        for (len in 0..140) {
+            val msg = LpWrappedTail(kind = 7, body = WrappedLabel("x".repeat(len)))
+            val buf = LpWrappedTailCodec.encodeToPlatformBuffer(msg)
+            assertEquals(msg, LpWrappedTailCodec.decode(buf, DecodeContext.Empty), "label length $len")
+        }
+    }
+
+    @Test
+    fun oversizedBodyUnderBytePrefixThrowsEncodeException() {
+        // body = 2-byte inner prefix + 300 chars = 302 bytes > 255.
+        val msg = LpByteWrappedTail(body = WrappedLabel("x".repeat(300)))
+        assertFailsWith<EncodeException> { LpByteWrappedTailCodec.encodeToPlatformBuffer(msg) }
+    }
+
+    @Test
+    fun maxFittingBodyUnderBytePrefixRoundTrips() {
+        // 253 chars + 2-byte inner prefix = 255 bytes — exactly the Byte max.
+        val msg = LpByteWrappedTail(body = WrappedLabel("x".repeat(253)))
+        val buf = LpByteWrappedTailCodec.encodeToPlatformBuffer(msg)
+        assertEquals(msg, LpByteWrappedTailCodec.decode(buf, DecodeContext.Empty))
+    }
+}

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/boundary/MalformedInputRejectionTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/boundary/MalformedInputRejectionTest.kt
@@ -1,0 +1,125 @@
+package com.ditchoom.buffer.codec.test.protocols.boundary
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.encodeToPlatformBuffer
+import com.ditchoom.buffer.codec.test.protocols.count.CountNamed
+import com.ditchoom.buffer.codec.test.protocols.count.CountVariableList
+import com.ditchoom.buffer.codec.test.protocols.count.CountVariableListCodec
+import com.ditchoom.buffer.codec.test.protocols.simple.TwoStrings
+import com.ditchoom.buffer.codec.test.protocols.simple.TwoStringsCodec
+import com.ditchoom.buffer.codec.test.protocols.valueclassstring.LpIntValueClassIdCodec
+import kotlin.test.Test
+import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
+
+/**
+ * Malformed / truncated wire input must make `decode` throw on every
+ * platform — never silently return a short or garbage value. This suite
+ * runs on JVM, JS, and native via commonTest; the platform spread is the
+ * point (buffer bounds signals differ per backing store).
+ */
+class MalformedInputRejectionTest {
+    // (a) truncated buffer — one byte short of a @LengthPrefixed body ------
+
+    @Test
+    fun truncatedLengthPrefixedBodyThrows() {
+        val whole = TwoStringsCodec.encodeToPlatformBuffer(TwoStrings("hello", "world"))
+        // Chop the final body byte: the second field's 2-byte prefix still
+        // claims 5 bytes, but only 4 remain.
+        whole.setLimit(whole.limit() - 1)
+        assertFails { TwoStringsCodec.decode(whole, DecodeContext.Empty) }
+    }
+
+    @Test
+    fun truncatedInsidePrefixThrows() {
+        val whole = TwoStringsCodec.encodeToPlatformBuffer(TwoStrings("hello", "world"))
+        // Cut mid-way through the second field's prefix itself.
+        whole.setLimit(2 + 5 + 1)
+        assertFails { TwoStringsCodec.decode(whole, DecodeContext.Empty) }
+    }
+
+    // (b) valid-but-oversized length prefix ---------------------------------
+
+    @Test
+    fun oversizedIntPrefixThrows() {
+        // 4-byte prefix claiming ~2^31 bytes with only 2 bytes present.
+        val buf = BufferFactory.Default.allocate(8, ByteOrder.BIG_ENDIAN)
+        buf.writeInt(0x7FFFFFF0)
+        buf.writeByte('h'.code.toByte())
+        buf.writeByte('i'.code.toByte())
+        buf.resetForRead()
+        assertFails { LpIntValueClassIdCodec.decode(buf, DecodeContext.Empty) }
+    }
+
+    @Test
+    fun oversizedShortPrefixThrows() {
+        // 2-byte prefix claiming 65535 bytes with 3 present.
+        val buf = BufferFactory.Default.allocate(8, ByteOrder.BIG_ENDIAN)
+        buf.writeShort(0xFFFF.toShort())
+        buf.writeByte('a'.code.toByte())
+        buf.writeByte('b'.code.toByte())
+        buf.writeByte('c'.code.toByte())
+        buf.resetForRead()
+        assertFails { TwoStringsCodec.decode(buf, DecodeContext.Empty) }
+    }
+
+    // (c) count prefix claiming more elements than the buffer holds ---------
+
+    @Test
+    fun countBeyondBufferThrows() {
+        // varint count = 5, but only one valid element follows.
+        val buf = BufferFactory.Default.allocate(16, ByteOrder.BIG_ENDIAN)
+        buf.writeByte(0x05.toByte()) // count = 5
+        buf.writeShort(0x0002.toShort()) // element 0: LP len 2
+        buf.writeByte('h'.code.toByte())
+        buf.writeByte('i'.code.toByte())
+        buf.resetForRead()
+        assertFails { CountVariableListCodec.decode(buf, DecodeContext.Empty) }
+    }
+
+    @Test
+    fun hugeCountWithEmptyBodyThrows() {
+        // varint count = 127 with zero element bytes.
+        val buf = BufferFactory.Default.allocate(4, ByteOrder.BIG_ENDIAN)
+        buf.writeByte(0x7F.toByte())
+        buf.resetForRead()
+        assertFails { CountVariableListCodec.decode(buf, DecodeContext.Empty) }
+    }
+
+    // (d) unknown @PacketType discriminator ---------------------------------
+
+    @Test
+    fun unknownDiscriminatorThrowsDecodeException() {
+        val buf = BufferFactory.Default.allocate(8, ByteOrder.BIG_ENDIAN)
+        buf.writeByte(0x63.toByte()) // no BoundaryDisp variant uses 0x63
+        buf.resetForRead()
+        assertFailsWith<DecodeException> { BoundaryDispCodec.decode(buf, DecodeContext.Empty) }
+    }
+
+    @Test
+    fun unknownNestedDiscriminatorThrowsDecodeException() {
+        // Valid host string, then a bogus discriminator for the nested
+        // sealed field.
+        val buf = BufferFactory.Default.allocate(16, ByteOrder.BIG_ENDIAN)
+        buf.writeShort(0x0002.toShort())
+        buf.writeByte('h'.code.toByte())
+        buf.writeByte('i'.code.toByte())
+        buf.writeByte(0x63.toByte())
+        buf.resetForRead()
+        assertFailsWith<DecodeException> { BoundaryHostCodec.decode(buf, DecodeContext.Empty) }
+    }
+
+    // Sanity: the well-formed twins of the malformed vectors decode fine ----
+
+    @Test
+    fun wellFormedTwinsStillDecode() {
+        val ts = TwoStringsCodec.encodeToPlatformBuffer(TwoStrings("hello", "world"))
+        TwoStringsCodec.decode(ts, DecodeContext.Empty)
+        val cl = CountVariableListCodec.encodeToPlatformBuffer(CountVariableList(listOf(CountNamed("hi"))))
+        CountVariableListCodec.decode(cl, DecodeContext.Empty)
+    }
+}

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/count/CountBackPatchGapsCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/count/CountBackPatchGapsCodecTest.kt
@@ -1,0 +1,123 @@
+package com.ditchoom.buffer.codec.test.protocols.count
+
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.codec.encodeToPlatformBuffer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Regression coverage for `@Count` lists whose element wireSize is BackPatch
+ * for a reason the element-level annotation scan used to miss. Every shape
+ * here previously generated a `wireSize()` that cast the element codec's
+ * result `as WireSize.Exact` and threw `ClassCastException` on every
+ * `encodeToPlatformBuffer` call.
+ *
+ * Contract: BackPatch-element lists report `WireSize.BackPatch` (never
+ * throw) and round-trip for empty / one / many elements. Exact-element
+ * lists must NOT regress to BackPatch — `CountPrefixedListCodecTest.
+ * wireSizeFixedListIsExact` pins that side.
+ */
+class CountBackPatchGapsCodecTest {
+    // ---- element with a bare nested sealed field --------------------------
+
+    @Test
+    fun sealedEntryListWireSizeIsBackPatchNotThrow() {
+        val msg =
+            CountSealedEntryList(
+                entries =
+                    listOf(
+                        CountSealedEntry(1u, CountBadge.Named("a")),
+                        CountSealedEntry(2u, CountBadge.Anonymous),
+                    ),
+            )
+        assertEquals(WireSize.BackPatch, CountSealedEntryListCodec.wireSize(msg, EncodeContext.Empty))
+    }
+
+    @Test
+    fun sealedEntryListRoundTripsEmptyOneMany() {
+        for (
+        entries in
+        listOf(
+            emptyList(),
+            listOf(CountSealedEntry(7u, CountBadge.Named("solo"))),
+            listOf(
+                CountSealedEntry(1u, CountBadge.Named("a")),
+                CountSealedEntry(2u, CountBadge.Anonymous),
+                CountSealedEntry(3u, CountBadge.Named("a longer badge name")),
+            ),
+        )
+        ) {
+            assertRoundTrips(CountSealedEntryList(entries))
+        }
+    }
+
+    // ---- element with a @LengthPrefixed value-class-over-String -----------
+
+    @Test
+    fun taggedListWireSizeIsBackPatchNotThrow() {
+        val msg = CountTaggedList(tags = listOf(CountTaggedEntry(CountTag("x"))))
+        assertEquals(WireSize.BackPatch, CountTaggedListCodec.wireSize(msg, EncodeContext.Empty))
+    }
+
+    @Test
+    fun taggedListRoundTripsEmptyOneMany() {
+        for (
+        tags in
+        listOf(
+            emptyList(),
+            listOf(CountTaggedEntry(CountTag("a"))),
+            listOf(
+                CountTaggedEntry(CountTag("")),
+                CountTaggedEntry(CountTag("bb")),
+                CountTaggedEntry(CountTag("ccc")),
+            ),
+        )
+        ) {
+            assertRoundTrips(CountTaggedList(tags))
+        }
+    }
+
+    // ---- element with a bare nested (all-fixed) data-class message --------
+
+    @Test
+    fun nestedEntryListWireSizeDoesNotThrow() {
+        // A bare ProtocolMessageScalar field conservatively collapses the
+        // element to BackPatch even though CountInnerFixed is all-fixed; the
+        // list must inherit BackPatch instead of CCEing on the Exact cast.
+        val msg = CountNestedEntryList(entries = listOf(CountNestedEntry(CountInnerFixed(5))))
+        assertEquals(WireSize.BackPatch, CountNestedEntryListCodec.wireSize(msg, EncodeContext.Empty))
+    }
+
+    @Test
+    fun nestedEntryListRoundTripsEmptyOneMany() {
+        for (
+        entries in
+        listOf(
+            emptyList(),
+            listOf(CountNestedEntry(CountInnerFixed(1))),
+            List(5) { CountNestedEntry(CountInnerFixed(it.toShort())) },
+        )
+        ) {
+            assertRoundTrips(CountNestedEntryList(entries))
+        }
+    }
+
+    // ---- helpers ----------------------------------------------------------
+
+    private fun assertRoundTrips(msg: CountSealedEntryList) {
+        val buf = CountSealedEntryListCodec.encodeToPlatformBuffer(msg)
+        assertEquals(msg, CountSealedEntryListCodec.decode(buf, DecodeContext.Empty))
+    }
+
+    private fun assertRoundTrips(msg: CountTaggedList) {
+        val buf = CountTaggedListCodec.encodeToPlatformBuffer(msg)
+        assertEquals(msg, CountTaggedListCodec.decode(buf, DecodeContext.Empty))
+    }
+
+    private fun assertRoundTrips(msg: CountNestedEntryList) {
+        val buf = CountNestedEntryListCodec.encodeToPlatformBuffer(msg)
+        assertEquals(msg, CountNestedEntryListCodec.decode(buf, DecodeContext.Empty))
+    }
+}

--- a/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/FrameStreaming.kt
+++ b/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/FrameStreaming.kt
@@ -15,7 +15,12 @@ private const val MAX_ENCODE_CAPACITY = 1 shl 30 // 1 GiB safety ceiling
  *
  * When the encoder reports a [WireSize.Exact] size the buffer is allocated exactly once. For
  * [WireSize.BackPatch] encoders the capacity starts from an estimate and doubles on
- * [BufferOverflowException] until the value fits (capped at 1 GiB).
+ * [BufferOverflowException] until the value fits (capped at 1 GiB). [IllegalArgumentException] is
+ * treated the same way as a backstop: a position seek past the current limit signals out-of-bounds
+ * differently per platform (java.nio throws [IllegalArgumentException] rather than
+ * [BufferOverflowException]), and that signal must grow-and-retry rather than escape. Generated
+ * codecs reserve prefix slots with placeholder writes (which overflow retryably), so the backstop
+ * only matters for hand-written encoders.
  *
  * Frees the allocated buffer on any exception from [Encoder.encode] — not just the overflow-retry
  * path — so a failing encode never leaks native memory.
@@ -46,7 +51,9 @@ public fun <T> Encoder<T>.encodeToPlatformBuffer(
             buffer.resetForRead()
             freeOnExit = false
             return buffer
-        } catch (overflow: BufferOverflowException) {
+        } catch (overflow: Exception) {
+            val retryable = overflow is BufferOverflowException || overflow is IllegalArgumentException
+            if (!retryable) throw overflow
             freeOnExit = false
             buffer.freeNativeMemory()
             if (capacity >= MAX_ENCODE_CAPACITY) throw overflow

--- a/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/FrameStreaming.kt
+++ b/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/FrameStreaming.kt
@@ -51,17 +51,27 @@ public fun <T> Encoder<T>.encodeToPlatformBuffer(
             buffer.resetForRead()
             freeOnExit = false
             return buffer
-        } catch (overflow: Exception) {
-            val retryable = overflow is BufferOverflowException || overflow is IllegalArgumentException
-            if (!retryable) throw overflow
+        } catch (overflow: BufferOverflowException) {
             freeOnExit = false
             buffer.freeNativeMemory()
-            if (capacity >= MAX_ENCODE_CAPACITY) throw overflow
-            capacity = minOf(capacity * 2, MAX_ENCODE_CAPACITY)
+            capacity = grownCapacityOrRethrow(capacity, overflow)
+        } catch (positionOverflow: IllegalArgumentException) {
+            freeOnExit = false
+            buffer.freeNativeMemory()
+            capacity = grownCapacityOrRethrow(capacity, positionOverflow)
         } finally {
             if (freeOnExit) buffer.freeNativeMemory()
         }
     }
+}
+
+/** Double [capacity] toward [MAX_ENCODE_CAPACITY]; rethrow [cause] once the ceiling is reached. */
+private fun grownCapacityOrRethrow(
+    capacity: Int,
+    cause: Exception,
+): Int {
+    if (capacity >= MAX_ENCODE_CAPACITY) throw cause
+    return minOf(capacity * 2, MAX_ENCODE_CAPACITY)
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes two encode-path crashes plus one latent silent-corruption path, all rooted in generated code assuming `WireSize.Exact` where `BackPatch` could appear at runtime.

### 1. `@Count` list wireSize threw `ClassCastException` for variable-size elements

`wireSize()` for a `@Count` list summed element sizes with an unconditional `as WireSize.Exact` cast. The `elementIsBackPatch` analyze-time guard existed but only scanned the element's direct annotations, missing:

- a bare nested `@ProtocolMessage` field (data class or sealed — carries no annotation for the scan to see),
- `@LengthPrefixed` on a `@JvmInline value class`-over-String (declared type isn't `kotlin.String`),
- nested `@Count` lists.

Any of these made `encodeToPlatformBuffer` throw CCE on every call — even a 1-element list.

**Fix (two layers):** `detectElementBackPatch` now covers those shapes, and — so no future analyzer gap can ever crash again — every generated summation *probes* each element's wireSize and short-circuits to `BackPatch` on the first non-Exact result instead of casting. Sealed dispatch size tables forward `BackPatch` the same way. Fixed-size element lists keep an `Exact` wireSize (pinned by existing tests).

### 2. Length-prefix reservation forward-seek overflowed at capacity boundaries

Generated codecs reserved prefix slots with `buffer.position(pos + width)`. When the slot straddled the current capacity (64, 128, …), that seek threw `IllegalArgumentException: newPosition > limit`, which escaped `encodeToPlatformBuffer`'s grow-and-retry loop (it only caught `BufferOverflowException`) — a hard failure that depended on exact field lengths.

**Fix:** reservation is now placeholder writes (`repeat(width) { buffer.writeUByte(0u) }`), which overflow with the retryable `BufferOverflowException` and grow correctly on growable scratch buffers. As a belt-and-suspenders backstop for platform-varying out-of-bounds signals in hand-written encoders, `encodeToPlatformBuffer` also treats `IllegalArgumentException` as a retryable grow signal (non-retryable exceptions still rethrow immediately).

### 3. Terminal `@LengthPrefixed` nested message: CCE + unguarded prefix (found while sweeping the remaining casts)

`@LengthPrefixed val body: SomeMessage` accepted any nested data class with no shape check; the generated encode cast the body's wireSize `as Exact` (CCE for a body carrying its own variable-length field) and wrote the prefix with **no range guard**, so an oversized body under a 1/2-byte prefix silently mask-truncated into corrupt framing.

**Fix:** encode forks at runtime — `Exact` writes the prefix up front; `BackPatch` reserves placeholders, encodes, measures, and back-patches — with an `EncodeException` range guard on both paths. The `@LengthPrefixed @UseCodec` list pre-measure path likewise falls back to the scratch `LengthPrefixedListEncoder` if an element probes `BackPatch`.

After this sweep, the only `as WireSize.Exact` casts left in generated output are `UnsignedVarIntCodec` calls, whose wireSize is `Exact` by construction.

## Wire compatibility

**No wire format changes.** `codec-schema.txt` shows pure additions for new test fixtures; every byte-exact test passes untouched. The codec source snapshots are regenerated to the new emit shapes (the diff is the migration note per the snapshot workflow).

## Test coverage (JVM + JS + linuxX64 + WASM, all green)

- **`CountBackPatchGapsCodecTest`** — the three under-detected element shapes: wireSize reports `BackPatch` (never throws), empty/one/many round-trips.
- **`LengthPrefixBoundarySweepTest`** — sweeps walking 2-byte, 4-byte, value-class, nested-sealed, and `@Count`-composed prefixes across both sides of the 64- and 128-byte growth boundaries (each point previously failed with `newPosition > limit`).
- **`LpNestedMessageBackPatchTest`** — nested BackPatch body round-trips across boundaries; oversized body under a Byte prefix throws `EncodeException`; the exact-fit 255-byte body round-trips.
- **`MalformedInputRejectionTest`** — truncated bodies, oversized length prefixes, over-claiming `@Count` prefixes, and unknown discriminators all throw uniformly on every platform (no silent garbage decode).