### PR TITLE
fix(codec): reject unframable @LengthFrom peek arithmetic, bound decoded frame size

### DIFF
--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterPeek.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterPeek.kt
@@ -1003,6 +1003,23 @@ internal fun appendSequentialPeekLengthFrom(
         name,
         source.decodeAccessor(),
     )
+    // `__offset + <name>Bytes` below must not overflow: the sibling carries a
+    // wire-supplied number, and `appendLengthFromIntMaxGuard` bounds it against
+    // `Int.MAX_VALUE` alone — which still overflows once a non-zero `__offset`
+    // is added, yielding a negative `PeekResult.Complete`. Signed and
+    // value-class-property sources can also deliver a negative count outright,
+    // which no upstream guard rejects. Same shape and message convention as
+    // `appendSequentialPeekLengthPrefixed`'s guard.
+    val bytesVar = "${name}Bytes"
+    body.beginControlFlow("if (%L < 0 || %L > Int.MAX_VALUE - __offset)", bytesVar, bytesVar)
+    body.addStatement(
+        "throw %T(fieldPath = %S, bufferPosition = baseOffset + __offset, expected = %S, actual = %P)",
+        DECODE_EXCEPTION_CN,
+        "$ownerSimpleName.$name",
+        "__offset + @LengthFrom source in 0..\${Int.MAX_VALUE}",
+        "\${__offset.toLong() + $bytesVar.toLong()}",
+    )
+    body.endControlFlow()
     body.addStatement(
         "if (stream.available() - baseOffset < __offset + %LBytes) return %T.NeedsMoreData",
         name,

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2FrameSettingsCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2FrameSettingsCodec.kt
@@ -5,6 +5,7 @@ import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.WriteBuffer
 import com.ditchoom.buffer.codec.Codec
 import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
 import com.ditchoom.buffer.codec.EncodeContext
 import com.ditchoom.buffer.codec.PeekResult
 import com.ditchoom.buffer.codec.WireSize
@@ -65,6 +66,9 @@ public object Http2FrameSettingsCodec : Codec<Http2Frame.Settings> {
     if (stream.available() - baseOffset < __offset + 4) return PeekResult.NeedsMoreData
     __offset += 4
     val entriesBytes = header.length
+    if (entriesBytes < 0 || entriesBytes > Int.MAX_VALUE - __offset) {
+      throw DecodeException(fieldPath = "Settings.entries", bufferPosition = baseOffset + __offset, expected = "__offset + @LengthFrom source in 0..${'$'}{Int.MAX_VALUE}", actual = """${__offset.toLong() + entriesBytes.toLong()}""")
+    }
     if (stream.available() - baseOffset < __offset + entriesBytes) return PeekResult.NeedsMoreData
     __offset += entriesBytes
     return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2SettingsFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2SettingsFrameCodec.kt
@@ -83,6 +83,9 @@ public object Http2SettingsFrameCodec : Codec<Http2SettingsFrame> {
       throw DecodeException(fieldPath = "Http2SettingsFrame.entries", bufferPosition = -1, expected = "@LengthFrom source <= ${'$'}{Int.MAX_VALUE}", actual = length.toString())
     }
     val entriesBytes = length.toInt()
+    if (entriesBytes < 0 || entriesBytes > Int.MAX_VALUE - __offset) {
+      throw DecodeException(fieldPath = "Http2SettingsFrame.entries", bufferPosition = baseOffset + __offset, expected = "__offset + @LengthFrom source in 0..${'$'}{Int.MAX_VALUE}", actual = """${__offset.toLong() + entriesBytes.toLong()}""")
+    }
     if (stream.available() - baseOffset < __offset + entriesBytes) return PeekResult.NeedsMoreData
     __offset += entriesBytes
     return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/LePacketCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/LePacketCodec.kt
@@ -6,6 +6,7 @@ import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.WriteBuffer
 import com.ditchoom.buffer.codec.Codec
 import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
 import com.ditchoom.buffer.codec.EncodeContext
 import com.ditchoom.buffer.codec.PeekResult
 import com.ditchoom.buffer.codec.WireSize
@@ -44,6 +45,9 @@ public object LePacketCodec : Codec<LePacket> {
     val header = LeHeader(headerRaw)
     __offset += 2
     val payloadBytes = header.length
+    if (payloadBytes < 0 || payloadBytes > Int.MAX_VALUE - __offset) {
+      throw DecodeException(fieldPath = "LePacket.payload", bufferPosition = baseOffset + __offset, expected = "__offset + @LengthFrom source in 0..${'$'}{Int.MAX_VALUE}", actual = """${__offset.toLong() + payloadBytes.toLong()}""")
+    }
     if (stream.available() - baseOffset < __offset + payloadBytes) return PeekResult.NeedsMoreData
     __offset += payloadBytes
     return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/RemoteHeaderCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/RemoteHeaderCodec.kt
@@ -5,6 +5,7 @@ import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.WriteBuffer
 import com.ditchoom.buffer.codec.Codec
 import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
 import com.ditchoom.buffer.codec.EncodeContext
 import com.ditchoom.buffer.codec.PeekResult
 import com.ditchoom.buffer.codec.WireSize
@@ -47,6 +48,9 @@ public object RemoteHeaderCodec : Codec<RemoteHeader> {
     if (stream.available() - baseOffset < __offset + 4) return PeekResult.NeedsMoreData
     __offset += 4
     val payloadBytes = payloadLength.toInt()
+    if (payloadBytes < 0 || payloadBytes > Int.MAX_VALUE - __offset) {
+      throw DecodeException(fieldPath = "RemoteHeader.payload", bufferPosition = baseOffset + __offset, expected = "__offset + @LengthFrom source in 0..${'$'}{Int.MAX_VALUE}", actual = """${__offset.toLong() + payloadBytes.toLong()}""")
+    }
     if (stream.available() - baseOffset < __offset + payloadBytes) return PeekResult.NeedsMoreData
     __offset += payloadBytes
     return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/WideLengthFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/simple/WideLengthFrameCodec.kt
@@ -1,0 +1,66 @@
+package com.ditchoom.buffer.codec.test.protocols.simple
+
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import com.ditchoom.buffer.swapBytes
+import kotlin.Int
+
+public object WideLengthFrameCodec : Codec<WideLengthFrame> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): WideLengthFrame {
+    val lengthRaw = buffer.readInt()
+    val length = (if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) lengthRaw else swapBytes(lengthRaw)).toUInt()
+    val flags = buffer.readUByte()
+    if (length > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "WideLengthFrame.payload", bufferPosition = -1, expected = "@LengthFrom source <= ${'$'}{Int.MAX_VALUE}", actual = length.toString())
+    }
+    val payload = buffer.readString(length.toInt(), Charset.UTF8)
+    return WideLengthFrame(length = length, flags = flags, payload = payload)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: WideLengthFrame,
+    context: EncodeContext,
+  ) {
+    val lengthRaw = value.length.toInt()
+    buffer.writeInt(if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) lengthRaw else swapBytes(lengthRaw))
+    buffer.writeUByte(value.flags)
+    buffer.writeString(value.payload, Charset.UTF8)
+  }
+
+  override fun wireSize(`value`: WideLengthFrame, context: EncodeContext): WireSize = WireSize.Exact(5 + value.length.toInt())
+
+  override fun sizeHint(`value`: WideLengthFrame, context: EncodeContext): Int = 5 + value.payload.length
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 4) return PeekResult.NeedsMoreData
+    val lengthB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val lengthB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val lengthB2 = stream.peekByte(baseOffset + __offset + 2).toInt() and 0xFF
+    val lengthB3 = stream.peekByte(baseOffset + __offset + 3).toInt() and 0xFF
+    val length = ((lengthB0 shl 24) or (lengthB1 shl 16) or (lengthB2 shl 8) or lengthB3).toUInt()
+    __offset += 4
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    __offset += 1
+    if (length > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "WideLengthFrame.payload", bufferPosition = -1, expected = "@LengthFrom source <= ${'$'}{Int.MAX_VALUE}", actual = length.toString())
+    }
+    val payloadBytes = length.toInt()
+    if (payloadBytes < 0 || payloadBytes > Int.MAX_VALUE - __offset) {
+      throw DecodeException(fieldPath = "WideLengthFrame.payload", bufferPosition = baseOffset + __offset, expected = "__offset + @LengthFrom source in 0..${'$'}{Int.MAX_VALUE}", actual = """${__offset.toLong() + payloadBytes.toLong()}""")
+    }
+    if (stream.available() - baseOffset < __offset + payloadBytes) return PeekResult.NeedsMoreData
+    __offset += payloadBytes
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeCodec.kt
@@ -66,6 +66,9 @@ public object TlsHandshakeCodec : Codec<TlsHandshake> {
       throw DecodeException(fieldPath = "TlsHandshake.body", bufferPosition = -1, expected = "@LengthFrom source <= ${'$'}{Int.MAX_VALUE}", actual = length.toString())
     }
     val bodyBytes = length.toInt()
