### PR TITLE
fix(codec): verify declared Exact size against actual encode in @LengthPrefixed framing

### DIFF
--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterFields.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterFields.kt
@@ -1106,15 +1106,51 @@ internal fun appendEncodeLengthPrefixed(
         field.name,
     )
     body.beginControlFlow("is %T.Exact ->", WIRE_SIZE_CN)
+    appendLengthPrefixedExactBranch(body, field, fieldPath, sizeVar)
+    body.endControlFlow()
+    body.beginControlFlow("%T.BackPatch ->", WIRE_SIZE_CN)
+    appendLengthPrefixedBackPatchBranch(body, field, fieldPath)
+    body.endControlFlow()
+    body.endControlFlow()
+}
+
+/** Exact branch: prefix from the declared size, then verify encode agreed. */
+private fun appendLengthPrefixedExactBranch(
+    body: CodeBlock.Builder,
+    field: FieldSpec.LengthPrefixedMessage,
+    fieldPath: String,
+    sizeVar: String,
+) {
     val byteCountVar = "${field.name}ByteCount"
     body.addStatement("val %L = %L.bytes", byteCountVar, sizeVar)
     appendPrefixWidthGuard(body, byteCountVar, field.prefixWidth, fieldPath)
     val prefixVar = "${field.name}Prefix"
     body.addStatement("val %L = %L.toUInt()", prefixVar, byteCountVar)
     appendBufferPrefixEncode(body, prefixVar, field.prefixWidth, field.prefixWireOrder)
+    // The prefix above was written from the DECLARED size. Verify the body
+    // actually encoded to that many bytes — a codec whose wireSize disagrees
+    // with its encode must fail loudly here, not ship a frame whose prefix
+    // and body disagree (silent wire corruption).
+    val bodyStartVar = "${field.name}BodyStart"
+    body.addStatement("val %L = buffer.position()", bodyStartVar)
     body.addStatement("%T.encode(buffer, value.%L, context)", field.codecType, field.name)
+    body.beginControlFlow("if (buffer.position() - %L != %L)", bodyStartVar, byteCountVar)
+    body.addStatement(
+        "throw %T(fieldPath = %S, reason = %P)",
+        ENCODE_EXCEPTION_CN,
+        fieldPath,
+        "wireSize declared \${$byteCountVar} bytes but encode wrote " +
+            "\${buffer.position() - $bodyStartVar} — the codec's wireSize and encode disagree",
+    )
     body.endControlFlow()
-    body.beginControlFlow("%T.BackPatch ->", WIRE_SIZE_CN)
+}
+
+/** BackPatch branch: reserve, encode, measure, guard, patch. */
+private fun appendLengthPrefixedBackPatchBranch(
+    body: CodeBlock.Builder,
+    field: FieldSpec.LengthPrefixedMessage,
+    fieldPath: String,
+) {
     val sizePosVar = "${field.name}SizePosition"
     val bodyStartVar = "${field.name}BodyStart"
     val endPosVar = "${field.name}EndPosition"
@@ -1131,8 +1167,6 @@ internal fun appendEncodeLengthPrefixed(
     body.addStatement("val %L = %L.toUInt()", patchPrefixVar, patchCountVar)
     appendBufferPrefixEncode(body, patchPrefixVar, field.prefixWidth, field.prefixWireOrder)
     body.addStatement("buffer.position(%L)", endPosVar)
-    body.endControlFlow()
-    body.endControlFlow()
 }
 
 /**

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/HonestHostCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/HonestHostCodec.kt
@@ -1,0 +1,96 @@
+package com.ditchoom.buffer.codec.test.protocols.boundary
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object HonestHostCodec : Codec<HonestHost> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): HonestHost {
+    val kind = buffer.readByte()
+    val innerPrefixB0 = buffer.readUByte().toUInt()
+    val innerPrefixB1 = buffer.readUByte().toUInt()
+    val innerPrefix = ((innerPrefixB0 shl 8) or innerPrefixB1)
+    if (innerPrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "HonestHost.inner", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = innerPrefix.toString())
+    }
+    val innerLength = innerPrefix.toInt()
+    val innerOuterLimit = buffer.limit()
+    buffer.setLimit(buffer.position() + innerLength)
+    val inner = try {
+      HonestInnerCodec.decode(buffer, context)
+    } finally {
+      buffer.setLimit(innerOuterLimit)
+    }
+    return HonestHost(kind = kind, inner = inner)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: HonestHost,
+    context: EncodeContext,
+  ) {
+    buffer.writeByte(value.kind)
+    when (val innerWireSize = HonestInnerCodec.wireSize(value.inner, context)) {
+      is WireSize.Exact -> {
+        val innerByteCount = innerWireSize.bytes
+        if (innerByteCount > 65_535) {
+          throw EncodeException(fieldPath = "HonestHost.inner", reason = """encoded message byte length ${innerByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+        }
+        val innerPrefix = innerByteCount.toUInt()
+        buffer.writeUByte(((innerPrefix shr 8) and 0xFFu).toUByte())
+        buffer.writeUByte((innerPrefix and 0xFFu).toUByte())
+        val innerBodyStart = buffer.position()
+        HonestInnerCodec.encode(buffer, value.inner, context)
+        if (buffer.position() - innerBodyStart != innerByteCount) {
+          throw EncodeException(fieldPath = "HonestHost.inner", reason = """wireSize declared ${innerByteCount} bytes but encode wrote ${buffer.position() - innerBodyStart} — the codec's wireSize and encode disagree""")
+        }
+      }
+      WireSize.BackPatch -> {
+        val innerSizePosition = buffer.position()
+        repeat(2) { buffer.writeUByte(0u) }
+        val innerBodyStart = buffer.position()
+        HonestInnerCodec.encode(buffer, value.inner, context)
+        val innerEndPosition = buffer.position()
+        val innerPatchByteCount = innerEndPosition - innerBodyStart
+        if (innerPatchByteCount > 65_535) {
+          throw EncodeException(fieldPath = "HonestHost.inner", reason = """encoded message byte length ${innerPatchByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+        }
+        buffer.position(innerSizePosition)
+        val innerPatchPrefix = innerPatchByteCount.toUInt()
+        buffer.writeUByte(((innerPatchPrefix shr 8) and 0xFFu).toUByte())
+        buffer.writeUByte((innerPatchPrefix and 0xFFu).toUByte())
+        buffer.position(innerEndPosition)
+      }
+    }
+  }
+
+  override fun wireSize(`value`: HonestHost, context: EncodeContext): WireSize = when (val innerSize = HonestInnerCodec.wireSize(value.inner, context)) {
+    is WireSize.Exact -> WireSize.Exact(3 + innerSize.bytes)
+    WireSize.BackPatch -> WireSize.BackPatch
+  }
+
+  override fun sizeHint(`value`: HonestHost, context: EncodeContext): Int = 3 + HonestInnerCodec.sizeHint(value.inner, context)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    __offset += 1
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val innerPrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val innerPrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val innerPrefix = ((innerPrefixB0 shl 8) or innerPrefixB1).toUInt()
+    if (innerPrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "HonestHost.inner", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + innerPrefix.toInt()}""")
+    }
+    __offset += 2 + innerPrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/HonestInnerCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/HonestInnerCodec.kt
@@ -1,0 +1,38 @@
+package com.ditchoom.buffer.codec.test.protocols.boundary
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object HonestInnerCodec : Codec<HonestInner> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): HonestInner {
+    val v = HonestSizeCodec.decode(buffer, context)
+    return HonestInner(v = v)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: HonestInner,
+    context: EncodeContext,
+  ) {
+    HonestSizeCodec.encode(buffer, value.v, context)
+  }
+
+  override fun wireSize(`value`: HonestInner, context: EncodeContext): WireSize {
+    val __vSize = when (val __s = HonestSizeCodec.wireSize(value.v, context)) {
+      is WireSize.Exact -> __s.bytes
+      WireSize.BackPatch -> return WireSize.BackPatch
+    }
+    return WireSize.Exact(0 + __vSize)
+  }
+
+  override fun sizeHint(`value`: HonestInner, context: EncodeContext): Int = 0
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/LpByteWrappedTailCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/LpByteWrappedTailCodec.kt
@@ -42,7 +42,11 @@ public object LpByteWrappedTailCodec : Codec<LpByteWrappedTail> {
         }
         val bodyPrefix = bodyByteCount.toUInt()
         buffer.writeUByte((bodyPrefix and 0xFFu).toUByte())
+        val bodyBodyStart = buffer.position()
         WrappedLabelCodec.encode(buffer, value.body, context)
+        if (buffer.position() - bodyBodyStart != bodyByteCount) {
+          throw EncodeException(fieldPath = "LpByteWrappedTail.body", reason = """wireSize declared ${bodyByteCount} bytes but encode wrote ${buffer.position() - bodyBodyStart} — the codec's wireSize and encode disagree""")
+        }
       }
       WireSize.BackPatch -> {
         val bodySizePosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/LpWrappedTailCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/LpWrappedTailCodec.kt
@@ -47,7 +47,11 @@ public object LpWrappedTailCodec : Codec<LpWrappedTail> {
         val bodyPrefix = bodyByteCount.toUInt()
         buffer.writeUByte(((bodyPrefix shr 8) and 0xFFu).toUByte())
         buffer.writeUByte((bodyPrefix and 0xFFu).toUByte())
+        val bodyBodyStart = buffer.position()
         WrappedLabelCodec.encode(buffer, value.body, context)
+        if (buffer.position() - bodyBodyStart != bodyByteCount) {
+          throw EncodeException(fieldPath = "LpWrappedTail.body", reason = """wireSize declared ${bodyByteCount} bytes but encode wrote ${buffer.position() - bodyBodyStart} — the codec's wireSize and encode disagree""")
+        }
       }
       WireSize.BackPatch -> {
         val bodySizePosition = buffer.position()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/MisdeclaredHostCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/MisdeclaredHostCodec.kt
@@ -1,0 +1,96 @@
+package com.ditchoom.buffer.codec.test.protocols.boundary
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MisdeclaredHostCodec : Codec<MisdeclaredHost> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MisdeclaredHost {
+    val kind = buffer.readByte()
+    val innerPrefixB0 = buffer.readUByte().toUInt()
+    val innerPrefixB1 = buffer.readUByte().toUInt()
+    val innerPrefix = ((innerPrefixB0 shl 8) or innerPrefixB1)
+    if (innerPrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "MisdeclaredHost.inner", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = innerPrefix.toString())
+    }
+    val innerLength = innerPrefix.toInt()
+    val innerOuterLimit = buffer.limit()
+    buffer.setLimit(buffer.position() + innerLength)
+    val inner = try {
+      MisdeclaredInnerCodec.decode(buffer, context)
+    } finally {
+      buffer.setLimit(innerOuterLimit)
+    }
+    return MisdeclaredHost(kind = kind, inner = inner)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MisdeclaredHost,
+    context: EncodeContext,
+  ) {
+    buffer.writeByte(value.kind)
+    when (val innerWireSize = MisdeclaredInnerCodec.wireSize(value.inner, context)) {
+      is WireSize.Exact -> {
+        val innerByteCount = innerWireSize.bytes
+        if (innerByteCount > 65_535) {
+          throw EncodeException(fieldPath = "MisdeclaredHost.inner", reason = """encoded message byte length ${innerByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+        }
+        val innerPrefix = innerByteCount.toUInt()
+        buffer.writeUByte(((innerPrefix shr 8) and 0xFFu).toUByte())
+        buffer.writeUByte((innerPrefix and 0xFFu).toUByte())
+        val innerBodyStart = buffer.position()
+        MisdeclaredInnerCodec.encode(buffer, value.inner, context)
+        if (buffer.position() - innerBodyStart != innerByteCount) {
+          throw EncodeException(fieldPath = "MisdeclaredHost.inner", reason = """wireSize declared ${innerByteCount} bytes but encode wrote ${buffer.position() - innerBodyStart} — the codec's wireSize and encode disagree""")
+        }
+      }
+      WireSize.BackPatch -> {
+        val innerSizePosition = buffer.position()
+        repeat(2) { buffer.writeUByte(0u) }
+        val innerBodyStart = buffer.position()
+        MisdeclaredInnerCodec.encode(buffer, value.inner, context)
+        val innerEndPosition = buffer.position()
+        val innerPatchByteCount = innerEndPosition - innerBodyStart
+        if (innerPatchByteCount > 65_535) {
+          throw EncodeException(fieldPath = "MisdeclaredHost.inner", reason = """encoded message byte length ${innerPatchByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+        }
+        buffer.position(innerSizePosition)
+        val innerPatchPrefix = innerPatchByteCount.toUInt()
+        buffer.writeUByte(((innerPatchPrefix shr 8) and 0xFFu).toUByte())
+        buffer.writeUByte((innerPatchPrefix and 0xFFu).toUByte())
+        buffer.position(innerEndPosition)
+      }
+    }
+  }
+
+  override fun wireSize(`value`: MisdeclaredHost, context: EncodeContext): WireSize = when (val innerSize = MisdeclaredInnerCodec.wireSize(value.inner, context)) {
+    is WireSize.Exact -> WireSize.Exact(3 + innerSize.bytes)
+    WireSize.BackPatch -> WireSize.BackPatch
+  }
+
+  override fun sizeHint(`value`: MisdeclaredHost, context: EncodeContext): Int = 3 + MisdeclaredInnerCodec.sizeHint(value.inner, context)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    __offset += 1
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val innerPrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val innerPrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val innerPrefix = ((innerPrefixB0 shl 8) or innerPrefixB1).toUInt()
+    if (innerPrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "MisdeclaredHost.inner", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + innerPrefix.toInt()}""")
+    }
+    __offset += 2 + innerPrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/MisdeclaredInnerCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/MisdeclaredInnerCodec.kt
@@ -1,0 +1,38 @@
+package com.ditchoom.buffer.codec.test.protocols.boundary
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object MisdeclaredInnerCodec : Codec<MisdeclaredInner> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): MisdeclaredInner {
+    val v = MisdeclaredSizeCodec.decode(buffer, context)
+    return MisdeclaredInner(v = v)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: MisdeclaredInner,
+    context: EncodeContext,
+  ) {
+    MisdeclaredSizeCodec.encode(buffer, value.v, context)
+  }
+
+  override fun wireSize(`value`: MisdeclaredInner, context: EncodeContext): WireSize {
+    val __vSize = when (val __s = MisdeclaredSizeCodec.wireSize(value.v, context)) {
+      is WireSize.Exact -> __s.bytes
+      WireSize.BackPatch -> return WireSize.BackPatch
+    }
+    return WireSize.Exact(0 + __vSize)
+  }
+
+  override fun sizeHint(`value`: MisdeclaredInner, context: EncodeContext): Int = 0
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = PeekResult.NoFraming
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/riff/WavFmtChunkCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/riff/WavFmtChunkCodec.kt
@@ -7,6 +7,7 @@ import com.ditchoom.buffer.codec.Codec
 import com.ditchoom.buffer.codec.DecodeContext
 import com.ditchoom.buffer.codec.DecodeException
 import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
 import com.ditchoom.buffer.codec.PeekResult
 import com.ditchoom.buffer.codec.WireSize
 import com.ditchoom.buffer.stream.StreamProcessor
@@ -51,7 +52,11 @@ public object WavFmtChunkCodec : Codec<WavFmtChunk> {
         buffer.writeUByte(((bodyPrefix shr 8) and 0xFFu).toUByte())
         buffer.writeUByte(((bodyPrefix shr 16) and 0xFFu).toUByte())
         buffer.writeUByte(((bodyPrefix shr 24) and 0xFFu).toUByte())
+        val bodyBodyStart = buffer.position()
         WavFmtBodyCodec.encode(buffer, value.body, context)
+        if (buffer.position() - bodyBodyStart != bodyByteCount) {
+          throw EncodeException(fieldPath = "WavFmtChunk.body", reason = """wireSize declared ${bodyByteCount} bytes but encode wrote ${buffer.position() - bodyBodyStart} — the codec's wireSize and encode disagree""")
+        }
       }
       WireSize.BackPatch -> {
         val bodySizePosition = buffer.position()

--- a/buffer-codec-test/src/codecSchema/codec-schema.txt
+++ b/buffer-codec-test/src/codecSchema/codec-schema.txt
@@ -126,11 +126,21 @@ message com.ditchoom.buffer.codec.test.protocols.boundary.BoundaryDisp.Named
 message com.ditchoom.buffer.codec.test.protocols.boundary.BoundaryHost
   0 host string len-prefix=2B/Default
   1 disp msg:com.ditchoom.buffer.codec.test.protocols.boundary.BoundaryDisp
+message com.ditchoom.buffer.codec.test.protocols.boundary.HonestHost
+  0 kind scalar:Byte wire=1B order=Default
+  1 inner msg:com.ditchoom.buffer.codec.test.protocols.boundary.HonestInner len-prefix=2B/Default
+message com.ditchoom.buffer.codec.test.protocols.boundary.HonestInner
+  0 v codec:com.ditchoom.buffer.codec.test.protocols.boundary.HonestSizeCodec bounding=false variable=false
 message com.ditchoom.buffer.codec.test.protocols.boundary.LpByteWrappedTail
   0 body msg:com.ditchoom.buffer.codec.test.protocols.boundary.WrappedLabel len-prefix=1B/Default
 message com.ditchoom.buffer.codec.test.protocols.boundary.LpWrappedTail
   0 kind scalar:Byte wire=1B order=Default
   1 body msg:com.ditchoom.buffer.codec.test.protocols.boundary.WrappedLabel len-prefix=2B/Default
+message com.ditchoom.buffer.codec.test.protocols.boundary.MisdeclaredHost
+  0 kind scalar:Byte wire=1B order=Default
+  1 inner msg:com.ditchoom.buffer.codec.test.protocols.boundary.MisdeclaredInner len-prefix=2B/Default
+message com.ditchoom.buffer.codec.test.protocols.boundary.MisdeclaredInner
+  0 v codec:com.ditchoom.buffer.codec.test.protocols.boundary.MisdeclaredSizeCodec bounding=false variable=false
 message com.ditchoom.buffer.codec.test.protocols.boundary.WithVid
   0 pad string len-prefix=2B/Default
   1 id string len-prefix=2B/Default

--- a/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/boundary/MisdeclaredWireSizeFixtures.kt
+++ b/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/boundary/MisdeclaredWireSizeFixtures.kt
@@ -1,0 +1,85 @@
+package com.ditchoom.buffer.codec.test.protocols.boundary
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.codec.annotations.LengthPrefixed
+import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+import com.ditchoom.buffer.codec.annotations.UseCodec
+
+/*
+ * Adversarial fixtures for the declared-size verification guard: a user
+ * codec whose `wireSize` DISAGREES with what its `encode` writes. Since the
+ * @UseCodec Exact promotion, a nested message's wireSize probes user codecs
+ * and parents write `@LengthPrefixed` prefixes from the declared size — a
+ * misdeclaring codec must produce a loud `EncodeException`, never a frame
+ * whose prefix and body disagree.
+ */
+
+/** Contract violation on purpose: declares 3 bytes, encode writes 4. */
+object MisdeclaredSizeCodec : Codec<UInt> {
+    override fun decode(
+        buffer: ReadBuffer,
+        context: DecodeContext,
+    ): UInt = buffer.readUInt()
+
+    override fun encode(
+        buffer: WriteBuffer,
+        value: UInt,
+        context: EncodeContext,
+    ) {
+        buffer.writeUInt(value)
+    }
+
+    override fun wireSize(
+        value: UInt,
+        context: EncodeContext,
+    ): WireSize = WireSize.Exact(3)
+}
+
+/** Honest twin: declares 4 bytes, encode writes 4. */
+object HonestSizeCodec : Codec<UInt> {
+    override fun decode(
+        buffer: ReadBuffer,
+        context: DecodeContext,
+    ): UInt = buffer.readUInt()
+
+    override fun encode(
+        buffer: WriteBuffer,
+        value: UInt,
+        context: EncodeContext,
+    ) {
+        buffer.writeUInt(value)
+    }
+
+    override fun wireSize(
+        value: UInt,
+        context: EncodeContext,
+    ): WireSize = WireSize.Exact(4)
+}
+
+@ProtocolMessage
+data class MisdeclaredInner(
+    @UseCodec(MisdeclaredSizeCodec::class) val v: UInt,
+)
+
+/** Terminal @LengthPrefixed nested message probing the misdeclaring codec. */
+@ProtocolMessage
+data class MisdeclaredHost(
+    val kind: Byte,
+    @LengthPrefixed val inner: MisdeclaredInner,
+)
+
+@ProtocolMessage
+data class HonestInner(
+    @UseCodec(HonestSizeCodec::class) val v: UInt,
+)
+
+@ProtocolMessage
+data class HonestHost(
+    val kind: Byte,
+    @LengthPrefixed val inner: HonestInner,
+)

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/boundary/MisdeclaredWireSizeTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/boundary/MisdeclaredWireSizeTest.kt
@@ -1,0 +1,42 @@
+package com.ditchoom.buffer.codec.test.protocols.boundary
+
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.codec.encodeToPlatformBuffer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * The declared-size verification guard: when a `@LengthPrefixed` prefix is
+ * written from a codec's DECLARED `Exact` wireSize, the generated encode
+ * verifies the body actually produced that many bytes. A codec whose
+ * wireSize and encode disagree must throw `EncodeException` — the
+ * alternative is a frame whose prefix and body disagree, i.e. silent wire
+ * corruption that only surfaces on the decode side of another machine.
+ */
+class MisdeclaredWireSizeTest {
+    @Test
+    fun misdeclaringCodecFailsLoudlyInsteadOfCorruptingFraming() {
+        val ex =
+            assertFailsWith<EncodeException> {
+                MisdeclaredHostCodec.encodeToPlatformBuffer(MisdeclaredHost(kind = 1, inner = MisdeclaredInner(7u)))
+            }
+        assertTrue(
+            "disagree" in (ex.message ?: ""),
+            "expected the wireSize/encode disagreement diagnostic, got: ${ex.message}",
+        )
+    }
+
+    @Test
+    fun honestCodecComposesExactAndRoundTrips() {
+        val msg = HonestHost(kind = 1, inner = HonestInner(0xDEADBEEFu))
+        // 1 (kind) + 2 (prefix) + 4 (body).
+        assertEquals(WireSize.Exact(7), HonestHostCodec.wireSize(msg, EncodeContext.Empty))
+        val buf = HonestHostCodec.encodeToPlatformBuffer(msg)
+        assertEquals(msg, HonestHostCodec.decode(buf, DecodeContext.Empty))
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up hardening for the `@UseCodec` Exact promotion merged in #305 (caught in a post-merge adversarial review; #305 was merged while this commit was in flight).

The promotion extended trust in declared wireSizes to `@LengthPrefixed` nested-message framing: the prefix is written from the nested codec's declared `Exact` **before** the body encodes. A user codec whose `wireSize` disagrees with its `encode` (declares 3 bytes, writes 4) would produce a frame whose prefix and body disagree — **silent wire corruption** that only surfaces on the decoding peer. Before the promotion the same codec was harmless in this position (the BackPatch collapse measured reality and ignored the declaration).

The Exact encode branch now measures the body's actual byte count after encoding and throws `EncodeException` on mismatch, naming both counts:

```
wireSize declared 3 bytes but encode wrote 4 — the codec's wireSize and encode disagree
```

The BackPatch branch and the scratch/pre-measure list paths are unaffected — they derive prefixes from measured positions, so a misdeclaring codec there costs at most allocation slack, never corruption.

## Tests

Adversarial fixture (`MisdeclaredSizeCodec`, declares 3/writes 4, nested under `@LengthPrefixed`) pins the loud failure; its honest twin pins Exact composition (`Exact(7)`) and round-trip. Runs on JVM, JS Node, linuxX64, WASM — all green locally along with the full suite (800 tests), processor tests, ktlint, detekt. Codec source snapshots regenerated (the guard adds 5 lines to Exact-framing codecs).

Wire formats unchanged for all honest codecs — the guard is a no-op unless the declaration/encode contract is already violated.