### PR TITLE
perf(codec): @UseCodec Exact wireSize composition + Encoder.sizeHint starting capacity

### DIFF
--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecAnalyzer.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecAnalyzer.kt
@@ -3234,18 +3234,23 @@ internal fun classifyVariantWireSize(shape: CodecShape): VariantWireSize {
     // wireSize is BackPatch (see buildWireSizeFun's RemainingBytesPayload
     // early-return); the dispatcher must skip the runtime-Exact cast.
     if (shape.fields.any { it is FieldSpec.RemainingBytesPayload }) return VariantWireSize.BackPatch
-    // A NON-`VariableLengthCodec` `@UseCodec` scalar may report `BackPatch` at runtime, so the
-    // dispatcher can't assume Exact — collapse (mirrors buildWireSizeFun's `!isVariableLength`
-    // BackPatch guard). A `VariableLengthCodec`-backed `@UseCodec` scalar reports
-    // `Exact(encodedLength)` and is promoted to RuntimeExact below — the "promote later if a vector
-    // benefits" note made good (a sealed grid-op union whose payloads are LEB128 `@UseCodec` fields).
-    if (shape.fields.any { it is FieldSpec.UseCodecScalar && !it.isVariableLength }) return VariantWireSize.BackPatch
-    // Same — buildWireSizeFun collapses
-    // LengthPrefixedUseCodecList-bearing shapes to BackPatch.
-    if (shape.fields.any { it is FieldSpec.LengthPrefixedUseCodecList }) return VariantWireSize.BackPatch
-    // Same — buildWireSizeFun collapses
-    // LengthPrefixedUseCodecPayload-bearing shapes to BackPatch.
-    if (shape.fields.any { it is FieldSpec.LengthPrefixedUseCodecPayload }) return VariantWireSize.BackPatch
+    // `@UseCodec` shapes (bare scalar, `@LengthPrefixed` payload/list) are
+    // RuntimeExact: the variant codec's wireSize probes the user codec per
+    // value (Exact composes, BackPatch degrades), and the dispatcher's
+    // RuntimeExact emit forwards whichever the probe reports — it no longer
+    // casts, so a runtime BackPatch is safe. A known-BackPatch list element
+    // type keeps the constant collapse (its wireSize fun never probes).
+    if (shape.fields.any { it is FieldSpec.LengthPrefixedUseCodecList && it.spec.elementIsBackPatch }) {
+        return VariantWireSize.BackPatch
+    }
+    if (shape.fields.any {
+            it is FieldSpec.UseCodecScalar ||
+                it is FieldSpec.LengthPrefixedUseCodecList ||
+                it is FieldSpec.LengthPrefixedUseCodecPayload
+        }
+    ) {
+        return VariantWireSize.RuntimeExact
+    }
     // Same — buildWireSizeFun collapses bare
     // `val: T : @ProtocolMessage` shapes to BackPatch.
     if (shape.fields.any { it is FieldSpec.ProtocolMessageScalar }) return VariantWireSize.BackPatch

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
@@ -581,6 +581,7 @@ internal class CodecEmitter(
                     .addFunction(buildDecodeFun(shape))
                     .addFunction(buildEncodeFun(shape))
                     .addFunction(buildWireSizeFun(shape))
+                    .addFunction(buildSizeHintFun(shape))
                     .addFunction(buildPeekFrameFun(shape))
                     .also { builder ->
                         // Every codec carrying a typed payload field
@@ -634,6 +635,7 @@ internal class CodecEmitter(
             .addFunction(buildDecodeFun(shape, parameterizedMessage))
             .addFunction(buildEncodeFun(shape, parameterizedMessage))
             .addFunction(buildWireSizeFun(shape, parameterizedMessage))
+            .addFunction(buildSizeHintFun(shape, parameterizedMessage))
             .addFunction(buildPeekFrameFun(shape))
             .also { builder ->
                 // For the (class) shape, `Partial` is a

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterDispatch.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterDispatch.kt
@@ -443,6 +443,55 @@ internal fun buildDispatchWireSizeFun(shape: DispatchShape): FunSpec {
 }
 
 /**
+ * Non-framed dispatch `sizeHint` builder — the starting-capacity companion
+ * to [buildDispatchWireSizeFun], forwarding to the matched variant codec's
+ * `sizeHint`. [DiscriminatorOwnership.ConsumedByDispatcher] adds the 1-byte
+ * discriminator the dispatcher writes; [DiscriminatorOwnership.ReReadByVariant]
+ * pure-delegates (the variant hint covers its self-framed discriminator).
+ * Mirrors the wireSize builder's generic-variant star-projection casts.
+ */
+internal fun buildDispatchSizeHintFun(shape: DispatchShape): FunSpec {
+    val parentTypeRef = shape.parentTypeRef()
+    val body = CodeBlock.builder()
+    val anyGeneric = shape.variants.any { it.codecRef is VariantCodecRef.GenericInstance }
+    if (anyGeneric) {
+        body.add("@Suppress(%S)\n", "UNCHECKED_CAST")
+    }
+    val discriminatorTerm =
+        when (shape.discriminator.ownership) {
+            DiscriminatorOwnership.ConsumedByDispatcher -> "1 + "
+            DiscriminatorOwnership.ReReadByVariant -> ""
+        }
+    body.beginControlFlow("return %Lwhen (value)", discriminatorTerm)
+    for (variant in shape.variants) {
+        val branchType = variant.branchTypeName(shape.genericity)
+        if (variant.codecRef is VariantCodecRef.GenericInstance) {
+            body.addStatement(
+                "is %T -> %L.sizeHint(value as %T, context)",
+                branchType,
+                variant.codecReceiver(),
+                variant.typedRef(shape.genericity),
+            )
+        } else {
+            body.addStatement(
+                "is %T -> %L.sizeHint(value, context)",
+                branchType,
+                variant.codecReceiver(),
+            )
+        }
+    }
+    body.endControlFlow()
+    return FunSpec
+        .builder("sizeHint")
+        .addModifiers(KModifier.OVERRIDE)
+        .addParameter("value", parentTypeRef)
+        .addParameter("context", ENCODE_CONTEXT_CN)
+        .returns(INT)
+        .addCode(body.build())
+        .build()
+}
+
+/**
  * THE unified NON-framed dispatch peekFrameSize builder. Reproduces the
  * (now-removed) simple-@PacketType `buildDispatcherPeekFrameFun` and
  * non-framed @DispatchOn `buildDispatchOnPeekFun` output byte-for-byte by
@@ -687,6 +736,7 @@ internal fun buildDispatchFileSpec(shape: DispatchShape): FileSpec {
                 } else {
                     builder.addFunction(buildDispatchEncodeFun(shape))
                     builder.addFunction(buildDispatchWireSizeFun(shape))
+                    builder.addFunction(buildDispatchSizeHintFun(shape))
                     builder.addFunction(buildDispatchPeekFun(shape))
                 }
                 builder.build()
@@ -731,6 +781,7 @@ internal fun buildDispatchFileSpec(shape: DispatchShape): FileSpec {
                 } else {
                     builder.addFunction(buildDispatchEncodeFun(shape))
                     builder.addFunction(buildDispatchWireSizeFun(shape))
+                    builder.addFunction(buildDispatchSizeHintFun(shape))
                     builder.addFunction(buildDispatchPeekFun(shape))
                 }
                 // The `decodeAggregating` companion (per-call payload-codec

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterWireSize.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterWireSize.kt
@@ -411,58 +411,76 @@ internal fun buildSizeHintFun(
             .addParameter("value", messageType)
             .addParameter("context", ENCODE_CONTEXT_CN)
             .returns(INT)
-    var constHint =
-        ((shape.singletonDispatchDiscriminator?.wireWidth ?: WireWidth.Zero) as? WireWidth.Fixed)?.bytes ?: 0
+    appendSizeHintBody(builder, collectSizeHintPlan(shape))
+    return builder.build()
+}
+
+/** The three ingredient kinds a generated `sizeHint` body sums. */
+private class SizeHintPlan(
+    initialConst: Int,
+) {
+    var constHint: Int = initialConst
     val dynamicTerms = mutableListOf<CodeBlock>()
     val elementLoops = mutableListOf<Pair<String, TypeName>>()
+}
+
+/** Walk the shape's fields into constant / per-value / per-element hint terms. */
+private fun collectSizeHintPlan(shape: CodecShape): SizeHintPlan {
+    val plan =
+        SizeHintPlan(
+            ((shape.singletonDispatchDiscriminator?.wireWidth ?: WireWidth.Zero) as? WireWidth.Fixed)?.bytes ?: 0,
+        )
     for (field in shape.fields) {
         when (field) {
             is FieldSpec.LengthPrefixedString -> {
-                constHint += field.prefixWidth
-                dynamicTerms += stringLengthTerm(field.name, field.valueClass)
+                plan.constHint += field.prefixWidth
+                plan.dynamicTerms += stringLengthTerm(field.name, field.valueClass)
             }
             is FieldSpec.RemainingBytesString ->
-                dynamicTerms += stringLengthTerm(field.name, field.valueClass)
+                plan.dynamicTerms += stringLengthTerm(field.name, field.valueClass)
             is FieldSpec.LengthFromString ->
-                dynamicTerms += stringLengthTerm(field.name, field.valueClass)
+                plan.dynamicTerms += stringLengthTerm(field.name, field.valueClass)
             is FieldSpec.ProtocolMessageScalar ->
-                dynamicTerms += CodeBlock.of("%T.sizeHint(value.%L, context)", field.codecType, field.name)
+                plan.dynamicTerms += CodeBlock.of("%T.sizeHint(value.%L, context)", field.codecType, field.name)
             is FieldSpec.LengthPrefixedMessage -> {
-                constHint += field.prefixWidth
-                dynamicTerms += CodeBlock.of("%T.sizeHint(value.%L, context)", field.codecType, field.name)
+                plan.constHint += field.prefixWidth
+                plan.dynamicTerms += CodeBlock.of("%T.sizeHint(value.%L, context)", field.codecType, field.name)
             }
             is FieldSpec.CountPrefixedProtocolMessageList -> {
-                constHint += 1 // minimum varint(count) width
-                elementLoops += field.name to field.elementCodecClassName
+                plan.constHint += 1 // minimum varint(count) width
+                plan.elementLoops += field.name to field.elementCodecClassName
             }
             is FieldSpec.RemainingBytesProtocolMessageList ->
-                elementLoops += field.name to field.elementCodecClassName
-            is FieldSpec.EnumScalar -> constHint += 1 // minimum ordinal-varint width
-            is FieldSpec.LengthPrefixedUseCodecPayload -> constHint += field.prefixWidth
-            is FieldSpec.FixedSize -> constHint += (field.wireWidth as? WireWidth.Fixed)?.bytes ?: 0
+                plan.elementLoops += field.name to field.elementCodecClassName
+            is FieldSpec.EnumScalar -> plan.constHint += 1 // minimum ordinal-varint width
+            is FieldSpec.LengthPrefixedUseCodecPayload -> plan.constHint += field.prefixWidth
+            is FieldSpec.FixedSize -> plan.constHint += (field.wireWidth as? WireWidth.Fixed)?.bytes ?: 0
             else -> {} // Conditional / opaque @UseCodec shapes: no cheap bound
         }
     }
-    if (dynamicTerms.isEmpty() && elementLoops.isEmpty()) {
-        builder.addStatement("return %L", constHint)
-        return builder.build()
-    }
-    if (elementLoops.isEmpty()) {
-        val sum = CodeBlock.builder().add("%L", constHint)
-        dynamicTerms.forEach { sum.add(" + %L", it) }
-        builder.addStatement("return %L", sum.build())
-        return builder.build()
-    }
-    builder.addStatement("var __hint = %L", constHint)
-    for ((listName, elementCodec) in elementLoops) {
-        builder.beginControlFlow("for (__elem in value.%L)", listName)
-        builder.addStatement("__hint += %T.sizeHint(__elem, context)", elementCodec)
-        builder.endControlFlow()
-    }
-    val sum = CodeBlock.builder().add("__hint")
-    dynamicTerms.forEach { sum.add(" + %L", it) }
+    return plan
+}
+
+/** Render the plan: constant-only, single-expression sum, or loop-accumulate. */
+private fun appendSizeHintBody(
+    builder: FunSpec.Builder,
+    plan: SizeHintPlan,
+) {
+    val base =
+        if (plan.elementLoops.isEmpty()) {
+            CodeBlock.of("%L", plan.constHint)
+        } else {
+            builder.addStatement("var __hint = %L", plan.constHint)
+            for ((listName, elementCodec) in plan.elementLoops) {
+                builder.beginControlFlow("for (__elem in value.%L)", listName)
+                builder.addStatement("__hint += %T.sizeHint(__elem, context)", elementCodec)
+                builder.endControlFlow()
+            }
+            CodeBlock.of("__hint")
+        }
+    val sum = CodeBlock.builder().add(base)
+    plan.dynamicTerms.forEach { sum.add(" + %L", it) }
     builder.addStatement("return %L", sum.build())
-    return builder.build()
 }
 
 private fun stringLengthTerm(

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterWireSize.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterWireSize.kt
@@ -41,35 +41,16 @@ internal fun buildWireSizeFun(
         builder.addStatement("return %T.BackPatch", WIRE_SIZE_CN)
         return builder.build()
     }
-    // An OPAQUE `@UseCodec val: <scalar>` field's wireSize is unknown to the framework, so
-    // the message collapses to BackPatch. A `VariableLengthCodec`-backed field
-    // (`isVariableLength`) is the exception: it reports `Exact(encodedLength(value))` at
-    // runtime, so a message whose only variable fields are such codecs stays on the
-    // precompute path via the runtime-Exact branch below (just before the terminal `when`).
-    // This subsumes the former sole-varint-value-class special case (#186): a single
-    // variable-length `@UseCodec` scalar (an HTTP/3 frame type wrapping a QUIC varint) now
-    // falls through to that branch, which yields the same `Exact(encodedLength)` the
-    // `@FramedBy`-after-varint emit needs to size its framing header per value.
-    if (shape.fields.any { it is FieldSpec.UseCodecScalar && !it.isVariableLength }) {
-        builder.addStatement("return %T.BackPatch", WIRE_SIZE_CN)
-        return builder.build()
-    }
-    // `@LengthPrefixed @UseCodec val: List<E>`
-    // wireSize composes the user codec's prefix size with the sum of
-    // element wireSizes. Same conservative BackPatch collapse as the
-    // bare-scalar case — runtime-Exact-via-cast is a follow-on.
-    if (shape.fields.any { it is FieldSpec.LengthPrefixedUseCodecList }) {
-        builder.addStatement("return %T.BackPatch", WIRE_SIZE_CN)
-        return builder.build()
-    }
-    // `@LengthPrefixed @UseCodec val: T: Payload`
-    // wireSize composes a fixed prefix with the user codec's body size,
-    // which is opaque. Same conservative BackPatch collapse as the
-    // bare-scalar / list cases — runtime-Exact-via-cast is a follow-on.
-    if (shape.fields.any { it is FieldSpec.LengthPrefixedUseCodecPayload }) {
-        builder.addStatement("return %T.BackPatch", WIRE_SIZE_CN)
-        return builder.build()
-    }
+    // `@UseCodec` field shapes (bare scalar, `@LengthPrefixed` payload,
+    // `@LengthPrefixed` list) are NOT collapsed here: when every other field
+    // is FixedSize they ride the runtime-Exact branch below, which PROBES the
+    // user codec's wireSize per value — `Exact` composes into the precompute
+    // sum, `BackPatch` (the `Codec` interface default) degrades the whole
+    // message at runtime. A user codec that declares its size (e.g.
+    // `AsciiStringCodec`'s `Exact(value.length)`) thus buys the enclosing
+    // message a single exact allocation in `encodeToPlatformBuffer`. Mixed
+    // shapes that don't qualify for the runtime-Exact branch fall to the
+    // conservative guards after it.
     // Bare `val: T: @ProtocolMessage` wireSize
     // delegates to T's codec at runtime (RuntimeExact). Same conservative
     // BackPatch collapse on the parent — promoting to runtime-Exact-via-
@@ -175,12 +156,58 @@ internal fun buildWireSizeFun(
                     )
                 is FieldSpec.CountPrefixedProtocolMessageList ->
                     appendCountListWireSizeLocal(builder, f)
+                is FieldSpec.LengthPrefixedUseCodecPayload -> {
+                    // Fixed-width prefix + probed payload body size.
+                    builder.beginControlFlow(
+                        "val %L = when (val __s = %T.wireSize(value.%L, context))",
+                        "__${f.name}Size",
+                        f.payloadCodecType,
+                        f.name,
+                    )
+                    builder.addStatement("is %T.Exact -> %L + __s.bytes", WIRE_SIZE_CN, f.prefixWidth)
+                    builder.addStatement("%T.BackPatch -> return %T.BackPatch", WIRE_SIZE_CN, WIRE_SIZE_CN)
+                    builder.endControlFlow()
+                }
+                is FieldSpec.LengthPrefixedUseCodecList -> {
+                    // Probed element-size sum + the prefix codec's width for
+                    // that byte count (the VBI prefix is value-dependent).
+                    val bodyBytesVar = "__${f.name}BodyBytes"
+                    appendElementWireSizeProbeLoop(
+                        builder = builder,
+                        listAccessor = "value.${f.name}",
+                        elementCodec = f.spec.elementCodecClassName,
+                        sumVar = bodyBytesVar,
+                    )
+                    builder.beginControlFlow(
+                        "val %L = when (val __p = %T.wireSize(%L.toUInt(), context))",
+                        "__${f.name}Size",
+                        f.spec.codecType,
+                        bodyBytesVar,
+                    )
+                    builder.addStatement("is %T.Exact -> __p.bytes + %L", WIRE_SIZE_CN, bodyBytesVar)
+                    builder.addStatement("%T.BackPatch -> return %T.BackPatch", WIRE_SIZE_CN, WIRE_SIZE_CN)
+                    builder.endControlFlow()
+                }
                 else -> {}
             }
         }
         val sizeTerms = listOf(fixedBytes.toString()) + runtimeExactVarFields.map { "__${it.name}Size" }
         val sumExpr = sizeTerms.joinToString(" + ")
         builder.addStatement("return %T.Exact(%L)", WIRE_SIZE_CN, sumExpr)
+        return builder.build()
+    }
+    // Conservative fallbacks for `@UseCodec` shapes that did NOT qualify for
+    // the runtime-Exact branch (mixed with another variable-width field the
+    // probe sum can't express). The terminal `when` below sums fixed scalar
+    // headers only and would silently under-count these fields, so they must
+    // collapse to BackPatch — the same behavior they had before promotion.
+    if (shape.fields.any {
+            it is FieldSpec.UseCodecScalar ||
+                it is FieldSpec.LengthPrefixedUseCodecList ||
+                it is FieldSpec.LengthPrefixedUseCodecPayload
+        }
+    ) {
+        builder.addStatement("return %T.BackPatch", WIRE_SIZE_CN)
         return builder.build()
     }
     when (val terminal = shape.fields.lastOrNull()) {
@@ -358,12 +385,19 @@ private fun appendElementWireSizeProbeLoop(
 }
 
 /**
- * A field whose wireSize is known only at runtime but always `Exact`: a
- * `VariableLengthCodec`-backed `@UseCodec` scalar, an enum riding its ordinal
- * as an `UnsignedVarIntCodec` varint, or a `@Count` element-count list (varint
- * element count plus the summed element wireSizes).
+ * A field whose wireSize the runtime-Exact branch can probe per value: an
+ * enum riding its ordinal as an `UnsignedVarIntCodec` varint, a `@Count`
+ * element-count list, or any `@UseCodec` shape (bare scalar, length-prefixed
+ * payload, length-prefixed list). `VariableLengthCodec`-backed scalars always
+ * probe `Exact(encodedLength)`; other user codecs report whatever their
+ * `wireSize` override declares (interface default `BackPatch`, in which case
+ * the probe degrades the message at runtime).
  */
 private fun FieldSpec.isRuntimeExactVar(): Boolean =
     this is FieldSpec.EnumScalar ||
         this is FieldSpec.CountPrefixedProtocolMessageList ||
-        (this is FieldSpec.UseCodecScalar && isVariableLength)
+        this is FieldSpec.UseCodecScalar ||
+        this is FieldSpec.LengthPrefixedUseCodecPayload ||
+        // A known-BackPatch element type would make the probe loop degrade on
+        // every call — let the shape fall to the constant-BackPatch guard.
+        (this is FieldSpec.LengthPrefixedUseCodecList && !spec.elementIsBackPatch)

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterWireSize.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterWireSize.kt
@@ -1,6 +1,8 @@
 package com.ditchoom.buffer.codec.processor
 
+import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.INT
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.TypeName
 
@@ -383,6 +385,95 @@ private fun appendElementWireSizeProbeLoop(
     builder.endControlFlow()
     builder.endControlFlow()
 }
+
+/**
+ * Emit the codec's `sizeHint(value, context): Int` override — the O(field
+ * count) lower-bound starting-capacity guess `encodeToPlatformBuffer`
+ * consults when `wireSize` reports BackPatch. Fixed widths and prefix widths
+ * fold into a compile-time constant; each string field contributes
+ * `accessor.length` (exact for ASCII content, a ≥⅓ lower bound for any
+ * UTF-8); nested messages and list elements contribute their own codec's
+ * `sizeHint`. Fields with no cheap bound (`@When` conditionals, opaque
+ * `@UseCodec` bodies) contribute 0 — under-hinting just falls back to the
+ * grow-and-retry behavior the hint replaces.
+ *
+ * Emitted for EVERY codec (all-fixed shapes get a constant) so parents'
+ * nested-field contributions never fall back to the interface default.
+ */
+internal fun buildSizeHintFun(
+    shape: CodecShape,
+    messageType: TypeName = shape.messageClassName,
+): FunSpec {
+    val builder =
+        FunSpec
+            .builder("sizeHint")
+            .addModifiers(KModifier.OVERRIDE)
+            .addParameter("value", messageType)
+            .addParameter("context", ENCODE_CONTEXT_CN)
+            .returns(INT)
+    var constHint =
+        ((shape.singletonDispatchDiscriminator?.wireWidth ?: WireWidth.Zero) as? WireWidth.Fixed)?.bytes ?: 0
+    val dynamicTerms = mutableListOf<CodeBlock>()
+    val elementLoops = mutableListOf<Pair<String, TypeName>>()
+    for (field in shape.fields) {
+        when (field) {
+            is FieldSpec.LengthPrefixedString -> {
+                constHint += field.prefixWidth
+                dynamicTerms += stringLengthTerm(field.name, field.valueClass)
+            }
+            is FieldSpec.RemainingBytesString ->
+                dynamicTerms += stringLengthTerm(field.name, field.valueClass)
+            is FieldSpec.LengthFromString ->
+                dynamicTerms += stringLengthTerm(field.name, field.valueClass)
+            is FieldSpec.ProtocolMessageScalar ->
+                dynamicTerms += CodeBlock.of("%T.sizeHint(value.%L, context)", field.codecType, field.name)
+            is FieldSpec.LengthPrefixedMessage -> {
+                constHint += field.prefixWidth
+                dynamicTerms += CodeBlock.of("%T.sizeHint(value.%L, context)", field.codecType, field.name)
+            }
+            is FieldSpec.CountPrefixedProtocolMessageList -> {
+                constHint += 1 // minimum varint(count) width
+                elementLoops += field.name to field.elementCodecClassName
+            }
+            is FieldSpec.RemainingBytesProtocolMessageList ->
+                elementLoops += field.name to field.elementCodecClassName
+            is FieldSpec.EnumScalar -> constHint += 1 // minimum ordinal-varint width
+            is FieldSpec.LengthPrefixedUseCodecPayload -> constHint += field.prefixWidth
+            is FieldSpec.FixedSize -> constHint += (field.wireWidth as? WireWidth.Fixed)?.bytes ?: 0
+            else -> {} // Conditional / opaque @UseCodec shapes: no cheap bound
+        }
+    }
+    if (dynamicTerms.isEmpty() && elementLoops.isEmpty()) {
+        builder.addStatement("return %L", constHint)
+        return builder.build()
+    }
+    if (elementLoops.isEmpty()) {
+        val sum = CodeBlock.builder().add("%L", constHint)
+        dynamicTerms.forEach { sum.add(" + %L", it) }
+        builder.addStatement("return %L", sum.build())
+        return builder.build()
+    }
+    builder.addStatement("var __hint = %L", constHint)
+    for ((listName, elementCodec) in elementLoops) {
+        builder.beginControlFlow("for (__elem in value.%L)", listName)
+        builder.addStatement("__hint += %T.sizeHint(__elem, context)", elementCodec)
+        builder.endControlFlow()
+    }
+    val sum = CodeBlock.builder().add("__hint")
+    dynamicTerms.forEach { sum.add(" + %L", it) }
+    builder.addStatement("return %L", sum.build())
+    return builder.build()
+}
+
+private fun stringLengthTerm(
+    fieldName: String,
+    valueClass: ValueClassStringWrapper?,
+): CodeBlock =
+    if (valueClass != null) {
+        CodeBlock.of("value.%L.%L.length", fieldName, valueClass.innerPropertyName)
+    } else {
+        CodeBlock.of("value.%L.length", fieldName)
+    }
 
 /**
  * A field whose wireSize the runtime-Exact branch can probe per value: an

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterWireSize.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterWireSize.kt
@@ -426,39 +426,53 @@ private class SizeHintPlan(
 
 /** Walk the shape's fields into constant / per-value / per-element hint terms. */
 private fun collectSizeHintPlan(shape: CodecShape): SizeHintPlan {
-    val plan =
-        SizeHintPlan(
-            ((shape.singletonDispatchDiscriminator?.wireWidth ?: WireWidth.Zero) as? WireWidth.Fixed)?.bytes ?: 0,
-        )
+    val plan = SizeHintPlan(singletonDiscriminatorHintBytes(shape))
     for (field in shape.fields) {
-        when (field) {
-            is FieldSpec.LengthPrefixedString -> {
-                plan.constHint += field.prefixWidth
-                plan.dynamicTerms += stringLengthTerm(field.name, field.valueClass)
-            }
-            is FieldSpec.RemainingBytesString ->
-                plan.dynamicTerms += stringLengthTerm(field.name, field.valueClass)
-            is FieldSpec.LengthFromString ->
-                plan.dynamicTerms += stringLengthTerm(field.name, field.valueClass)
-            is FieldSpec.ProtocolMessageScalar ->
-                plan.dynamicTerms += CodeBlock.of("%T.sizeHint(value.%L, context)", field.codecType, field.name)
-            is FieldSpec.LengthPrefixedMessage -> {
-                plan.constHint += field.prefixWidth
-                plan.dynamicTerms += CodeBlock.of("%T.sizeHint(value.%L, context)", field.codecType, field.name)
-            }
-            is FieldSpec.CountPrefixedProtocolMessageList -> {
-                plan.constHint += 1 // minimum varint(count) width
-                plan.elementLoops += field.name to field.elementCodecClassName
-            }
-            is FieldSpec.RemainingBytesProtocolMessageList ->
-                plan.elementLoops += field.name to field.elementCodecClassName
-            is FieldSpec.EnumScalar -> plan.constHint += 1 // minimum ordinal-varint width
-            is FieldSpec.LengthPrefixedUseCodecPayload -> plan.constHint += field.prefixWidth
-            is FieldSpec.FixedSize -> plan.constHint += (field.wireWidth as? WireWidth.Fixed)?.bytes ?: 0
-            else -> {} // Conditional / opaque @UseCodec shapes: no cheap bound
-        }
+        plan.addString(field) || plan.addStructural(field)
     }
     return plan
+}
+
+private fun singletonDiscriminatorHintBytes(shape: CodecShape): Int =
+    ((shape.singletonDispatchDiscriminator?.wireWidth ?: WireWidth.Zero) as? WireWidth.Fixed)?.bytes ?: 0
+
+/** String-shaped contributions: prefix constants + `accessor.length` terms. Returns false when not string-shaped. */
+private fun SizeHintPlan.addString(field: FieldSpec): Boolean {
+    when (field) {
+        is FieldSpec.LengthPrefixedString -> {
+            constHint += field.prefixWidth
+            dynamicTerms += stringLengthTerm(field.name, field.valueClass)
+        }
+        is FieldSpec.RemainingBytesString ->
+            dynamicTerms += stringLengthTerm(field.name, field.valueClass)
+        is FieldSpec.LengthFromString ->
+            dynamicTerms += stringLengthTerm(field.name, field.valueClass)
+        else -> return false
+    }
+    return true
+}
+
+/** Structural contributions: nested-message hints, element loops, fixed widths. */
+private fun SizeHintPlan.addStructural(field: FieldSpec): Boolean {
+    when (field) {
+        is FieldSpec.ProtocolMessageScalar ->
+            dynamicTerms += CodeBlock.of("%T.sizeHint(value.%L, context)", field.codecType, field.name)
+        is FieldSpec.LengthPrefixedMessage -> {
+            constHint += field.prefixWidth
+            dynamicTerms += CodeBlock.of("%T.sizeHint(value.%L, context)", field.codecType, field.name)
+        }
+        is FieldSpec.CountPrefixedProtocolMessageList -> {
+            constHint += 1 // minimum varint(count) width
+            elementLoops += field.name to field.elementCodecClassName
+        }
+        is FieldSpec.RemainingBytesProtocolMessageList ->
+            elementLoops += field.name to field.elementCodecClassName
+        is FieldSpec.EnumScalar -> constHint += 1 // minimum ordinal-varint width
+        is FieldSpec.LengthPrefixedUseCodecPayload -> constHint += field.prefixWidth
+        is FieldSpec.FixedSize -> constHint += (field.wireWidth as? WireWidth.Fixed)?.bytes ?: 0
+        else -> {} // Conditional / opaque @UseCodec shapes: no cheap bound
+    }
+    return true
 }
 
 /** Render the plan: constant-only, single-expression sum, or loop-accumulate. */

--- a/buffer-codec-test/build.gradle.kts
+++ b/buffer-codec-test/build.gradle.kts
@@ -8,6 +8,13 @@ plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.ksp)
     alias(libs.plugins.ktlint)
+    alias(libs.plugins.kotlinx.benchmark)
+    alias(libs.plugins.kotlin.allopen)
+}
+
+// Required for JMH @State classes
+allOpen {
+    annotation("org.openjdk.jmh.annotations.State")
 }
 
 group = "com.ditchoom"
@@ -29,6 +36,9 @@ kotlin {
 
     jvm {
         compilerOptions.jvmTarget.set(JvmTarget.JVM_1_8)
+        compilations.create("benchmark") {
+            associateWith(this@jvm.compilations.getByName("main"))
+        }
     }
     js {
         browser()
@@ -55,7 +65,11 @@ kotlin {
             tvosX64()
         }
         if (HostManager.hostIsLinux) {
-            linuxX64()
+            linuxX64 {
+                compilations.create("benchmark") {
+                    associateWith(this@linuxX64.compilations.getByName("main"))
+                }
+            }
             linuxArm64()
         }
     } else {
@@ -63,7 +77,11 @@ kotlin {
             val osArch = System.getProperty("os.arch")
             if (osArch == "aarch64") macosArm64() else macosX64()
         } else if (HostManager.hostIsLinux) {
-            linuxX64()
+            linuxX64 {
+                compilations.create("benchmark") {
+                    associateWith(this@linuxX64.compilations.getByName("main"))
+                }
+            }
         }
     }
 
@@ -84,6 +102,45 @@ kotlin {
         // the plugin's task wiring is covered by buffer-codec-gradle-plugin's TestKit tests.
         jvmTest.dependencies {
             implementation(project(":buffer-codec-schema"))
+        }
+        // Benchmark source sets - all share the same source directory
+        val jvmBenchmark by getting {
+            kotlin.srcDir("src/commonBenchmark/kotlin")
+            dependencies {
+                implementation(libs.kotlinx.benchmark.runtime)
+            }
+        }
+        if (HostManager.hostIsLinux) {
+            val linuxX64Benchmark by getting {
+                kotlin.srcDir("src/commonBenchmark/kotlin")
+                dependencies {
+                    implementation(libs.kotlinx.benchmark.runtime)
+                }
+            }
+        }
+    }
+}
+
+// kotlinx-benchmark configuration (mirrors :buffer-flow)
+benchmark {
+    targets {
+        register("jvmBenchmark")
+        if (HostManager.hostIsLinux) {
+            register("linuxX64Benchmark")
+        }
+    }
+    configurations {
+        named("main") {
+            warmups = 3
+            iterations = 5
+            iterationTime = 1000
+            iterationTimeUnit = "ms"
+        }
+        register("quick") {
+            warmups = 1
+            iterations = 2
+            iterationTime = 500
+            iterationTimeUnit = "ms"
         }
     }
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/CommandPayloadCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/CommandPayloadCodec.kt
@@ -52,6 +52,12 @@ public object CommandPayloadCodec : Codec<CommandPayload> {
     is CommandPayload.ResetDevice -> WireSize.Exact(1)
   }
 
+  override fun sizeHint(`value`: CommandPayload, context: EncodeContext): Int = 1 + when (value) {
+    is CommandPayload.SetRgbState -> CommandPayloadSetRgbStateCodec.sizeHint(value, context)
+    is CommandPayload.GetRgbState -> CommandPayloadGetRgbStateCodec.sizeHint(value, context)
+    is CommandPayload.ResetDevice -> CommandPayloadResetDeviceCodec.sizeHint(value, context)
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
     val discriminator = stream.peekByte(baseOffset).toInt() and 0xFF

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/CommandPayloadGetRgbStateCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/CommandPayloadGetRgbStateCodec.kt
@@ -22,5 +22,7 @@ public object CommandPayloadGetRgbStateCodec : Codec<CommandPayload.GetRgbState>
 
   override fun wireSize(`value`: CommandPayload.GetRgbState, context: EncodeContext): WireSize = WireSize.Exact(0)
 
+  override fun sizeHint(`value`: CommandPayload.GetRgbState, context: EncodeContext): Int = 0
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 0) PeekResult.Complete(0) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/CommandPayloadResetDeviceCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/CommandPayloadResetDeviceCodec.kt
@@ -22,5 +22,7 @@ public object CommandPayloadResetDeviceCodec : Codec<CommandPayload.ResetDevice>
 
   override fun wireSize(`value`: CommandPayload.ResetDevice, context: EncodeContext): WireSize = WireSize.Exact(0)
 
+  override fun sizeHint(`value`: CommandPayload.ResetDevice, context: EncodeContext): Int = 0
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 0) PeekResult.Complete(0) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/CommandPayloadSetRgbStateCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/CommandPayloadSetRgbStateCodec.kt
@@ -42,5 +42,7 @@ public object CommandPayloadSetRgbStateCodec : Codec<CommandPayload.SetRgbState>
 
   override fun wireSize(`value`: CommandPayload.SetRgbState, context: EncodeContext): WireSize = WireSize.Exact(3)
 
+  override fun sizeHint(`value`: CommandPayload.SetRgbState, context: EncodeContext): Int = 3
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 3) PeekResult.Complete(3) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ConnectionStatusCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ConnectionStatusCodec.kt
@@ -58,6 +58,13 @@ public object ConnectionStatusCodec : Codec<ConnectionStatus> {
     is ConnectionStatus.Failed -> WireSize.Exact(1)
   }
 
+  override fun sizeHint(`value`: ConnectionStatus, context: EncodeContext): Int = 1 + when (value) {
+    is ConnectionStatus.Disconnected -> ConnectionStatusDisconnectedCodec.sizeHint(value, context)
+    is ConnectionStatus.Connecting -> ConnectionStatusConnectingCodec.sizeHint(value, context)
+    is ConnectionStatus.Connected -> ConnectionStatusConnectedCodec.sizeHint(value, context)
+    is ConnectionStatus.Failed -> ConnectionStatusFailedCodec.sizeHint(value, context)
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
     val discriminator = stream.peekByte(baseOffset).toInt() and 0xFF

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ConnectionStatusConnectedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ConnectionStatusConnectedCodec.kt
@@ -22,5 +22,7 @@ public object ConnectionStatusConnectedCodec : Codec<ConnectionStatus.Connected>
 
   override fun wireSize(`value`: ConnectionStatus.Connected, context: EncodeContext): WireSize = WireSize.Exact(0)
 
+  override fun sizeHint(`value`: ConnectionStatus.Connected, context: EncodeContext): Int = 0
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 0) PeekResult.Complete(0) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ConnectionStatusConnectingCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ConnectionStatusConnectingCodec.kt
@@ -26,5 +26,7 @@ public object ConnectionStatusConnectingCodec : Codec<ConnectionStatus.Connectin
 
   override fun wireSize(`value`: ConnectionStatus.Connecting, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: ConnectionStatus.Connecting, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ConnectionStatusDisconnectedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ConnectionStatusDisconnectedCodec.kt
@@ -22,5 +22,7 @@ public object ConnectionStatusDisconnectedCodec : Codec<ConnectionStatus.Disconn
 
   override fun wireSize(`value`: ConnectionStatus.Disconnected, context: EncodeContext): WireSize = WireSize.Exact(0)
 
+  override fun sizeHint(`value`: ConnectionStatus.Disconnected, context: EncodeContext): Int = 0
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 0) PeekResult.Complete(0) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ConnectionStatusFailedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ConnectionStatusFailedCodec.kt
@@ -22,5 +22,7 @@ public object ConnectionStatusFailedCodec : Codec<ConnectionStatus.Failed> {
 
   override fun wireSize(`value`: ConnectionStatus.Failed, context: EncodeContext): WireSize = WireSize.Exact(0)
 
+  override fun sizeHint(`value`: ConnectionStatus.Failed, context: EncodeContext): Int = 0
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 0) PeekResult.Complete(0) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/DeviceStateCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/DeviceStateCodec.kt
@@ -28,5 +28,7 @@ public object DeviceStateCodec : Codec<DeviceState> {
 
   override fun wireSize(`value`: DeviceState, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: DeviceState, context: EncodeContext): Int = 1 + ConnectionStatusCodec.sizeHint(value.connection, context)
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/Issue156CommandCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/Issue156CommandCodec.kt
@@ -40,6 +40,10 @@ public object Issue156CommandCodec : Codec<Issue156Command> {
     is Issue156Command.LedStateSet -> WireSize.Exact(4)
   }
 
+  override fun sizeHint(`value`: Issue156Command, context: EncodeContext): Int = 1 + when (value) {
+    is Issue156Command.LedStateSet -> Issue156CommandLedStateSetCodec.sizeHint(value, context)
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
     val discriminator = stream.peekByte(baseOffset).toInt() and 0xFF

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/Issue156CommandLedStateSetCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/Issue156CommandLedStateSetCodec.kt
@@ -28,5 +28,7 @@ public object Issue156CommandLedStateSetCodec : Codec<Issue156Command.LedStateSe
 
   override fun wireSize(`value`: Issue156Command.LedStateSet, context: EncodeContext): WireSize = WireSize.Exact(3)
 
+  override fun sizeHint(`value`: Issue156Command.LedStateSet, context: EncodeContext): Int = 3
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 3) PeekResult.Complete(3) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/Issue156ResponseCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/Issue156ResponseCodec.kt
@@ -40,6 +40,10 @@ public object Issue156ResponseCodec : Codec<Issue156Response> {
     is Issue156Response.LedStateSet -> WireSize.Exact(4)
   }
 
+  override fun sizeHint(`value`: Issue156Response, context: EncodeContext): Int = 1 + when (value) {
+    is Issue156Response.LedStateSet -> Issue156ResponseLedStateSetCodec.sizeHint(value, context)
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
     val discriminator = stream.peekByte(baseOffset).toInt() and 0xFF

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/Issue156ResponseLedStateSetCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/Issue156ResponseLedStateSetCodec.kt
@@ -28,5 +28,7 @@ public object Issue156ResponseLedStateSetCodec : Codec<Issue156Response.LedState
 
   override fun wireSize(`value`: Issue156Response.LedStateSet, context: EncodeContext): WireSize = WireSize.Exact(3)
 
+  override fun sizeHint(`value`: Issue156Response.LedStateSet, context: EncodeContext): Int = 3
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 3) PeekResult.Complete(3) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/asciistring/AsciiGreetingCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/asciistring/AsciiGreetingCodec.kt
@@ -61,6 +61,8 @@ public object AsciiGreetingCodec : Codec<AsciiGreeting> {
     return WireSize.Exact(0 + __commandSize)
   }
 
+  override fun sizeHint(`value`: AsciiGreeting, context: EncodeContext): Int = 2
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/asciistring/AsciiGreetingCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/asciistring/AsciiGreetingCodec.kt
@@ -53,7 +53,13 @@ public object AsciiGreetingCodec : Codec<AsciiGreeting> {
     buffer.position(commandEndPosition)
   }
 
-  override fun wireSize(`value`: AsciiGreeting, context: EncodeContext): WireSize = WireSize.BackPatch
+  override fun wireSize(`value`: AsciiGreeting, context: EncodeContext): WireSize {
+    val __commandSize = when (val __s = AsciiStringCodec.wireSize(value.command, context)) {
+      is WireSize.Exact -> 2 + __s.bytes
+      WireSize.BackPatch -> return WireSize.BackPatch
+    }
+    return WireSize.Exact(0 + __commandSize)
+  }
 
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/batch/BigDispatchFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/batch/BigDispatchFrameCodec.kt
@@ -46,6 +46,11 @@ public object BigDispatchFrameCodec : Codec<BigDispatchFrame> {
     is BigDispatchFrame.TypeB -> WireSize.Exact(9)
   }
 
+  override fun sizeHint(`value`: BigDispatchFrame, context: EncodeContext): Int = 1 + when (value) {
+    is BigDispatchFrame.TypeA -> BigDispatchFrameTypeACodec.sizeHint(value, context)
+    is BigDispatchFrame.TypeB -> BigDispatchFrameTypeBCodec.sizeHint(value, context)
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
     val discriminator = stream.peekByte(baseOffset).toInt() and 0xFF

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/batch/BigDispatchFrameTypeACodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/batch/BigDispatchFrameTypeACodec.kt
@@ -34,5 +34,7 @@ public object BigDispatchFrameTypeACodec : Codec<BigDispatchFrame.TypeA> {
 
   override fun wireSize(`value`: BigDispatchFrame.TypeA, context: EncodeContext): WireSize = WireSize.Exact(8)
 
+  override fun sizeHint(`value`: BigDispatchFrame.TypeA, context: EncodeContext): Int = 8
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 8) PeekResult.Complete(8) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/batch/BigDispatchFrameTypeBCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/batch/BigDispatchFrameTypeBCodec.kt
@@ -34,5 +34,7 @@ public object BigDispatchFrameTypeBCodec : Codec<BigDispatchFrame.TypeB> {
 
   override fun wireSize(`value`: BigDispatchFrame.TypeB, context: EncodeContext): WireSize = WireSize.Exact(8)
 
+  override fun sizeHint(`value`: BigDispatchFrame.TypeB, context: EncodeContext): Int = 8
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 8) PeekResult.Complete(8) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/batch/BigHeaderCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/batch/BigHeaderCodec.kt
@@ -34,5 +34,7 @@ public object BigHeaderCodec : Codec<BigHeader> {
 
   override fun wireSize(`value`: BigHeader, context: EncodeContext): WireSize = WireSize.Exact(8)
 
+  override fun sizeHint(`value`: BigHeader, context: EncodeContext): Int = 8
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 8) PeekResult.Complete(8) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/batch/ConditionalBreaksBatchCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/batch/ConditionalBreaksBatchCodec.kt
@@ -37,6 +37,8 @@ public object ConditionalBreaksBatchCodec : Codec<ConditionalBreaksBatch> {
 
   override fun wireSize(`value`: ConditionalBreaksBatch, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: ConditionalBreaksBatch, context: EncodeContext): Int = 3
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/batch/EightUBytesCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/batch/EightUBytesCodec.kt
@@ -58,5 +58,7 @@ public object EightUBytesCodec : Codec<EightUBytes> {
 
   override fun wireSize(`value`: EightUBytes, context: EncodeContext): WireSize = WireSize.Exact(8)
 
+  override fun sizeHint(`value`: EightUBytes, context: EncodeContext): Int = 8
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 8) PeekResult.Complete(8) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/batch/FourUBytesCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/batch/FourUBytesCodec.kt
@@ -46,5 +46,7 @@ public object FourUBytesCodec : Codec<FourUBytes> {
 
   override fun wireSize(`value`: FourUBytes, context: EncodeContext): WireSize = WireSize.Exact(4)
 
+  override fun sizeHint(`value`: FourUBytes, context: EncodeContext): Int = 4
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 4) PeekResult.Complete(4) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/batch/HeaderByteCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/batch/HeaderByteCodec.kt
@@ -26,5 +26,7 @@ public object HeaderByteCodec : Codec<HeaderByte> {
 
   override fun wireSize(`value`: HeaderByte, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: HeaderByte, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/batch/LittleHeaderCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/batch/LittleHeaderCodec.kt
@@ -34,5 +34,7 @@ public object LittleHeaderCodec : Codec<LittleHeader> {
 
   override fun wireSize(`value`: LittleHeader, context: EncodeContext): WireSize = WireSize.Exact(8)
 
+  override fun sizeHint(`value`: LittleHeader, context: EncodeContext): Int = 8
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 8) PeekResult.Complete(8) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/batch/LittleTagCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/batch/LittleTagCodec.kt
@@ -30,5 +30,7 @@ public object LittleTagCodec : Codec<LittleTag> {
 
   override fun wireSize(`value`: LittleTag, context: EncodeContext): WireSize = WireSize.Exact(2)
 
+  override fun sizeHint(`value`: LittleTag, context: EncodeContext): Int = 2
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/batch/MixedNaturalScalarsCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/batch/MixedNaturalScalarsCodec.kt
@@ -46,5 +46,7 @@ public object MixedNaturalScalarsCodec : Codec<MixedNaturalScalars> {
 
   override fun wireSize(`value`: MixedNaturalScalars, context: EncodeContext): WireSize = WireSize.Exact(8)
 
+  override fun sizeHint(`value`: MixedNaturalScalars, context: EncodeContext): Int = 8
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 8) PeekResult.Complete(8) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/batch/MixedOrderFlushCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/batch/MixedOrderFlushCodec.kt
@@ -38,5 +38,7 @@ public object MixedOrderFlushCodec : Codec<MixedOrderFlush> {
 
   override fun wireSize(`value`: MixedOrderFlush, context: EncodeContext): WireSize = WireSize.Exact(8)
 
+  override fun sizeHint(`value`: MixedOrderFlush, context: EncodeContext): Int = 8
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 8) PeekResult.Complete(8) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/batch/MixedOrderPartialBatchCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/batch/MixedOrderPartialBatchCodec.kt
@@ -36,5 +36,7 @@ public object MixedOrderPartialBatchCodec : Codec<MixedOrderPartialBatch> {
 
   override fun wireSize(`value`: MixedOrderPartialBatch, context: EncodeContext): WireSize = WireSize.Exact(8)
 
+  override fun sizeHint(`value`: MixedOrderPartialBatch, context: EncodeContext): Int = 8
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 8) PeekResult.Complete(8) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/batch/MixedOrderValueClassCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/batch/MixedOrderValueClassCodec.kt
@@ -38,5 +38,7 @@ public object MixedOrderValueClassCodec : Codec<MixedOrderValueClass> {
 
   override fun wireSize(`value`: MixedOrderValueClass, context: EncodeContext): WireSize = WireSize.Exact(8)
 
+  override fun sizeHint(`value`: MixedOrderValueClass, context: EncodeContext): Int = 8
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 8) PeekResult.Complete(8) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/batch/SandwichBatchCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/batch/SandwichBatchCodec.kt
@@ -53,6 +53,8 @@ public object SandwichBatchCodec : Codec<SandwichBatch> {
 
   override fun wireSize(`value`: SandwichBatch, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: SandwichBatch, context: EncodeContext): Int = 9
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/batch/SignedAndUnsignedMixCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/batch/SignedAndUnsignedMixCodec.kt
@@ -43,5 +43,7 @@ public object SignedAndUnsignedMixCodec : Codec<SignedAndUnsignedMix> {
 
   override fun wireSize(`value`: SignedAndUnsignedMix, context: EncodeContext): WireSize = WireSize.Exact(4)
 
+  override fun sizeHint(`value`: SignedAndUnsignedMix, context: EncodeContext): Int = 4
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 4) PeekResult.Complete(4) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/batch/ValueClassBatchCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/batch/ValueClassBatchCodec.kt
@@ -40,5 +40,7 @@ public object ValueClassBatchCodec : Codec<ValueClassBatch> {
 
   override fun wireSize(`value`: ValueClassBatch, context: EncodeContext): WireSize = WireSize.Exact(2)
 
+  override fun sizeHint(`value`: ValueClassBatch, context: EncodeContext): Int = 2
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/BigTailCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/BigTailCodec.kt
@@ -72,6 +72,8 @@ public object BigTailCodec : Codec<BigTail> {
 
   override fun wireSize(`value`: BigTail, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: BigTail, context: EncodeContext): Int = 6 + value.a.length + value.b.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/BoundaryDispCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/BoundaryDispCodec.kt
@@ -46,6 +46,11 @@ public object BoundaryDispCodec : Codec<BoundaryDisp> {
     is BoundaryDisp.Inherits -> WireSize.Exact(1)
   }
 
+  override fun sizeHint(`value`: BoundaryDisp, context: EncodeContext): Int = 1 + when (value) {
+    is BoundaryDisp.Named -> BoundaryDispNamedCodec.sizeHint(value, context)
+    is BoundaryDisp.Inherits -> BoundaryDispInheritsCodec.sizeHint(value, context)
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
     val discriminator = stream.peekByte(baseOffset).toInt() and 0xFF

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/BoundaryDispInheritsCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/BoundaryDispInheritsCodec.kt
@@ -22,5 +22,7 @@ public object BoundaryDispInheritsCodec : Codec<BoundaryDisp.Inherits> {
 
   override fun wireSize(`value`: BoundaryDisp.Inherits, context: EncodeContext): WireSize = WireSize.Exact(0)
 
+  override fun sizeHint(`value`: BoundaryDisp.Inherits, context: EncodeContext): Int = 0
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 0) PeekResult.Complete(0) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/BoundaryDispNamedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/BoundaryDispNamedCodec.kt
@@ -49,6 +49,8 @@ public object BoundaryDispNamedCodec : Codec<BoundaryDisp.Named> {
 
   override fun wireSize(`value`: BoundaryDisp.Named, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: BoundaryDisp.Named, context: EncodeContext): Int = 2 + value.name.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/BoundaryHostCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/BoundaryHostCodec.kt
@@ -51,5 +51,7 @@ public object BoundaryHostCodec : Codec<BoundaryHost> {
 
   override fun wireSize(`value`: BoundaryHost, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: BoundaryHost, context: EncodeContext): Int = 2 + value.host.length + BoundaryDispCodec.sizeHint(value.disp, context)
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/LpByteWrappedTailCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/LpByteWrappedTailCodec.kt
@@ -67,6 +67,8 @@ public object LpByteWrappedTailCodec : Codec<LpByteWrappedTail> {
     WireSize.BackPatch -> WireSize.BackPatch
   }
 
+  override fun sizeHint(`value`: LpByteWrappedTail, context: EncodeContext): Int = 1 + WrappedLabelCodec.sizeHint(value.body, context)
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/LpWrappedTailCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/LpWrappedTailCodec.kt
@@ -73,6 +73,8 @@ public object LpWrappedTailCodec : Codec<LpWrappedTail> {
     WireSize.BackPatch -> WireSize.BackPatch
   }
 
+  override fun sizeHint(`value`: LpWrappedTail, context: EncodeContext): Int = 3 + WrappedLabelCodec.sizeHint(value.body, context)
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/WithVidCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/WithVidCodec.kt
@@ -71,6 +71,8 @@ public object WithVidCodec : Codec<WithVid> {
 
   override fun wireSize(`value`: WithVid, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: WithVid, context: EncodeContext): Int = 4 + value.pad.length + value.id.value.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/WrappedLabelCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/WrappedLabelCodec.kt
@@ -49,6 +49,8 @@ public object WrappedLabelCodec : Codec<WrappedLabel> {
 
   override fun wireSize(`value`: WrappedLabel, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: WrappedLabel, context: EncodeContext): Int = 2 + value.label.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountBadgeAnonymousCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountBadgeAnonymousCodec.kt
@@ -22,5 +22,7 @@ public object CountBadgeAnonymousCodec : Codec<CountBadge.Anonymous> {
 
   override fun wireSize(`value`: CountBadge.Anonymous, context: EncodeContext): WireSize = WireSize.Exact(0)
 
+  override fun sizeHint(`value`: CountBadge.Anonymous, context: EncodeContext): Int = 0
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 0) PeekResult.Complete(0) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountBadgeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountBadgeCodec.kt
@@ -46,6 +46,11 @@ public object CountBadgeCodec : Codec<CountBadge> {
     is CountBadge.Anonymous -> WireSize.Exact(1)
   }
 
+  override fun sizeHint(`value`: CountBadge, context: EncodeContext): Int = 1 + when (value) {
+    is CountBadge.Named -> CountBadgeNamedCodec.sizeHint(value, context)
+    is CountBadge.Anonymous -> CountBadgeAnonymousCodec.sizeHint(value, context)
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
     val discriminator = stream.peekByte(baseOffset).toInt() and 0xFF

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountBadgeNamedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountBadgeNamedCodec.kt
@@ -49,6 +49,8 @@ public object CountBadgeNamedCodec : Codec<CountBadge.Named> {
 
   override fun wireSize(`value`: CountBadge.Named, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: CountBadge.Named, context: EncodeContext): Int = 2 + value.name.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountFixedListCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountFixedListCodec.kt
@@ -47,5 +47,13 @@ public object CountFixedListCodec : Codec<CountFixedList> {
     return WireSize.Exact(1 + __pointsSize)
   }
 
+  override fun sizeHint(`value`: CountFixedList, context: EncodeContext): Int {
+    var __hint = 2
+    for (__elem in value.points) {
+      __hint += CountPointCodec.sizeHint(__elem, context)
+    }
+    return __hint
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountInnerFixedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountInnerFixedCodec.kt
@@ -30,5 +30,7 @@ public object CountInnerFixedCodec : Codec<CountInnerFixed> {
 
   override fun wireSize(`value`: CountInnerFixed, context: EncodeContext): WireSize = WireSize.Exact(2)
 
+  override fun sizeHint(`value`: CountInnerFixed, context: EncodeContext): Int = 2
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountNamedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountNamedCodec.kt
@@ -49,6 +49,8 @@ public object CountNamedCodec : Codec<CountNamed> {
 
   override fun wireSize(`value`: CountNamed, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: CountNamed, context: EncodeContext): Int = 2 + value.name.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountNestedEntryCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountNestedEntryCodec.kt
@@ -26,5 +26,7 @@ public object CountNestedEntryCodec : Codec<CountNestedEntry> {
 
   override fun wireSize(`value`: CountNestedEntry, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: CountNestedEntry, context: EncodeContext): Int = 0 + CountInnerFixedCodec.sizeHint(value.inner, context)
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountNestedEntryListCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountNestedEntryListCodec.kt
@@ -34,5 +34,13 @@ public object CountNestedEntryListCodec : Codec<CountNestedEntryList> {
 
   override fun wireSize(`value`: CountNestedEntryList, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: CountNestedEntryList, context: EncodeContext): Int {
+    var __hint = 1
+    for (__elem in value.entries) {
+      __hint += CountNestedEntryCodec.sizeHint(__elem, context)
+    }
+    return __hint
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountPointCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountPointCodec.kt
@@ -32,5 +32,7 @@ public object CountPointCodec : Codec<CountPoint> {
 
   override fun wireSize(`value`: CountPoint, context: EncodeContext): WireSize = WireSize.Exact(3)
 
+  override fun sizeHint(`value`: CountPoint, context: EncodeContext): Int = 3
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 3) PeekResult.Complete(3) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountSealedEntryCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountSealedEntryCodec.kt
@@ -32,5 +32,7 @@ public object CountSealedEntryCodec : Codec<CountSealedEntry> {
 
   override fun wireSize(`value`: CountSealedEntry, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: CountSealedEntry, context: EncodeContext): Int = 2 + CountBadgeCodec.sizeHint(value.badge, context)
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountSealedEntryListCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountSealedEntryListCodec.kt
@@ -34,5 +34,13 @@ public object CountSealedEntryListCodec : Codec<CountSealedEntryList> {
 
   override fun wireSize(`value`: CountSealedEntryList, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: CountSealedEntryList, context: EncodeContext): Int {
+    var __hint = 1
+    for (__elem in value.entries) {
+      __hint += CountSealedEntryCodec.sizeHint(__elem, context)
+    }
+    return __hint
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountTaggedEntryCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountTaggedEntryCodec.kt
@@ -49,6 +49,8 @@ public object CountTaggedEntryCodec : Codec<CountTaggedEntry> {
 
   override fun wireSize(`value`: CountTaggedEntry, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: CountTaggedEntry, context: EncodeContext): Int = 2 + value.tag.value.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountTaggedListCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountTaggedListCodec.kt
@@ -34,5 +34,13 @@ public object CountTaggedListCodec : Codec<CountTaggedList> {
 
   override fun wireSize(`value`: CountTaggedList, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: CountTaggedList, context: EncodeContext): Int {
+    var __hint = 1
+    for (__elem in value.tags) {
+      __hint += CountTaggedEntryCodec.sizeHint(__elem, context)
+    }
+    return __hint
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountThenTrailerCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountThenTrailerCodec.kt
@@ -51,5 +51,13 @@ public object CountThenTrailerCodec : Codec<CountThenTrailer> {
     return WireSize.Exact(4 + __pointsSize)
   }
 
+  override fun sizeHint(`value`: CountThenTrailer, context: EncodeContext): Int {
+    var __hint = 5
+    for (__elem in value.points) {
+      __hint += CountPointCodec.sizeHint(__elem, context)
+    }
+    return __hint
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountVariableListCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/count/CountVariableListCodec.kt
@@ -34,5 +34,13 @@ public object CountVariableListCodec : Codec<CountVariableList> {
 
   override fun wireSize(`value`: CountVariableList, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: CountVariableList, context: EncodeContext): Int {
+    var __hint = 1
+    for (__elem in value.names) {
+      __hint += CountNamedCodec.sizeHint(__elem, context)
+    }
+    return __hint
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/dns/DnsHeaderCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/dns/DnsHeaderCodec.kt
@@ -40,5 +40,7 @@ public object DnsHeaderCodec : Codec<DnsHeader> {
 
   override fun wireSize(`value`: DnsHeader, context: EncodeContext): WireSize = WireSize.Exact(12)
 
+  override fun sizeHint(`value`: DnsHeader, context: EncodeContext): Int = 12
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 12) PeekResult.Complete(12) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/enums/StyleCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/enums/StyleCodec.kt
@@ -38,5 +38,7 @@ public object StyleCodec : Codec<Style> {
     return WireSize.Exact(1 + __colorSize + __prioritySize)
   }
 
+  override fun sizeHint(`value`: Style, context: EncodeContext): Int = 3
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/enums/TaggedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/enums/TaggedCodec.kt
@@ -34,6 +34,8 @@ public object TaggedCodec : Codec<Tagged> {
     return WireSize.Exact(1 + __levelSize)
   }
 
+  override fun sizeHint(`value`: Tagged, context: EncodeContext): Int = 2
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     val __levelFrame = UnsignedVarIntCodec.peekFrameSize(stream, baseOffset + 0)
     if (__levelFrame !is PeekResult.Complete) {

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ethernet/EtherTypeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ethernet/EtherTypeCodec.kt
@@ -26,5 +26,7 @@ public object EtherTypeCodec : Codec<EtherType> {
 
   override fun wireSize(`value`: EtherType, context: EncodeContext): WireSize = WireSize.Exact(2)
 
+  override fun sizeHint(`value`: EtherType, context: EncodeContext): Int = 2
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ethernet/EthernetFrameByEtherTypeArpCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ethernet/EthernetFrameByEtherTypeArpCodec.kt
@@ -26,5 +26,7 @@ public object EthernetFrameByEtherTypeArpCodec : Codec<EthernetFrameByEtherType.
 
   override fun wireSize(`value`: EthernetFrameByEtherType.Arp, context: EncodeContext): WireSize = WireSize.Exact(2)
 
+  override fun sizeHint(`value`: EthernetFrameByEtherType.Arp, context: EncodeContext): Int = 2
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ethernet/EthernetFrameByEtherTypeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ethernet/EthernetFrameByEtherTypeCodec.kt
@@ -48,6 +48,13 @@ public object EthernetFrameByEtherTypeCodec : Codec<EthernetFrameByEtherType> {
     is EthernetFrameByEtherType.Ipv6 -> EthernetFrameByEtherTypeIpv6Codec.wireSize(value, context)
   }
 
+  override fun sizeHint(`value`: EthernetFrameByEtherType, context: EncodeContext): Int = when (value) {
+    is EthernetFrameByEtherType.Ipv4 -> EthernetFrameByEtherTypeIpv4Codec.sizeHint(value, context)
+    is EthernetFrameByEtherType.Arp -> EthernetFrameByEtherTypeArpCodec.sizeHint(value, context)
+    is EthernetFrameByEtherType.VlanTag -> EthernetFrameByEtherTypeVlanTagCodec.sizeHint(value, context)
+    is EthernetFrameByEtherType.Ipv6 -> EthernetFrameByEtherTypeIpv6Codec.sizeHint(value, context)
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
     val __discRawB0 = stream.peekByte(baseOffset + 0).toInt() and 0xFF

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ethernet/EthernetFrameByEtherTypeIpv4Codec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ethernet/EthernetFrameByEtherTypeIpv4Codec.kt
@@ -26,5 +26,7 @@ public object EthernetFrameByEtherTypeIpv4Codec : Codec<EthernetFrameByEtherType
 
   override fun wireSize(`value`: EthernetFrameByEtherType.Ipv4, context: EncodeContext): WireSize = WireSize.Exact(2)
 
+  override fun sizeHint(`value`: EthernetFrameByEtherType.Ipv4, context: EncodeContext): Int = 2
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ethernet/EthernetFrameByEtherTypeIpv6Codec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ethernet/EthernetFrameByEtherTypeIpv6Codec.kt
@@ -26,5 +26,7 @@ public object EthernetFrameByEtherTypeIpv6Codec : Codec<EthernetFrameByEtherType
 
   override fun wireSize(`value`: EthernetFrameByEtherType.Ipv6, context: EncodeContext): WireSize = WireSize.Exact(2)
 
+  override fun sizeHint(`value`: EthernetFrameByEtherType.Ipv6, context: EncodeContext): Int = 2
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ethernet/EthernetFrameByEtherTypeVlanTagCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/ethernet/EthernetFrameByEtherTypeVlanTagCodec.kt
@@ -26,5 +26,7 @@ public object EthernetFrameByEtherTypeVlanTagCodec : Codec<EthernetFrameByEtherT
 
   override fun wireSize(`value`: EthernetFrameByEtherType.VlanTag, context: EncodeContext): WireSize = WireSize.Exact(2)
 
+  override fun sizeHint(`value`: EthernetFrameByEtherType.VlanTag, context: EncodeContext): Int = 2
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/flv/FlvTagHeaderCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/flv/FlvTagHeaderCodec.kt
@@ -59,5 +59,7 @@ public object FlvTagHeaderCodec : Codec<FlvTagHeader> {
 
   override fun wireSize(`value`: FlvTagHeader, context: EncodeContext): WireSize = WireSize.Exact(11)
 
+  override fun sizeHint(`value`: FlvTagHeader, context: EncodeContext): Int = 11
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 11) PeekResult.Complete(11) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/forwardcompat/OpCodeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/forwardcompat/OpCodeCodec.kt
@@ -26,5 +26,7 @@ public object OpCodeCodec : Codec<OpCode> {
 
   override fun wireSize(`value`: OpCode, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: OpCode, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/grpc/GrpcLengthPrefixedMessageCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/grpc/GrpcLengthPrefixedMessageCodec.kt
@@ -55,7 +55,13 @@ public object GrpcLengthPrefixedMessageCodec : Codec<GrpcLengthPrefixedMessage> 
     buffer.position(messageEndPosition)
   }
 
-  override fun wireSize(`value`: GrpcLengthPrefixedMessage, context: EncodeContext): WireSize = WireSize.BackPatch
+  override fun wireSize(`value`: GrpcLengthPrefixedMessage, context: EncodeContext): WireSize {
+    val __messageSize = when (val __s = BinaryDataCodec.wireSize(value.message, context)) {
+      is WireSize.Exact -> 4 + __s.bytes
+      WireSize.BackPatch -> return WireSize.BackPatch
+    }
+    return WireSize.Exact(1 + __messageSize)
+  }
 
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/grpc/GrpcLengthPrefixedMessageCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/grpc/GrpcLengthPrefixedMessageCodec.kt
@@ -63,6 +63,8 @@ public object GrpcLengthPrefixedMessageCodec : Codec<GrpcLengthPrefixedMessage> 
     return WireSize.Exact(1 + __messageSize)
   }
 
+  override fun sizeHint(`value`: GrpcLengthPrefixedMessage, context: EncodeContext): Int = 5
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2FrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2FrameCodec.kt
@@ -57,6 +57,16 @@ public class Http2FrameCodec<P : Payload>(
     }
   }
 
+  override fun sizeHint(`value`: Http2Frame<P>, context: EncodeContext): Int {
+    @Suppress("UNCHECKED_CAST")
+    return when (value) {
+      is Http2Frame.Data<*> -> dataCodec.sizeHint(value as Http2Frame.Data<P>, context)
+      is Http2Frame.Settings -> Http2FrameSettingsCodec.sizeHint(value, context)
+      is Http2Frame.Ping -> Http2FramePingCodec.sizeHint(value, context)
+      is Http2Frame.WindowUpdate -> Http2FrameWindowUpdateCodec.sizeHint(value, context)
+    }
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     if (stream.available() - baseOffset < 4) return PeekResult.NeedsMoreData
     val __discRawB0 = stream.peekByte(baseOffset + 0).toInt() and 0xFF

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2FrameDataCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2FrameDataCodec.kt
@@ -41,6 +41,8 @@ public class Http2FrameDataCodec<P : Payload>(
 
   override fun wireSize(`value`: Http2Frame.Data<P>, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: Http2Frame.Data<P>, context: EncodeContext): Int = 9
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 
   public class Partial<P : Payload> internal constructor(

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2FramePingCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2FramePingCodec.kt
@@ -38,5 +38,7 @@ public object Http2FramePingCodec : Codec<Http2Frame.Ping> {
 
   override fun wireSize(`value`: Http2Frame.Ping, context: EncodeContext): WireSize = WireSize.Exact(17)
 
+  override fun sizeHint(`value`: Http2Frame.Ping, context: EncodeContext): Int = 17
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 17) PeekResult.Complete(17) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2FrameSettingsCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2FrameSettingsCodec.kt
@@ -48,6 +48,8 @@ public object Http2FrameSettingsCodec : Codec<Http2Frame.Settings> {
 
   override fun wireSize(`value`: Http2Frame.Settings, context: EncodeContext): WireSize = WireSize.Exact(9 + value.header.length)
 
+  override fun sizeHint(`value`: Http2Frame.Settings, context: EncodeContext): Int = 9
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 4) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2FrameWindowUpdateCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2FrameWindowUpdateCodec.kt
@@ -38,5 +38,7 @@ public object Http2FrameWindowUpdateCodec : Codec<Http2Frame.WindowUpdate> {
 
   override fun wireSize(`value`: Http2Frame.WindowUpdate, context: EncodeContext): WireSize = WireSize.Exact(13)
 
+  override fun sizeHint(`value`: Http2Frame.WindowUpdate, context: EncodeContext): Int = 13
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 13) PeekResult.Complete(13) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2LengthAndTypeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2LengthAndTypeCodec.kt
@@ -30,5 +30,7 @@ public object Http2LengthAndTypeCodec : Codec<Http2LengthAndType> {
 
   override fun wireSize(`value`: Http2LengthAndType, context: EncodeContext): WireSize = WireSize.Exact(4)
 
+  override fun sizeHint(`value`: Http2LengthAndType, context: EncodeContext): Int = 4
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 4) PeekResult.Complete(4) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2SettingCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2SettingCodec.kt
@@ -34,5 +34,7 @@ public object Http2SettingCodec : Codec<Http2Setting> {
 
   override fun wireSize(`value`: Http2Setting, context: EncodeContext): WireSize = WireSize.Exact(6)
 
+  override fun sizeHint(`value`: Http2Setting, context: EncodeContext): Int = 6
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 6) PeekResult.Complete(6) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2SettingsFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2SettingsFrameCodec.kt
@@ -63,6 +63,8 @@ public object Http2SettingsFrameCodec : Codec<Http2SettingsFrame> {
 
   override fun wireSize(`value`: Http2SettingsFrame, context: EncodeContext): WireSize = WireSize.Exact(9 + value.length.toInt())
 
+  override fun sizeHint(`value`: Http2SettingsFrame, context: EncodeContext): Int = 9
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 3) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameCodec.kt
@@ -49,6 +49,13 @@ public object Http3FrameCodec : Codec<Http3Frame> {
     is Http3Frame.Extension -> Http3FrameExtensionCodec.wireSize(value, context)
   }
 
+  override fun sizeHint(`value`: Http3Frame, context: EncodeContext): Int = when (value) {
+    is Http3Frame.Data -> Http3FrameDataCodec.sizeHint(value, context)
+    is Http3Frame.Headers -> Http3FrameHeadersCodec.sizeHint(value, context)
+    is Http3Frame.Settings -> Http3FrameSettingsCodec.sizeHint(value, context)
+    is Http3Frame.Extension -> Http3FrameExtensionCodec.sizeHint(value, context)
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     val __discFrame = Http3FrameTypeCodec.peekFrameSize(stream, baseOffset)
     if (__discFrame !is PeekResult.Complete) {

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameDataCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameDataCodec.kt
@@ -40,6 +40,8 @@ public object Http3FrameDataCodec : Codec<Http3Frame.Data> {
 
   override fun wireSize(`value`: Http3Frame.Data, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: Http3Frame.Data, context: EncodeContext): Int = 0
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __priorBytes = 0
     val __frameTypeFrame = Http3FrameTypeCodec.peekFrameSize(stream, baseOffset + __priorBytes)

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameExtensionCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameExtensionCodec.kt
@@ -40,6 +40,8 @@ public object Http3FrameExtensionCodec : Codec<Http3Frame.Extension> {
 
   override fun wireSize(`value`: Http3Frame.Extension, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: Http3Frame.Extension, context: EncodeContext): Int = 0
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __priorBytes = 0
     val __frameTypeFrame = Http3FrameTypeCodec.peekFrameSize(stream, baseOffset + __priorBytes)

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameHeadersCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameHeadersCodec.kt
@@ -40,6 +40,8 @@ public object Http3FrameHeadersCodec : Codec<Http3Frame.Headers> {
 
   override fun wireSize(`value`: Http3Frame.Headers, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: Http3Frame.Headers, context: EncodeContext): Int = 0
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __priorBytes = 0
     val __frameTypeFrame = Http3FrameTypeCodec.peekFrameSize(stream, baseOffset + __priorBytes)

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameSettingsCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameSettingsCodec.kt
@@ -40,6 +40,8 @@ public object Http3FrameSettingsCodec : Codec<Http3Frame.Settings> {
 
   override fun wireSize(`value`: Http3Frame.Settings, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: Http3Frame.Settings, context: EncodeContext): Int = 0
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __priorBytes = 0
     val __frameTypeFrame = Http3FrameTypeCodec.peekFrameSize(stream, baseOffset + __priorBytes)

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameTypeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameTypeCodec.kt
@@ -33,6 +33,8 @@ public object Http3FrameTypeCodec : Codec<Http3FrameType> {
     return WireSize.Exact(0 + __rawSize)
   }
 
+  override fun sizeHint(`value`: Http3FrameType, context: EncodeContext): Int = 0
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     val __rawFrame = QuicVarintCodec.peekFrameSize(stream, baseOffset + 0)
     if (__rawFrame !is PeekResult.Complete) {

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcFrameTypeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcFrameTypeCodec.kt
@@ -33,6 +33,8 @@ public object Http3FcFrameTypeCodec : Codec<Http3FcFrameType> {
     return WireSize.Exact(0 + __rawSize)
   }
 
+  override fun sizeHint(`value`: Http3FcFrameType, context: EncodeContext): Int = 0
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     val __rawFrame = QuicVarintCodec.peekFrameSize(stream, baseOffset + 0)
     if (__rawFrame !is PeekResult.Complete) {

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcSettingCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3fc/Http3FcSettingCodec.kt
@@ -39,5 +39,7 @@ public object Http3FcSettingCodec : Codec<Http3FcSetting> {
     return WireSize.Exact(0 + __identifierSize + __valueSize)
   }
 
+  override fun sizeHint(`value`: Http3FcSetting, context: EncodeContext): Int = 0
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/PropertyBagFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/PropertyBagFrameCodec.kt
@@ -72,6 +72,8 @@ public object PropertyBagFrameCodec : Codec<PropertyBagFrame> {
     return WireSize.Exact(0 + __propertiesSize)
   }
 
+  override fun sizeHint(`value`: PropertyBagFrame, context: EncodeContext): Int = 0
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
     val __propertiesPeekView = stream.peekBuffer(baseOffset + 0, 5) ?: return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/PropertyBagFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/PropertyBagFrameCodec.kt
@@ -57,7 +57,20 @@ public object PropertyBagFrameCodec : Codec<PropertyBagFrame> {
     }
   }
 
-  override fun wireSize(`value`: PropertyBagFrame, context: EncodeContext): WireSize = WireSize.BackPatch
+  override fun wireSize(`value`: PropertyBagFrame, context: EncodeContext): WireSize {
+    var __propertiesBodyBytes = 0
+    for (__elem in value.properties) {
+      when (val __elemSize = PropertyEntryCodec.wireSize(__elem, context)) {
+        is WireSize.Exact -> __propertiesBodyBytes += __elemSize.bytes
+        WireSize.BackPatch -> return WireSize.BackPatch
+      }
+    }
+    val __propertiesSize = when (val __p = MqttRemainingLengthCodec.wireSize(__propertiesBodyBytes.toUInt(), context)) {
+      is WireSize.Exact -> __p.bytes + __propertiesBodyBytes
+      WireSize.BackPatch -> return WireSize.BackPatch
+    }
+    return WireSize.Exact(0 + __propertiesSize)
+  }
 
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/PropertyEntryCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/PropertyEntryCodec.kt
@@ -28,5 +28,7 @@ public object PropertyEntryCodec : Codec<PropertyEntry> {
 
   override fun wireSize(`value`: PropertyEntry, context: EncodeContext): WireSize = WireSize.Exact(5)
 
+  override fun sizeHint(`value`: PropertyEntry, context: EncodeContext): Int = 5
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 5) PeekResult.Complete(5) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/StringTaggedPropertyBagCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/StringTaggedPropertyBagCodec.kt
@@ -42,6 +42,8 @@ public object StringTaggedPropertyBagCodec : Codec<StringTaggedPropertyBag> {
 
   override fun wireSize(`value`: StringTaggedPropertyBag, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: StringTaggedPropertyBag, context: EncodeContext): Int = 0
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
     val __propertiesPeekView = stream.peekBuffer(baseOffset + 0, 5) ?: return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/StringTaggedPropertyCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/StringTaggedPropertyCodec.kt
@@ -51,6 +51,8 @@ public object StringTaggedPropertyCodec : Codec<StringTaggedProperty> {
 
   override fun wireSize(`value`: StringTaggedProperty, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: StringTaggedProperty, context: EncodeContext): Int = 3 + value.tag.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/TaggedPropertyBagCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/TaggedPropertyBagCodec.kt
@@ -59,7 +59,20 @@ public object TaggedPropertyBagCodec : Codec<TaggedPropertyBag> {
     }
   }
 
-  override fun wireSize(`value`: TaggedPropertyBag, context: EncodeContext): WireSize = WireSize.BackPatch
+  override fun wireSize(`value`: TaggedPropertyBag, context: EncodeContext): WireSize {
+    var __propertiesBodyBytes = 0
+    for (__elem in value.properties) {
+      when (val __elemSize = PropertyEntryCodec.wireSize(__elem, context)) {
+        is WireSize.Exact -> __propertiesBodyBytes += __elemSize.bytes
+        WireSize.BackPatch -> return WireSize.BackPatch
+      }
+    }
+    val __propertiesSize = when (val __p = MqttRemainingLengthCodec.wireSize(__propertiesBodyBytes.toUInt(), context)) {
+      is WireSize.Exact -> __p.bytes + __propertiesBodyBytes
+      WireSize.BackPatch -> return WireSize.BackPatch
+    }
+    return WireSize.Exact(1 + __propertiesSize)
+  }
 
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/TaggedPropertyBagCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/TaggedPropertyBagCodec.kt
@@ -74,6 +74,8 @@ public object TaggedPropertyBagCodec : Codec<TaggedPropertyBag> {
     return WireSize.Exact(1 + __propertiesSize)
   }
 
+  override fun sizeHint(`value`: TaggedPropertyBag, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
     val __propertiesPeekView = stream.peekBuffer(baseOffset + 1, 5) ?: return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttConnectFlagsCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttConnectFlagsCodec.kt
@@ -26,5 +26,7 @@ public object MqttConnectFlagsCodec : Codec<MqttConnectFlags> {
 
   override fun wireSize(`value`: MqttConnectFlags, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: MqttConnectFlags, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttConnectProtocolNameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttConnectProtocolNameCodec.kt
@@ -49,6 +49,8 @@ public object MqttConnectProtocolNameCodec : Codec<MqttConnectProtocolName> {
 
   override fun wireSize(`value`: MqttConnectProtocolName, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: MqttConnectProtocolName, context: EncodeContext): Int = 2 + value.name.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttFixedHeaderCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttFixedHeaderCodec.kt
@@ -26,5 +26,7 @@ public object MqttFixedHeaderCodec : Codec<MqttFixedHeader> {
 
   override fun wireSize(`value`: MqttFixedHeader, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: MqttFixedHeader, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttTopicFilterCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttTopicFilterCodec.kt
@@ -51,6 +51,8 @@ public object MqttTopicFilterCodec : Codec<MqttTopicFilter> {
 
   override fun wireSize(`value`: MqttTopicFilter, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: MqttTopicFilter, context: EncodeContext): Int = 3 + value.filter.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttUnsubscribeTopicCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttUnsubscribeTopicCodec.kt
@@ -49,6 +49,8 @@ public object MqttUnsubscribeTopicCodec : Codec<MqttUnsubscribeTopic> {
 
   override fun wireSize(`value`: MqttUnsubscribeTopic, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: MqttUnsubscribeTopic, context: EncodeContext): Int = 2 + value.name.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/suback/MqttV3SubAckReturnCodeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/suback/MqttV3SubAckReturnCodeCodec.kt
@@ -48,6 +48,13 @@ public object MqttV3SubAckReturnCodeCodec : Codec<MqttV3SubAckReturnCode> {
     is MqttV3SubAckReturnCode.Failure -> MqttV3SubAckReturnCodeFailureCodec.wireSize(value, context)
   }
 
+  override fun sizeHint(`value`: MqttV3SubAckReturnCode, context: EncodeContext): Int = when (value) {
+    is MqttV3SubAckReturnCode.SuccessMaximumQoS0 -> MqttV3SubAckReturnCodeSuccessMaximumQoS0Codec.sizeHint(value, context)
+    is MqttV3SubAckReturnCode.SuccessMaximumQoS1 -> MqttV3SubAckReturnCodeSuccessMaximumQoS1Codec.sizeHint(value, context)
+    is MqttV3SubAckReturnCode.SuccessMaximumQoS2 -> MqttV3SubAckReturnCodeSuccessMaximumQoS2Codec.sizeHint(value, context)
+    is MqttV3SubAckReturnCode.Failure -> MqttV3SubAckReturnCodeFailureCodec.sizeHint(value, context)
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
     val __discRaw = stream.peekByte(baseOffset + 0).toUByte()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/suback/MqttV3SubAckReturnCodeFailureCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/suback/MqttV3SubAckReturnCodeFailureCodec.kt
@@ -26,5 +26,7 @@ public object MqttV3SubAckReturnCodeFailureCodec : Codec<MqttV3SubAckReturnCode.
 
   override fun wireSize(`value`: MqttV3SubAckReturnCode.Failure, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: MqttV3SubAckReturnCode.Failure, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/suback/MqttV3SubAckReturnCodeRawCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/suback/MqttV3SubAckReturnCodeRawCodec.kt
@@ -26,5 +26,7 @@ public object MqttV3SubAckReturnCodeRawCodec : Codec<MqttV3SubAckReturnCodeRaw> 
 
   override fun wireSize(`value`: MqttV3SubAckReturnCodeRaw, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: MqttV3SubAckReturnCodeRaw, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/suback/MqttV3SubAckReturnCodeSuccessMaximumQoS0Codec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/suback/MqttV3SubAckReturnCodeSuccessMaximumQoS0Codec.kt
@@ -26,5 +26,7 @@ public object MqttV3SubAckReturnCodeSuccessMaximumQoS0Codec : Codec<MqttV3SubAck
 
   override fun wireSize(`value`: MqttV3SubAckReturnCode.SuccessMaximumQoS0, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: MqttV3SubAckReturnCode.SuccessMaximumQoS0, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/suback/MqttV3SubAckReturnCodeSuccessMaximumQoS1Codec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/suback/MqttV3SubAckReturnCodeSuccessMaximumQoS1Codec.kt
@@ -26,5 +26,7 @@ public object MqttV3SubAckReturnCodeSuccessMaximumQoS1Codec : Codec<MqttV3SubAck
 
   override fun wireSize(`value`: MqttV3SubAckReturnCode.SuccessMaximumQoS1, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: MqttV3SubAckReturnCode.SuccessMaximumQoS1, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/suback/MqttV3SubAckReturnCodeSuccessMaximumQoS2Codec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/suback/MqttV3SubAckReturnCodeSuccessMaximumQoS2Codec.kt
@@ -26,5 +26,7 @@ public object MqttV3SubAckReturnCodeSuccessMaximumQoS2Codec : Codec<MqttV3SubAck
 
   override fun wireSize(`value`: MqttV3SubAckReturnCode.SuccessMaximumQoS2, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: MqttV3SubAckReturnCode.SuccessMaximumQoS2, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyAssignedClientIdentifierCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyAssignedClientIdentifierCodec.kt
@@ -51,6 +51,8 @@ public object MqttV5PropertyAssignedClientIdentifierCodec : Codec<MqttV5Property
 
   override fun wireSize(`value`: MqttV5Property.AssignedClientIdentifier, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: MqttV5Property.AssignedClientIdentifier, context: EncodeContext): Int = 3 + value.value.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyAuthenticationDataCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyAuthenticationDataCodec.kt
@@ -55,7 +55,13 @@ public object MqttV5PropertyAuthenticationDataCodec : Codec<MqttV5Property.Authe
     buffer.position(dataEndPosition)
   }
 
-  override fun wireSize(`value`: MqttV5Property.AuthenticationData, context: EncodeContext): WireSize = WireSize.BackPatch
+  override fun wireSize(`value`: MqttV5Property.AuthenticationData, context: EncodeContext): WireSize {
+    val __dataSize = when (val __s = BinaryDataCodec.wireSize(value.data, context)) {
+      is WireSize.Exact -> 2 + __s.bytes
+      WireSize.BackPatch -> return WireSize.BackPatch
+    }
+    return WireSize.Exact(1 + __dataSize)
+  }
 
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyAuthenticationDataCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyAuthenticationDataCodec.kt
@@ -63,6 +63,8 @@ public object MqttV5PropertyAuthenticationDataCodec : Codec<MqttV5Property.Authe
     return WireSize.Exact(1 + __dataSize)
   }
 
+  override fun sizeHint(`value`: MqttV5Property.AuthenticationData, context: EncodeContext): Int = 3
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyAuthenticationMethodCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyAuthenticationMethodCodec.kt
@@ -51,6 +51,8 @@ public object MqttV5PropertyAuthenticationMethodCodec : Codec<MqttV5Property.Aut
 
   override fun wireSize(`value`: MqttV5Property.AuthenticationMethod, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: MqttV5Property.AuthenticationMethod, context: EncodeContext): Int = 3 + value.value.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyCodec.kt
@@ -117,6 +117,36 @@ public object MqttV5PropertyCodec : Codec<MqttV5Property> {
     is MqttV5Property.SharedSubscriptionAvailable -> MqttV5PropertySharedSubscriptionAvailableCodec.wireSize(value, context)
   }
 
+  override fun sizeHint(`value`: MqttV5Property, context: EncodeContext): Int = when (value) {
+    is MqttV5Property.PayloadFormatIndicator -> MqttV5PropertyPayloadFormatIndicatorCodec.sizeHint(value, context)
+    is MqttV5Property.MessageExpiryInterval -> MqttV5PropertyMessageExpiryIntervalCodec.sizeHint(value, context)
+    is MqttV5Property.ContentType -> MqttV5PropertyContentTypeCodec.sizeHint(value, context)
+    is MqttV5Property.ResponseTopic -> MqttV5PropertyResponseTopicCodec.sizeHint(value, context)
+    is MqttV5Property.CorrelationData -> MqttV5PropertyCorrelationDataCodec.sizeHint(value, context)
+    is MqttV5Property.SubscriptionIdentifier -> MqttV5PropertySubscriptionIdentifierCodec.sizeHint(value, context)
+    is MqttV5Property.SessionExpiryInterval -> MqttV5PropertySessionExpiryIntervalCodec.sizeHint(value, context)
+    is MqttV5Property.AssignedClientIdentifier -> MqttV5PropertyAssignedClientIdentifierCodec.sizeHint(value, context)
+    is MqttV5Property.ServerKeepAlive -> MqttV5PropertyServerKeepAliveCodec.sizeHint(value, context)
+    is MqttV5Property.AuthenticationMethod -> MqttV5PropertyAuthenticationMethodCodec.sizeHint(value, context)
+    is MqttV5Property.AuthenticationData -> MqttV5PropertyAuthenticationDataCodec.sizeHint(value, context)
+    is MqttV5Property.RequestProblemInformation -> MqttV5PropertyRequestProblemInformationCodec.sizeHint(value, context)
+    is MqttV5Property.WillDelayInterval -> MqttV5PropertyWillDelayIntervalCodec.sizeHint(value, context)
+    is MqttV5Property.RequestResponseInformation -> MqttV5PropertyRequestResponseInformationCodec.sizeHint(value, context)
+    is MqttV5Property.ResponseInformation -> MqttV5PropertyResponseInformationCodec.sizeHint(value, context)
+    is MqttV5Property.ServerReference -> MqttV5PropertyServerReferenceCodec.sizeHint(value, context)
+    is MqttV5Property.ReasonString -> MqttV5PropertyReasonStringCodec.sizeHint(value, context)
+    is MqttV5Property.ReceiveMaximum -> MqttV5PropertyReceiveMaximumCodec.sizeHint(value, context)
+    is MqttV5Property.TopicAliasMaximum -> MqttV5PropertyTopicAliasMaximumCodec.sizeHint(value, context)
+    is MqttV5Property.TopicAlias -> MqttV5PropertyTopicAliasCodec.sizeHint(value, context)
+    is MqttV5Property.MaximumQoS -> MqttV5PropertyMaximumQoSCodec.sizeHint(value, context)
+    is MqttV5Property.RetainAvailable -> MqttV5PropertyRetainAvailableCodec.sizeHint(value, context)
+    is MqttV5Property.UserProperty -> MqttV5PropertyUserPropertyCodec.sizeHint(value, context)
+    is MqttV5Property.MaximumPacketSize -> MqttV5PropertyMaximumPacketSizeCodec.sizeHint(value, context)
+    is MqttV5Property.WildcardSubscriptionAvailable -> MqttV5PropertyWildcardSubscriptionAvailableCodec.sizeHint(value, context)
+    is MqttV5Property.SubscriptionIdentifiersAvailable -> MqttV5PropertySubscriptionIdentifiersAvailableCodec.sizeHint(value, context)
+    is MqttV5Property.SharedSubscriptionAvailable -> MqttV5PropertySharedSubscriptionAvailableCodec.sizeHint(value, context)
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
     val __discRaw = stream.peekByte(baseOffset + 0).toUByte()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyContentTypeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyContentTypeCodec.kt
@@ -51,6 +51,8 @@ public object MqttV5PropertyContentTypeCodec : Codec<MqttV5Property.ContentType>
 
   override fun wireSize(`value`: MqttV5Property.ContentType, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: MqttV5Property.ContentType, context: EncodeContext): Int = 3 + value.value.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyCorrelationDataCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyCorrelationDataCodec.kt
@@ -63,6 +63,8 @@ public object MqttV5PropertyCorrelationDataCodec : Codec<MqttV5Property.Correlat
     return WireSize.Exact(1 + __dataSize)
   }
 
+  override fun sizeHint(`value`: MqttV5Property.CorrelationData, context: EncodeContext): Int = 3
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyCorrelationDataCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyCorrelationDataCodec.kt
@@ -55,7 +55,13 @@ public object MqttV5PropertyCorrelationDataCodec : Codec<MqttV5Property.Correlat
     buffer.position(dataEndPosition)
   }
 
-  override fun wireSize(`value`: MqttV5Property.CorrelationData, context: EncodeContext): WireSize = WireSize.BackPatch
+  override fun wireSize(`value`: MqttV5Property.CorrelationData, context: EncodeContext): WireSize {
+    val __dataSize = when (val __s = BinaryDataCodec.wireSize(value.data, context)) {
+      is WireSize.Exact -> 2 + __s.bytes
+      WireSize.BackPatch -> return WireSize.BackPatch
+    }
+    return WireSize.Exact(1 + __dataSize)
+  }
 
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyIdCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyIdCodec.kt
@@ -26,5 +26,7 @@ public object MqttV5PropertyIdCodec : Codec<MqttV5PropertyId> {
 
   override fun wireSize(`value`: MqttV5PropertyId, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: MqttV5PropertyId, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyMaximumPacketSizeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyMaximumPacketSizeCodec.kt
@@ -32,5 +32,7 @@ public object MqttV5PropertyMaximumPacketSizeCodec : Codec<MqttV5Property.Maximu
 
   override fun wireSize(`value`: MqttV5Property.MaximumPacketSize, context: EncodeContext): WireSize = WireSize.Exact(5)
 
+  override fun sizeHint(`value`: MqttV5Property.MaximumPacketSize, context: EncodeContext): Int = 5
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 5) PeekResult.Complete(5) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyMaximumQoSCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyMaximumQoSCodec.kt
@@ -28,5 +28,7 @@ public object MqttV5PropertyMaximumQoSCodec : Codec<MqttV5Property.MaximumQoS> {
 
   override fun wireSize(`value`: MqttV5Property.MaximumQoS, context: EncodeContext): WireSize = WireSize.Exact(2)
 
+  override fun sizeHint(`value`: MqttV5Property.MaximumQoS, context: EncodeContext): Int = 2
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyMessageExpiryIntervalCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyMessageExpiryIntervalCodec.kt
@@ -32,5 +32,7 @@ public object MqttV5PropertyMessageExpiryIntervalCodec : Codec<MqttV5Property.Me
 
   override fun wireSize(`value`: MqttV5Property.MessageExpiryInterval, context: EncodeContext): WireSize = WireSize.Exact(5)
 
+  override fun sizeHint(`value`: MqttV5Property.MessageExpiryInterval, context: EncodeContext): Int = 5
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 5) PeekResult.Complete(5) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyPayloadFormatIndicatorCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyPayloadFormatIndicatorCodec.kt
@@ -28,5 +28,7 @@ public object MqttV5PropertyPayloadFormatIndicatorCodec : Codec<MqttV5Property.P
 
   override fun wireSize(`value`: MqttV5Property.PayloadFormatIndicator, context: EncodeContext): WireSize = WireSize.Exact(2)
 
+  override fun sizeHint(`value`: MqttV5Property.PayloadFormatIndicator, context: EncodeContext): Int = 2
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyReasonStringCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyReasonStringCodec.kt
@@ -51,6 +51,8 @@ public object MqttV5PropertyReasonStringCodec : Codec<MqttV5Property.ReasonStrin
 
   override fun wireSize(`value`: MqttV5Property.ReasonString, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: MqttV5Property.ReasonString, context: EncodeContext): Int = 3 + value.value.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyReceiveMaximumCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyReceiveMaximumCodec.kt
@@ -32,5 +32,7 @@ public object MqttV5PropertyReceiveMaximumCodec : Codec<MqttV5Property.ReceiveMa
 
   override fun wireSize(`value`: MqttV5Property.ReceiveMaximum, context: EncodeContext): WireSize = WireSize.Exact(3)
 
+  override fun sizeHint(`value`: MqttV5Property.ReceiveMaximum, context: EncodeContext): Int = 3
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 3) PeekResult.Complete(3) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyRequestProblemInformationCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyRequestProblemInformationCodec.kt
@@ -28,5 +28,7 @@ public object MqttV5PropertyRequestProblemInformationCodec : Codec<MqttV5Propert
 
   override fun wireSize(`value`: MqttV5Property.RequestProblemInformation, context: EncodeContext): WireSize = WireSize.Exact(2)
 
+  override fun sizeHint(`value`: MqttV5Property.RequestProblemInformation, context: EncodeContext): Int = 2
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyRequestResponseInformationCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyRequestResponseInformationCodec.kt
@@ -28,5 +28,7 @@ public object MqttV5PropertyRequestResponseInformationCodec : Codec<MqttV5Proper
 
   override fun wireSize(`value`: MqttV5Property.RequestResponseInformation, context: EncodeContext): WireSize = WireSize.Exact(2)
 
+  override fun sizeHint(`value`: MqttV5Property.RequestResponseInformation, context: EncodeContext): Int = 2
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyResponseInformationCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyResponseInformationCodec.kt
@@ -51,6 +51,8 @@ public object MqttV5PropertyResponseInformationCodec : Codec<MqttV5Property.Resp
 
   override fun wireSize(`value`: MqttV5Property.ResponseInformation, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: MqttV5Property.ResponseInformation, context: EncodeContext): Int = 3 + value.value.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyResponseTopicCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyResponseTopicCodec.kt
@@ -51,6 +51,8 @@ public object MqttV5PropertyResponseTopicCodec : Codec<MqttV5Property.ResponseTo
 
   override fun wireSize(`value`: MqttV5Property.ResponseTopic, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: MqttV5Property.ResponseTopic, context: EncodeContext): Int = 3 + value.value.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyRetainAvailableCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyRetainAvailableCodec.kt
@@ -28,5 +28,7 @@ public object MqttV5PropertyRetainAvailableCodec : Codec<MqttV5Property.RetainAv
 
   override fun wireSize(`value`: MqttV5Property.RetainAvailable, context: EncodeContext): WireSize = WireSize.Exact(2)
 
+  override fun sizeHint(`value`: MqttV5Property.RetainAvailable, context: EncodeContext): Int = 2
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyServerKeepAliveCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyServerKeepAliveCodec.kt
@@ -32,5 +32,7 @@ public object MqttV5PropertyServerKeepAliveCodec : Codec<MqttV5Property.ServerKe
 
   override fun wireSize(`value`: MqttV5Property.ServerKeepAlive, context: EncodeContext): WireSize = WireSize.Exact(3)
 
+  override fun sizeHint(`value`: MqttV5Property.ServerKeepAlive, context: EncodeContext): Int = 3
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 3) PeekResult.Complete(3) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyServerReferenceCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyServerReferenceCodec.kt
@@ -51,6 +51,8 @@ public object MqttV5PropertyServerReferenceCodec : Codec<MqttV5Property.ServerRe
 
   override fun wireSize(`value`: MqttV5Property.ServerReference, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: MqttV5Property.ServerReference, context: EncodeContext): Int = 3 + value.value.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertySessionExpiryIntervalCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertySessionExpiryIntervalCodec.kt
@@ -32,5 +32,7 @@ public object MqttV5PropertySessionExpiryIntervalCodec : Codec<MqttV5Property.Se
 
   override fun wireSize(`value`: MqttV5Property.SessionExpiryInterval, context: EncodeContext): WireSize = WireSize.Exact(5)
 
+  override fun sizeHint(`value`: MqttV5Property.SessionExpiryInterval, context: EncodeContext): Int = 5
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 5) PeekResult.Complete(5) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertySharedSubscriptionAvailableCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertySharedSubscriptionAvailableCodec.kt
@@ -28,5 +28,7 @@ public object MqttV5PropertySharedSubscriptionAvailableCodec : Codec<MqttV5Prope
 
   override fun wireSize(`value`: MqttV5Property.SharedSubscriptionAvailable, context: EncodeContext): WireSize = WireSize.Exact(2)
 
+  override fun sizeHint(`value`: MqttV5Property.SharedSubscriptionAvailable, context: EncodeContext): Int = 2
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertySubscriptionIdentifierCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertySubscriptionIdentifierCodec.kt
@@ -34,5 +34,7 @@ public object MqttV5PropertySubscriptionIdentifierCodec : Codec<MqttV5Property.S
     return WireSize.Exact(1 + __valueSize)
   }
 
+  override fun sizeHint(`value`: MqttV5Property.SubscriptionIdentifier, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertySubscriptionIdentifierCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertySubscriptionIdentifierCodec.kt
@@ -26,7 +26,13 @@ public object MqttV5PropertySubscriptionIdentifierCodec : Codec<MqttV5Property.S
     VariableByteIntegerCodec.encode(buffer, value.value, context)
   }
 
-  override fun wireSize(`value`: MqttV5Property.SubscriptionIdentifier, context: EncodeContext): WireSize = WireSize.BackPatch
+  override fun wireSize(`value`: MqttV5Property.SubscriptionIdentifier, context: EncodeContext): WireSize {
+    val __valueSize = when (val __s = VariableByteIntegerCodec.wireSize(value.value, context)) {
+      is WireSize.Exact -> __s.bytes
+      WireSize.BackPatch -> return WireSize.BackPatch
+    }
+    return WireSize.Exact(1 + __valueSize)
+  }
 
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertySubscriptionIdentifiersAvailableCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertySubscriptionIdentifiersAvailableCodec.kt
@@ -28,5 +28,7 @@ public object MqttV5PropertySubscriptionIdentifiersAvailableCodec : Codec<MqttV5
 
   override fun wireSize(`value`: MqttV5Property.SubscriptionIdentifiersAvailable, context: EncodeContext): WireSize = WireSize.Exact(2)
 
+  override fun sizeHint(`value`: MqttV5Property.SubscriptionIdentifiersAvailable, context: EncodeContext): Int = 2
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyTopicAliasCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyTopicAliasCodec.kt
@@ -32,5 +32,7 @@ public object MqttV5PropertyTopicAliasCodec : Codec<MqttV5Property.TopicAlias> {
 
   override fun wireSize(`value`: MqttV5Property.TopicAlias, context: EncodeContext): WireSize = WireSize.Exact(3)
 
+  override fun sizeHint(`value`: MqttV5Property.TopicAlias, context: EncodeContext): Int = 3
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 3) PeekResult.Complete(3) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyTopicAliasMaximumCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyTopicAliasMaximumCodec.kt
@@ -32,5 +32,7 @@ public object MqttV5PropertyTopicAliasMaximumCodec : Codec<MqttV5Property.TopicA
 
   override fun wireSize(`value`: MqttV5Property.TopicAliasMaximum, context: EncodeContext): WireSize = WireSize.Exact(3)
 
+  override fun sizeHint(`value`: MqttV5Property.TopicAliasMaximum, context: EncodeContext): Int = 3
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 3) PeekResult.Complete(3) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyUserPropertyCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyUserPropertyCodec.kt
@@ -73,6 +73,8 @@ public object MqttV5PropertyUserPropertyCodec : Codec<MqttV5Property.UserPropert
 
   override fun wireSize(`value`: MqttV5Property.UserProperty, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: MqttV5Property.UserProperty, context: EncodeContext): Int = 5 + value.key.length + value.value.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyWildcardSubscriptionAvailableCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyWildcardSubscriptionAvailableCodec.kt
@@ -28,5 +28,7 @@ public object MqttV5PropertyWildcardSubscriptionAvailableCodec : Codec<MqttV5Pro
 
   override fun wireSize(`value`: MqttV5Property.WildcardSubscriptionAvailable, context: EncodeContext): WireSize = WireSize.Exact(2)
 
+  override fun sizeHint(`value`: MqttV5Property.WildcardSubscriptionAvailable, context: EncodeContext): Int = 2
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyWillDelayIntervalCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyWillDelayIntervalCodec.kt
@@ -32,5 +32,7 @@ public object MqttV5PropertyWillDelayIntervalCodec : Codec<MqttV5Property.WillDe
 
   override fun wireSize(`value`: MqttV5Property.WillDelayInterval, context: EncodeContext): WireSize = WireSize.Exact(5)
 
+  override fun sizeHint(`value`: MqttV5Property.WillDelayInterval, context: EncodeContext): Int = 5
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 5) PeekResult.Complete(5) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/V5SubscriptionCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/V5SubscriptionCodec.kt
@@ -51,6 +51,8 @@ public object V5SubscriptionCodec : Codec<V5Subscription> {
 
   override fun wireSize(`value`: V5Subscription, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: V5Subscription, context: EncodeContext): Int = 3 + value.topicFilter.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/V5SubscriptionOptionsCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/V5SubscriptionOptionsCodec.kt
@@ -26,5 +26,7 @@ public object V5SubscriptionOptionsCodec : Codec<V5SubscriptionOptions> {
 
   override fun wireSize(`value`: V5SubscriptionOptions, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5SubscriptionOptions, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/authrc/V5AuthReasonCodeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/authrc/V5AuthReasonCodeCodec.kt
@@ -45,6 +45,12 @@ public object V5AuthReasonCodeCodec : Codec<V5AuthReasonCode> {
     is V5AuthReasonCode.ReAuthenticate -> V5AuthReasonCodeReAuthenticateCodec.wireSize(value, context)
   }
 
+  override fun sizeHint(`value`: V5AuthReasonCode, context: EncodeContext): Int = when (value) {
+    is V5AuthReasonCode.Success -> V5AuthReasonCodeSuccessCodec.sizeHint(value, context)
+    is V5AuthReasonCode.ContinueAuthentication -> V5AuthReasonCodeContinueAuthenticationCodec.sizeHint(value, context)
+    is V5AuthReasonCode.ReAuthenticate -> V5AuthReasonCodeReAuthenticateCodec.sizeHint(value, context)
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
     val __discRaw = stream.peekByte(baseOffset + 0).toUByte()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/authrc/V5AuthReasonCodeContinueAuthenticationCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/authrc/V5AuthReasonCodeContinueAuthenticationCodec.kt
@@ -26,5 +26,7 @@ public object V5AuthReasonCodeContinueAuthenticationCodec : Codec<V5AuthReasonCo
 
   override fun wireSize(`value`: V5AuthReasonCode.ContinueAuthentication, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5AuthReasonCode.ContinueAuthentication, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/authrc/V5AuthReasonCodeRawCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/authrc/V5AuthReasonCodeRawCodec.kt
@@ -26,5 +26,7 @@ public object V5AuthReasonCodeRawCodec : Codec<V5AuthReasonCodeRaw> {
 
   override fun wireSize(`value`: V5AuthReasonCodeRaw, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5AuthReasonCodeRaw, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/authrc/V5AuthReasonCodeReAuthenticateCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/authrc/V5AuthReasonCodeReAuthenticateCodec.kt
@@ -26,5 +26,7 @@ public object V5AuthReasonCodeReAuthenticateCodec : Codec<V5AuthReasonCode.ReAut
 
   override fun wireSize(`value`: V5AuthReasonCode.ReAuthenticate, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5AuthReasonCode.ReAuthenticate, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/authrc/V5AuthReasonCodeSuccessCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/authrc/V5AuthReasonCodeSuccessCodec.kt
@@ -26,5 +26,7 @@ public object V5AuthReasonCodeSuccessCodec : Codec<V5AuthReasonCode.Success> {
 
   override fun wireSize(`value`: V5AuthReasonCode.Success, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5AuthReasonCode.Success, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeBadAuthenticationMethodCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeBadAuthenticationMethodCodec.kt
@@ -26,5 +26,7 @@ public object V5ConnectReasonCodeBadAuthenticationMethodCodec : Codec<V5ConnectR
 
   override fun wireSize(`value`: V5ConnectReasonCode.BadAuthenticationMethod, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5ConnectReasonCode.BadAuthenticationMethod, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeBadUserNameOrPasswordCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeBadUserNameOrPasswordCodec.kt
@@ -26,5 +26,7 @@ public object V5ConnectReasonCodeBadUserNameOrPasswordCodec : Codec<V5ConnectRea
 
   override fun wireSize(`value`: V5ConnectReasonCode.BadUserNameOrPassword, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5ConnectReasonCode.BadUserNameOrPassword, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeBannedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeBannedCodec.kt
@@ -26,5 +26,7 @@ public object V5ConnectReasonCodeBannedCodec : Codec<V5ConnectReasonCode.Banned>
 
   override fun wireSize(`value`: V5ConnectReasonCode.Banned, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5ConnectReasonCode.Banned, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeClientIdentifierNotValidCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeClientIdentifierNotValidCodec.kt
@@ -26,5 +26,7 @@ public object V5ConnectReasonCodeClientIdentifierNotValidCodec : Codec<V5Connect
 
   override fun wireSize(`value`: V5ConnectReasonCode.ClientIdentifierNotValid, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5ConnectReasonCode.ClientIdentifierNotValid, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeCodec.kt
@@ -102,6 +102,31 @@ public object V5ConnectReasonCodeCodec : Codec<V5ConnectReasonCode> {
     is V5ConnectReasonCode.ConnectionRateExceeded -> V5ConnectReasonCodeConnectionRateExceededCodec.wireSize(value, context)
   }
 
+  override fun sizeHint(`value`: V5ConnectReasonCode, context: EncodeContext): Int = when (value) {
+    is V5ConnectReasonCode.Success -> V5ConnectReasonCodeSuccessCodec.sizeHint(value, context)
+    is V5ConnectReasonCode.UnspecifiedError -> V5ConnectReasonCodeUnspecifiedErrorCodec.sizeHint(value, context)
+    is V5ConnectReasonCode.MalformedPacket -> V5ConnectReasonCodeMalformedPacketCodec.sizeHint(value, context)
+    is V5ConnectReasonCode.ProtocolError -> V5ConnectReasonCodeProtocolErrorCodec.sizeHint(value, context)
+    is V5ConnectReasonCode.ImplementationSpecificError -> V5ConnectReasonCodeImplementationSpecificErrorCodec.sizeHint(value, context)
+    is V5ConnectReasonCode.UnsupportedProtocolVersion -> V5ConnectReasonCodeUnsupportedProtocolVersionCodec.sizeHint(value, context)
+    is V5ConnectReasonCode.ClientIdentifierNotValid -> V5ConnectReasonCodeClientIdentifierNotValidCodec.sizeHint(value, context)
+    is V5ConnectReasonCode.BadUserNameOrPassword -> V5ConnectReasonCodeBadUserNameOrPasswordCodec.sizeHint(value, context)
+    is V5ConnectReasonCode.NotAuthorized -> V5ConnectReasonCodeNotAuthorizedCodec.sizeHint(value, context)
+    is V5ConnectReasonCode.ServerUnavailable -> V5ConnectReasonCodeServerUnavailableCodec.sizeHint(value, context)
+    is V5ConnectReasonCode.ServerBusy -> V5ConnectReasonCodeServerBusyCodec.sizeHint(value, context)
+    is V5ConnectReasonCode.Banned -> V5ConnectReasonCodeBannedCodec.sizeHint(value, context)
+    is V5ConnectReasonCode.BadAuthenticationMethod -> V5ConnectReasonCodeBadAuthenticationMethodCodec.sizeHint(value, context)
+    is V5ConnectReasonCode.TopicNameInvalid -> V5ConnectReasonCodeTopicNameInvalidCodec.sizeHint(value, context)
+    is V5ConnectReasonCode.PacketTooLarge -> V5ConnectReasonCodePacketTooLargeCodec.sizeHint(value, context)
+    is V5ConnectReasonCode.QuotaExceeded -> V5ConnectReasonCodeQuotaExceededCodec.sizeHint(value, context)
+    is V5ConnectReasonCode.PayloadFormatInvalid -> V5ConnectReasonCodePayloadFormatInvalidCodec.sizeHint(value, context)
+    is V5ConnectReasonCode.RetainNotSupported -> V5ConnectReasonCodeRetainNotSupportedCodec.sizeHint(value, context)
+    is V5ConnectReasonCode.QoSNotSupported -> V5ConnectReasonCodeQoSNotSupportedCodec.sizeHint(value, context)
+    is V5ConnectReasonCode.UseAnotherServer -> V5ConnectReasonCodeUseAnotherServerCodec.sizeHint(value, context)
+    is V5ConnectReasonCode.ServerMoved -> V5ConnectReasonCodeServerMovedCodec.sizeHint(value, context)
+    is V5ConnectReasonCode.ConnectionRateExceeded -> V5ConnectReasonCodeConnectionRateExceededCodec.sizeHint(value, context)
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
     val __discRaw = stream.peekByte(baseOffset + 0).toUByte()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeConnectionRateExceededCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeConnectionRateExceededCodec.kt
@@ -26,5 +26,7 @@ public object V5ConnectReasonCodeConnectionRateExceededCodec : Codec<V5ConnectRe
 
   override fun wireSize(`value`: V5ConnectReasonCode.ConnectionRateExceeded, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5ConnectReasonCode.ConnectionRateExceeded, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeImplementationSpecificErrorCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeImplementationSpecificErrorCodec.kt
@@ -26,5 +26,7 @@ public object V5ConnectReasonCodeImplementationSpecificErrorCodec : Codec<V5Conn
 
   override fun wireSize(`value`: V5ConnectReasonCode.ImplementationSpecificError, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5ConnectReasonCode.ImplementationSpecificError, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeMalformedPacketCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeMalformedPacketCodec.kt
@@ -26,5 +26,7 @@ public object V5ConnectReasonCodeMalformedPacketCodec : Codec<V5ConnectReasonCod
 
   override fun wireSize(`value`: V5ConnectReasonCode.MalformedPacket, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5ConnectReasonCode.MalformedPacket, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeNotAuthorizedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeNotAuthorizedCodec.kt
@@ -26,5 +26,7 @@ public object V5ConnectReasonCodeNotAuthorizedCodec : Codec<V5ConnectReasonCode.
 
   override fun wireSize(`value`: V5ConnectReasonCode.NotAuthorized, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5ConnectReasonCode.NotAuthorized, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodePacketTooLargeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodePacketTooLargeCodec.kt
@@ -26,5 +26,7 @@ public object V5ConnectReasonCodePacketTooLargeCodec : Codec<V5ConnectReasonCode
 
   override fun wireSize(`value`: V5ConnectReasonCode.PacketTooLarge, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5ConnectReasonCode.PacketTooLarge, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodePayloadFormatInvalidCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodePayloadFormatInvalidCodec.kt
@@ -26,5 +26,7 @@ public object V5ConnectReasonCodePayloadFormatInvalidCodec : Codec<V5ConnectReas
 
   override fun wireSize(`value`: V5ConnectReasonCode.PayloadFormatInvalid, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5ConnectReasonCode.PayloadFormatInvalid, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeProtocolErrorCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeProtocolErrorCodec.kt
@@ -26,5 +26,7 @@ public object V5ConnectReasonCodeProtocolErrorCodec : Codec<V5ConnectReasonCode.
 
   override fun wireSize(`value`: V5ConnectReasonCode.ProtocolError, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5ConnectReasonCode.ProtocolError, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeQoSNotSupportedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeQoSNotSupportedCodec.kt
@@ -26,5 +26,7 @@ public object V5ConnectReasonCodeQoSNotSupportedCodec : Codec<V5ConnectReasonCod
 
   override fun wireSize(`value`: V5ConnectReasonCode.QoSNotSupported, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5ConnectReasonCode.QoSNotSupported, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeQuotaExceededCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeQuotaExceededCodec.kt
@@ -26,5 +26,7 @@ public object V5ConnectReasonCodeQuotaExceededCodec : Codec<V5ConnectReasonCode.
 
   override fun wireSize(`value`: V5ConnectReasonCode.QuotaExceeded, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5ConnectReasonCode.QuotaExceeded, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeRawCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeRawCodec.kt
@@ -26,5 +26,7 @@ public object V5ConnectReasonCodeRawCodec : Codec<V5ConnectReasonCodeRaw> {
 
   override fun wireSize(`value`: V5ConnectReasonCodeRaw, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5ConnectReasonCodeRaw, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeRetainNotSupportedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeRetainNotSupportedCodec.kt
@@ -26,5 +26,7 @@ public object V5ConnectReasonCodeRetainNotSupportedCodec : Codec<V5ConnectReason
 
   override fun wireSize(`value`: V5ConnectReasonCode.RetainNotSupported, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5ConnectReasonCode.RetainNotSupported, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeServerBusyCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeServerBusyCodec.kt
@@ -26,5 +26,7 @@ public object V5ConnectReasonCodeServerBusyCodec : Codec<V5ConnectReasonCode.Ser
 
   override fun wireSize(`value`: V5ConnectReasonCode.ServerBusy, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5ConnectReasonCode.ServerBusy, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeServerMovedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeServerMovedCodec.kt
@@ -26,5 +26,7 @@ public object V5ConnectReasonCodeServerMovedCodec : Codec<V5ConnectReasonCode.Se
 
   override fun wireSize(`value`: V5ConnectReasonCode.ServerMoved, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5ConnectReasonCode.ServerMoved, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeServerUnavailableCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeServerUnavailableCodec.kt
@@ -26,5 +26,7 @@ public object V5ConnectReasonCodeServerUnavailableCodec : Codec<V5ConnectReasonC
 
   override fun wireSize(`value`: V5ConnectReasonCode.ServerUnavailable, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5ConnectReasonCode.ServerUnavailable, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeSuccessCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeSuccessCodec.kt
@@ -26,5 +26,7 @@ public object V5ConnectReasonCodeSuccessCodec : Codec<V5ConnectReasonCode.Succes
 
   override fun wireSize(`value`: V5ConnectReasonCode.Success, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5ConnectReasonCode.Success, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeTopicNameInvalidCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeTopicNameInvalidCodec.kt
@@ -26,5 +26,7 @@ public object V5ConnectReasonCodeTopicNameInvalidCodec : Codec<V5ConnectReasonCo
 
   override fun wireSize(`value`: V5ConnectReasonCode.TopicNameInvalid, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5ConnectReasonCode.TopicNameInvalid, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeUnspecifiedErrorCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeUnspecifiedErrorCodec.kt
@@ -26,5 +26,7 @@ public object V5ConnectReasonCodeUnspecifiedErrorCodec : Codec<V5ConnectReasonCo
 
   override fun wireSize(`value`: V5ConnectReasonCode.UnspecifiedError, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5ConnectReasonCode.UnspecifiedError, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeUnsupportedProtocolVersionCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeUnsupportedProtocolVersionCodec.kt
@@ -26,5 +26,7 @@ public object V5ConnectReasonCodeUnsupportedProtocolVersionCodec : Codec<V5Conne
 
   override fun wireSize(`value`: V5ConnectReasonCode.UnsupportedProtocolVersion, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5ConnectReasonCode.UnsupportedProtocolVersion, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeUseAnotherServerCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/connack/V5ConnectReasonCodeUseAnotherServerCodec.kt
@@ -26,5 +26,7 @@ public object V5ConnectReasonCodeUseAnotherServerCodec : Codec<V5ConnectReasonCo
 
   override fun wireSize(`value`: V5ConnectReasonCode.UseAnotherServer, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5ConnectReasonCode.UseAnotherServer, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeAdministrativeActionCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeAdministrativeActionCodec.kt
@@ -26,5 +26,7 @@ public object V5DisconnectReasonCodeAdministrativeActionCodec : Codec<V5Disconne
 
   override fun wireSize(`value`: V5DisconnectReasonCode.AdministrativeAction, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5DisconnectReasonCode.AdministrativeAction, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeCodec.kt
@@ -120,6 +120,37 @@ public object V5DisconnectReasonCodeCodec : Codec<V5DisconnectReasonCode> {
     is V5DisconnectReasonCode.WildcardSubscriptionsNotSupported -> V5DisconnectReasonCodeWildcardSubscriptionsNotSupportedCodec.wireSize(value, context)
   }
 
+  override fun sizeHint(`value`: V5DisconnectReasonCode, context: EncodeContext): Int = when (value) {
+    is V5DisconnectReasonCode.NormalDisconnection -> V5DisconnectReasonCodeNormalDisconnectionCodec.sizeHint(value, context)
+    is V5DisconnectReasonCode.DisconnectWithWillMessage -> V5DisconnectReasonCodeDisconnectWithWillMessageCodec.sizeHint(value, context)
+    is V5DisconnectReasonCode.UnspecifiedError -> V5DisconnectReasonCodeUnspecifiedErrorCodec.sizeHint(value, context)
+    is V5DisconnectReasonCode.MalformedPacket -> V5DisconnectReasonCodeMalformedPacketCodec.sizeHint(value, context)
+    is V5DisconnectReasonCode.ProtocolError -> V5DisconnectReasonCodeProtocolErrorCodec.sizeHint(value, context)
+    is V5DisconnectReasonCode.ImplementationSpecificError -> V5DisconnectReasonCodeImplementationSpecificErrorCodec.sizeHint(value, context)
+    is V5DisconnectReasonCode.NotAuthorized -> V5DisconnectReasonCodeNotAuthorizedCodec.sizeHint(value, context)
+    is V5DisconnectReasonCode.ServerBusy -> V5DisconnectReasonCodeServerBusyCodec.sizeHint(value, context)
+    is V5DisconnectReasonCode.ServerShuttingDown -> V5DisconnectReasonCodeServerShuttingDownCodec.sizeHint(value, context)
+    is V5DisconnectReasonCode.KeepAliveTimeout -> V5DisconnectReasonCodeKeepAliveTimeoutCodec.sizeHint(value, context)
+    is V5DisconnectReasonCode.SessionTakenOver -> V5DisconnectReasonCodeSessionTakenOverCodec.sizeHint(value, context)
+    is V5DisconnectReasonCode.TopicFilterInvalid -> V5DisconnectReasonCodeTopicFilterInvalidCodec.sizeHint(value, context)
+    is V5DisconnectReasonCode.TopicNameInvalid -> V5DisconnectReasonCodeTopicNameInvalidCodec.sizeHint(value, context)
+    is V5DisconnectReasonCode.ReceiveMaximumExceeded -> V5DisconnectReasonCodeReceiveMaximumExceededCodec.sizeHint(value, context)
+    is V5DisconnectReasonCode.TopicAliasInvalid -> V5DisconnectReasonCodeTopicAliasInvalidCodec.sizeHint(value, context)
+    is V5DisconnectReasonCode.PacketTooLarge -> V5DisconnectReasonCodePacketTooLargeCodec.sizeHint(value, context)
+    is V5DisconnectReasonCode.QuotaExceeded -> V5DisconnectReasonCodeQuotaExceededCodec.sizeHint(value, context)
+    is V5DisconnectReasonCode.AdministrativeAction -> V5DisconnectReasonCodeAdministrativeActionCodec.sizeHint(value, context)
+    is V5DisconnectReasonCode.PayloadFormatInvalid -> V5DisconnectReasonCodePayloadFormatInvalidCodec.sizeHint(value, context)
+    is V5DisconnectReasonCode.RetainNotSupported -> V5DisconnectReasonCodeRetainNotSupportedCodec.sizeHint(value, context)
+    is V5DisconnectReasonCode.QoSNotSupported -> V5DisconnectReasonCodeQoSNotSupportedCodec.sizeHint(value, context)
+    is V5DisconnectReasonCode.UseAnotherServer -> V5DisconnectReasonCodeUseAnotherServerCodec.sizeHint(value, context)
+    is V5DisconnectReasonCode.ServerMoved -> V5DisconnectReasonCodeServerMovedCodec.sizeHint(value, context)
+    is V5DisconnectReasonCode.SharedSubscriptionsNotSupported -> V5DisconnectReasonCodeSharedSubscriptionsNotSupportedCodec.sizeHint(value, context)
+    is V5DisconnectReasonCode.ConnectionRateExceeded -> V5DisconnectReasonCodeConnectionRateExceededCodec.sizeHint(value, context)
+    is V5DisconnectReasonCode.MaximumConnectTime -> V5DisconnectReasonCodeMaximumConnectTimeCodec.sizeHint(value, context)
+    is V5DisconnectReasonCode.SubscriptionIdentifiersNotSupported -> V5DisconnectReasonCodeSubscriptionIdentifiersNotSupportedCodec.sizeHint(value, context)
+    is V5DisconnectReasonCode.WildcardSubscriptionsNotSupported -> V5DisconnectReasonCodeWildcardSubscriptionsNotSupportedCodec.sizeHint(value, context)
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
     val __discRaw = stream.peekByte(baseOffset + 0).toUByte()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeConnectionRateExceededCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeConnectionRateExceededCodec.kt
@@ -26,5 +26,7 @@ public object V5DisconnectReasonCodeConnectionRateExceededCodec : Codec<V5Discon
 
   override fun wireSize(`value`: V5DisconnectReasonCode.ConnectionRateExceeded, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5DisconnectReasonCode.ConnectionRateExceeded, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeDisconnectWithWillMessageCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeDisconnectWithWillMessageCodec.kt
@@ -26,5 +26,7 @@ public object V5DisconnectReasonCodeDisconnectWithWillMessageCodec : Codec<V5Dis
 
   override fun wireSize(`value`: V5DisconnectReasonCode.DisconnectWithWillMessage, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5DisconnectReasonCode.DisconnectWithWillMessage, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeImplementationSpecificErrorCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeImplementationSpecificErrorCodec.kt
@@ -26,5 +26,7 @@ public object V5DisconnectReasonCodeImplementationSpecificErrorCodec : Codec<V5D
 
   override fun wireSize(`value`: V5DisconnectReasonCode.ImplementationSpecificError, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5DisconnectReasonCode.ImplementationSpecificError, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeKeepAliveTimeoutCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeKeepAliveTimeoutCodec.kt
@@ -26,5 +26,7 @@ public object V5DisconnectReasonCodeKeepAliveTimeoutCodec : Codec<V5DisconnectRe
 
   override fun wireSize(`value`: V5DisconnectReasonCode.KeepAliveTimeout, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5DisconnectReasonCode.KeepAliveTimeout, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeMalformedPacketCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeMalformedPacketCodec.kt
@@ -26,5 +26,7 @@ public object V5DisconnectReasonCodeMalformedPacketCodec : Codec<V5DisconnectRea
 
   override fun wireSize(`value`: V5DisconnectReasonCode.MalformedPacket, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5DisconnectReasonCode.MalformedPacket, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeMaximumConnectTimeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeMaximumConnectTimeCodec.kt
@@ -26,5 +26,7 @@ public object V5DisconnectReasonCodeMaximumConnectTimeCodec : Codec<V5Disconnect
 
   override fun wireSize(`value`: V5DisconnectReasonCode.MaximumConnectTime, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5DisconnectReasonCode.MaximumConnectTime, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeNormalDisconnectionCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeNormalDisconnectionCodec.kt
@@ -26,5 +26,7 @@ public object V5DisconnectReasonCodeNormalDisconnectionCodec : Codec<V5Disconnec
 
   override fun wireSize(`value`: V5DisconnectReasonCode.NormalDisconnection, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5DisconnectReasonCode.NormalDisconnection, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeNotAuthorizedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeNotAuthorizedCodec.kt
@@ -26,5 +26,7 @@ public object V5DisconnectReasonCodeNotAuthorizedCodec : Codec<V5DisconnectReaso
 
   override fun wireSize(`value`: V5DisconnectReasonCode.NotAuthorized, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5DisconnectReasonCode.NotAuthorized, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodePacketTooLargeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodePacketTooLargeCodec.kt
@@ -26,5 +26,7 @@ public object V5DisconnectReasonCodePacketTooLargeCodec : Codec<V5DisconnectReas
 
   override fun wireSize(`value`: V5DisconnectReasonCode.PacketTooLarge, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5DisconnectReasonCode.PacketTooLarge, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodePayloadFormatInvalidCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodePayloadFormatInvalidCodec.kt
@@ -26,5 +26,7 @@ public object V5DisconnectReasonCodePayloadFormatInvalidCodec : Codec<V5Disconne
 
   override fun wireSize(`value`: V5DisconnectReasonCode.PayloadFormatInvalid, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5DisconnectReasonCode.PayloadFormatInvalid, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeProtocolErrorCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeProtocolErrorCodec.kt
@@ -26,5 +26,7 @@ public object V5DisconnectReasonCodeProtocolErrorCodec : Codec<V5DisconnectReaso
 
   override fun wireSize(`value`: V5DisconnectReasonCode.ProtocolError, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5DisconnectReasonCode.ProtocolError, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeQoSNotSupportedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeQoSNotSupportedCodec.kt
@@ -26,5 +26,7 @@ public object V5DisconnectReasonCodeQoSNotSupportedCodec : Codec<V5DisconnectRea
 
   override fun wireSize(`value`: V5DisconnectReasonCode.QoSNotSupported, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5DisconnectReasonCode.QoSNotSupported, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeQuotaExceededCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeQuotaExceededCodec.kt
@@ -26,5 +26,7 @@ public object V5DisconnectReasonCodeQuotaExceededCodec : Codec<V5DisconnectReaso
 
   override fun wireSize(`value`: V5DisconnectReasonCode.QuotaExceeded, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5DisconnectReasonCode.QuotaExceeded, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeRawCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeRawCodec.kt
@@ -26,5 +26,7 @@ public object V5DisconnectReasonCodeRawCodec : Codec<V5DisconnectReasonCodeRaw> 
 
   override fun wireSize(`value`: V5DisconnectReasonCodeRaw, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5DisconnectReasonCodeRaw, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeReceiveMaximumExceededCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeReceiveMaximumExceededCodec.kt
@@ -26,5 +26,7 @@ public object V5DisconnectReasonCodeReceiveMaximumExceededCodec : Codec<V5Discon
 
   override fun wireSize(`value`: V5DisconnectReasonCode.ReceiveMaximumExceeded, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5DisconnectReasonCode.ReceiveMaximumExceeded, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeRetainNotSupportedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeRetainNotSupportedCodec.kt
@@ -26,5 +26,7 @@ public object V5DisconnectReasonCodeRetainNotSupportedCodec : Codec<V5Disconnect
 
   override fun wireSize(`value`: V5DisconnectReasonCode.RetainNotSupported, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5DisconnectReasonCode.RetainNotSupported, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeServerBusyCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeServerBusyCodec.kt
@@ -26,5 +26,7 @@ public object V5DisconnectReasonCodeServerBusyCodec : Codec<V5DisconnectReasonCo
 
   override fun wireSize(`value`: V5DisconnectReasonCode.ServerBusy, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5DisconnectReasonCode.ServerBusy, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeServerMovedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeServerMovedCodec.kt
@@ -26,5 +26,7 @@ public object V5DisconnectReasonCodeServerMovedCodec : Codec<V5DisconnectReasonC
 
   override fun wireSize(`value`: V5DisconnectReasonCode.ServerMoved, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5DisconnectReasonCode.ServerMoved, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeServerShuttingDownCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeServerShuttingDownCodec.kt
@@ -26,5 +26,7 @@ public object V5DisconnectReasonCodeServerShuttingDownCodec : Codec<V5Disconnect
 
   override fun wireSize(`value`: V5DisconnectReasonCode.ServerShuttingDown, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5DisconnectReasonCode.ServerShuttingDown, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeSessionTakenOverCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeSessionTakenOverCodec.kt
@@ -26,5 +26,7 @@ public object V5DisconnectReasonCodeSessionTakenOverCodec : Codec<V5DisconnectRe
 
   override fun wireSize(`value`: V5DisconnectReasonCode.SessionTakenOver, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5DisconnectReasonCode.SessionTakenOver, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeSharedSubscriptionsNotSupportedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeSharedSubscriptionsNotSupportedCodec.kt
@@ -26,5 +26,7 @@ public object V5DisconnectReasonCodeSharedSubscriptionsNotSupportedCodec : Codec
 
   override fun wireSize(`value`: V5DisconnectReasonCode.SharedSubscriptionsNotSupported, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5DisconnectReasonCode.SharedSubscriptionsNotSupported, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeSubscriptionIdentifiersNotSupportedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeSubscriptionIdentifiersNotSupportedCodec.kt
@@ -26,5 +26,7 @@ public object V5DisconnectReasonCodeSubscriptionIdentifiersNotSupportedCodec : C
 
   override fun wireSize(`value`: V5DisconnectReasonCode.SubscriptionIdentifiersNotSupported, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5DisconnectReasonCode.SubscriptionIdentifiersNotSupported, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeTopicAliasInvalidCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeTopicAliasInvalidCodec.kt
@@ -26,5 +26,7 @@ public object V5DisconnectReasonCodeTopicAliasInvalidCodec : Codec<V5DisconnectR
 
   override fun wireSize(`value`: V5DisconnectReasonCode.TopicAliasInvalid, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5DisconnectReasonCode.TopicAliasInvalid, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeTopicFilterInvalidCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeTopicFilterInvalidCodec.kt
@@ -26,5 +26,7 @@ public object V5DisconnectReasonCodeTopicFilterInvalidCodec : Codec<V5Disconnect
 
   override fun wireSize(`value`: V5DisconnectReasonCode.TopicFilterInvalid, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5DisconnectReasonCode.TopicFilterInvalid, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeTopicNameInvalidCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeTopicNameInvalidCodec.kt
@@ -26,5 +26,7 @@ public object V5DisconnectReasonCodeTopicNameInvalidCodec : Codec<V5DisconnectRe
 
   override fun wireSize(`value`: V5DisconnectReasonCode.TopicNameInvalid, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5DisconnectReasonCode.TopicNameInvalid, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeUnspecifiedErrorCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeUnspecifiedErrorCodec.kt
@@ -26,5 +26,7 @@ public object V5DisconnectReasonCodeUnspecifiedErrorCodec : Codec<V5DisconnectRe
 
   override fun wireSize(`value`: V5DisconnectReasonCode.UnspecifiedError, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5DisconnectReasonCode.UnspecifiedError, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeUseAnotherServerCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeUseAnotherServerCodec.kt
@@ -26,5 +26,7 @@ public object V5DisconnectReasonCodeUseAnotherServerCodec : Codec<V5DisconnectRe
 
   override fun wireSize(`value`: V5DisconnectReasonCode.UseAnotherServer, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5DisconnectReasonCode.UseAnotherServer, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeWildcardSubscriptionsNotSupportedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/disconnectrc/V5DisconnectReasonCodeWildcardSubscriptionsNotSupportedCodec.kt
@@ -26,5 +26,7 @@ public object V5DisconnectReasonCodeWildcardSubscriptionsNotSupportedCodec : Cod
 
   override fun wireSize(`value`: V5DisconnectReasonCode.WildcardSubscriptionsNotSupported, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5DisconnectReasonCode.WildcardSubscriptionsNotSupported, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodeCodec.kt
@@ -66,6 +66,19 @@ public object V5PubAckReasonCodeCodec : Codec<V5PubAckReasonCode> {
     is V5PubAckReasonCode.PayloadFormatInvalid -> V5PubAckReasonCodePayloadFormatInvalidCodec.wireSize(value, context)
   }
 
+  override fun sizeHint(`value`: V5PubAckReasonCode, context: EncodeContext): Int = when (value) {
+    is V5PubAckReasonCode.Success -> V5PubAckReasonCodeSuccessCodec.sizeHint(value, context)
+    is V5PubAckReasonCode.NoMatchingSubscribers -> V5PubAckReasonCodeNoMatchingSubscribersCodec.sizeHint(value, context)
+    is V5PubAckReasonCode.UnspecifiedError -> V5PubAckReasonCodeUnspecifiedErrorCodec.sizeHint(value, context)
+    is V5PubAckReasonCode.ImplementationSpecificError -> V5PubAckReasonCodeImplementationSpecificErrorCodec.sizeHint(value, context)
+    is V5PubAckReasonCode.NotAuthorized -> V5PubAckReasonCodeNotAuthorizedCodec.sizeHint(value, context)
+    is V5PubAckReasonCode.TopicNameInvalid -> V5PubAckReasonCodeTopicNameInvalidCodec.sizeHint(value, context)
+    is V5PubAckReasonCode.PacketIdentifierInUse -> V5PubAckReasonCodePacketIdentifierInUseCodec.sizeHint(value, context)
+    is V5PubAckReasonCode.PacketIdentifierNotFound -> V5PubAckReasonCodePacketIdentifierNotFoundCodec.sizeHint(value, context)
+    is V5PubAckReasonCode.QuotaExceeded -> V5PubAckReasonCodeQuotaExceededCodec.sizeHint(value, context)
+    is V5PubAckReasonCode.PayloadFormatInvalid -> V5PubAckReasonCodePayloadFormatInvalidCodec.sizeHint(value, context)
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
     val __discRaw = stream.peekByte(baseOffset + 0).toUByte()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodeImplementationSpecificErrorCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodeImplementationSpecificErrorCodec.kt
@@ -26,5 +26,7 @@ public object V5PubAckReasonCodeImplementationSpecificErrorCodec : Codec<V5PubAc
 
   override fun wireSize(`value`: V5PubAckReasonCode.ImplementationSpecificError, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5PubAckReasonCode.ImplementationSpecificError, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodeNoMatchingSubscribersCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodeNoMatchingSubscribersCodec.kt
@@ -26,5 +26,7 @@ public object V5PubAckReasonCodeNoMatchingSubscribersCodec : Codec<V5PubAckReaso
 
   override fun wireSize(`value`: V5PubAckReasonCode.NoMatchingSubscribers, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5PubAckReasonCode.NoMatchingSubscribers, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodeNotAuthorizedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodeNotAuthorizedCodec.kt
@@ -26,5 +26,7 @@ public object V5PubAckReasonCodeNotAuthorizedCodec : Codec<V5PubAckReasonCode.No
 
   override fun wireSize(`value`: V5PubAckReasonCode.NotAuthorized, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5PubAckReasonCode.NotAuthorized, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodePacketIdentifierInUseCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodePacketIdentifierInUseCodec.kt
@@ -26,5 +26,7 @@ public object V5PubAckReasonCodePacketIdentifierInUseCodec : Codec<V5PubAckReaso
 
   override fun wireSize(`value`: V5PubAckReasonCode.PacketIdentifierInUse, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5PubAckReasonCode.PacketIdentifierInUse, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodePacketIdentifierNotFoundCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodePacketIdentifierNotFoundCodec.kt
@@ -26,5 +26,7 @@ public object V5PubAckReasonCodePacketIdentifierNotFoundCodec : Codec<V5PubAckRe
 
   override fun wireSize(`value`: V5PubAckReasonCode.PacketIdentifierNotFound, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5PubAckReasonCode.PacketIdentifierNotFound, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodePayloadFormatInvalidCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodePayloadFormatInvalidCodec.kt
@@ -26,5 +26,7 @@ public object V5PubAckReasonCodePayloadFormatInvalidCodec : Codec<V5PubAckReason
 
   override fun wireSize(`value`: V5PubAckReasonCode.PayloadFormatInvalid, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5PubAckReasonCode.PayloadFormatInvalid, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodeQuotaExceededCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodeQuotaExceededCodec.kt
@@ -26,5 +26,7 @@ public object V5PubAckReasonCodeQuotaExceededCodec : Codec<V5PubAckReasonCode.Qu
 
   override fun wireSize(`value`: V5PubAckReasonCode.QuotaExceeded, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5PubAckReasonCode.QuotaExceeded, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodeRawCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodeRawCodec.kt
@@ -26,5 +26,7 @@ public object V5PubAckReasonCodeRawCodec : Codec<V5PubAckReasonCodeRaw> {
 
   override fun wireSize(`value`: V5PubAckReasonCodeRaw, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5PubAckReasonCodeRaw, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodeSuccessCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodeSuccessCodec.kt
@@ -26,5 +26,7 @@ public object V5PubAckReasonCodeSuccessCodec : Codec<V5PubAckReasonCode.Success>
 
   override fun wireSize(`value`: V5PubAckReasonCode.Success, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5PubAckReasonCode.Success, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodeTopicNameInvalidCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodeTopicNameInvalidCodec.kt
@@ -26,5 +26,7 @@ public object V5PubAckReasonCodeTopicNameInvalidCodec : Codec<V5PubAckReasonCode
 
   override fun wireSize(`value`: V5PubAckReasonCode.TopicNameInvalid, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5PubAckReasonCode.TopicNameInvalid, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodeUnspecifiedErrorCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/puback/V5PubAckReasonCodeUnspecifiedErrorCodec.kt
@@ -26,5 +26,7 @@ public object V5PubAckReasonCodeUnspecifiedErrorCodec : Codec<V5PubAckReasonCode
 
   override fun wireSize(`value`: V5PubAckReasonCode.UnspecifiedError, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5PubAckReasonCode.UnspecifiedError, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeCodec.kt
@@ -72,6 +72,21 @@ public object V5SubAckReasonCodeCodec : Codec<V5SubAckReasonCode> {
     is V5SubAckReasonCode.WildcardSubscriptionsNotSupported -> V5SubAckReasonCodeWildcardSubscriptionsNotSupportedCodec.wireSize(value, context)
   }
 
+  override fun sizeHint(`value`: V5SubAckReasonCode, context: EncodeContext): Int = when (value) {
+    is V5SubAckReasonCode.GrantedQoS0 -> V5SubAckReasonCodeGrantedQoS0Codec.sizeHint(value, context)
+    is V5SubAckReasonCode.GrantedQoS1 -> V5SubAckReasonCodeGrantedQoS1Codec.sizeHint(value, context)
+    is V5SubAckReasonCode.GrantedQoS2 -> V5SubAckReasonCodeGrantedQoS2Codec.sizeHint(value, context)
+    is V5SubAckReasonCode.UnspecifiedError -> V5SubAckReasonCodeUnspecifiedErrorCodec.sizeHint(value, context)
+    is V5SubAckReasonCode.ImplementationSpecificError -> V5SubAckReasonCodeImplementationSpecificErrorCodec.sizeHint(value, context)
+    is V5SubAckReasonCode.NotAuthorized -> V5SubAckReasonCodeNotAuthorizedCodec.sizeHint(value, context)
+    is V5SubAckReasonCode.TopicFilterInvalid -> V5SubAckReasonCodeTopicFilterInvalidCodec.sizeHint(value, context)
+    is V5SubAckReasonCode.PacketIdentifierInUse -> V5SubAckReasonCodePacketIdentifierInUseCodec.sizeHint(value, context)
+    is V5SubAckReasonCode.QuotaExceeded -> V5SubAckReasonCodeQuotaExceededCodec.sizeHint(value, context)
+    is V5SubAckReasonCode.SharedSubscriptionsNotSupported -> V5SubAckReasonCodeSharedSubscriptionsNotSupportedCodec.sizeHint(value, context)
+    is V5SubAckReasonCode.SubscriptionIdentifiersNotSupported -> V5SubAckReasonCodeSubscriptionIdentifiersNotSupportedCodec.sizeHint(value, context)
+    is V5SubAckReasonCode.WildcardSubscriptionsNotSupported -> V5SubAckReasonCodeWildcardSubscriptionsNotSupportedCodec.sizeHint(value, context)
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
     val __discRaw = stream.peekByte(baseOffset + 0).toUByte()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeGrantedQoS0Codec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeGrantedQoS0Codec.kt
@@ -26,5 +26,7 @@ public object V5SubAckReasonCodeGrantedQoS0Codec : Codec<V5SubAckReasonCode.Gran
 
   override fun wireSize(`value`: V5SubAckReasonCode.GrantedQoS0, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5SubAckReasonCode.GrantedQoS0, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeGrantedQoS1Codec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeGrantedQoS1Codec.kt
@@ -26,5 +26,7 @@ public object V5SubAckReasonCodeGrantedQoS1Codec : Codec<V5SubAckReasonCode.Gran
 
   override fun wireSize(`value`: V5SubAckReasonCode.GrantedQoS1, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5SubAckReasonCode.GrantedQoS1, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeGrantedQoS2Codec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeGrantedQoS2Codec.kt
@@ -26,5 +26,7 @@ public object V5SubAckReasonCodeGrantedQoS2Codec : Codec<V5SubAckReasonCode.Gran
 
   override fun wireSize(`value`: V5SubAckReasonCode.GrantedQoS2, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5SubAckReasonCode.GrantedQoS2, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeImplementationSpecificErrorCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeImplementationSpecificErrorCodec.kt
@@ -26,5 +26,7 @@ public object V5SubAckReasonCodeImplementationSpecificErrorCodec : Codec<V5SubAc
 
   override fun wireSize(`value`: V5SubAckReasonCode.ImplementationSpecificError, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5SubAckReasonCode.ImplementationSpecificError, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeNotAuthorizedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeNotAuthorizedCodec.kt
@@ -26,5 +26,7 @@ public object V5SubAckReasonCodeNotAuthorizedCodec : Codec<V5SubAckReasonCode.No
 
   override fun wireSize(`value`: V5SubAckReasonCode.NotAuthorized, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5SubAckReasonCode.NotAuthorized, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodePacketIdentifierInUseCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodePacketIdentifierInUseCodec.kt
@@ -26,5 +26,7 @@ public object V5SubAckReasonCodePacketIdentifierInUseCodec : Codec<V5SubAckReaso
 
   override fun wireSize(`value`: V5SubAckReasonCode.PacketIdentifierInUse, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5SubAckReasonCode.PacketIdentifierInUse, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeQuotaExceededCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeQuotaExceededCodec.kt
@@ -26,5 +26,7 @@ public object V5SubAckReasonCodeQuotaExceededCodec : Codec<V5SubAckReasonCode.Qu
 
   override fun wireSize(`value`: V5SubAckReasonCode.QuotaExceeded, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5SubAckReasonCode.QuotaExceeded, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeRawCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeRawCodec.kt
@@ -26,5 +26,7 @@ public object V5SubAckReasonCodeRawCodec : Codec<V5SubAckReasonCodeRaw> {
 
   override fun wireSize(`value`: V5SubAckReasonCodeRaw, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5SubAckReasonCodeRaw, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeSharedSubscriptionsNotSupportedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeSharedSubscriptionsNotSupportedCodec.kt
@@ -26,5 +26,7 @@ public object V5SubAckReasonCodeSharedSubscriptionsNotSupportedCodec : Codec<V5S
 
   override fun wireSize(`value`: V5SubAckReasonCode.SharedSubscriptionsNotSupported, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5SubAckReasonCode.SharedSubscriptionsNotSupported, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeSubscriptionIdentifiersNotSupportedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeSubscriptionIdentifiersNotSupportedCodec.kt
@@ -26,5 +26,7 @@ public object V5SubAckReasonCodeSubscriptionIdentifiersNotSupportedCodec : Codec
 
   override fun wireSize(`value`: V5SubAckReasonCode.SubscriptionIdentifiersNotSupported, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5SubAckReasonCode.SubscriptionIdentifiersNotSupported, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeTopicFilterInvalidCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeTopicFilterInvalidCodec.kt
@@ -26,5 +26,7 @@ public object V5SubAckReasonCodeTopicFilterInvalidCodec : Codec<V5SubAckReasonCo
 
   override fun wireSize(`value`: V5SubAckReasonCode.TopicFilterInvalid, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5SubAckReasonCode.TopicFilterInvalid, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeUnspecifiedErrorCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeUnspecifiedErrorCodec.kt
@@ -26,5 +26,7 @@ public object V5SubAckReasonCodeUnspecifiedErrorCodec : Codec<V5SubAckReasonCode
 
   override fun wireSize(`value`: V5SubAckReasonCode.UnspecifiedError, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5SubAckReasonCode.UnspecifiedError, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeWildcardSubscriptionsNotSupportedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/suback/V5SubAckReasonCodeWildcardSubscriptionsNotSupportedCodec.kt
@@ -26,5 +26,7 @@ public object V5SubAckReasonCodeWildcardSubscriptionsNotSupportedCodec : Codec<V
 
   override fun wireSize(`value`: V5SubAckReasonCode.WildcardSubscriptionsNotSupported, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5SubAckReasonCode.WildcardSubscriptionsNotSupported, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/unsuback/V5UnsubAckReasonCodeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/unsuback/V5UnsubAckReasonCodeCodec.kt
@@ -57,6 +57,16 @@ public object V5UnsubAckReasonCodeCodec : Codec<V5UnsubAckReasonCode> {
     is V5UnsubAckReasonCode.PacketIdentifierInUse -> V5UnsubAckReasonCodePacketIdentifierInUseCodec.wireSize(value, context)
   }
 
+  override fun sizeHint(`value`: V5UnsubAckReasonCode, context: EncodeContext): Int = when (value) {
+    is V5UnsubAckReasonCode.Success -> V5UnsubAckReasonCodeSuccessCodec.sizeHint(value, context)
+    is V5UnsubAckReasonCode.NoSubscriptionExisted -> V5UnsubAckReasonCodeNoSubscriptionExistedCodec.sizeHint(value, context)
+    is V5UnsubAckReasonCode.UnspecifiedError -> V5UnsubAckReasonCodeUnspecifiedErrorCodec.sizeHint(value, context)
+    is V5UnsubAckReasonCode.ImplementationSpecificError -> V5UnsubAckReasonCodeImplementationSpecificErrorCodec.sizeHint(value, context)
+    is V5UnsubAckReasonCode.NotAuthorized -> V5UnsubAckReasonCodeNotAuthorizedCodec.sizeHint(value, context)
+    is V5UnsubAckReasonCode.TopicFilterInvalid -> V5UnsubAckReasonCodeTopicFilterInvalidCodec.sizeHint(value, context)
+    is V5UnsubAckReasonCode.PacketIdentifierInUse -> V5UnsubAckReasonCodePacketIdentifierInUseCodec.sizeHint(value, context)
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
     val __discRaw = stream.peekByte(baseOffset + 0).toUByte()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/unsuback/V5UnsubAckReasonCodeImplementationSpecificErrorCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/unsuback/V5UnsubAckReasonCodeImplementationSpecificErrorCodec.kt
@@ -26,5 +26,7 @@ public object V5UnsubAckReasonCodeImplementationSpecificErrorCodec : Codec<V5Uns
 
   override fun wireSize(`value`: V5UnsubAckReasonCode.ImplementationSpecificError, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5UnsubAckReasonCode.ImplementationSpecificError, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/unsuback/V5UnsubAckReasonCodeNoSubscriptionExistedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/unsuback/V5UnsubAckReasonCodeNoSubscriptionExistedCodec.kt
@@ -26,5 +26,7 @@ public object V5UnsubAckReasonCodeNoSubscriptionExistedCodec : Codec<V5UnsubAckR
 
   override fun wireSize(`value`: V5UnsubAckReasonCode.NoSubscriptionExisted, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5UnsubAckReasonCode.NoSubscriptionExisted, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/unsuback/V5UnsubAckReasonCodeNotAuthorizedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/unsuback/V5UnsubAckReasonCodeNotAuthorizedCodec.kt
@@ -26,5 +26,7 @@ public object V5UnsubAckReasonCodeNotAuthorizedCodec : Codec<V5UnsubAckReasonCod
 
   override fun wireSize(`value`: V5UnsubAckReasonCode.NotAuthorized, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5UnsubAckReasonCode.NotAuthorized, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/unsuback/V5UnsubAckReasonCodePacketIdentifierInUseCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/unsuback/V5UnsubAckReasonCodePacketIdentifierInUseCodec.kt
@@ -26,5 +26,7 @@ public object V5UnsubAckReasonCodePacketIdentifierInUseCodec : Codec<V5UnsubAckR
 
   override fun wireSize(`value`: V5UnsubAckReasonCode.PacketIdentifierInUse, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5UnsubAckReasonCode.PacketIdentifierInUse, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/unsuback/V5UnsubAckReasonCodeRawCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/unsuback/V5UnsubAckReasonCodeRawCodec.kt
@@ -26,5 +26,7 @@ public object V5UnsubAckReasonCodeRawCodec : Codec<V5UnsubAckReasonCodeRaw> {
 
   override fun wireSize(`value`: V5UnsubAckReasonCodeRaw, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5UnsubAckReasonCodeRaw, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/unsuback/V5UnsubAckReasonCodeSuccessCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/unsuback/V5UnsubAckReasonCodeSuccessCodec.kt
@@ -26,5 +26,7 @@ public object V5UnsubAckReasonCodeSuccessCodec : Codec<V5UnsubAckReasonCode.Succ
 
   override fun wireSize(`value`: V5UnsubAckReasonCode.Success, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5UnsubAckReasonCode.Success, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/unsuback/V5UnsubAckReasonCodeTopicFilterInvalidCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/unsuback/V5UnsubAckReasonCodeTopicFilterInvalidCodec.kt
@@ -26,5 +26,7 @@ public object V5UnsubAckReasonCodeTopicFilterInvalidCodec : Codec<V5UnsubAckReas
 
   override fun wireSize(`value`: V5UnsubAckReasonCode.TopicFilterInvalid, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5UnsubAckReasonCode.TopicFilterInvalid, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/unsuback/V5UnsubAckReasonCodeUnspecifiedErrorCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/unsuback/V5UnsubAckReasonCodeUnspecifiedErrorCodec.kt
@@ -26,5 +26,7 @@ public object V5UnsubAckReasonCodeUnspecifiedErrorCodec : Codec<V5UnsubAckReason
 
   override fun wireSize(`value`: V5UnsubAckReasonCode.UnspecifiedError, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: V5UnsubAckReasonCode.UnspecifiedError, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedOpcodeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedOpcodeCodec.kt
@@ -30,5 +30,7 @@ public object SignedOpcodeCodec : Codec<SignedOpcode> {
 
   override fun wireSize(`value`: SignedOpcode, context: EncodeContext): WireSize = WireSize.Exact(2)
 
+  override fun sizeHint(`value`: SignedOpcode, context: EncodeContext): Int = 2
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedOpcodeFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedOpcodeFrameCodec.kt
@@ -42,6 +42,11 @@ public object SignedOpcodeFrameCodec : Codec<SignedOpcodeFrame> {
     is SignedOpcodeFrame.Positive -> SignedOpcodeFramePositiveCodec.wireSize(value, context)
   }
 
+  override fun sizeHint(`value`: SignedOpcodeFrame, context: EncodeContext): Int = when (value) {
+    is SignedOpcodeFrame.Negative -> SignedOpcodeFrameNegativeCodec.sizeHint(value, context)
+    is SignedOpcodeFrame.Positive -> SignedOpcodeFramePositiveCodec.sizeHint(value, context)
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     if (stream.available() - baseOffset < 2) return PeekResult.NeedsMoreData
     val __discRawB0 = stream.peekByte(baseOffset + 0).toInt() and 0xFF

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedOpcodeFrameNegativeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedOpcodeFrameNegativeCodec.kt
@@ -32,5 +32,7 @@ public object SignedOpcodeFrameNegativeCodec : Codec<SignedOpcodeFrame.Negative>
 
   override fun wireSize(`value`: SignedOpcodeFrame.Negative, context: EncodeContext): WireSize = WireSize.Exact(6)
 
+  override fun sizeHint(`value`: SignedOpcodeFrame.Negative, context: EncodeContext): Int = 6
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 6) PeekResult.Complete(6) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedOpcodeFramePositiveCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedOpcodeFramePositiveCodec.kt
@@ -32,5 +32,7 @@ public object SignedOpcodeFramePositiveCodec : Codec<SignedOpcodeFrame.Positive>
 
   override fun wireSize(`value`: SignedOpcodeFrame.Positive, context: EncodeContext): WireSize = WireSize.Exact(6)
 
+  override fun sizeHint(`value`: SignedOpcodeFrame.Positive, context: EncodeContext): Int = 6
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 6) PeekResult.Complete(6) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedSelectorCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedSelectorCodec.kt
@@ -30,5 +30,7 @@ public object SignedSelectorCodec : Codec<SignedSelector> {
 
   override fun wireSize(`value`: SignedSelector, context: EncodeContext): WireSize = WireSize.Exact(8)
 
+  override fun sizeHint(`value`: SignedSelector, context: EncodeContext): Int = 8
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 8) PeekResult.Complete(8) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedSelectorFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedSelectorFrameCodec.kt
@@ -42,6 +42,11 @@ public object SignedSelectorFrameCodec : Codec<SignedSelectorFrame> {
     is SignedSelectorFrame.Nine -> SignedSelectorFrameNineCodec.wireSize(value, context)
   }
 
+  override fun sizeHint(`value`: SignedSelectorFrame, context: EncodeContext): Int = when (value) {
+    is SignedSelectorFrame.Two -> SignedSelectorFrameTwoCodec.sizeHint(value, context)
+    is SignedSelectorFrame.Nine -> SignedSelectorFrameNineCodec.sizeHint(value, context)
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     if (stream.available() - baseOffset < 8) return PeekResult.NeedsMoreData
     val __discRawB0 = stream.peekByte(baseOffset + 0).toLong() and 0xFFL

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedSelectorFrameNineCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedSelectorFrameNineCodec.kt
@@ -32,5 +32,7 @@ public object SignedSelectorFrameNineCodec : Codec<SignedSelectorFrame.Nine> {
 
   override fun wireSize(`value`: SignedSelectorFrame.Nine, context: EncodeContext): WireSize = WireSize.Exact(12)
 
+  override fun sizeHint(`value`: SignedSelectorFrame.Nine, context: EncodeContext): Int = 12
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 12) PeekResult.Complete(12) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedSelectorFrameTwoCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedSelectorFrameTwoCodec.kt
@@ -32,5 +32,7 @@ public object SignedSelectorFrameTwoCodec : Codec<SignedSelectorFrame.Two> {
 
   override fun wireSize(`value`: SignedSelectorFrame.Two, context: EncodeContext): WireSize = WireSize.Exact(12)
 
+  override fun sizeHint(`value`: SignedSelectorFrame.Two, context: EncodeContext): Int = 12
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 12) PeekResult.Complete(12) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedTagCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedTagCodec.kt
@@ -30,5 +30,7 @@ public object SignedTagCodec : Codec<SignedTag> {
 
   override fun wireSize(`value`: SignedTag, context: EncodeContext): WireSize = WireSize.Exact(4)
 
+  override fun sizeHint(`value`: SignedTag, context: EncodeContext): Int = 4
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 4) PeekResult.Complete(4) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedTagFrameAlphaCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedTagFrameAlphaCodec.kt
@@ -32,5 +32,7 @@ public object SignedTagFrameAlphaCodec : Codec<SignedTagFrame.Alpha> {
 
   override fun wireSize(`value`: SignedTagFrame.Alpha, context: EncodeContext): WireSize = WireSize.Exact(6)
 
+  override fun sizeHint(`value`: SignedTagFrame.Alpha, context: EncodeContext): Int = 6
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 6) PeekResult.Complete(6) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedTagFrameBetaCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedTagFrameBetaCodec.kt
@@ -32,5 +32,7 @@ public object SignedTagFrameBetaCodec : Codec<SignedTagFrame.Beta> {
 
   override fun wireSize(`value`: SignedTagFrame.Beta, context: EncodeContext): WireSize = WireSize.Exact(6)
 
+  override fun sizeHint(`value`: SignedTagFrame.Beta, context: EncodeContext): Int = 6
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 6) PeekResult.Complete(6) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedTagFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/SignedTagFrameCodec.kt
@@ -42,6 +42,11 @@ public object SignedTagFrameCodec : Codec<SignedTagFrame> {
     is SignedTagFrame.Beta -> SignedTagFrameBetaCodec.wireSize(value, context)
   }
 
+  override fun sizeHint(`value`: SignedTagFrame, context: EncodeContext): Int = when (value) {
+    is SignedTagFrame.Alpha -> SignedTagFrameAlphaCodec.sizeHint(value, context)
+    is SignedTagFrame.Beta -> SignedTagFrameBetaCodec.sizeHint(value, context)
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     if (stream.available() - baseOffset < 4) return PeekResult.NeedsMoreData
     val __discRawB0 = stream.peekByte(baseOffset + 0).toInt() and 0xFF

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/UnsignedMagicCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/UnsignedMagicCodec.kt
@@ -30,5 +30,7 @@ public object UnsignedMagicCodec : Codec<UnsignedMagic> {
 
   override fun wireSize(`value`: UnsignedMagic, context: EncodeContext): WireSize = WireSize.Exact(8)
 
+  override fun sizeHint(`value`: UnsignedMagic, context: EncodeContext): Int = 8
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 8) PeekResult.Complete(8) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/UnsignedMagicFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/UnsignedMagicFrameCodec.kt
@@ -42,6 +42,11 @@ public object UnsignedMagicFrameCodec : Codec<UnsignedMagicFrame> {
     is UnsignedMagicFrame.Second -> UnsignedMagicFrameSecondCodec.wireSize(value, context)
   }
 
+  override fun sizeHint(`value`: UnsignedMagicFrame, context: EncodeContext): Int = when (value) {
+    is UnsignedMagicFrame.First -> UnsignedMagicFrameFirstCodec.sizeHint(value, context)
+    is UnsignedMagicFrame.Second -> UnsignedMagicFrameSecondCodec.sizeHint(value, context)
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     if (stream.available() - baseOffset < 8) return PeekResult.NeedsMoreData
     val __discRawB0 = stream.peekByte(baseOffset + 0).toLong() and 0xFFL

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/UnsignedMagicFrameFirstCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/UnsignedMagicFrameFirstCodec.kt
@@ -32,5 +32,7 @@ public object UnsignedMagicFrameFirstCodec : Codec<UnsignedMagicFrame.First> {
 
   override fun wireSize(`value`: UnsignedMagicFrame.First, context: EncodeContext): WireSize = WireSize.Exact(12)
 
+  override fun sizeHint(`value`: UnsignedMagicFrame.First, context: EncodeContext): Int = 12
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 12) PeekResult.Complete(12) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/UnsignedMagicFrameSecondCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/multibytedisc/UnsignedMagicFrameSecondCodec.kt
@@ -32,5 +32,7 @@ public object UnsignedMagicFrameSecondCodec : Codec<UnsignedMagicFrame.Second> {
 
   override fun wireSize(`value`: UnsignedMagicFrame.Second, context: EncodeContext): WireSize = WireSize.Exact(12)
 
+  override fun sizeHint(`value`: UnsignedMagicFrame.Second, context: EncodeContext): Int = 12
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 12) PeekResult.Complete(12) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mysql/MySqlPacketHeaderCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mysql/MySqlPacketHeaderCodec.kt
@@ -30,5 +30,7 @@ public object MySqlPacketHeaderCodec : Codec<MySqlPacketHeader> {
 
   override fun wireSize(`value`: MySqlPacketHeader, context: EncodeContext): WireSize = WireSize.Exact(4)
 
+  override fun sizeHint(`value`: MySqlPacketHeader, context: EncodeContext): Int = 4
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 4) PeekResult.Complete(4) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/partialnonterminal/CommandFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/partialnonterminal/CommandFrameCodec.kt
@@ -49,6 +49,8 @@ public class CommandFrameCodec<P : Payload>(
 
   override fun wireSize(`value`: CommandFrame<P>, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: CommandFrame<P>, context: EncodeContext): Int = 6
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 
   public class Partial<P : Payload> internal constructor(

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/payload/MqttPublishV3Codec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/payload/MqttPublishV3Codec.kt
@@ -61,6 +61,8 @@ public class MqttPublishV3Codec<P : Payload>(
 
   override fun wireSize(`value`: MqttPublishV3<P>, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: MqttPublishV3<P>, context: EncodeContext): Int = 5 + value.topic.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 
   public class Partial<P : Payload> internal constructor(

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/payload/MqttPublishV3ConcreteCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/payload/MqttPublishV3ConcreteCodec.kt
@@ -57,6 +57,8 @@ public object MqttPublishV3ConcreteCodec : Codec<MqttPublishV3Concrete> {
 
   override fun wireSize(`value`: MqttPublishV3Concrete, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: MqttPublishV3Concrete, context: EncodeContext): Int = 5 + value.topic.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 
   public fun partial(buffer: ReadBuffer, context: DecodeContext): Partial {

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/payload/PacketIdCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/payload/PacketIdCodec.kt
@@ -26,5 +26,7 @@ public object PacketIdCodec : Codec<PacketId> {
 
   override fun wireSize(`value`: PacketId, context: EncodeContext): WireSize = WireSize.Exact(2)
 
+  override fun sizeHint(`value`: PacketId, context: EncodeContext): Int = 2
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/png/PngChunkCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/png/PngChunkCodec.kt
@@ -46,6 +46,8 @@ public object PngChunkCodec : Codec<PngChunk> {
 
   override fun wireSize(`value`: PngChunk, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: PngChunk, context: EncodeContext): Int = 12
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 
   public fun partial(buffer: ReadBuffer, context: DecodeContext): Partial {

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/quic/QuicHeaderByteCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/quic/QuicHeaderByteCodec.kt
@@ -26,5 +26,7 @@ public object QuicHeaderByteCodec : Codec<QuicHeaderByte> {
 
   override fun wireSize(`value`: QuicHeaderByte, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: QuicHeaderByte, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/quic/QuicPacketHeaderCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/quic/QuicPacketHeaderCodec.kt
@@ -42,6 +42,11 @@ public object QuicPacketHeaderCodec : Codec<QuicPacketHeader> {
     is QuicPacketHeader.LongHeader -> QuicPacketHeaderLongHeaderCodec.wireSize(value, context)
   }
 
+  override fun sizeHint(`value`: QuicPacketHeader, context: EncodeContext): Int = when (value) {
+    is QuicPacketHeader.ShortHeader -> QuicPacketHeaderShortHeaderCodec.sizeHint(value, context)
+    is QuicPacketHeader.LongHeader -> QuicPacketHeaderLongHeaderCodec.sizeHint(value, context)
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
     val __discRaw = stream.peekByte(baseOffset + 0).toUByte()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/quic/QuicPacketHeaderLongHeaderCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/quic/QuicPacketHeaderLongHeaderCodec.kt
@@ -26,5 +26,7 @@ public object QuicPacketHeaderLongHeaderCodec : Codec<QuicPacketHeader.LongHeade
 
   override fun wireSize(`value`: QuicPacketHeader.LongHeader, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: QuicPacketHeader.LongHeader, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/quic/QuicPacketHeaderShortHeaderCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/quic/QuicPacketHeaderShortHeaderCodec.kt
@@ -26,5 +26,7 @@ public object QuicPacketHeaderShortHeaderCodec : Codec<QuicPacketHeader.ShortHea
 
   override fun wireSize(`value`: QuicPacketHeader.ShortHeader, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: QuicPacketHeader.ShortHeader, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/riff/RiffChunkHeaderCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/riff/RiffChunkHeaderCodec.kt
@@ -34,5 +34,7 @@ public object RiffChunkHeaderCodec : Codec<RiffChunkHeader> {
 
   override fun wireSize(`value`: RiffChunkHeader, context: EncodeContext): WireSize = WireSize.Exact(8)
 
+  override fun sizeHint(`value`: RiffChunkHeader, context: EncodeContext): Int = 8
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 8) PeekResult.Complete(8) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/riff/WavFmtBodyCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/riff/WavFmtBodyCodec.kt
@@ -40,5 +40,7 @@ public object WavFmtBodyCodec : Codec<WavFmtBody> {
 
   override fun wireSize(`value`: WavFmtBody, context: EncodeContext): WireSize = WireSize.Exact(16)
 
+  override fun sizeHint(`value`: WavFmtBody, context: EncodeContext): Int = 16
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 16) PeekResult.Complete(16) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/riff/WavFmtChunkCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/riff/WavFmtChunkCodec.kt
@@ -76,6 +76,8 @@ public object WavFmtChunkCodec : Codec<WavFmtChunk> {
     WireSize.BackPatch -> WireSize.BackPatch
   }
 
+  override fun sizeHint(`value`: WavFmtChunk, context: EncodeContext): Int = 8 + WavFmtBodyCodec.sizeHint(value.body, context)
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 4) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/BytePrefixedStringCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/BytePrefixedStringCodec.kt
@@ -46,6 +46,8 @@ public object BytePrefixedStringCodec : Codec<BytePrefixedString> {
 
   override fun wireSize(`value`: BytePrefixedString, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: BytePrefixedString, context: EncodeContext): Int = 1 + value.name.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/CommandCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/CommandCodec.kt
@@ -46,6 +46,11 @@ public object CommandCodec : Codec<Command> {
     is Command.Echo -> WireSize.BackPatch
   }
 
+  override fun sizeHint(`value`: Command, context: EncodeContext): Int = 1 + when (value) {
+    is Command.Ping -> CommandPingCodec.sizeHint(value, context)
+    is Command.Echo -> CommandEchoCodec.sizeHint(value, context)
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
     val discriminator = stream.peekByte(baseOffset).toInt() and 0xFF

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/CommandEchoCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/CommandEchoCodec.kt
@@ -49,6 +49,8 @@ public object CommandEchoCodec : Codec<Command.Echo> {
 
   override fun wireSize(`value`: Command.Echo, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: Command.Echo, context: EncodeContext): Int = 2 + value.msg.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/CommandPingCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/CommandPingCodec.kt
@@ -26,5 +26,7 @@ public object CommandPingCodec : Codec<Command.Ping> {
 
   override fun wireSize(`value`: Command.Ping, context: EncodeContext): WireSize = WireSize.Exact(8)
 
+  override fun sizeHint(`value`: Command.Ping, context: EncodeContext): Int = 8
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 8) PeekResult.Complete(8) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/IntPrefixedStringCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/IntPrefixedStringCodec.kt
@@ -49,6 +49,8 @@ public object IntPrefixedStringCodec : Codec<IntPrefixedString> {
 
   override fun wireSize(`value`: IntPrefixedString, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: IntPrefixedString, context: EncodeContext): Int = 4 + value.name.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 4) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/LeHeaderCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/LeHeaderCodec.kt
@@ -30,5 +30,7 @@ public object LeHeaderCodec : Codec<LeHeader> {
 
   override fun wireSize(`value`: LeHeader, context: EncodeContext): WireSize = WireSize.Exact(2)
 
+  override fun sizeHint(`value`: LeHeader, context: EncodeContext): Int = 2
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/LePacketCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/LePacketCodec.kt
@@ -33,6 +33,8 @@ public object LePacketCodec : Codec<LePacket> {
 
   override fun wireSize(`value`: LePacket, context: EncodeContext): WireSize = WireSize.Exact(2 + value.header.length)
 
+  override fun sizeHint(`value`: LePacket, context: EncodeContext): Int = 2 + value.payload.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/RemoteHeaderCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/RemoteHeaderCodec.kt
@@ -33,6 +33,8 @@ public object RemoteHeaderCodec : Codec<RemoteHeader> {
 
   override fun wireSize(`value`: RemoteHeader, context: EncodeContext): WireSize = WireSize.Exact(7 + value.payloadLength.toInt())
 
+  override fun sizeHint(`value`: RemoteHeader, context: EncodeContext): Int = 7 + value.payload.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/SimpleHeaderCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/SimpleHeaderCodec.kt
@@ -51,6 +51,8 @@ public object SimpleHeaderCodec : Codec<SimpleHeader> {
 
   override fun wireSize(`value`: SimpleHeader, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: SimpleHeader, context: EncodeContext): Int = 6 + value.name.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 4) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/SmallFlagsCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/SmallFlagsCodec.kt
@@ -26,5 +26,7 @@ public object SmallFlagsCodec : Codec<SmallFlags> {
 
   override fun wireSize(`value`: SmallFlags, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: SmallFlags, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/TwoStringsCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/TwoStringsCodec.kt
@@ -71,6 +71,8 @@ public object TwoStringsCodec : Codec<TwoStrings> {
 
   override fun wireSize(`value`: TwoStrings, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: TwoStrings, context: EncodeContext): Int = 4 + value.first.length + value.second.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/WithFlagPayloadCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/WithFlagPayloadCodec.kt
@@ -59,6 +59,8 @@ public object WithFlagPayloadCodec : Codec<WithFlagPayload> {
 
   override fun wireSize(`value`: WithFlagPayload, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: WithFlagPayload, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/WithOptionalCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/WithOptionalCodec.kt
@@ -32,6 +32,8 @@ public object WithOptionalCodec : Codec<WithOptional> {
 
   override fun wireSize(`value`: WithOptional, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: WithOptional, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simplegeneric/SimpleGenericFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simplegeneric/SimpleGenericFrameCodec.kt
@@ -53,6 +53,14 @@ public class SimpleGenericFrameCodec<P : Payload>(
     is SimpleGenericFrame.Status -> WireSize.Exact(2)
   }
 
+  override fun sizeHint(`value`: SimpleGenericFrame<P>, context: EncodeContext): Int {
+    @Suppress("UNCHECKED_CAST")
+    return 1 + when (value) {
+      is SimpleGenericFrame.Command<*> -> commandCodec.sizeHint(value as SimpleGenericFrame.Command<P>, context)
+      is SimpleGenericFrame.Status -> SimpleGenericFrameStatusCodec.sizeHint(value, context)
+    }
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
     val discriminator = stream.peekByte(baseOffset).toInt() and 0xFF

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simplegeneric/SimpleGenericFrameCommandCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simplegeneric/SimpleGenericFrameCommandCodec.kt
@@ -33,6 +33,8 @@ public class SimpleGenericFrameCommandCodec<P : Payload>(
 
   override fun wireSize(`value`: SimpleGenericFrame.Command<P>, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: SimpleGenericFrame.Command<P>, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 
   public class Partial<P : Payload> internal constructor(

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simplegeneric/SimpleGenericFrameStatusCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simplegeneric/SimpleGenericFrameStatusCodec.kt
@@ -26,5 +26,7 @@ public object SimpleGenericFrameStatusCodec : Codec<SimpleGenericFrame.Status> {
 
   override fun wireSize(`value`: SimpleGenericFrame.Status, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: SimpleGenericFrame.Status, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice10e/RemoteCommandCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice10e/RemoteCommandCodec.kt
@@ -52,6 +52,8 @@ public object RemoteCommandCodec : Codec<RemoteCommand> {
 
   override fun wireSize(`value`: RemoteCommand, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: RemoteCommand, context: EncodeContext): Int = 2 + value.id.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 
   public fun partial(buffer: ReadBuffer, context: DecodeContext): Partial {

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice11a/ProbeConditionalCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice11a/ProbeConditionalCodec.kt
@@ -32,5 +32,7 @@ public object ProbeConditionalCodec : Codec<ProbeConditional> {
 
   override fun wireSize(`value`: ProbeConditional, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: ProbeConditional, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice11a/ProbeRemainingBytesListCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice11a/ProbeRemainingBytesListCodec.kt
@@ -31,5 +31,13 @@ public object ProbeRemainingBytesListCodec : Codec<ProbeRemainingBytesList> {
 
   override fun wireSize(`value`: ProbeRemainingBytesList, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: ProbeRemainingBytesList, context: EncodeContext): Int {
+    var __hint = 0
+    for (__elem in value.xs) {
+      __hint += ProbeSealedCodec.sizeHint(__elem, context)
+    }
+    return __hint
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice11a/ProbeSealedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice11a/ProbeSealedCodec.kt
@@ -46,6 +46,11 @@ public object ProbeSealedCodec : Codec<ProbeSealed> {
     is ProbeSealed.Tag2 -> WireSize.BackPatch
   }
 
+  override fun sizeHint(`value`: ProbeSealed, context: EncodeContext): Int = 1 + when (value) {
+    is ProbeSealed.Tag1 -> ProbeSealedTag1Codec.sizeHint(value, context)
+    is ProbeSealed.Tag2 -> ProbeSealedTag2Codec.sizeHint(value, context)
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
     val discriminator = stream.peekByte(baseOffset).toInt() and 0xFF

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice11a/ProbeSealedTag1Codec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice11a/ProbeSealedTag1Codec.kt
@@ -26,5 +26,7 @@ public object ProbeSealedTag1Codec : Codec<ProbeSealed.Tag1> {
 
   override fun wireSize(`value`: ProbeSealed.Tag1, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: ProbeSealed.Tag1, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice11a/ProbeSealedTag2Codec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice11a/ProbeSealedTag2Codec.kt
@@ -49,6 +49,8 @@ public object ProbeSealedTag2Codec : Codec<ProbeSealed.Tag2> {
 
   override fun wireSize(`value`: ProbeSealed.Tag2, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: ProbeSealed.Tag2, context: EncodeContext): Int = 2 + value.msg.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14c/Slice14cTinyHeaderCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice14c/Slice14cTinyHeaderCodec.kt
@@ -26,5 +26,7 @@ public object Slice14cTinyHeaderCodec : Codec<Slice14cTinyHeader> {
 
   override fun wireSize(`value`: Slice14cTinyHeader, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: Slice14cTinyHeader, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice15a/Slice15aLengthPrefixedPayloadCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice15a/Slice15aLengthPrefixedPayloadCodec.kt
@@ -61,6 +61,8 @@ public object Slice15aLengthPrefixedPayloadCodec : Codec<Slice15aLengthPrefixedP
     return WireSize.Exact(0 + __dataSize)
   }
 
+  override fun sizeHint(`value`: Slice15aLengthPrefixedPayload, context: EncodeContext): Int = 2
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice15a/Slice15aLengthPrefixedPayloadCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice15a/Slice15aLengthPrefixedPayloadCodec.kt
@@ -53,7 +53,13 @@ public object Slice15aLengthPrefixedPayloadCodec : Codec<Slice15aLengthPrefixedP
     buffer.position(dataEndPosition)
   }
 
-  override fun wireSize(`value`: Slice15aLengthPrefixedPayload, context: EncodeContext): WireSize = WireSize.BackPatch
+  override fun wireSize(`value`: Slice15aLengthPrefixedPayload, context: EncodeContext): WireSize {
+    val __dataSize = when (val __s = BinaryDataCodec.wireSize(value.data, context)) {
+      is WireSize.Exact -> 2 + __s.bytes
+      WireSize.BackPatch -> return WireSize.BackPatch
+    }
+    return WireSize.Exact(0 + __dataSize)
+  }
 
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice7c/RepeatedBlockCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice7c/RepeatedBlockCodec.kt
@@ -32,5 +32,7 @@ public object RepeatedBlockCodec : Codec<RepeatedBlock> {
 
   override fun wireSize(`value`: RepeatedBlock, context: EncodeContext): WireSize = WireSize.Exact(3)
 
+  override fun sizeHint(`value`: RepeatedBlock, context: EncodeContext): Int = 3
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 3) PeekResult.Complete(3) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice7c/RepeatedBlocksCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice7c/RepeatedBlocksCodec.kt
@@ -46,5 +46,13 @@ public object RepeatedBlocksCodec : Codec<RepeatedBlocks> {
     return WireSize.Exact(2 + __blocksBodySize)
   }
 
+  override fun sizeHint(`value`: RepeatedBlocks, context: EncodeContext): Int {
+    var __hint = 2
+    for (__elem in value.blocks) {
+      __hint += RepeatedBlockCodec.sizeHint(__elem, context)
+    }
+    return __hint
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tcp/TcpFlagsByteCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tcp/TcpFlagsByteCodec.kt
@@ -26,5 +26,7 @@ public object TcpFlagsByteCodec : Codec<TcpFlagsByte> {
 
   override fun wireSize(`value`: TcpFlagsByte, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: TcpFlagsByte, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tcp/TcpSegmentByFlagsAckCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tcp/TcpSegmentByFlagsAckCodec.kt
@@ -26,5 +26,7 @@ public object TcpSegmentByFlagsAckCodec : Codec<TcpSegmentByFlags.Ack> {
 
   override fun wireSize(`value`: TcpSegmentByFlags.Ack, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: TcpSegmentByFlags.Ack, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tcp/TcpSegmentByFlagsCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tcp/TcpSegmentByFlagsCodec.kt
@@ -51,6 +51,14 @@ public object TcpSegmentByFlagsCodec : Codec<TcpSegmentByFlags> {
     is TcpSegmentByFlags.SynAck -> TcpSegmentByFlagsSynAckCodec.wireSize(value, context)
   }
 
+  override fun sizeHint(`value`: TcpSegmentByFlags, context: EncodeContext): Int = when (value) {
+    is TcpSegmentByFlags.Syn -> TcpSegmentByFlagsSynCodec.sizeHint(value, context)
+    is TcpSegmentByFlags.Rst -> TcpSegmentByFlagsRstCodec.sizeHint(value, context)
+    is TcpSegmentByFlags.Ack -> TcpSegmentByFlagsAckCodec.sizeHint(value, context)
+    is TcpSegmentByFlags.FinAck -> TcpSegmentByFlagsFinAckCodec.sizeHint(value, context)
+    is TcpSegmentByFlags.SynAck -> TcpSegmentByFlagsSynAckCodec.sizeHint(value, context)
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
     val __discRaw = stream.peekByte(baseOffset + 0).toUByte()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tcp/TcpSegmentByFlagsFinAckCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tcp/TcpSegmentByFlagsFinAckCodec.kt
@@ -26,5 +26,7 @@ public object TcpSegmentByFlagsFinAckCodec : Codec<TcpSegmentByFlags.FinAck> {
 
   override fun wireSize(`value`: TcpSegmentByFlags.FinAck, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: TcpSegmentByFlags.FinAck, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tcp/TcpSegmentByFlagsRstCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tcp/TcpSegmentByFlagsRstCodec.kt
@@ -26,5 +26,7 @@ public object TcpSegmentByFlagsRstCodec : Codec<TcpSegmentByFlags.Rst> {
 
   override fun wireSize(`value`: TcpSegmentByFlags.Rst, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: TcpSegmentByFlags.Rst, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tcp/TcpSegmentByFlagsSynAckCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tcp/TcpSegmentByFlagsSynAckCodec.kt
@@ -26,5 +26,7 @@ public object TcpSegmentByFlagsSynAckCodec : Codec<TcpSegmentByFlags.SynAck> {
 
   override fun wireSize(`value`: TcpSegmentByFlags.SynAck, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: TcpSegmentByFlags.SynAck, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tcp/TcpSegmentByFlagsSynCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tcp/TcpSegmentByFlagsSynCodec.kt
@@ -26,5 +26,7 @@ public object TcpSegmentByFlagsSynCodec : Codec<TcpSegmentByFlags.Syn> {
 
   override fun wireSize(`value`: TcpSegmentByFlags.Syn, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: TcpSegmentByFlags.Syn, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeBodyCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeBodyCodec.kt
@@ -34,6 +34,8 @@ public object TlsHandshakeBodyCodec : Codec<TlsHandshakeBody> {
 
   override fun wireSize(`value`: TlsHandshakeBody, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: TlsHandshakeBody, context: EncodeContext): Int = 2
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 
   public fun partial(buffer: ReadBuffer, context: DecodeContext): Partial {

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeCodec.kt
@@ -50,6 +50,8 @@ public object TlsHandshakeCodec : Codec<TlsHandshake> {
 
   override fun wireSize(`value`: TlsHandshake, context: EncodeContext): WireSize = WireSize.Exact(4 + value.length.toInt())
 
+  override fun sizeHint(`value`: TlsHandshake, context: EncodeContext): Int = 4
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeSealedBodyClientHelloCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeSealedBodyClientHelloCodec.kt
@@ -26,5 +26,7 @@ public object TlsHandshakeSealedBodyClientHelloCodec : Codec<TlsHandshakeSealedB
 
   override fun wireSize(`value`: TlsHandshakeSealedBody.ClientHello, context: EncodeContext): WireSize = WireSize.Exact(2)
 
+  override fun sizeHint(`value`: TlsHandshakeSealedBody.ClientHello, context: EncodeContext): Int = 2
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 2) PeekResult.Complete(2) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeSealedBodyCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeSealedBodyCodec.kt
@@ -46,6 +46,11 @@ public object TlsHandshakeSealedBodyCodec : Codec<TlsHandshakeSealedBody> {
     is TlsHandshakeSealedBody.EndOfEarlyData -> WireSize.Exact(1)
   }
 
+  override fun sizeHint(`value`: TlsHandshakeSealedBody, context: EncodeContext): Int = 1 + when (value) {
+    is TlsHandshakeSealedBody.ClientHello -> TlsHandshakeSealedBodyClientHelloCodec.sizeHint(value, context)
+    is TlsHandshakeSealedBody.EndOfEarlyData -> TlsHandshakeSealedBodyEndOfEarlyDataCodec.sizeHint(value, context)
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
     val discriminator = stream.peekByte(baseOffset).toInt() and 0xFF

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeSealedBodyEndOfEarlyDataCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeSealedBodyEndOfEarlyDataCodec.kt
@@ -22,5 +22,7 @@ public object TlsHandshakeSealedBodyEndOfEarlyDataCodec : Codec<TlsHandshakeSeal
 
   override fun wireSize(`value`: TlsHandshakeSealedBody.EndOfEarlyData, context: EncodeContext): WireSize = WireSize.Exact(0)
 
+  override fun sizeHint(`value`: TlsHandshakeSealedBody.EndOfEarlyData, context: EncodeContext): Int = 0
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 0) PeekResult.Complete(0) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeWithSealedBodyCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeWithSealedBodyCodec.kt
@@ -50,6 +50,8 @@ public object TlsHandshakeWithSealedBodyCodec : Codec<TlsHandshakeWithSealedBody
 
   override fun wireSize(`value`: TlsHandshakeWithSealedBody, context: EncodeContext): WireSize = WireSize.Exact(4 + value.length.toInt())
 
+  override fun sizeHint(`value`: TlsHandshakeWithSealedBody, context: EncodeContext): Int = 4
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/BoundedFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/BoundedFrameCodec.kt
@@ -41,6 +41,8 @@ public object BoundedFrameCodec : Codec<BoundedFrame> {
 
   override fun wireSize(`value`: BoundedFrame, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: BoundedFrame, context: EncodeContext): Int = 2
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     if (stream.available() - baseOffset < 3) return PeekResult.NeedsMoreData
     val __lengthPeekView = stream.peekBuffer(baseOffset + 2, 5) ?: return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/DispatchVarintUnionCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/DispatchVarintUnionCodec.kt
@@ -73,6 +73,13 @@ public object DispatchVarintUnionCodec : Codec<DispatchVarintUnion> {
     }
   }
 
+  override fun sizeHint(`value`: DispatchVarintUnion, context: EncodeContext): Int = 1 + when (value) {
+    is DispatchVarintUnion.Single -> DispatchVarintUnionSingleCodec.sizeHint(value, context)
+    is DispatchVarintUnion.Mixed -> DispatchVarintUnionMixedCodec.sizeHint(value, context)
+    is DispatchVarintUnion.Marker -> DispatchVarintUnionMarkerCodec.sizeHint(value, context)
+    is DispatchVarintUnion.Plain -> DispatchVarintUnionPlainCodec.sizeHint(value, context)
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
     val discriminator = stream.peekByte(baseOffset).toInt() and 0xFF

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/DispatchVarintUnionCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/DispatchVarintUnionCodec.kt
@@ -65,7 +65,12 @@ public object DispatchVarintUnionCodec : Codec<DispatchVarintUnion> {
       }
     }
     is DispatchVarintUnion.Marker -> WireSize.Exact(1)
-    is DispatchVarintUnion.Plain -> WireSize.BackPatch
+    is DispatchVarintUnion.Plain -> {
+      when (val inner = DispatchVarintUnionPlainCodec.wireSize(value, context)) {
+        is WireSize.Exact -> WireSize.Exact(1 + inner.bytes)
+        WireSize.BackPatch -> WireSize.BackPatch
+      }
+    }
   }
 
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/DispatchVarintUnionMarkerCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/DispatchVarintUnionMarkerCodec.kt
@@ -22,5 +22,7 @@ public object DispatchVarintUnionMarkerCodec : Codec<DispatchVarintUnion.Marker>
 
   override fun wireSize(`value`: DispatchVarintUnion.Marker, context: EncodeContext): WireSize = WireSize.Exact(0)
 
+  override fun sizeHint(`value`: DispatchVarintUnion.Marker, context: EncodeContext): Int = 0
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 0) PeekResult.Complete(0) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/DispatchVarintUnionMixedCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/DispatchVarintUnionMixedCodec.kt
@@ -35,6 +35,8 @@ public object DispatchVarintUnionMixedCodec : Codec<DispatchVarintUnion.Mixed> {
     return WireSize.Exact(1 + __vSize)
   }
 
+  override fun sizeHint(`value`: DispatchVarintUnion.Mixed, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     val __vFrame = QuicVarintCodec.peekFrameSize(stream, baseOffset + 0)
     if (__vFrame !is PeekResult.Complete) {

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/DispatchVarintUnionPlainCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/DispatchVarintUnionPlainCodec.kt
@@ -32,5 +32,7 @@ public object DispatchVarintUnionPlainCodec : Codec<DispatchVarintUnion.Plain> {
     return WireSize.Exact(0 + __valueSize)
   }
 
+  override fun sizeHint(`value`: DispatchVarintUnion.Plain, context: EncodeContext): Int = 0
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/DispatchVarintUnionPlainCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/DispatchVarintUnionPlainCodec.kt
@@ -24,7 +24,13 @@ public object DispatchVarintUnionPlainCodec : Codec<DispatchVarintUnion.Plain> {
     ZigZagUIntCodec.encode(buffer, value.value, context)
   }
 
-  override fun wireSize(`value`: DispatchVarintUnion.Plain, context: EncodeContext): WireSize = WireSize.BackPatch
+  override fun wireSize(`value`: DispatchVarintUnion.Plain, context: EncodeContext): WireSize {
+    val __valueSize = when (val __s = ZigZagUIntCodec.wireSize(value.value, context)) {
+      is WireSize.Exact -> __s.bytes
+      WireSize.BackPatch -> return WireSize.BackPatch
+    }
+    return WireSize.Exact(0 + __valueSize)
+  }
 
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/DispatchVarintUnionSingleCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/DispatchVarintUnionSingleCodec.kt
@@ -33,6 +33,8 @@ public object DispatchVarintUnionSingleCodec : Codec<DispatchVarintUnion.Single>
     return WireSize.Exact(0 + __vSize)
   }
 
+  override fun sizeHint(`value`: DispatchVarintUnion.Single, context: EncodeContext): Int = 0
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     val __vFrame = QuicVarintCodec.peekFrameSize(stream, baseOffset + 0)
     if (__vFrame !is PeekResult.Complete) {

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/ZigZagFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/ZigZagFrameCodec.kt
@@ -34,5 +34,7 @@ public object ZigZagFrameCodec : Codec<ZigZagFrame> {
     return WireSize.Exact(4 + __valueSize)
   }
 
+  override fun sizeHint(`value`: ZigZagFrame, context: EncodeContext): Int = 4
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/ZigZagFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/ZigZagFrameCodec.kt
@@ -26,7 +26,13 @@ public object ZigZagFrameCodec : Codec<ZigZagFrame> {
     ZigZagUIntCodec.encode(buffer, value.value, context)
   }
 
-  override fun wireSize(`value`: ZigZagFrame, context: EncodeContext): WireSize = WireSize.BackPatch
+  override fun wireSize(`value`: ZigZagFrame, context: EncodeContext): WireSize {
+    val __valueSize = when (val __s = ZigZagUIntCodec.wireSize(value.value, context)) {
+      is WireSize.Exact -> __s.bytes
+      WireSize.BackPatch -> return WireSize.BackPatch
+    }
+    return WireSize.Exact(4 + __valueSize)
+  }
 
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/LengthFromValueClassIdCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/LengthFromValueClassIdCodec.kt
@@ -43,6 +43,8 @@ public object LengthFromValueClassIdCodec : Codec<LengthFromValueClassId> {
 
   override fun wireSize(`value`: LengthFromValueClassId, context: EncodeContext): WireSize = WireSize.Exact(2 + value.len.toInt())
 
+  override fun sizeHint(`value`: LengthFromValueClassId, context: EncodeContext): Int = 2 + value.payload.value.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/LpByteValueClassIdCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/LpByteValueClassIdCodec.kt
@@ -46,6 +46,8 @@ public object LpByteValueClassIdCodec : Codec<LpByteValueClassId> {
 
   override fun wireSize(`value`: LpByteValueClassId, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: LpByteValueClassId, context: EncodeContext): Int = 1 + value.id.value.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/LpIntValueClassIdCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/LpIntValueClassIdCodec.kt
@@ -49,6 +49,8 @@ public object LpIntValueClassIdCodec : Codec<LpIntValueClassId> {
 
   override fun wireSize(`value`: LpIntValueClassId, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: LpIntValueClassId, context: EncodeContext): Int = 4 + value.id.hex.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 4) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/LpPlainStringIdCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/LpPlainStringIdCodec.kt
@@ -49,6 +49,8 @@ public object LpPlainStringIdCodec : Codec<LpPlainStringId> {
 
   override fun wireSize(`value`: LpPlainStringId, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: LpPlainStringId, context: EncodeContext): Int = 2 + value.id.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/LpValueClassIdCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/LpValueClassIdCodec.kt
@@ -49,6 +49,8 @@ public object LpValueClassIdCodec : Codec<LpValueClassId> {
 
   override fun wireSize(`value`: LpValueClassId, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: LpValueClassId, context: EncodeContext): Int = 2 + value.id.value.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/OptionalValueClassIdCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/OptionalValueClassIdCodec.kt
@@ -58,6 +58,8 @@ public object OptionalValueClassIdCodec : Codec<OptionalValueClassId> {
 
   override fun wireSize(`value`: OptionalValueClassId, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: OptionalValueClassId, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/RemainingValueClassIdCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/RemainingValueClassIdCodec.kt
@@ -29,5 +29,7 @@ public object RemainingValueClassIdCodec : Codec<RemainingValueClassId> {
 
   override fun wireSize(`value`: RemainingValueClassId, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: RemainingValueClassId, context: EncodeContext): Int = 1 + value.id.value.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/RemainingValueClassWithTrailerCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/RemainingValueClassWithTrailerCodec.kt
@@ -31,5 +31,7 @@ public object RemainingValueClassWithTrailerCodec : Codec<RemainingValueClassWit
 
   override fun wireSize(`value`: RemainingValueClassWithTrailer, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: RemainingValueClassWithTrailer, context: EncodeContext): Int = 5 + value.id.value.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/varintfield/VarintLengthFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/varintfield/VarintLengthFrameCodec.kt
@@ -35,6 +35,8 @@ public object VarintLengthFrameCodec : Codec<VarintLengthFrame> {
     return WireSize.Exact(1 + __valueSize)
   }
 
+  override fun sizeHint(`value`: VarintLengthFrame, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     val __valueFrame = QuicVarintCodec.peekFrameSize(stream, baseOffset + 0)
     if (__valueFrame !is PeekResult.Complete) {

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/visibility/InternalCommandCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/visibility/InternalCommandCodec.kt
@@ -46,6 +46,11 @@ internal object InternalCommandCodec : Codec<InternalCommand> {
     is InternalCommand.Echo -> WireSize.BackPatch
   }
 
+  override fun sizeHint(`value`: InternalCommand, context: EncodeContext): Int = 1 + when (value) {
+    is InternalCommand.Ping -> InternalCommandPingCodec.sizeHint(value, context)
+    is InternalCommand.Echo -> InternalCommandEchoCodec.sizeHint(value, context)
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
     val discriminator = stream.peekByte(baseOffset).toInt() and 0xFF

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/visibility/InternalCommandEchoCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/visibility/InternalCommandEchoCodec.kt
@@ -49,6 +49,8 @@ internal object InternalCommandEchoCodec : Codec<InternalCommand.Echo> {
 
   override fun wireSize(`value`: InternalCommand.Echo, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: InternalCommand.Echo, context: EncodeContext): Int = 2 + value.msg.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/visibility/InternalCommandPingCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/visibility/InternalCommandPingCodec.kt
@@ -26,5 +26,7 @@ internal object InternalCommandPingCodec : Codec<InternalCommand.Ping> {
 
   override fun wireSize(`value`: InternalCommand.Ping, context: EncodeContext): WireSize = WireSize.Exact(8)
 
+  override fun sizeHint(`value`: InternalCommand.Ping, context: EncodeContext): Int = 8
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 8) PeekResult.Complete(8) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/visibility/InternalPacketCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/visibility/InternalPacketCodec.kt
@@ -51,6 +51,8 @@ internal object InternalPacketCodec : Codec<InternalPacket> {
 
   override fun wireSize(`value`: InternalPacket, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: InternalPacket, context: EncodeContext): Int = 6 + value.name.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 4) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/FrameHeaderByte1Codec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/FrameHeaderByte1Codec.kt
@@ -26,5 +26,7 @@ public object FrameHeaderByte1Codec : Codec<FrameHeaderByte1> {
 
   override fun wireSize(`value`: FrameHeaderByte1, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: FrameHeaderByte1, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsCloseBodyCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsCloseBodyCodec.kt
@@ -33,5 +33,7 @@ public object WsCloseBodyCodec : Codec<WsCloseBody> {
 
   override fun wireSize(`value`: WsCloseBody, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: WsCloseBody, context: EncodeContext): Int = 2 + value.reason.length
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsFrameBinaryCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsFrameBinaryCodec.kt
@@ -77,6 +77,8 @@ public class WsFrameBinaryCodec<P : Payload>(
 
   override fun wireSize(`value`: WsFrame.Binary<P>, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: WsFrame.Binary<P>, context: EncodeContext): Int = 2
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 
   public class Partial<P : Payload> internal constructor(

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsFrameCloseCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsFrameCloseCodec.kt
@@ -76,5 +76,7 @@ public object WsFrameCloseCodec : Codec<WsFrame.Close> {
 
   override fun wireSize(`value`: WsFrame.Close, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: WsFrame.Close, context: EncodeContext): Int = 2
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsFrameCodec.kt
@@ -72,6 +72,18 @@ public class WsFrameCodec<P : Payload>(
     }
   }
 
+  override fun sizeHint(`value`: WsFrame<P>, context: EncodeContext): Int {
+    @Suppress("UNCHECKED_CAST")
+    return when (value) {
+      is WsFrame.Continuation<*> -> continuationCodec.sizeHint(value as WsFrame.Continuation<P>, context)
+      is WsFrame.Text<*> -> textCodec.sizeHint(value as WsFrame.Text<P>, context)
+      is WsFrame.Binary<*> -> binaryCodec.sizeHint(value as WsFrame.Binary<P>, context)
+      is WsFrame.Close -> WsFrameCloseCodec.sizeHint(value, context)
+      is WsFrame.Ping<*> -> pingCodec.sizeHint(value as WsFrame.Ping<P>, context)
+      is WsFrame.Pong<*> -> pongCodec.sizeHint(value as WsFrame.Pong<P>, context)
+    }
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = WsFrame.peekFrameSize(stream, baseOffset)
 
   public companion object {

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsFrameContinuationCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsFrameContinuationCodec.kt
@@ -77,6 +77,8 @@ public class WsFrameContinuationCodec<P : Payload>(
 
   override fun wireSize(`value`: WsFrame.Continuation<P>, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: WsFrame.Continuation<P>, context: EncodeContext): Int = 2
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 
   public class Partial<P : Payload> internal constructor(

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsFrameHeaderCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsFrameHeaderCodec.kt
@@ -71,6 +71,8 @@ public object WsFrameHeaderCodec : Codec<WsFrameHeader> {
 
   override fun wireSize(`value`: WsFrameHeader, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: WsFrameHeader, context: EncodeContext): Int = 2
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     var __offset = 0
     if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsFramePingCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsFramePingCodec.kt
@@ -77,6 +77,8 @@ public class WsFramePingCodec<P : Payload>(
 
   override fun wireSize(`value`: WsFrame.Ping<P>, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: WsFrame.Ping<P>, context: EncodeContext): Int = 2
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 
   public class Partial<P : Payload> internal constructor(

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsFramePongCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsFramePongCodec.kt
@@ -77,6 +77,8 @@ public class WsFramePongCodec<P : Payload>(
 
   override fun wireSize(`value`: WsFrame.Pong<P>, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: WsFrame.Pong<P>, context: EncodeContext): Int = 2
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 
   public class Partial<P : Payload> internal constructor(

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsFrameTextCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsFrameTextCodec.kt
@@ -77,6 +77,8 @@ public class WsFrameTextCodec<P : Payload>(
 
   override fun wireSize(`value`: WsFrame.Text<P>, context: EncodeContext): WireSize = WireSize.BackPatch
 
+  override fun sizeHint(`value`: WsFrame.Text<P>, context: EncodeContext): Int = 2
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
 
   public class Partial<P : Payload> internal constructor(

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsHeaderByte2Codec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsHeaderByte2Codec.kt
@@ -26,5 +26,7 @@ public object WsHeaderByte2Codec : Codec<WsHeaderByte2> {
 
   override fun wireSize(`value`: WsHeaderByte2, context: EncodeContext): WireSize = WireSize.Exact(1)
 
+  override fun sizeHint(`value`: WsHeaderByte2, context: EncodeContext): Int = 1
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsMaskingKeyCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/websocket/WsMaskingKeyCodec.kt
@@ -26,5 +26,7 @@ public object WsMaskingKeyCodec : Codec<WsMaskingKey> {
 
   override fun wireSize(`value`: WsMaskingKey, context: EncodeContext): WireSize = WireSize.Exact(4)
 
+  override fun sizeHint(`value`: WsMaskingKey, context: EncodeContext): Int = 4
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 4) PeekResult.Complete(4) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/wireorderMismatch/BigWireFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/wireorderMismatch/BigWireFrameCodec.kt
@@ -46,6 +46,11 @@ public object BigWireFrameCodec : Codec<BigWireFrame> {
     is BigWireFrame.Status -> WireSize.Exact(13)
   }
 
+  override fun sizeHint(`value`: BigWireFrame, context: EncodeContext): Int = 1 + when (value) {
+    is BigWireFrame.Sample -> BigWireFrameSampleCodec.sizeHint(value, context)
+    is BigWireFrame.Status -> BigWireFrameStatusCodec.sizeHint(value, context)
+  }
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
     if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
     val discriminator = stream.peekByte(baseOffset).toInt() and 0xFF

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/wireorderMismatch/BigWireFrameSampleCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/wireorderMismatch/BigWireFrameSampleCodec.kt
@@ -46,5 +46,7 @@ public object BigWireFrameSampleCodec : Codec<BigWireFrame.Sample> {
 
   override fun wireSize(`value`: BigWireFrame.Sample, context: EncodeContext): WireSize = WireSize.Exact(26)
 
+  override fun sizeHint(`value`: BigWireFrame.Sample, context: EncodeContext): Int = 26
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 26) PeekResult.Complete(26) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/wireorderMismatch/BigWireFrameStatusCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/wireorderMismatch/BigWireFrameStatusCodec.kt
@@ -34,5 +34,7 @@ public object BigWireFrameStatusCodec : Codec<BigWireFrame.Status> {
 
   override fun wireSize(`value`: BigWireFrame.Status, context: EncodeContext): WireSize = WireSize.Exact(12)
 
+  override fun sizeHint(`value`: BigWireFrame.Status, context: EncodeContext): Int = 12
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 12) PeekResult.Complete(12) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/wireorderMismatch/BigWirePacketCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/wireorderMismatch/BigWirePacketCodec.kt
@@ -61,5 +61,7 @@ public object BigWirePacketCodec : Codec<BigWirePacket> {
 
   override fun wireSize(`value`: BigWirePacket, context: EncodeContext): WireSize = WireSize.Exact(43)
 
+  override fun sizeHint(`value`: BigWirePacket, context: EncodeContext): Int = 43
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 43) PeekResult.Complete(43) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/wireorderMismatch/LittleWirePacketCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/wireorderMismatch/LittleWirePacketCodec.kt
@@ -61,5 +61,7 @@ public object LittleWirePacketCodec : Codec<LittleWirePacket> {
 
   override fun wireSize(`value`: LittleWirePacket, context: EncodeContext): WireSize = WireSize.Exact(43)
 
+  override fun sizeHint(`value`: LittleWirePacket, context: EncodeContext): Int = 43
+
   override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 43) PeekResult.Complete(43) else PeekResult.NeedsMoreData
 }

--- a/buffer-codec-test/src/commonBenchmark/kotlin/com/ditchoom/buffer/codec/test/benchmark/EncodeSizingBenchmark.kt
+++ b/buffer-codec-test/src/commonBenchmark/kotlin/com/ditchoom/buffer/codec/test/benchmark/EncodeSizingBenchmark.kt
@@ -1,0 +1,138 @@
+package com.ditchoom.buffer.codec.test.benchmark
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.codec.AsciiStringCodec
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.Encoder
+import com.ditchoom.buffer.codec.encodeToPlatformBuffer
+import com.ditchoom.buffer.codec.test.protocols.asciistring.AsciiGreeting
+import com.ditchoom.buffer.codec.test.protocols.asciistring.AsciiGreetingCodec
+import com.ditchoom.buffer.codec.test.protocols.count.CountFixedList
+import com.ditchoom.buffer.codec.test.protocols.count.CountFixedListCodec
+import com.ditchoom.buffer.codec.test.protocols.count.CountPoint
+import com.ditchoom.buffer.codec.test.protocols.simple.TwoStrings
+import com.ditchoom.buffer.codec.test.protocols.simple.TwoStringsCodec
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.BenchmarkMode
+import kotlinx.benchmark.BenchmarkTimeUnit
+import kotlinx.benchmark.Measurement
+import kotlinx.benchmark.Mode
+import kotlinx.benchmark.OutputTimeUnit
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+import kotlinx.benchmark.Warmup
+
+/**
+ * Measures `encodeToPlatformBuffer` sizing strategies across the three
+ * wireSize regimes:
+ *
+ * - **BackPatch via `@UseCodec`** ([AsciiGreeting]) — the user codec reports
+ *   `Exact(value.length)` but message-level codegen currently collapses to
+ *   BackPatch, so encode pays the 64-byte-doubling grow-and-retry loop. The
+ *   `@UseCodec` Exact promotion should move these rows to single-allocation;
+ *   the before/after delta on this fixture is the promotion's whole case.
+ * - **BackPatch via bare UTF-8 strings** ([TwoStrings]) — stays BackPatch
+ *   until/unless UTF-8 pre-measuring lands; baseline for that decision.
+ * - **Exact control** ([CountFixedList]) — already single-allocation; the
+ *   floor the BackPatch rows should approach.
+ *
+ * Plus a micro pair isolating [AsciiStringCodec]'s validation scan from the
+ * underlying bulk `writeString`, into a pre-allocated buffer (no sizing loop).
+ *
+ * Sizes: SMALL fits the 64-byte initial estimate (zero retries — BackPatch's
+ * best case), MEDIUM forces ~3 doublings, LARGE ~7.
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(BenchmarkTimeUnit.SECONDS)
+open class EncodeSizingBenchmark {
+    private lateinit var asciiSmall: AsciiGreeting
+    private lateinit var asciiMedium: AsciiGreeting
+    private lateinit var asciiLarge: AsciiGreeting
+    private lateinit var utf8Small: TwoStrings
+    private lateinit var utf8Medium: TwoStrings
+    private lateinit var utf8Large: TwoStrings
+    private lateinit var fixedControl: CountFixedList
+    private lateinit var largeAsciiText: String
+    private lateinit var scratch: PlatformBuffer
+
+    @Setup
+    fun setup() {
+        asciiSmall = AsciiGreeting("x".repeat(SMALL_CHARS))
+        asciiMedium = AsciiGreeting("x".repeat(MEDIUM_CHARS))
+        asciiLarge = AsciiGreeting("x".repeat(LARGE_CHARS))
+        // Split across the two fields so both prefixes participate.
+        utf8Small = TwoStrings("x".repeat(SMALL_CHARS / 2), "y".repeat(SMALL_CHARS / 2))
+        utf8Medium = TwoStrings("x".repeat(MEDIUM_CHARS / 2), "y".repeat(MEDIUM_CHARS / 2))
+        utf8Large = TwoStrings("x".repeat(LARGE_CHARS / 2), "y".repeat(LARGE_CHARS / 2))
+        fixedControl = CountFixedList(id = 1u, points = List(MEDIUM_CHARS / 3) { CountPoint(it.toUShort(), 0u) })
+        largeAsciiText = "x".repeat(LARGE_CHARS)
+        scratch = BufferFactory.Default.allocate(LARGE_CHARS + SCRATCH_SLACK)
+    }
+
+    // ---- encodeToPlatformBuffer: @UseCodec ASCII (promotion target) -------
+
+    @Benchmark
+    fun asciiGreetingSmall(): Int = encodeAndFree(AsciiGreetingCodec, asciiSmall)
+
+    @Benchmark
+    fun asciiGreetingMedium(): Int = encodeAndFree(AsciiGreetingCodec, asciiMedium)
+
+    @Benchmark
+    fun asciiGreetingLarge(): Int = encodeAndFree(AsciiGreetingCodec, asciiLarge)
+
+    // ---- encodeToPlatformBuffer: bare UTF-8 strings (stays BackPatch) -----
+
+    @Benchmark
+    fun utf8TwoStringsSmall(): Int = encodeAndFree(TwoStringsCodec, utf8Small)
+
+    @Benchmark
+    fun utf8TwoStringsMedium(): Int = encodeAndFree(TwoStringsCodec, utf8Medium)
+
+    @Benchmark
+    fun utf8TwoStringsLarge(): Int = encodeAndFree(TwoStringsCodec, utf8Large)
+
+    // ---- encodeToPlatformBuffer: Exact control -----------------------------
+
+    @Benchmark
+    fun fixedListControl(): Int = encodeAndFree(CountFixedListCodec, fixedControl)
+
+    // ---- micro: validation scan vs bare bulk write (no sizing loop) --------
+
+    @Benchmark
+    fun asciiCodecEncodeIntoPreallocated(): Int {
+        scratch.resetForWrite()
+        AsciiStringCodec.encode(scratch, largeAsciiText, EncodeContext.Empty)
+        return scratch.position()
+    }
+
+    @Benchmark
+    fun bareWriteStringIntoPreallocated(): Int {
+        scratch.resetForWrite()
+        scratch.writeString(largeAsciiText, Charset.UTF8)
+        return scratch.position()
+    }
+
+    private fun <T> encodeAndFree(
+        codec: Encoder<T>,
+        value: T,
+    ): Int {
+        val buffer = codec.encodeToPlatformBuffer(value)
+        val size = buffer.limit()
+        buffer.freeNativeMemory()
+        return size
+    }
+
+    private companion object {
+        const val SMALL_CHARS = 24 // body fits the 64-byte initial estimate
+        const val MEDIUM_CHARS = 400 // ~3 doublings from 64
+        const val LARGE_CHARS = 8_000 // ~7 doublings from 64
+        const val SCRATCH_SLACK = 64
+    }
+}

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/asciistring/AsciiStringCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/asciistring/AsciiStringCodecTest.kt
@@ -102,6 +102,22 @@ class AsciiStringCodecTest {
     }
 
     @Test
+    fun lengthPrefixedFixtureWireSizeComposesExact() {
+        // The codec's Exact(value.length) is probed by the generated
+        // message-level wireSize and composed with the 2-byte prefix, so
+        // encodeToPlatformBuffer allocates exactly once instead of walking
+        // the 64-byte-doubling BackPatch loop.
+        assertEquals(
+            WireSize.Exact(2 + 7),
+            AsciiGreetingCodec.wireSize(AsciiGreeting(command = "CONNECT"), EncodeContext.Empty),
+        )
+        assertEquals(
+            WireSize.Exact(2),
+            AsciiGreetingCodec.wireSize(AsciiGreeting(command = ""), EncodeContext.Empty),
+        )
+    }
+
+    @Test
     fun lengthPrefixedFixtureRoundTripsEmpty() {
         val original = AsciiGreeting(command = "")
         val buffer = BufferFactory.Default.allocate(8)

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/boundary/SizeHintTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/boundary/SizeHintTest.kt
@@ -1,0 +1,93 @@
+package com.ditchoom.buffer.codec.test.protocols.boundary
+
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.Encoder
+import com.ditchoom.buffer.codec.encodeToPlatformBuffer
+import com.ditchoom.buffer.codec.test.protocols.count.CountNamed
+import com.ditchoom.buffer.codec.test.protocols.count.CountNamedCodec
+import com.ditchoom.buffer.codec.test.protocols.count.CountVariableList
+import com.ditchoom.buffer.codec.test.protocols.count.CountVariableListCodec
+import com.ditchoom.buffer.codec.test.protocols.simple.TwoStrings
+import com.ditchoom.buffer.codec.test.protocols.simple.TwoStringsCodec
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * `sizeHint` — the O(field count) starting-capacity guess consulted by
+ * `encodeToPlatformBuffer` for BackPatch shapes. Contract under test:
+ *
+ * 1. For ASCII content the hint equals the encoded byte count exactly
+ *    (1 char = 1 UTF-8 byte), so the first allocation fits — zero retries.
+ * 2. For any content the hint is a LOWER bound on the encoded size (every
+ *    Char encodes to ≥ 1 byte) — an under-hint only costs doublings, never
+ *    correctness.
+ * 3. Hints compose through nested sealed fields and list elements.
+ * 4. Encoders without an override keep the documented default.
+ */
+class SizeHintTest {
+    private fun <T> encodedSize(
+        codec: Encoder<T>,
+        value: T,
+    ): Int = codec.encodeToPlatformBuffer(value).limit()
+
+    @Test
+    fun asciiHintMatchesEncodedSizeExactly() {
+        val msg = TwoStrings("hello", "world!")
+        assertEquals(4 + 5 + 6, TwoStringsCodec.sizeHint(msg, EncodeContext.Empty))
+        assertEquals(encodedSize(TwoStringsCodec, msg), TwoStringsCodec.sizeHint(msg, EncodeContext.Empty))
+    }
+
+    @Test
+    fun hintIsLowerBoundForMultibyteContent() {
+        for (msg in listOf(
+            TwoStrings("héllo", "wörld"),
+            TwoStrings("日本語のテキスト", "byte"),
+            TwoStrings("mixed 语言 content", "🎉🎊"),
+        )) {
+            val hint = TwoStringsCodec.sizeHint(msg, EncodeContext.Empty)
+            val actual = encodedSize(TwoStringsCodec, msg)
+            assertTrue(hint <= actual, "hint $hint must not exceed encoded size $actual for $msg")
+        }
+    }
+
+    @Test
+    fun hintComposesThroughNestedSealedField() {
+        // 2 (host prefix) + 4 (host) + 1 (discriminator) + 2 (name prefix) + 3 (name).
+        val msg = BoundaryHost("host", BoundaryDisp.Named("abc"))
+        assertEquals(12, BoundaryHostCodec.sizeHint(msg, EncodeContext.Empty))
+        assertEquals(encodedSize(BoundaryHostCodec, msg), BoundaryHostCodec.sizeHint(msg, EncodeContext.Empty))
+    }
+
+    @Test
+    fun hintComposesThroughCountListElements() {
+        // varint(count) min 1 + per element (2-byte prefix + chars).
+        val msg = CountVariableList(List(3) { CountNamed("abcd") })
+        assertEquals(1 + 3 * (2 + 4), CountVariableListCodec.sizeHint(msg, EncodeContext.Empty))
+        assertEquals(2 + 4, CountNamedCodec.sizeHint(CountNamed("abcd"), EncodeContext.Empty))
+    }
+
+    @Test
+    fun handWrittenEncoderKeepsDocumentedDefault() {
+        val bare =
+            object : Encoder<Int> {
+                override fun encode(
+                    buffer: com.ditchoom.buffer.WriteBuffer,
+                    value: Int,
+                    context: EncodeContext,
+                ) {
+                    buffer.writeInt(value)
+                }
+            }
+        assertEquals(Encoder.DEFAULT_SIZE_HINT, bare.sizeHint(7, EncodeContext.Empty))
+    }
+
+    @Test
+    fun largeAsciiMessageRoundTripsThroughSingleShotAllocation() {
+        // 8KB ASCII: hint == exact size, so the first allocation fits.
+        val msg = TwoStrings("x".repeat(4000), "y".repeat(4000))
+        val buf = TwoStringsCodec.encodeToPlatformBuffer(msg)
+        assertEquals(TwoStringsCodec.sizeHint(msg, EncodeContext.Empty), buf.limit())
+        assertEquals(msg, TwoStringsCodec.decode(buf, com.ditchoom.buffer.codec.DecodeContext.Empty))
+    }
+}

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/LengthPrefixedUseCodecListCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/LengthPrefixedUseCodecListCodecTest.kt
@@ -106,12 +106,28 @@ class LengthPrefixedUseCodecListCodecTest {
     }
 
     @Test
-    fun propertyBagWireSizeIsBackPatch() {
-        // Conservative collapse — runtime-Exact composition is a follow-on.
+    fun propertyBagWireSizeComposesExact() {
+        // The element codec's wireSize is probed per element and the VBI
+        // prefix codec sizes the byte count: empty list = varint(0) alone;
+        // three 5-byte entries = varint(15) + 15.
         assertEquals(
-            WireSize.BackPatch,
+            WireSize.Exact(1),
             PropertyBagFrameCodec.wireSize(
                 PropertyBagFrame(properties = emptyList()),
+                EncodeContext.Empty,
+            ),
+        )
+        assertEquals(
+            WireSize.Exact(1 + 15),
+            PropertyBagFrameCodec.wireSize(
+                PropertyBagFrame(
+                    properties =
+                        listOf(
+                            PropertyEntry(1u, 0x0101u),
+                            PropertyEntry(2u, 0x0202u),
+                            PropertyEntry(3u, 0x0303u),
+                        ),
+                ),
                 EncodeContext.Empty,
             ),
         )

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/slice15a/Slice15aLengthPrefixedPayloadCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/slice15a/Slice15aLengthPrefixedPayloadCodecTest.kt
@@ -105,13 +105,14 @@ class Slice15aLengthPrefixedPayloadCodecTest {
     }
 
     @Test
-    fun wireSizeReportsBackPatchForTopLevelMessage() {
-        // The containing message's wireSize collapses to BackPatch
-        // ( parallel of slices 10a/11 — the user codec's body
-        // size is opaque, conservative collapse).
+    fun wireSizeComposesUserCodecExactForTopLevelMessage() {
+        // BinaryDataCodec declares Exact(byteSize()); the message-level
+        // wireSize probes it and composes 2 (Short prefix) + 1 (body byte).
+        // Before the @UseCodec promotion this collapsed to BackPatch.
         val msg = Slice15aLengthPrefixedPayload(data = BinaryData(byteArrayOf(0x42)))
         val ws = Slice15aLengthPrefixedPayloadCodec.wireSize(msg, EncodeContext.Empty)
-        assertIs<WireSize.BackPatch>(ws)
+        assertIs<WireSize.Exact>(ws)
+        assertEquals(3, ws.bytes)
     }
 
     @Test

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/DispatchVarintUnionCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/DispatchVarintUnionCodecTest.kt
@@ -38,9 +38,12 @@ class DispatchVarintUnionCodecTest {
     }
 
     @Test
-    fun nonVariableLengthUseCodecVariantStaysBackPatch() {
+    fun nonVariableLengthUseCodecVariantComposesExact() {
+        // Plain's user codec declares Exact(4); the dispatcher probes the
+        // variant codec and composes 1 (discriminator) + 4 (body). Before the
+        // @UseCodec promotion this collapsed to BackPatch at analyze time.
         assertEquals(
-            WireSize.BackPatch,
+            WireSize.Exact(5),
             DispatchVarintUnionCodec.wireSize(DispatchVarintUnion.Plain(1u), EncodeContext.Empty),
         )
     }

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/UseCodecScalarCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/UseCodecScalarCodecTest.kt
@@ -47,9 +47,12 @@ class UseCodecScalarCodecTest {
     }
 
     @Test
-    fun zigZagFrameWireSizeIsBackPatch() {
+    fun zigZagFrameWireSizeComposesUserCodecExact() {
+        // The user codec declares Exact(4); the message-level wireSize probes
+        // it and composes: 4 (id: Int) + 4 (zig-zag body) — no BackPatch
+        // collapse, so encodeToPlatformBuffer allocates exactly once.
         assertEquals(
-            WireSize.BackPatch,
+            WireSize.Exact(8),
             ZigZagFrameCodec.wireSize(ZigZagFrame(id = 1, value = 1u), EncodeContext.Empty),
         )
     }

--- a/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/Codec.kt
+++ b/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/Codec.kt
@@ -58,6 +58,29 @@ interface Encoder<in T> {
         value: T,
         context: EncodeContext,
     ): WireSize = WireSize.BackPatch
+
+    /**
+     * Starting-capacity hint consulted by `encodeToPlatformBuffer` when
+     * [wireSize] reports [WireSize.BackPatch]. A cheap lower-bound guess —
+     * NOT a contract: under-hinting costs grow-and-retry doublings (the
+     * pre-hint behavior), over-hinting costs one-time allocation slack;
+     * neither affects the encoded bytes.
+     *
+     * Generated codecs override this with `O(field count)` arithmetic —
+     * fixed widths as constants plus `String.length` per string field
+     * (exact for ASCII content, a ≥⅓ lower bound for any UTF-8) plus
+     * nested/element hints. Hand-written encoders may override it whenever
+     * they can guess better than [DEFAULT_SIZE_HINT].
+     */
+    fun sizeHint(
+        value: T,
+        context: EncodeContext,
+    ): Int = DEFAULT_SIZE_HINT
+
+    companion object {
+        /** Fallback starting capacity when an encoder offers no better guess. */
+        public const val DEFAULT_SIZE_HINT: Int = 64
+    }
 }
 
 /**

--- a/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/FrameStreaming.kt
+++ b/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/FrameStreaming.kt
@@ -6,7 +6,6 @@ import com.ditchoom.buffer.Default
 import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.stream.StreamProcessor
 
-private const val MIN_ESTIMATE = 64
 private const val MAX_ENCODE_CAPACITY = 1 shl 30 // 1 GiB safety ceiling
 
 /**
@@ -41,7 +40,10 @@ public fun <T> Encoder<T>.encodeToPlatformBuffer(
     var capacity =
         when (val size = wireSize(value, context)) {
             is WireSize.Exact -> maxOf(size.bytes, 1)
-            WireSize.BackPatch -> MIN_ESTIMATE
+            // The encoder's lower-bound guess (generated codecs sum fixed
+            // widths + String.length per string field); clamped ≥ 1 so a
+            // zero hint still allocates. Under-hints grow-and-retry.
+            WireSize.BackPatch -> maxOf(sizeHint(value, context), 1)
         }
     while (true) {
         val buffer = factory.allocate(capacity)


### PR DESCRIPTION
## Summary

Two changes that together fix `encodeToPlatformBuffer`'s sizing for variable-size messages. Wire formats are unchanged by both — only the allocation strategy improves; all byte-exact tests pass untouched.

### 1. `@UseCodec` Exact wireSize composition

A user codec that declares its wire size — `AsciiStringCodec`'s `Exact(value.length)`, a fixed-width payload codec's `Exact(N)` — had that information discarded: any message carrying a `@UseCodec` field (bare scalar, `@LengthPrefixed` payload, `@LengthPrefixed` list) collapsed its `wireSize` to `BackPatch` at analyze time.

Generated `wireSize` now rides the runtime-Exact branch for these shapes and **probes** the user codec per value: `Exact` composes into the precompute sum (single exact allocation, no retries); `BackPatch` (the `Codec` interface default) degrades the whole message at runtime — the probe-and-degrade convention from #304, so an under-declaring codec can never hit a cast crash. Variant classification and dispatcher size tables compose identically. Mixed shapes keep the conservative collapse via guards placed **after** the probe branch, so the terminal fixed-scalar sum can never silently under-count.

### 2. `Encoder.sizeHint` — informed starting capacity for BackPatch shapes

`WireSize` is a one-bit channel — `BackPatch` carries no size information — so BackPatch encodes started at a constant 64 bytes and doubled through grow-and-retry even when the codec could see a 4KB string in the value. `Encoder` gains `sizeHint(value, context): Int` (defaulted to 64 → source/binary compatible), consulted by `encodeToPlatformBuffer` as the starting capacity.

Generated codecs override it with O(field count) arithmetic: fixed/prefix widths fold to a constant, string fields contribute `accessor.length` (**exact** for ASCII content, a guaranteed **lower bound** for any UTF-8 — every `Char` encodes to ≥1 byte), nested messages/list elements/sealed variants contribute their own hints. No-cheap-bound fields (`@When`, opaque `@UseCodec` bodies) contribute 0 — under-hinting falls back to exactly the pre-hint behavior. The hint is a guess, never a contract: it cannot affect encoded bytes.

(History note: this is not a revival of 4.x `sizeOf(SizeEstimate)` — #149 renamed that API 1:1 into today's `wireSize`/`WireSize`. A lower-bound hint channel is new.)

## Benchmarks

New `EncodeSizingBenchmark` (kotlinx-benchmark wired into `buffer-codec-test`, JVM + linuxX64 mirroring `:buffer-flow`). `encodeToPlatformBuffer` throughput:

**`@UseCodec` ASCII message (fixed by change 1 — wireSize now Exact):**

| size | JVM before → after | native before → after |
|---|---|---|
| 26 B | 2.19M → 2.27M (flat) | 10.2M → 9.5M (−7%, note below) |
| 402 B | 189K → **1.39M (7.3×)** | 62.3K → **1.44M (23×)** |
| 8 KB | 40.5K → **190K (4.7×)** | 7.8K → **78.6K (10.1×)** |

**Bare UTF-8 string message (fixed by change 2 — hint sizes the first allocation):**

| size | JVM before → after | native before → after |
|---|---|---|
| 26 B | 2.17M → 2.19M (flat) | 9.05M → 9.13M (flat) |
| 402 B | 200K → **1.35M (6.7×)** | 70K → **2.02M (29×)** |
| 8 KB | 54K → **224K (4.1×)** | 14.3K → **112K (7.8×)** |

Both large rows now sit near the preallocated-encode ceiling (367K/475K JVM micros) instead of ~9× below it. Fixed-size control flat throughout. Known trade: 26-byte `@UseCodec` messages on native lose ~7% (probe + exact-size alloc vs one 64-byte estimate); small-and-hot callers encoding into pooled buffers never call `wireSize`/`sizeHint` and are unaffected.

## Behavior changes (minor label)

- `wireSize()` for `@UseCodec`-bearing messages whose user codec declares `Exact` now reports `Exact` instead of `BackPatch`. Fixture tests pinning the old collapse updated to pin composed values.
- `Encoder` has a new defaulted method `sizeHint` and companion constant `DEFAULT_SIZE_HINT` (existing implementers unaffected).
- Codec source snapshots regenerated (every codec gains a `sizeHint` override; `@UseCodec` fixtures gain probe-composed `wireSize`).

## Test coverage

Full suite green on JVM (798), JS Node, linuxX64, WASM: `SizeHintTest` (ASCII hint == encoded size; multibyte hint ≤ encoded size; composition through sealed fields and `@Count` elements; hand-written default preserved; 8KB single-shot round-trip), updated `@UseCodec` Exact-composition tests, the #304 boundary sweeps and malformed-input suites, processor tests, ktlint, detekt.