+    if (bodyBytes < 0 || bodyBytes > Int.MAX_VALUE - __offset) {
+      throw DecodeException(fieldPath = "TlsHandshake.body", bufferPosition = baseOffset + __offset, expected = "__offset + @LengthFrom source in 0..${'$'}{Int.MAX_VALUE}", actual = """${__offset.toLong() + bodyBytes.toLong()}""")
+    }
     if (stream.available() - baseOffset < __offset + bodyBytes) return PeekResult.NeedsMoreData
     __offset += bodyBytes
     return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeWithSealedBodyCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeWithSealedBodyCodec.kt
@@ -66,6 +66,9 @@ public object TlsHandshakeWithSealedBodyCodec : Codec<TlsHandshakeWithSealedBody
       throw DecodeException(fieldPath = "TlsHandshakeWithSealedBody.body", bufferPosition = -1, expected = "@LengthFrom source <= ${'$'}{Int.MAX_VALUE}", actual = length.toString())
     }
     val bodyBytes = length.toInt()
+    if (bodyBytes < 0 || bodyBytes > Int.MAX_VALUE - __offset) {
+      throw DecodeException(fieldPath = "TlsHandshakeWithSealedBody.body", bufferPosition = baseOffset + __offset, expected = "__offset + @LengthFrom source in 0..${'$'}{Int.MAX_VALUE}", actual = """${__offset.toLong() + bodyBytes.toLong()}""")
+    }
     if (stream.available() - baseOffset < __offset + bodyBytes) return PeekResult.NeedsMoreData
     __offset += bodyBytes
     return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/LengthFromValueClassIdCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/valueclassstring/LengthFromValueClassIdCodec.kt
@@ -6,6 +6,7 @@ import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.WriteBuffer
 import com.ditchoom.buffer.codec.Codec
 import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
 import com.ditchoom.buffer.codec.EncodeContext
 import com.ditchoom.buffer.codec.PeekResult
 import com.ditchoom.buffer.codec.WireSize
@@ -53,6 +54,9 @@ public object LengthFromValueClassIdCodec : Codec<LengthFromValueClassId> {
     if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
     __offset += 1
     val payloadBytes = len.toInt()
+    if (payloadBytes < 0 || payloadBytes > Int.MAX_VALUE - __offset) {
+      throw DecodeException(fieldPath = "LengthFromValueClassId.payload", bufferPosition = baseOffset + __offset, expected = "__offset + @LengthFrom source in 0..${'$'}{Int.MAX_VALUE}", actual = """${__offset.toLong() + payloadBytes.toLong()}""")
+    }
     if (stream.available() - baseOffset < __offset + payloadBytes) return PeekResult.NeedsMoreData
     __offset += payloadBytes
     return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData

--- a/buffer-codec-test/src/codecSchema/codec-schema.txt
+++ b/buffer-codec-test/src/codecSchema/codec-schema.txt
@@ -1019,6 +1019,10 @@ message com.ditchoom.buffer.codec.test.protocols.simple.SmallFlags
 message com.ditchoom.buffer.codec.test.protocols.simple.TwoStrings
   0 first string len-prefix=2B/Default
   1 second string len-prefix=2B/Default
+message com.ditchoom.buffer.codec.test.protocols.simple.WideLengthFrame
+  0 length scalar:UInt wire=4B order=Big
+  1 flags scalar:UByte wire=1B order=Big
+  2 payload string len-from=sibling:length
 message com.ditchoom.buffer.codec.test.protocols.simple.WithFlagPayload
   0 flags valueclass:com.ditchoom.buffer.codec.test.protocols.simple.SmallFlags scalar:UByte wire=1B order=Default
   1 payload? when(sibling:flags.want) string len-prefix=2B/Default

--- a/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/simple/WideLengthFrame.kt
+++ b/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/simple/WideLengthFrame.kt
@@ -1,0 +1,23 @@
+package com.ditchoom.buffer.codec.test.protocols.simple
+
+import com.ditchoom.buffer.codec.annotations.Endianness
+import com.ditchoom.buffer.codec.annotations.LengthFrom
+import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+
+/**
+ * Hostile-length probe — `@LengthFrom("siblingField")` whose carrier is a
+ * full-width `UInt` (4 wire bytes), unlike [RemoteHeader] (`UShort`, max
+ * 65535) and the TLS / HTTP/2 fixtures (`@WireBytes(3)`, max 16777215).
+ *
+ * A full-width carrier is the only shape where a wire-supplied length can
+ * reach `Int.MAX_VALUE` and overflow `peekFrameSize`'s running offset
+ * (`__offset + payloadBytes`). Non-adjacent carrier (`flags` separates it
+ * from the body) so the fixture does not trip R1's adjacent-`@LengthFrom`
+ * migration suggestion.
+ */
+@ProtocolMessage(wireOrder = Endianness.Big)
+data class WideLengthFrame(
+    val length: UInt,
+    val flags: UByte,
+    @LengthFrom("length") val payload: String,
+)

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/simple/WideLengthFramePeekTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/simple/WideLengthFramePeekTest.kt
@@ -1,0 +1,158 @@
+package com.ditchoom.buffer.codec.test.protocols.simple
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.FrameTooLargeException
+import com.ditchoom.buffer.codec.MaxFrameBytesKey
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.readFrame
+import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * `peekFrameSize` reads a wire-supplied length before any decode runs, so a
+ * hostile peer controls its arithmetic, and `readFrame` decides how many bytes
+ * a streaming loop will buffer on the strength of that number.
+ *
+ * [WideLengthFrame]'s full-width `UInt` carrier is the shape that reaches both
+ * limits: a length near `Int.MAX_VALUE` overflows the peek walk's running
+ * offset, and a merely-large one drives unbounded accumulation.
+ */
+class WideLengthFramePeekTest {
+    private fun streamOf(bytes: ByteArray): StreamProcessor {
+        val stream = StreamProcessor.create(BufferPool(), ByteOrder.BIG_ENDIAN)
+        val buf: PlatformBuffer = BufferFactory.Default.allocate(bytes.size, ByteOrder.BIG_ENDIAN)
+        for (b in bytes) buf.writeByte(b)
+        buf.resetForRead()
+        stream.append(buf)
+        return stream
+    }
+
+    /** `length` big-endian, then `flags`, then [body] as the payload bytes. */
+    private fun frameBytes(
+        length: UInt,
+        body: ByteArray = ByteArray(0),
+    ): ByteArray =
+        byteArrayOf(
+            (length shr 24).toByte(),
+            (length shr 16).toByte(),
+            (length shr 8).toByte(),
+            length.toByte(),
+            0x00,
+        ) + body
+
+    @Test
+    fun peekRejectsLengthThatOverflowsTheRunningOffset() {
+        // 0x7FFFFFFF passes the emitted `> Int.MAX_VALUE` guard on its own, but
+        // the walk has already advanced 5 bytes: `__offset + payloadBytes` wraps
+        // negative, and a negative `Complete` reaches `readBufferScoped`.
+        val stream = streamOf(frameBytes(0x7FFFFFFFu))
+        try {
+            assertFailsWith<DecodeException> { WideLengthFrameCodec.peekFrameSize(stream) }
+        } finally {
+            stream.release()
+        }
+    }
+
+    @Test
+    fun peekReportsCompleteForAWellFormedFrame() {
+        val payload = "hi".encodeToByteArray()
+        val stream = streamOf(frameBytes(payload.size.toUInt(), payload))
+        try {
+            assertEquals(PeekResult.Complete(5 + payload.size), WideLengthFrameCodec.peekFrameSize(stream))
+        } finally {
+            stream.release()
+        }
+    }
+
+    @Test
+    fun readFrameDoesNotYetBoundPreArrivalAccumulation() {
+        // Known gap, tracked in issue #308. The peek walk computes 8 MiB and then
+        // discards it — `NeedsMoreData` cannot say "known, but unsatisfied" — so
+        // `readFrame` never sees a `Complete` to check the ceiling against and
+        // returns null. A caller looping on that null keeps appending transport
+        // bytes for a frame the peer never intends to send. Closing this needs
+        // `PeekResult.Incomplete(requiredBytes)`, a v7 change.
+        val stream = streamOf(frameBytes(8u * 1024u * 1024u))
+        try {
+            assertNull(WideLengthFrameCodec.readFrame(stream))
+        } finally {
+            stream.release()
+        }
+    }
+
+    @Test
+    fun maxFrameBytesKeyOverridesTheDefaultCeiling() {
+        val payload = "hi".encodeToByteArray()
+        val frame = frameBytes(payload.size.toUInt(), payload)
+        val lowered = DecodeContext.Empty.with(MaxFrameBytesKey, 4)
+        val tooSmall = streamOf(frame)
+        try {
+            val thrown =
+                assertFailsWith<FrameTooLargeException> {
+                    WideLengthFrameCodec.readFrame(tooSmall, lowered)
+                }
+            assertEquals(4, thrown.maxBytes)
+        } finally {
+            tooSmall.release()
+        }
+        // The same frame decodes once the ceiling admits it.
+        val raised = streamOf(frame)
+        try {
+            val decoded = WideLengthFrameCodec.readFrame(raised, DecodeContext.Empty.with(MaxFrameBytesKey, 64))
+            assertEquals("hi", decoded?.payload)
+        } finally {
+            raised.release()
+        }
+    }
+
+    @Test
+    fun readFrameWaitsForAnIncompleteFrameUnderTheCeiling() {
+        // Declared size is legal; the body simply has not arrived yet. This must
+        // stay `null` ("append more bytes and retry"), not throw.
+        val stream = streamOf(frameBytes(64u))
+        try {
+            assertNull(WideLengthFrameCodec.readFrame(stream))
+        } finally {
+            stream.release()
+        }
+    }
+
+    @Test
+    fun roundTripsThroughTheStreamingLoop() {
+        val value = WideLengthFrame(length = 2u, flags = 0x07u, payload = "hi")
+        val encoded = BufferFactory.Default.allocate(16, ByteOrder.BIG_ENDIAN)
+        WideLengthFrameCodec.encode(encoded, value, EncodeContext.Empty)
+        encoded.resetForRead()
+        val stream = StreamProcessor.create(BufferPool(), ByteOrder.BIG_ENDIAN)
+        try {
+            // Byte at a time: every prefix must wait, only the last byte completes.
+            val total = encoded.remaining()
+            for (i in 0 until total) {
+                val one = BufferFactory.Default.allocate(1)
+                one.writeByte(encoded.readByte())
+                one.resetForRead()
+                stream.append(one)
+                val decoded = WideLengthFrameCodec.readFrame(stream)
+                if (i < total - 1) {
+                    assertNull(decoded, "frame completed early after ${i + 1}/$total bytes")
+                } else {
+                    assertEquals(value, decoded)
+                }
+            }
+            assertTrue(stream.available() == 0, "the completed frame was consumed")
+        } finally {
+            stream.release()
+        }
+    }
+}

--- a/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/FrameLimits.kt
+++ b/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/FrameLimits.kt
@@ -1,0 +1,64 @@
+package com.ditchoom.buffer.codec
+
+/**
+ * Default ceiling on a single frame read by [readFrame], applied when
+ * [MaxFrameBytesKey] is absent from the [DecodeContext].
+ *
+ * 4 MiB — deliberately far below the encode side's 1 GiB
+ * `MAX_ENCODE_CAPACITY`, and the asymmetry is the point: an encode
+ * capacity is driven by data the process already holds, while a frame
+ * size is a number a remote peer sent. A ceiling high enough to never
+ * inconvenience anyone is not a limit, so this one is set where real
+ * protocol frames do not reach but runaway buffering does. Consumers
+ * that legitimately stream larger frames raise it explicitly via
+ * [MaxFrameBytesKey]; the resulting [FrameTooLargeException] names both
+ * the limit and the key, so the first oversized frame says how to fix
+ * itself.
+ */
+public const val DEFAULT_MAX_FRAME_BYTES: Int = 4 * 1024 * 1024
+
+/**
+ * [DecodeContext] key overriding [DEFAULT_MAX_FRAME_BYTES] for
+ * [readFrame].
+ *
+ * Set it to the largest frame the protocol can legitimately produce.
+ *
+ * **Scope of the guarantee**: this bounds the frame [readFrame] will
+ * slice and decode — it does not bound how much a streaming loop
+ * accumulates while waiting. A codec's `peekFrameSize` reports
+ * [PeekResult.NeedsMoreData] until the whole frame has arrived, which
+ * cannot carry the size the codec already computed, so a peer that
+ * declares a large frame and never sends it is not rejected here. See
+ * issue #308: closing that gap needs `PeekResult` to express a
+ * known-but-unsatisfied size, which is a breaking change.
+ *
+ * ```kotlin
+ * val ctx = DecodeContext.Empty.with(MaxFrameBytesKey, 64 * 1024)
+ * val packet = PacketCodec.readFrame(stream, ctx)
+ * ```
+ *
+ * Decode-only: framing has no encode-side counterpart, so this is a
+ * [DecodeKey] rather than a bidirectional [CodecKey].
+ */
+public object MaxFrameBytesKey : DecodeKey<Int>
+
+/**
+ * A frame's declared size is unusable: either larger than the ceiling in
+ * effect ([MaxFrameBytesKey], defaulting to [DEFAULT_MAX_FRAME_BYTES]),
+ * or not a positive byte count at all.
+ *
+ * Thrown by [readFrame] before any buffer is sliced, so an oversized or
+ * malformed declaration costs nothing beyond the bytes already buffered.
+ * Callers branch on the type — a hostile or desynchronized peer is not
+ * the same condition as a decode failure inside a well-formed frame, and
+ * typically warrants dropping the connection rather than resyncing.
+ */
+public class FrameTooLargeException(
+    public val declaredBytes: Int,
+    public val maxBytes: Int,
+) : DecodeException(
+        fieldPath = "<frame>",
+        bufferPosition = 0,
+        expected = "frame size in 1..$maxBytes (raise via MaxFrameBytesKey)",
+        actual = declaredBytes.toString(),
+    )

--- a/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/FrameStreaming.kt
+++ b/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/FrameStreaming.kt
@@ -86,21 +86,35 @@ private fun grownCapacityOrRethrow(
  * bytes, then decodes exactly that many via [StreamProcessor.readBufferScoped] so the sliced frame
  * is released back to the pool after [Decoder.decode] returns.
  *
+ * The declared frame size is checked against [MaxFrameBytesKey] (defaulting to
+ * [DEFAULT_MAX_FRAME_BYTES]) before any bytes are sliced. This is the only bound on how much a
+ * streaming loop will accumulate: a peer that declares a frame far larger than it intends to send
+ * would otherwise have the caller buffer transport bytes indefinitely, waiting for a frame that
+ * never completes. The check rejects non-positive sizes for the same reason — a codec whose
+ * `peekFrameSize` arithmetic overflowed must not reach [StreamProcessor.readBufferScoped].
+ *
  * @throws IllegalStateException if this codec does not participate in frame detection
  *   ([PeekResult.NoFraming]) — i.e. its wire format has no determinable frame size. Such a codec
  *   cannot drive a streaming loop; frame it explicitly (e.g. a length prefix) instead.
+ * @throws FrameTooLargeException if the declared frame size exceeds the ceiling in effect or is
+ *   not a positive byte count.
  */
 public fun <T> Codec<T>.readFrame(
     stream: StreamProcessor,
     context: DecodeContext = DecodeContext.Empty,
 ): T? =
     when (val peek = peekFrameSize(stream)) {
-        is PeekResult.Complete ->
+        is PeekResult.Complete -> {
+            val maxFrameBytes = context[MaxFrameBytesKey] ?: DEFAULT_MAX_FRAME_BYTES
+            if (peek.bytes !in 1..maxFrameBytes) {
+                throw FrameTooLargeException(declaredBytes = peek.bytes, maxBytes = maxFrameBytes)
+            }
             if (stream.available() < peek.bytes) {
                 null
             } else {
                 stream.readBufferScoped(peek.bytes) { decode(this, context) }
             }
+        }
         PeekResult.NeedsMoreData -> null
         PeekResult.NoFraming ->
             throw IllegalStateException(


### PR DESCRIPTION
## The bug

`peekFrameSize` reads a wire-supplied length before any decode runs, so a remote peer controls its arithmetic. The emitted `@LengthFrom` guard bounded the source value against `Int.MAX_VALUE` — but not against `Int.MAX_VALUE - __offset`, so the addition wrapped once the walk had advanced:

```
peek     = Complete(bytes=-2147483644)          // 5 + 0x7FFFFFFF, from a 4-byte carrier
readFrame= IllegalArgumentException: newLimit < 0: (-2147483644 < 0)
```

Untyped, remote-triggerable, and indistinguishable from a programming error. Signed and value-class-property length sources could also deliver a negative count outright, which no upstream guard rejected.

Reachable today via any full-width carrier — `@LengthFrom("len") val body: String` with `len: UInt`. The existing fixtures all dodge it by width (`RemoteHeader` is `UShort`; TLS and HTTP/2 are `@WireBytes(3)`), which is why it went unnoticed.

`appendSequentialPeekLengthPrefixed` already carried the correct guard. `@LengthFrom` never got it; this mirrors it, message convention included.

## The boundary

`readFrame` now checks the declared size against `MaxFrameBytesKey` (default `DEFAULT_MAX_FRAME_BYTES` = 4 MiB) and rejects non-positive sizes, so no codec — generated or hand-written — can drive `readBufferScoped` with a size it cannot honestly justify.

4 MiB is deliberately far below the encode side's 1 GiB `MAX_ENCODE_CAPACITY`. An encode capacity is driven by data the process already holds; a frame size by a number a stranger sent. gRPC defaults inbound messages to 4 MiB on the same reasoning. `FrameTooLargeException` carries `declaredBytes` / `maxBytes` as typed fields and names the key in its message, so the first oversized frame says how to raise the limit.

## What this does not fix

It bounds frames that **arrive**, not pre-arrival accumulation. `peekFrameSize` reports `NeedsMoreData` until a frame is whole, and that result cannot carry the size the codec already computed — so a peer that declares an 8 MiB frame and sends 5 bytes still has `readFrame` return `null` forever while the caller keeps appending. `readFrameDoesNotYetBoundPreArrivalAccumulation` asserts that gap rather than hiding it, and `MaxFrameBytesKey`'s kdoc states the limit of the guarantee.

Closing it needs `PeekResult` to express a known-but-unsatisfied size — a new arm on a public sealed interface, breaking every exhaustive `when (peek)` in consumer code. Tracked in #308 for the v7 batch.

## Public API

Additive: `DEFAULT_MAX_FRAME_BYTES`, `MaxFrameBytesKey`, `FrameTooLargeException`. `buffer-codec` has no binary-compat dump, so no `.api` update.

**Behavior change:** a streaming loop that previously hung on a malformed length now throws. That is the fix, but it is user-visible — worth a release note.

## Verification

- `WideLengthFrame` fixture: full-width `UInt` carrier, non-adjacent (does not trip R1's adjacent-`@LengthFrom` suggestion) — the only shape that reaches the overflow.
- 6 tests: overflow rejected, well-formed frame still `Complete`, key overrides the ceiling both directions, incomplete-but-legal still waits, byte-at-a-time round trip through the streaming loop, and the #308 gap.
- Snapshot regen: +25 lines across 7 codecs, guard-only, no other emit change.
- `:buffer-codec-processor:test`, `:buffer-codec:jvmTest`, `:buffer-codec-test:jvmTest`, `ktlintCheck` green; changed lines ≤120 for detekt.