### PR TITLE
feat(codec): widen @LengthFrom to deferred payloads

### DIFF
--- a/buffer-codec-processor/SUPPORT_MATRIX.md
+++ b/buffer-codec-processor/SUPPORT_MATRIX.md
@@ -135,8 +135,10 @@ contract):
 | `@LengthFrom("sibling.property")` dotted value-class-property form | `LengthSource.ValueClassProperty`; HTTP/2 SETTINGS |
 | `@RemainingBytes val: String` (or value class over `String`) | `RemainingBytesString` |
 | `@RemainingBytes val: @ProtocolMessage` bare, or `List<@ProtocolMessage>` | `RemainingBytesProtocolMessageList` |
-| `@RemainingBytes @UseCodec(Codec) val: P : Payload` | `DeferredPayload`; `BinaryData` |
-| `@RemainingBytes val: P` (generic `<P : Payload>`) | `DeferredPayload` with `PayloadCodecSource.ConstructorInjected` |
+| `@RemainingBytes @UseCodec(Codec) val: P : Payload` | `DeferredPayload` + `PayloadExtent.ToLimit`; `BinaryData` |
+| `@RemainingBytes val: P` (generic `<P : Payload>`) | `DeferredPayload` + `ToLimit` with `PayloadCodecSource.ConstructorInjected` |
+| `@LengthFrom(sibling) @UseCodec(Codec) val: P : Payload` | `DeferredPayload` + `PayloadExtent.Sibling`; `deferredpayload/SmpFrame` (#293) |
+| `@LengthFrom(sibling) val: P` (generic `<P : Payload>`) | `DeferredPayload` + `Sibling` with `ConstructorInjected`; `deferredpayload/SmpGenericFrame` (#293) |
 | `@Count val: List<@ProtocolMessage>` (varint element count, non-terminal) | `CountPrefixedProtocolMessageList` |
 | `@When(sibling: Boolean) val: T?` — scalar / value-class scalar / string / `@ProtocolMessage` / `@UseCodec` inner | `Conditional` + `ConditionalInner.*` |
 | `@When("sibling.property → Boolean)` dotted form | `ConditionRef.ValueClassProperty`; MQTT `MqttFixedHeader.qosGreaterThanZero` |
@@ -161,7 +163,7 @@ Diagnostics live in `ProtocolMessageProcessor.kt` (`validate*`) and `CodecAnalyz
 | `@RemainingBytes` primitive array | "Primitive array element types … : Payload with a hand-written Codec<T>" — `validateRemainingBytesElementType` |
 | `@LengthFrom` bad bound type / sibling declared at-or-after / non-numeric sibling / dotted-property not value class / property not Int | `validateLengthFrom` (message family begins "@LengthFrom(…") |
 | `@When` on a non-nullable type / non-Boolean source / source declared at-or-after / dotted-property not value class or not Boolean / malformed grammar-2 | `validateWhen` |
-| `@UseCodec` composed with `@LengthFrom` | "@UseCodec … composed with `@LengthFrom` is not yet supported … deferred to a future release" — `validateUseCodec` |
+| `@UseCodec` composed with `@LengthFrom` on a non-`Payload`, non-`ViewCodec` bound type | "@LengthFrom @UseCodec … requires the bound field's type to extend `Payload`" — `validateUseCodec` |
 | `@UseCodec` target not a Kotlin `object` / not implementing `Codec<T>` | `validateUseCodec` |
 | `Payload` field without `@UseCodec` / `@RemainingBytes @UseCodec` on a non-`Payload` type | "Payload field requires @UseCodec" — `validateUseCodec` |
 | `@LengthPrefixed @UseCodec` codec not `BoundingLengthCodec<UInt>` / List element not `@ProtocolMessage` / element carrying `<P : Payload>` | `validateLengthPrefixedUseCodec` |

--- a/buffer-codec-processor/SUPPORT_MATRIX.md
+++ b/buffer-codec-processor/SUPPORT_MATRIX.md
@@ -135,8 +135,8 @@ contract):
 | `@LengthFrom("sibling.property")` dotted value-class-property form | `LengthSource.ValueClassProperty`; HTTP/2 SETTINGS |
 | `@RemainingBytes val: String` (or value class over `String`) | `RemainingBytesString` |
 | `@RemainingBytes val: @ProtocolMessage` bare, or `List<@ProtocolMessage>` | `RemainingBytesProtocolMessageList` |
-| `@RemainingBytes @UseCodec(Codec) val: P : Payload` | `RemainingBytesPayload`; `BinaryData` |
-| `@RemainingBytes val: P` (generic `<P : Payload>`) | `RemainingBytesPayload` with `PayloadCodecSource.ConstructorInjected` |
+| `@RemainingBytes @UseCodec(Codec) val: P : Payload` | `DeferredPayload`; `BinaryData` |
+| `@RemainingBytes val: P` (generic `<P : Payload>`) | `DeferredPayload` with `PayloadCodecSource.ConstructorInjected` |
 | `@Count val: List<@ProtocolMessage>` (varint element count, non-terminal) | `CountPrefixedProtocolMessageList` |
 | `@When(sibling: Boolean) val: T?` — scalar / value-class scalar / string / `@ProtocolMessage` / `@UseCodec` inner | `Conditional` + `ConditionalInner.*` |
 | `@When("sibling.property → Boolean)` dotted form | `ConditionRef.ValueClassProperty`; MQTT `MqttFixedHeader.qosGreaterThanZero` |

--- a/buffer-codec-processor/SUPPORT_MATRIX.md
+++ b/buffer-codec-processor/SUPPORT_MATRIX.md
@@ -105,6 +105,7 @@ applied identically to standalone codecs (`CodecShape.payloadTypeParameter`) and
 | Generic parent emitted as `class FooCodec<P : Payload>(payloadCodec)` (not `object`) for any `Genericity.Generic`, including `FixedByte` | `buildDispatchFileSpec` (`Genericity.Generic` arm) |
 | Generic variant carrying `<P : Payload>` referenced from the dispatcher as a constructor-injected `GenericInstance` codec field | `VariantCodecRef.GenericInstance`; `analyzeSealedDispatcher` / `analyzeDispatchOnSealedDispatcher` |
 | `Partial<P>` aggregator machinery for constructor-injected codec resolution | snapshot `slice10e/RemoteCommandCodec.kt` (`Partial<P>`); `buildDispatchOnAggregatorCompanion` |
+| `Partial` for a sibling-sized payload, incl. a **variable-width** trailer after it | `deferredpayload/SmpFrameWithTrailer` (#293); `partialCapturesPayloadRegion` |
 
 #### Rejected (with diagnostic)
 
@@ -137,7 +138,7 @@ contract):
 | `@RemainingBytes val: @ProtocolMessage` bare, or `List<@ProtocolMessage>` | `RemainingBytesProtocolMessageList` |
 | `@RemainingBytes @UseCodec(Codec) val: P : Payload` | `DeferredPayload` + `PayloadExtent.ToLimit`; `BinaryData` |
 | `@RemainingBytes val: P` (generic `<P : Payload>`) | `DeferredPayload` + `ToLimit` with `PayloadCodecSource.ConstructorInjected` |
-| `@LengthFrom(sibling) @UseCodec(Codec) val: P : Payload` | `DeferredPayload` + `PayloadExtent.Sibling`; `deferredpayload/SmpFrame` (#293) |
+| `@LengthFrom(sibling) @UseCodec(Codec) val: P : Payload` | `DeferredPayload` + `PayloadExtent.Sibling`; `deferredpayload/SmpFrame` (#293) — framable via `peekFrameSize`, unlike `@RemainingBytes` |
 | `@LengthFrom(sibling) val: P` (generic `<P : Payload>`) | `DeferredPayload` + `Sibling` with `ConstructorInjected`; `deferredpayload/SmpGenericFrame` (#293) |
 | `@Count val: List<@ProtocolMessage>` (varint element count, non-terminal) | `CountPrefixedProtocolMessageList` |
 | `@When(sibling: Boolean) val: T?` — scalar / value-class scalar / string / `@ProtocolMessage` / `@UseCodec` inner | `Conditional` + `ConditionalInner.*` |

--- a/buffer-codec-processor/config/detekt/baseline.xml
+++ b/buffer-codec-processor/config/detekt/baseline.xml
@@ -102,6 +102,7 @@
     <ID>ReturnCount:CodecAnalyzer.kt:internal fun analyzeConditionalProtocolMessageInner: ConditionalInner.ProtocolMessageScalar?</ID>
     <ID>ReturnCount:CodecAnalyzer.kt:internal fun analyzeConditionalUseCodecInner: ConditionalInner.UseCodecScalar?</ID>
     <ID>ReturnCount:CodecAnalyzer.kt:internal fun analyzeConditionalValueClassInner: ConditionalInner.ValueClassScalar?</ID>
+    <ID>ReturnCount:CodecAnalyzer.kt:internal fun analyzeDeferredPayloadField: FieldAnalysis</ID>
     <ID>ReturnCount:CodecAnalyzer.kt:internal fun analyzeDispatchOnSealedDispatcher: DispatchAnalysisResult</ID>
     <ID>ReturnCount:CodecAnalyzer.kt:internal fun analyzeEnumField: FieldAnalysis</ID>
     <ID>ReturnCount:CodecAnalyzer.kt:internal fun analyzeField: FieldAnalysis</ID>
@@ -112,7 +113,6 @@
     <ID>ReturnCount:CodecAnalyzer.kt:internal fun analyzeLengthPrefixedUseCodecListField: FieldAnalysis</ID>
     <ID>ReturnCount:CodecAnalyzer.kt:internal fun analyzeLengthPrefixedUseCodecPayloadField: FieldAnalysis</ID>
     <ID>ReturnCount:CodecAnalyzer.kt:internal fun analyzeLengthSource: LengthSource?</ID>
-    <ID>ReturnCount:CodecAnalyzer.kt:internal fun analyzeRemainingBytesPayloadField: FieldAnalysis</ID>
     <ID>ReturnCount:CodecAnalyzer.kt:internal fun analyzeRemainingBytesProtocolMessageListField: FieldAnalysis</ID>
     <ID>ReturnCount:CodecAnalyzer.kt:internal fun analyzeSealedDispatcher: DispatchAnalysisResult</ID>
     <ID>ReturnCount:CodecAnalyzer.kt:internal fun analyzeUseCodecScalarField: FieldAnalysis</ID>

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecAnalyzer.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecAnalyzer.kt
@@ -222,7 +222,13 @@ internal fun analyze(symbol: KSClassDeclaration): AnalysisResult {
         ) {
             return AnalysisResult.NotApplicable
         }
-        if (field is FieldSpec.DeferredPayload &&
+        // Only a to-limit payload is position-constrained. Its end is
+        // `limit - <fixed trailer bytes>`, so a variable-size trailer would
+        // leave it with no way to know where it stops. A sibling-sized payload
+        // (#293) is told its byte count outright, so anything may follow it.
+        val isToLimitPayload =
+            field is FieldSpec.DeferredPayload && field.extent is PayloadExtent.ToLimit
+        if (isToLimitPayload &&
             index != fields.lastIndex &&
             !trailingFieldsAreFixedSize(fields, index)
         ) {
@@ -254,10 +260,13 @@ internal fun analyze(symbol: KSClassDeclaration): AnalysisResult {
                 is FieldSpec.DeferredPayload ->
                     when (field.extent) {
                         // Only a to-limit payload needs a reservation — it is how
-                        // the payload learns where it ends. A sibling-sized extent
-                        // (#293 phase 3) already knows, so it keeps its own extent.
+                        // the payload learns where it ends.
                         is PayloadExtent.ToLimit ->
                             field.copy(extent = PayloadExtent.ToLimit(reserved))
+                        // A sibling states the byte count outright, so the payload
+                        // already knows where it ends and trailing fields need no
+                        // reservation carved out for them.
+                        is PayloadExtent.Sibling -> field
                     }
                 else -> field
             }
@@ -599,7 +608,13 @@ internal fun analyzeField(
             // self-contained value, or a non-`Payload` borrowed view whose
             // codec opts in via `ViewCodec` (the zero-copy escape — see
             // [implementsViewCodec]).
-            return analyzeDeferredPayloadField(param, type, useCodecAnn, ownerSimpleName)
+            return analyzeDeferredPayloadField(
+                param,
+                type,
+                useCodecAnn,
+                ownerSimpleName,
+                extent = PayloadExtent.ToLimit(),
+            )
         }
         if (useCodecAnn == null && payloadTypeParameter != null && type.matchesTypeParameter(payloadTypeParameter)) {
             return FieldAnalysis.Ok(
@@ -669,6 +684,23 @@ internal fun analyzeField(
                 Diagnostic("@LengthFrom cannot be combined with @LengthPrefixed/@WireBytes", param),
             )
         }
+        //   - a deferred payload sized by the sibling (issue #293), either
+        //     `@LengthFrom("n") @UseCodec(C) val: P` or `@LengthFrom("n")
+        //     val: P` for the enclosing class's `<P : Payload>` parameter.
+        // Routed BEFORE the `when (typeQname)` below: a type parameter has no
+        // useful `qualifiedName`, so `P` would fall through to the
+        // nested-@ProtocolMessage arm and be rejected there for not carrying
+        // `@ProtocolMessage`.
+        analyzeLengthFromDeferredPayloadField(
+            param = param,
+            type = type,
+            lengthFromAnn = lengthFromAnn,
+            useCodecAnn = useCodecAnn,
+            ownerSimpleName = ownerSimpleName,
+            payloadTypeParameter = payloadTypeParameter,
+            params = params,
+            index = index,
+        )?.let { return it }
         val typeQname = type.declaration.qualifiedName?.asString()
         return when (typeQname) {
             "kotlin.String" ->
@@ -1688,18 +1720,22 @@ internal fun analyzeEnumField(
 }
 
 /**
- * `@RemainingBytes @UseCodec(C::class) val: P`
- * where `P` extends `com.ditchoom.buffer.codec.Payload` and `C` is
- * a Kotlin `object` implementing `Codec<P>`. Returns null silently
- * for shapes the validator rejects (target not an `object`, target
- * doesn't implement `Codec<P>`); the validator surfaces the
- * user-facing diagnostic.
+ * `@UseCodec(C::class) val: P` where `P` extends
+ * `com.ditchoom.buffer.codec.Payload` and `C` is a Kotlin `object`
+ * implementing `Codec<P>`. The caller supplies the [extent] — this
+ * resolves only the codec source, so the same routine serves
+ * `@RemainingBytes` (to-limit) and `@LengthFrom` (sibling-sized).
+ *
+ * Returns null silently for shapes the validator rejects (target not an
+ * `object`, target doesn't implement `Codec<P>`); the validator surfaces
+ * the user-facing diagnostic.
  */
 internal fun analyzeDeferredPayloadField(
     param: KSValueParameter,
     type: KSType,
     useCodecAnn: KSAnnotation,
     ownerSimpleName: String,
+    extent: PayloadExtent,
 ): FieldAnalysis {
     val name =
         param.name?.asString() ?: return FieldAnalysis.Err(Diagnostic("field has no name", param))
@@ -1727,7 +1763,70 @@ internal fun analyzeDeferredPayloadField(
             ownerSimpleName = ownerSimpleName,
             payloadType = classNameOf(payloadDecl),
             source = PayloadCodecSource.UserCodecObject(ClassName(codecPkg, codecSimple)),
-            extent = PayloadExtent.ToLimit(),
+            extent = extent,
+        ),
+    )
+}
+
+/**
+ * `@LengthFrom("n") @UseCodec(C) val: P` and `@LengthFrom("n") val: P`
+ * (issue #293) — a deferred payload whose region is the `n` bytes named
+ * by a prior sibling rather than the rest of the caller-bounded buffer.
+ * Both [PayloadCodecSource] forms are accepted; the extent is what is
+ * new here, so the two axes are resolved independently and combined.
+ *
+ * Returns null when the field is not a deferred-payload shape at all,
+ * letting `analyzeField` fall through to the String / List /
+ * nested-message `@LengthFrom` arms. Returns `Err` only once the shape
+ * has been *recognised* and something about it is wrong, so a real
+ * mistake is never silently reinterpreted as some other shape.
+ */
+@Suppress("ReturnCount") // guard-clause validity checks, consistent with the analyze* family
+internal fun analyzeLengthFromDeferredPayloadField(
+    param: KSValueParameter,
+    type: KSType,
+    lengthFromAnn: KSAnnotation,
+    useCodecAnn: KSAnnotation?,
+    ownerSimpleName: String,
+    payloadTypeParameter: PayloadTypeParameter?,
+    params: List<KSValueParameter>,
+    index: Int,
+): FieldAnalysis? {
+    // Mirrors the `@RemainingBytes` routing: a `Payload` (or a borrowed
+    // view whose codec opts in via `ViewCodec`) named by `@UseCodec`, or
+    // the enclosing message's `<P : Payload>` parameter resolved through
+    // the constructor-injected codec.
+    val userCodecAnn = useCodecAnn?.takeIf { type.implementsPayload() || param.hasViewUseCodec() }
+    val injected =
+        payloadTypeParameter?.takeIf { useCodecAnn == null && type.matchesTypeParameter(it) }
+    if (userCodecAnn == null && injected == null) return null
+
+    val referenced =
+        lengthFromAnn.arguments
+            .firstOrNull { it.name?.asString() == "field" }
+            ?.value as? String
+            ?: return FieldAnalysis.Err(Diagnostic("@LengthFrom is missing its field argument", param))
+    val source =
+        analyzeLengthSource(referenced, params, index)
+            ?: return FieldAnalysis.Err(
+                Diagnostic("@LengthFrom(\"$referenced\") does not resolve to a supported length carrier", param),
+            )
+    val extent = PayloadExtent.Sibling(source)
+
+    if (userCodecAnn != null) {
+        return analyzeDeferredPayloadField(param, type, userCodecAnn, ownerSimpleName, extent)
+    }
+    // Injected form — `injected` is non-null by the guard above.
+    val binding = injected ?: return null
+    val name =
+        param.name?.asString() ?: return FieldAnalysis.Err(Diagnostic("field has no name", param))
+    return FieldAnalysis.Ok(
+        FieldSpec.DeferredPayload(
+            name = name,
+            ownerSimpleName = ownerSimpleName,
+            payloadType = TypeVariableName(binding.typeVariableName),
+            source = PayloadCodecSource.ConstructorInjected(binding.codecParameterName),
+            extent = extent,
         ),
     )
 }

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecAnalyzer.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecAnalyzer.kt
@@ -252,7 +252,13 @@ internal fun analyze(symbol: KSClassDeclaration): AnalysisResult {
                 is FieldSpec.RemainingBytesProtocolMessageList ->
                     field.copy(reservedTrailingBytes = reserved)
                 is FieldSpec.DeferredPayload ->
-                    field.copy(reservedTrailingBytes = reserved)
+                    when (field.extent) {
+                        // Only a to-limit payload needs a reservation — it is how
+                        // the payload learns where it ends. A sibling-sized extent
+                        // (#293 phase 3) already knows, so it keeps its own extent.
+                        is PayloadExtent.ToLimit ->
+                            field.copy(extent = PayloadExtent.ToLimit(reserved))
+                    }
                 else -> field
             }
     }
@@ -602,6 +608,7 @@ internal fun analyzeField(
                     ownerSimpleName = ownerSimpleName,
                     payloadType = TypeVariableName(payloadTypeParameter.typeVariableName),
                     source = PayloadCodecSource.ConstructorInjected(payloadTypeParameter.codecParameterName),
+                    extent = PayloadExtent.ToLimit(),
                 ),
             )
         }
@@ -1720,6 +1727,7 @@ internal fun analyzeDeferredPayloadField(
             ownerSimpleName = ownerSimpleName,
             payloadType = classNameOf(payloadDecl),
             source = PayloadCodecSource.UserCodecObject(ClassName(codecPkg, codecSimple)),
+            extent = PayloadExtent.ToLimit(),
         ),
     )
 }

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecAnalyzer.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecAnalyzer.kt
@@ -222,7 +222,7 @@ internal fun analyze(symbol: KSClassDeclaration): AnalysisResult {
         ) {
             return AnalysisResult.NotApplicable
         }
-        if (field is FieldSpec.RemainingBytesPayload &&
+        if (field is FieldSpec.DeferredPayload &&
             index != fields.lastIndex &&
             !trailingFieldsAreFixedSize(fields, index)
         ) {
@@ -251,7 +251,7 @@ internal fun analyze(symbol: KSClassDeclaration): AnalysisResult {
                     field.copy(reservedTrailingBytes = reserved)
                 is FieldSpec.RemainingBytesProtocolMessageList ->
                     field.copy(reservedTrailingBytes = reserved)
-                is FieldSpec.RemainingBytesPayload ->
+                is FieldSpec.DeferredPayload ->
                     field.copy(reservedTrailingBytes = reserved)
                 else -> field
             }
@@ -259,7 +259,7 @@ internal fun analyze(symbol: KSClassDeclaration): AnalysisResult {
 
     val pkg = symbol.packageName.asString()
     // If the data class declares <P: Payload> but no
-    // RemainingBytesPayload field uses it via ConstructorInjected,
+    // DeferredPayload field uses it via ConstructorInjected,
     // the type parameter is unused — return null so the emitter
     // skips. The validator in ProtocolMessageProcessor surfaces
     // the user-facing diagnostic.
@@ -270,7 +270,7 @@ internal fun analyze(symbol: KSClassDeclaration): AnalysisResult {
     // is a true silent gap → Rejected (loud in the next pass).
     if (payloadTypeParameter != null &&
         fields.none { f ->
-            f is FieldSpec.RemainingBytesPayload &&
+            f is FieldSpec.DeferredPayload &&
                 f.source is PayloadCodecSource.ConstructorInjected
         }
     ) {
@@ -576,10 +576,10 @@ internal fun analyzeField(
         // is expected and composes via the Partial
         // outer-limit machinery).
         // `@RemainingBytes @UseCodec val: P` where
-        // P : Payload routes to RemainingBytesPayload.
+        // P : Payload routes to DeferredPayload.
         // `@RemainingBytes val: P` where P is the
         // type parameter `<P : Payload>` of the enclosing data class
-        // routes to RemainingBytesPayload via ConstructorInjected.
+        // routes to DeferredPayload via ConstructorInjected.
         if (lengthFromAnn != null || lengthPrefixed != null || wireBytesAnn != null) {
             return FieldAnalysis.Err(
                 Diagnostic(
@@ -593,11 +593,11 @@ internal fun analyzeField(
             // self-contained value, or a non-`Payload` borrowed view whose
             // codec opts in via `ViewCodec` (the zero-copy escape — see
             // [implementsViewCodec]).
-            return analyzeRemainingBytesPayloadField(param, type, useCodecAnn, ownerSimpleName)
+            return analyzeDeferredPayloadField(param, type, useCodecAnn, ownerSimpleName)
         }
         if (useCodecAnn == null && payloadTypeParameter != null && type.matchesTypeParameter(payloadTypeParameter)) {
             return FieldAnalysis.Ok(
-                FieldSpec.RemainingBytesPayload(
+                FieldSpec.DeferredPayload(
                     name = name,
                     ownerSimpleName = ownerSimpleName,
                     payloadType = TypeVariableName(payloadTypeParameter.typeVariableName),
@@ -1688,7 +1688,7 @@ internal fun analyzeEnumField(
  * doesn't implement `Codec<P>`); the validator surfaces the
  * user-facing diagnostic.
  */
-internal fun analyzeRemainingBytesPayloadField(
+internal fun analyzeDeferredPayloadField(
     param: KSValueParameter,
     type: KSType,
     useCodecAnn: KSAnnotation,
@@ -1715,7 +1715,7 @@ internal fun analyzeRemainingBytesPayloadField(
     val codecPkg = codecDecl.packageName.asString()
     val codecSimple = codecDecl.simpleName.asString()
     return FieldAnalysis.Ok(
-        FieldSpec.RemainingBytesPayload(
+        FieldSpec.DeferredPayload(
             name = name,
             ownerSimpleName = ownerSimpleName,
             payloadType = classNameOf(payloadDecl),
@@ -1947,7 +1947,7 @@ internal fun analyzeLengthPrefixedListSpec(
  *  - `@When` (`Conditional` field shape, row 19),
  *  - `@RemainingBytes` (variable-bounded body),
  *  - `@UseCodec` (user codec wireSize is opaque, conservatively
- *    BackPatch — covers `UseCodecScalar`, `RemainingBytesPayload`,
+ *    BackPatch — covers `UseCodecScalar`, `DeferredPayload`,
  *    `LengthPrefixedUseCodecList`),
  *  - `@Count` (the nested list's own elements may probe to BackPatch
  *    at runtime, so the enclosing element can't be assumed Exact),
@@ -2016,7 +2016,7 @@ internal fun detectElementBackPatch(elementDecl: KSClassDeclaration): Boolean {
  * Does this type implement
  * `com.ditchoom.buffer.codec.Payload`? Used in `analyzeField` to
  * route `@RemainingBytes @UseCodec` on a Payload-typed field to
- * `RemainingBytesPayload` (the analyzer falls through to other
+ * `DeferredPayload` (the analyzer falls through to other
  * shapes when this returns false).
  */
 internal fun KSType.implementsPayload(): Boolean {
@@ -3231,9 +3231,9 @@ internal fun classifyVariantWireSize(shape: CodecShape): VariantWireSize {
     // wireSize per the buildWireSizeFun early-return rule.
     if (shape.fields.any { it is FieldSpec.RemainingBytesString }) return VariantWireSize.BackPatch
     // Same BackPatch classification — variant codec's own
-    // wireSize is BackPatch (see buildWireSizeFun's RemainingBytesPayload
+    // wireSize is BackPatch (see buildWireSizeFun's DeferredPayload
     // early-return); the dispatcher must skip the runtime-Exact cast.
-    if (shape.fields.any { it is FieldSpec.RemainingBytesPayload }) return VariantWireSize.BackPatch
+    if (shape.fields.any { it is FieldSpec.DeferredPayload }) return VariantWireSize.BackPatch
     // `@UseCodec` shapes (bare scalar, `@LengthPrefixed` payload/list) are
     // RuntimeExact: the variant codec's wireSize probes the user codec per
     // value (Exact composes, BackPatch degrades), and the dispatcher's
@@ -3324,9 +3324,9 @@ internal fun classifyVariantWireSize(shape: CodecShape): VariantWireSize {
         is FieldSpec.LengthPrefixedString, is FieldSpec.Conditional -> VariantWireSize.BackPatch
         // Handled by the upfront BackPatch short-circuit; this
         // branch is unreachable because the early return collapses any
-        // shape carrying a RemainingBytesPayload field before the
+        // shape carrying a DeferredPayload field before the
         // terminal-shape `when` runs.
-        is FieldSpec.RemainingBytesPayload -> VariantWireSize.BackPatch
+        is FieldSpec.DeferredPayload -> VariantWireSize.BackPatch
         // Both cases handled upfront — a non-VariableLengthCodec `@UseCodec` scalar by the BackPatch
         // short-circuit, a VariableLengthCodec one by the RuntimeExact early-return. This defensive
         // branch is unreachable; it keeps the `when` exhaustive (BackPatch is the conservative arm).

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
@@ -1421,6 +1421,19 @@ internal class CodecEmitter(
     private fun shouldEmitPartial(shape: CodecShape): Boolean {
         val payloadIndex = shape.fields.indexOfFirst { it is FieldSpec.DeferredPayload }
         if (payloadIndex < 0) return false
+        // A sibling-sized payload (#293) does not get Partial yet. Nothing about
+        // the shape forbids it — `complete()` would recompute the bound from the
+        // length carrier, which `partial()` has already decoded and exposed as a
+        // header `val`, needing no new Partial state. What is unresolved is how
+        // that recomputed bound composes with the *other* bounds Partial already
+        // juggles (`@FramedBy`, a bounding `@UseCodec` field, the eager trailer
+        // seek), and getting that wrong desynchronises a stream rather than
+        // failing loudly. Deliberately deferred rather than guessed; these shapes
+        // fall back to normal decode/encode, which is fully supported. Framing —
+        // the actual ask in #293 — comes from peekFrameSize and is unaffected.
+        if ((shape.fields[payloadIndex] as FieldSpec.DeferredPayload).extent is PayloadExtent.Sibling) {
+            return false
+        }
         val trailing = shape.fields.subList(payloadIndex + 1, shape.fields.size)
         // Terminal payload — the original streaming-defer shape.
         if (trailing.isEmpty()) return true
@@ -1704,13 +1717,18 @@ internal class CodecEmitter(
             // by `shouldEmitPartial`, so no framing/bounding handling here.
             appendDecodeFields(body, beforeFields)
             body.addStatement("val __payloadStart = buffer.position()")
-            // A non-terminal payload is a to-limit extent by construction: the
-            // reservation is what makes the end computable without decoding.
-            // A sibling-sized extent (#293 phase 4) derives its end from the
-            // already-decoded header instead, with no new Partial state.
+            // A non-terminal payload here is a to-limit extent: the reservation is
+            // what makes the end computable without decoding. Sibling extents are
+            // turned away by `shouldEmitPartial` (see the note there), so this is
+            // the only arm the Partial emit can reach.
             val reservedTrailingBytes =
                 when (val extent = payloadField.extent) {
                     is PayloadExtent.ToLimit -> extent.reservedTrailingBytes
+                    is PayloadExtent.Sibling ->
+                        error(
+                            "Partial decode reached a sibling-sized payload — shouldEmitPartial " +
+                                "gates these out, so the Partial class should never have been emitted.",
+                        )
                 }
             body.addStatement("val __payloadEnd = buffer.limit() - %L", reservedTrailingBytes)
             body.addStatement("buffer.position(__payloadEnd)")

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
@@ -607,7 +607,7 @@ internal class CodecEmitter(
      * `class FooCodec<P : Payload>(private val payloadCodec: Codec<P>)
      *  : Codec<Foo<P>>`
      * for shapes whose data class declares a `<P : Payload>` type
-     * parameter and a corresponding `RemainingBytesPayload` field with
+     * parameter and a corresponding `DeferredPayload` field with
      * `ConstructorInjected` source.
      */
     private fun buildGenericCodecTypeSpec(
@@ -775,7 +775,7 @@ internal class CodecEmitter(
                 appendDecodeRemainingBytesProtocolMessageList(body, field)
             is FieldSpec.CountPrefixedProtocolMessageList ->
                 appendDecodeCountPrefixedProtocolMessageList(body, field)
-            is FieldSpec.RemainingBytesPayload -> appendDecodeRemainingBytesPayload(body, field)
+            is FieldSpec.DeferredPayload -> appendDecodeDeferredPayload(body, field)
             is FieldSpec.RemainingBytesString -> appendDecodeRemainingBytesString(body, field)
             is FieldSpec.UseCodecScalar -> appendDecodeUseCodecScalar(body, field)
             is FieldSpec.LengthPrefixedUseCodecList -> appendDecodeLengthPrefixedUseCodecList(body, field)
@@ -860,7 +860,7 @@ internal class CodecEmitter(
                 appendEncodeRemainingBytesProtocolMessageList(body, field)
             is FieldSpec.CountPrefixedProtocolMessageList ->
                 appendEncodeCountPrefixedProtocolMessageList(body, field)
-            is FieldSpec.RemainingBytesPayload -> appendEncodeRemainingBytesPayload(body, field)
+            is FieldSpec.DeferredPayload -> appendEncodeDeferredPayload(body, field)
             is FieldSpec.RemainingBytesString -> appendEncodeRemainingBytesString(body, field)
             is FieldSpec.UseCodecScalar -> appendEncodeUseCodecScalar(body, field, shape)
             is FieldSpec.LengthPrefixedUseCodecList -> appendEncodeLengthPrefixedUseCodecList(body, field)
@@ -1390,7 +1390,7 @@ internal class CodecEmitter(
 
     /**
      * Gate for emitting the `Partial` decode pattern. Partial is emitted
-     * only when [FieldSpec.RemainingBytesPayload] is the *last* field of
+     * only when [FieldSpec.DeferredPayload] is the *last* field of
      * the shape. The Partial flow is the streaming-style "decode the
      * header now, defer the payload" contract — meaningful only when the
      * payload is genuinely trailing (e.g. `MqttPacket.Publish<P>`, v3/v5
@@ -1407,7 +1407,7 @@ internal class CodecEmitter(
      * and restoring on completion — no consumer-visible API change versus
      * the unbounded path.
      *
-     * Non-terminal payload (issue #168): when [FieldSpec.RemainingBytesPayload]
+     * Non-terminal payload (issue #168): when [FieldSpec.DeferredPayload]
      * is followed only by fixed-size trailers (e.g. a `checksum: UShort` after
      * `@RemainingBytes val payload: P`), Partial still applies — `partial(...)`
      * reads the header *and* the trailer eagerly (the payload's wire extent is
@@ -1419,7 +1419,7 @@ internal class CodecEmitter(
      * scope here), so those shapes fall back to normal decode/encode.
      */
     private fun shouldEmitPartial(shape: CodecShape): Boolean {
-        val payloadIndex = shape.fields.indexOfFirst { it is FieldSpec.RemainingBytesPayload }
+        val payloadIndex = shape.fields.indexOfFirst { it is FieldSpec.DeferredPayload }
         if (payloadIndex < 0) return false
         val trailing = shape.fields.subList(payloadIndex + 1, shape.fields.size)
         // Terminal payload — the original streaming-defer shape.
@@ -1466,8 +1466,8 @@ internal class CodecEmitter(
     ): TypeSpec {
         val payloadIndex = shape.payloadFieldIndex()
         val payloadField =
-            (shape.fields.getOrNull(payloadIndex) as? FieldSpec.RemainingBytesPayload)
-                ?: error("buildPartialClassTypeSpec called for shape without a RemainingBytesPayload")
+            (shape.fields.getOrNull(payloadIndex) as? FieldSpec.DeferredPayload)
+                ?: error("buildPartialClassTypeSpec called for shape without a DeferredPayload")
         // Fields before the payload (decoded eagerly in `partial`) and the
         // fixed-size trailer after it (also decoded eagerly — non-terminal
         // payload, issue #168). For the terminal shape `afterFields` is empty
@@ -1575,7 +1575,7 @@ internal class CodecEmitter(
     private fun buildPartialCompleteFun(
         shape: CodecShape,
         payloadTypeParameter: PayloadTypeParameter?,
-        payloadField: FieldSpec.RemainingBytesPayload,
+        payloadField: FieldSpec.DeferredPayload,
         hasBoundingField: Boolean,
         nonTerminal: Boolean = false,
     ): FunSpec {
@@ -1660,7 +1660,7 @@ internal class CodecEmitter(
      * surrounding generic codec class).
      *
      * The body decodes every header field (everything before the
-     * trailing `RemainingBytesPayload`), then constructs the nested
+     * trailing `DeferredPayload`), then constructs the nested
      * `Partial` capturing the buffer + context. The header decode
      * statements are the same `appendDecodeField` emit used by the
      * full `decode(...)` — Partial differs only in stopping before
@@ -1672,7 +1672,7 @@ internal class CodecEmitter(
         payloadTypeParameter: PayloadTypeParameter?,
     ): FunSpec {
         val payloadIndex = shape.payloadFieldIndex()
-        val payloadField = shape.fields[payloadIndex] as FieldSpec.RemainingBytesPayload
+        val payloadField = shape.fields[payloadIndex] as FieldSpec.DeferredPayload
         val beforeFields = shape.fields.subList(0, payloadIndex)
         val afterFields = shape.fields.subList(payloadIndex + 1, shape.fields.size)
         val nonTerminal = afterFields.isNotEmpty()
@@ -1792,7 +1792,7 @@ internal class CodecEmitter(
      * field on the `Partial` class. The `Partial` mirrors the data
      * class's header fields with their original Kotlin types, so this
      * map is a closed mirror of `FieldSpec`'s shape-to-type mapping.
-     * The trailing `RemainingBytesPayload` field is never asked for
+     * The trailing `DeferredPayload` field is never asked for
      * (it's stripped by `headerFields = shape.fields.dropLast(1)` at
      * every call site).
      */
@@ -1809,26 +1809,26 @@ internal class CodecEmitter(
                 ClassName("kotlin.collections", "List").parameterizedBy(field.elementClassName)
             is FieldSpec.CountPrefixedProtocolMessageList ->
                 // Self-delimiting, so a `@Count` list may sit as a non-terminal
-                // header field ahead of a trailing RemainingBytesPayload; map it
+                // header field ahead of a trailing DeferredPayload; map it
                 // to its `List<Element>` Kotlin type (mirror of LengthFromList).
                 ClassName("kotlin.collections", "List").parameterizedBy(field.elementClassName)
             is FieldSpec.RemainingBytesProtocolMessageList ->
                 error(
                     "partialFieldTypeName called on a RemainingBytesProtocolMessageList field — " +
                         "this shape is terminal-only and the Partial decode pattern only fires " +
-                        "for shapes with a trailing RemainingBytesPayload. The two shapes are " +
+                        "for shapes with a trailing DeferredPayload. The two shapes are " +
                         "mutually exclusive at the terminal slot, so this branch is unreachable.",
                 )
-            is FieldSpec.RemainingBytesPayload ->
+            is FieldSpec.DeferredPayload ->
                 error(
-                    "partialFieldTypeName called on a RemainingBytesPayload field — caller " +
+                    "partialFieldTypeName called on a DeferredPayload field — caller " +
                         "should strip the payload field before mapping header types.",
                 )
             is FieldSpec.RemainingBytesString ->
                 error(
                     "partialFieldTypeName called on a RemainingBytesString field — this shape " +
                         "is terminal-only and the Partial decode pattern only fires for shapes " +
-                        "with a trailing RemainingBytesPayload. The two are mutually exclusive " +
+                        "with a trailing DeferredPayload. The two are mutually exclusive " +
                         "at the terminal slot, so this branch is unreachable.",
                 )
             is FieldSpec.UseCodecScalar -> field.fieldType
@@ -1842,8 +1842,8 @@ internal class CodecEmitter(
         }
 }
 
-/** Index of the (single) `RemainingBytesPayload` field, or -1. */
-private fun CodecShape.payloadFieldIndex(): Int = fields.indexOfFirst { it is FieldSpec.RemainingBytesPayload }
+/** Index of the (single) `DeferredPayload` field, or -1. */
+private fun CodecShape.payloadFieldIndex(): Int = fields.indexOfFirst { it is FieldSpec.DeferredPayload }
 
 /**
  * Emits the framed-body truncation guard between the framing codec's `decode`

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
@@ -1421,18 +1421,20 @@ internal class CodecEmitter(
     private fun shouldEmitPartial(shape: CodecShape): Boolean {
         val payloadIndex = shape.fields.indexOfFirst { it is FieldSpec.DeferredPayload }
         if (payloadIndex < 0) return false
-        // A sibling-sized payload (#293) does not get Partial yet. Nothing about
-        // the shape forbids it — `complete()` would recompute the bound from the
-        // length carrier, which `partial()` has already decoded and exposed as a
-        // header `val`, needing no new Partial state. What is unresolved is how
-        // that recomputed bound composes with the *other* bounds Partial already
-        // juggles (`@FramedBy`, a bounding `@UseCodec` field, the eager trailer
-        // seek), and getting that wrong desynchronises a stream rather than
-        // failing loudly. Deliberately deferred rather than guessed; these shapes
-        // fall back to normal decode/encode, which is fully supported. Framing —
-        // the actual ask in #293 — comes from peekFrameSize and is unaffected.
-        if ((shape.fields[payloadIndex] as FieldSpec.DeferredPayload).extent is PayloadExtent.Sibling) {
-            return false
+        val payloadField = shape.fields[payloadIndex] as FieldSpec.DeferredPayload
+        // A sibling-sized payload (#293) states its own extent, so the
+        // fixed-size-trailer rule below does not apply to it: that rule exists
+        // because a to-limit payload's end is `limit - <trailer bytes>` and a
+        // variable-width trailer makes it uncomputable. `start + <sibling>`
+        // needs nothing from the trailer, so anything may follow.
+        //
+        // The external-bound carve-out below IS kept, for the reason it already
+        // exists rather than a new one: `complete()` would have to restore a
+        // bound it did not set, and the terminal `@FramedBy` partial walk
+        // reorders fields around that bound. Composing region capture with it is
+        // untested, so those shapes keep falling back to normal decode/encode.
+        if (payloadField.extent is PayloadExtent.Sibling) {
+            return shape.framedBy == null && shape.fields.none { it.isBoundingShape() }
         }
         val trailing = shape.fields.subList(payloadIndex + 1, shape.fields.size)
         // Terminal payload — the original streaming-defer shape.
@@ -1487,7 +1489,7 @@ internal class CodecEmitter(
         // and the behavior is unchanged.
         val beforeFields = shape.fields.subList(0, payloadIndex)
         val afterFields = shape.fields.subList(payloadIndex + 1, shape.fields.size)
-        val nonTerminal = afterFields.isNotEmpty()
+        val capturesRegion = shape.partialCapturesPayloadRegion()
         val exposedFields = beforeFields + afterFields
         // When the headers contain a bounding `@UseCodec` field (codec
         // implements `BoundingLengthCodec`), the partial decode mid-walk
@@ -1520,10 +1522,9 @@ internal class CodecEmitter(
         if (hasBoundingField) {
             ctorBuilder.addParameter("outerLimit", INT)
         }
-        // Non-terminal payload: capture the payload's wire region so
-        // `complete()` can re-seek to it (the trailer was already consumed
-        // in `partial`, so the buffer position no longer sits at the payload).
-        if (nonTerminal) {
+        // Capture the payload's wire region so `complete()` can re-seek and
+        // bound to it. See `partialCapturesPayloadRegion`.
+        if (capturesRegion) {
             ctorBuilder.addParameter("payloadStart", INT)
             ctorBuilder.addParameter("payloadEnd", INT)
         }
@@ -1542,7 +1543,7 @@ internal class CodecEmitter(
                     .build(),
             )
         }
-        if (nonTerminal) {
+        if (capturesRegion) {
             classBuilder.addProperty(
                 com.squareup.kotlinpoet.PropertySpec
                     .builder("payloadStart", INT, KModifier.PRIVATE)
@@ -1570,7 +1571,7 @@ internal class CodecEmitter(
         )
 
         classBuilder.addFunction(
-            buildPartialCompleteFun(shape, payloadTypeParameter, payloadField, hasBoundingField, nonTerminal),
+            buildPartialCompleteFun(shape, payloadTypeParameter, payloadField, hasBoundingField, capturesRegion),
         )
         return classBuilder.build()
     }
@@ -1590,7 +1591,7 @@ internal class CodecEmitter(
         payloadTypeParameter: PayloadTypeParameter?,
         payloadField: FieldSpec.DeferredPayload,
         hasBoundingField: Boolean,
-        nonTerminal: Boolean = false,
+        capturesRegion: Boolean = false,
     ): FunSpec {
         val funBuilder = FunSpec.builder("complete")
         val returnType =
@@ -1631,20 +1632,8 @@ internal class CodecEmitter(
             }
         val ctorArgs = shape.fields.joinToString(", ") { "${it.name} = ${it.name}" }
         val body = CodeBlock.builder()
-        if (nonTerminal) {
-            // The trailer was consumed eagerly in `partial`, so the buffer
-            // position no longer sits at the payload. Re-seek to the captured
-            // payload region, narrow the limit to it, decode, then restore the
-            // limit. `payloadStart`/`payloadEnd` were captured at partial time.
-            body.addStatement("buffer.position(payloadStart)")
-            body.addStatement("val __payloadSavedLimit = buffer.limit()")
-            body.addStatement("buffer.setLimit(payloadEnd)")
-            body.beginControlFlow("return try")
-            body.add(payloadDecodeStmt)
-            body.addStatement("%T(%L)", returnType, ctorArgs)
-            body.nextControlFlow("finally")
-            body.addStatement("buffer.setLimit(__payloadSavedLimit)")
-            body.endControlFlow()
+        if (capturesRegion) {
+            appendCompleteFromCapturedRegion(body, payloadField, payloadDecodeStmt, returnType, ctorArgs)
         } else if (hasBoundingField) {
             // Payload decode runs inside the bounding-field-narrowed
             // limit (correct for payload bounding); the outer limit is
@@ -1662,6 +1651,47 @@ internal class CodecEmitter(
         }
         funBuilder.addCode(body.build())
         return funBuilder.build()
+    }
+
+    /**
+     * `complete()` body for a Partial that captured the payload's wire region.
+     *
+     * Reached when `partial()` moved the position past the payload (eager
+     * trailer, issue #168) or when the payload's bound is not recoverable from
+     * the buffer at all (sibling extent, issue #293). Either way: re-seek to
+     * the captured region, narrow the limit to it, decode, restore the limit.
+     */
+    private fun appendCompleteFromCapturedRegion(
+        body: CodeBlock.Builder,
+        payloadField: FieldSpec.DeferredPayload,
+        payloadDecodeStmt: CodeBlock,
+        returnType: TypeName,
+        ctorArgs: String,
+    ) {
+        body.addStatement("buffer.position(payloadStart)")
+        body.addStatement("val __payloadSavedLimit = buffer.limit()")
+        body.addStatement("buffer.setLimit(payloadEnd)")
+        body.beginControlFlow("return try")
+        body.add(payloadDecodeStmt)
+        // Same strict-consumption contract the sibling-extent decode path
+        // enforces (issue #293) — a deferred codec that stops short of a region
+        // the wire declared is a bug, and reporting it here keeps `complete()`
+        // and `decode()` telling the consumer the same thing. Not extended to
+        // to-limit payloads: their region *is* whatever the codec chooses to
+        // read, so there is no shortfall to detect, and asserting one would
+        // break shapes that work today.
+        if (payloadField.extent is PayloadExtent.Sibling) {
+            appendPayloadConsumptionCheck(
+                body,
+                payloadField,
+                endExpr = "payloadEnd",
+                bytesExpr = "(payloadEnd - payloadStart)",
+            )
+        }
+        body.addStatement("%T(%L)", returnType, ctorArgs)
+        body.nextControlFlow("finally")
+        body.addStatement("buffer.setLimit(__payloadSavedLimit)")
+        body.endControlFlow()
     }
 
     /**
@@ -1688,7 +1718,7 @@ internal class CodecEmitter(
         val payloadField = shape.fields[payloadIndex] as FieldSpec.DeferredPayload
         val beforeFields = shape.fields.subList(0, payloadIndex)
         val afterFields = shape.fields.subList(payloadIndex + 1, shape.fields.size)
-        val nonTerminal = afterFields.isNotEmpty()
+        val capturesRegion = shape.partialCapturesPayloadRegion()
         val partialClassName = ClassName(shape.packageName, shape.codecSimpleName, "Partial")
         val funBuilder = FunSpec.builder("partial")
         val returnType =
@@ -1708,29 +1738,35 @@ internal class CodecEmitter(
             .returns(returnType)
 
         val body = CodeBlock.builder()
-        if (nonTerminal) {
-            // Non-terminal payload (issue #168): read the leading fields, then
-            // skip the payload region (its end is `limit - reservedTrailingBytes`,
-            // computable without decoding) and read the fixed-size trailer
-            // eagerly. `complete()` re-seeks to [payloadStart, payloadEnd) to
-            // decode the deferred payload. Gated to the unframed/unbounded case
-            // by `shouldEmitPartial`, so no framing/bounding handling here.
+        if (capturesRegion) {
+            // Read the leading fields, compute the payload's region without
+            // decoding it, skip over it, then read whatever follows eagerly.
+            // `complete()` re-seeks to [payloadStart, payloadEnd). Gated to the
+            // unframed/unbounded case by `shouldEmitPartial`, so no
+            // framing/bounding handling here.
             appendDecodeFields(body, beforeFields)
             body.addStatement("val __payloadStart = buffer.position()")
-            // A non-terminal payload here is a to-limit extent: the reservation is
-            // what makes the end computable without decoding. Sibling extents are
-            // turned away by `shouldEmitPartial` (see the note there), so this is
-            // the only arm the Partial emit can reach.
-            val reservedTrailingBytes =
-                when (val extent = payloadField.extent) {
-                    is PayloadExtent.ToLimit -> extent.reservedTrailingBytes
-                    is PayloadExtent.Sibling ->
-                        error(
-                            "Partial decode reached a sibling-sized payload — shouldEmitPartial " +
-                                "gates these out, so the Partial class should never have been emitted.",
+            when (val extent = payloadField.extent) {
+                // Issue #168: end is `limit - <fixed trailer bytes>`.
+                is PayloadExtent.ToLimit ->
+                    body.addStatement("val __payloadEnd = buffer.limit() - %L", extent.reservedTrailingBytes)
+                // Issue #293: end is `start + <sibling>`, independent of the
+                // limit. The carrier is a prior field, so it is already decoded
+                // into a local by `appendDecodeFields(body, beforeFields)` above
+                // — no new Partial state is needed to recover the bound.
+                is PayloadExtent.Sibling -> {
+                    if (extent.source is LengthSource.Sibling) {
+                        appendLengthFromIntMaxGuard(
+                            body = body,
+                            siblingAccessor = extent.source.siblingName,
+                            siblingKind = extent.source.siblingKind,
+                            ownerSimpleName = payloadField.ownerSimpleName,
+                            fieldName = payloadField.name,
                         )
+                    }
+                    body.addStatement("val __payloadEnd = __payloadStart + %L", extent.source.decodeAccessor())
                 }
-            body.addStatement("val __payloadEnd = buffer.limit() - %L", reservedTrailingBytes)
+            }
             body.addStatement("buffer.position(__payloadEnd)")
             appendDecodeFields(body, afterFields)
             val ctorArgs =
@@ -1870,6 +1906,29 @@ internal class CodecEmitter(
 
 /** Index of the (single) `DeferredPayload` field, or -1. */
 private fun CodecShape.payloadFieldIndex(): Int = fields.indexOfFirst { it is FieldSpec.DeferredPayload }
+
+/**
+ * Does the `Partial` capture the payload's wire region as
+ * `payloadStart` / `payloadEnd`, instead of leaving the buffer parked at
+ * the payload for `complete()` to read to the limit?
+ *
+ * Two independent reasons to capture, and the emit is the same either way:
+ *  - fields follow the payload, so `partial()` consumed them eagerly and the
+ *    position has moved past it (issue #168);
+ *  - the payload is sibling-sized (issue #293), so its end is
+ *    `start + <sibling>` rather than the buffer's limit. `complete()` cannot
+ *    recover that bound from the buffer alone, so it must be captured even
+ *    when the payload is terminal and nothing moved the position.
+ *
+ * Shared by the Partial class, its `partial()` builder, and `complete()` —
+ * all three must agree or the generated constructor call won't line up.
+ */
+private fun CodecShape.partialCapturesPayloadRegion(): Boolean {
+    val index = payloadFieldIndex()
+    if (index < 0) return false
+    val payloadField = fields[index] as FieldSpec.DeferredPayload
+    return index != fields.lastIndex || payloadField.extent is PayloadExtent.Sibling
+}
 
 /**
  * Emits the framed-body truncation guard between the framing codec's `decode`

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
@@ -1704,7 +1704,15 @@ internal class CodecEmitter(
             // by `shouldEmitPartial`, so no framing/bounding handling here.
             appendDecodeFields(body, beforeFields)
             body.addStatement("val __payloadStart = buffer.position()")
-            body.addStatement("val __payloadEnd = buffer.limit() - %L", payloadField.reservedTrailingBytes)
+            // A non-terminal payload is a to-limit extent by construction: the
+            // reservation is what makes the end computable without decoding.
+            // A sibling-sized extent (#293 phase 4) derives its end from the
+            // already-decoded header instead, with no new Partial state.
+            val reservedTrailingBytes =
+                when (val extent = payloadField.extent) {
+                    is PayloadExtent.ToLimit -> extent.reservedTrailingBytes
+                }
+            body.addStatement("val __payloadEnd = buffer.limit() - %L", reservedTrailingBytes)
             body.addStatement("buffer.position(__payloadEnd)")
             appendDecodeFields(body, afterFields)
             val ctorArgs =

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterFields.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterFields.kt
@@ -1660,15 +1660,34 @@ private fun appendDecodeDeferredPayloadSibling(
     body.nextControlFlow("finally")
     body.addStatement("buffer.setLimit(%L)", outerLimitVar)
     body.endControlFlow()
-    body.beginControlFlow("if (buffer.position() != %L)", endVar)
+    appendPayloadConsumptionCheck(body, field, endExpr = endVar, bytesExpr = bytesVar)
+}
+
+/**
+ * Emit the strict-consumption guard for a sibling-sized deferred payload: the
+ * wire declared the region, so a codec that stops short of it has left every
+ * following field reading from the wrong offset.
+ *
+ * Shared by the two places that know the region — the inline decode path and
+ * `Partial.complete()` — so both report the same failure the same way. Only
+ * reachable for [PayloadExtent.Sibling]; a to-limit payload's region *is*
+ * whatever its codec reads, so there is no shortfall to detect.
+ */
+internal fun appendPayloadConsumptionCheck(
+    body: CodeBlock.Builder,
+    field: FieldSpec.DeferredPayload,
+    endExpr: String,
+    bytesExpr: String,
+) {
+    body.beginControlFlow("if (buffer.position() != %L)", endExpr)
     body.addStatement(
         "throw %T(\n  fieldPath = %S,\n  bufferPosition = buffer.position(),\n" +
             "  expected = \"the payload codec to consume all \" + %L + \" bytes\",\n" +
             "  actual = (%L - buffer.position()).toString() + \" bytes left unread\",\n)",
         DECODE_EXCEPTION_CN,
         "${field.ownerSimpleName}.${field.name}",
-        bytesVar,
-        endVar,
+        bytesExpr,
+        endExpr,
     )
     body.endControlFlow()
 }

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterFields.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterFields.kt
@@ -1561,6 +1561,7 @@ internal fun appendDecodeDeferredPayload(
 ) {
     when (val extent = field.extent) {
         is PayloadExtent.ToLimit -> appendDecodeDeferredPayloadToLimit(body, field, extent)
+        is PayloadExtent.Sibling -> appendDecodeDeferredPayloadSibling(body, field, extent)
     }
 }
 
@@ -1604,12 +1605,87 @@ private fun appendDecodeDeferredPayloadToLimit(
 }
 
 /**
+ * (issue #293) — emit decode for `@LengthFrom("n") val: P`, the
+ * sibling-sized deferred payload. Union of
+ * [appendDecodeLengthFromMessage]'s bound (sibling → `setLimit`, outer
+ * limit restored in a `finally`) and [appendDecodeDeferredPayloadToLimit]'s
+ * delegation to a codec the generated code does not own.
+ *
+ * Adds one thing neither parent has: a strict-consumption check. The
+ * bound tells us exactly where the payload ends, so a codec that stops
+ * short has desynchronised the stream for every field after it. The
+ * `@LengthFrom @ProtocolMessage` path can trust-and-restore instead
+ * because its codec is generated from the same schema; a runtime-supplied
+ * `Codec<P>` is arbitrary user code and gets no such benefit of the
+ * doubt. Over-reading is already impossible — the narrowed limit stops it.
+ *
+ * Generated shape:
+ * ```
+ * <Int.MAX_VALUE guard for the sibling kind, if needed>
+ * val <name>Bytes = <sibling>.toInt()
+ * val <name>OuterLimit = buffer.limit()
+ * val <name>End = buffer.position() + <name>Bytes
+ * buffer.setLimit(<name>End)
+ * val <name> = try {
+ *     <codec>.decode(buffer, context)
+ * } finally {
+ *     buffer.setLimit(<name>OuterLimit)
+ * }
+ * if (buffer.position() != <name>End) throw DecodeException(...)
+ * ```
+ */
+private fun appendDecodeDeferredPayloadSibling(
+    body: CodeBlock.Builder,
+    field: FieldSpec.DeferredPayload,
+    extent: PayloadExtent.Sibling,
+) {
+    if (extent.source is LengthSource.Sibling) {
+        appendLengthFromIntMaxGuard(
+            body = body,
+            siblingAccessor = extent.source.siblingName,
+            siblingKind = extent.source.siblingKind,
+            ownerSimpleName = field.ownerSimpleName,
+            fieldName = field.name,
+        )
+    }
+    val bytesVar = "${field.name}Bytes"
+    val outerLimitVar = "${field.name}OuterLimit"
+    val endVar = "${field.name}End"
+    body.addStatement("val %L = %L", bytesVar, extent.source.decodeAccessor())
+    body.addStatement("val %L = buffer.limit()", outerLimitVar)
+    body.addStatement("val %L = buffer.position() + %L", endVar, bytesVar)
+    body.addStatement("buffer.setLimit(%L)", endVar)
+    body.beginControlFlow("val %L = try", field.name)
+    body.addStatement("%L.decode(buffer, context)", field.source.codecReceiver())
+    body.nextControlFlow("finally")
+    body.addStatement("buffer.setLimit(%L)", outerLimitVar)
+    body.endControlFlow()
+    body.beginControlFlow("if (buffer.position() != %L)", endVar)
+    body.addStatement(
+        "throw %T(\n  fieldPath = %S,\n  bufferPosition = buffer.position(),\n" +
+            "  expected = \"the payload codec to consume all \" + %L + \" bytes\",\n" +
+            "  actual = (%L - buffer.position()).toString() + \" bytes left unread\",\n)",
+        DECODE_EXCEPTION_CN,
+        "${field.ownerSimpleName}.${field.name}",
+        bytesVar,
+        endVar,
+    )
+    body.endControlFlow()
+}
+
+/**
  * Emit encode for
  * `@RemainingBytes @UseCodec(C::class) val: P`. Delegates to the
  * user-supplied `C.encode(buffer, value.<name>, context)`. No length
  * carrier on the wire — the user codec writes its bytes against the
  * buffer's current position and the trust contract (row 16) leaves
  * total-byte-count consistency to the outer dispatcher.
+ *
+ * Shared by both extents. Under [PayloadExtent.Sibling] the length
+ * carrier is an ordinary prior field encoded by its own emit step, so
+ * the same row-16 trust contract as `@LengthFrom @ProtocolMessage`
+ * applies: keeping `value.<sibling>` consistent with the bytes the
+ * payload codec writes is the caller's job.
  */
 internal fun appendEncodeDeferredPayload(
     body: CodeBlock.Builder,

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterFields.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterFields.kt
@@ -1556,9 +1556,9 @@ internal fun appendEncodeLengthFromMessage(
  * as the other `@RemainingBytes` shapes. The outer dispatcher (slice
  * 10d for MQTT) sets the limit before calling this codec.
  */
-internal fun appendDecodeRemainingBytesPayload(
+internal fun appendDecodeDeferredPayload(
     body: CodeBlock.Builder,
-    field: FieldSpec.RemainingBytesPayload,
+    field: FieldSpec.DeferredPayload,
 ) {
     if (field.reservedTrailingBytes == 0) {
         body.addStatement(
@@ -1568,7 +1568,7 @@ internal fun appendDecodeRemainingBytesPayload(
         )
         return
     }
-    // Non-terminal RemainingBytesPayload. Narrow the
+    // Non-terminal DeferredPayload. Narrow the
     // buffer's limit to leave the trailing FixedSize fields in the
     // outer-limit region; restore the outer limit in a try/finally
     // so the trailing field emits run against the original limit.
@@ -1594,9 +1594,9 @@ internal fun appendDecodeRemainingBytesPayload(
  * buffer's current position and the trust contract (row 16) leaves
  * total-byte-count consistency to the outer dispatcher.
  */
-internal fun appendEncodeRemainingBytesPayload(
+internal fun appendEncodeDeferredPayload(
     body: CodeBlock.Builder,
-    field: FieldSpec.RemainingBytesPayload,
+    field: FieldSpec.DeferredPayload,
 ) {
     body.addStatement(
         "%L.encode(buffer, value.%L, context)",
@@ -1610,7 +1610,7 @@ internal fun appendEncodeRemainingBytesPayload(
  * position to `buffer.limit()`. The caller (or an outer dispatcher) is
  * responsible for narrowing `buffer.limit()` to the bounded extent before
  * invoking decode; same caller-bounds-buffer contract as
- * [appendDecodeRemainingBytesPayload].
+ * [appendDecodeDeferredPayload].
  */
 internal fun appendDecodeRemainingBytesString(
     body: CodeBlock.Builder,

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterFields.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterFields.kt
@@ -1549,6 +1549,22 @@ internal fun appendEncodeLengthFromMessage(
 }
 
 /**
+ * Emit decode for a payload whose codec is not owned by the generated
+ * codec, dispatching on how its region is bounded. Each
+ * [PayloadExtent] arm owns a whole emit strategy — the bound is the
+ * only thing the generated code contributes, so it is the thing that
+ * differs.
+ */
+internal fun appendDecodeDeferredPayload(
+    body: CodeBlock.Builder,
+    field: FieldSpec.DeferredPayload,
+) {
+    when (val extent = field.extent) {
+        is PayloadExtent.ToLimit -> appendDecodeDeferredPayloadToLimit(body, field, extent)
+    }
+}
+
+/**
  * Emit decode for
  * `@RemainingBytes @UseCodec(C::class) val: P`. Delegates to the
  * user-supplied `C.decode(buffer, context)` against whatever
@@ -1556,11 +1572,12 @@ internal fun appendEncodeLengthFromMessage(
  * as the other `@RemainingBytes` shapes. The outer dispatcher (slice
  * 10d for MQTT) sets the limit before calling this codec.
  */
-internal fun appendDecodeDeferredPayload(
+private fun appendDecodeDeferredPayloadToLimit(
     body: CodeBlock.Builder,
     field: FieldSpec.DeferredPayload,
+    extent: PayloadExtent.ToLimit,
 ) {
-    if (field.reservedTrailingBytes == 0) {
+    if (extent.reservedTrailingBytes == 0) {
         body.addStatement(
             "val %L = %L.decode(buffer, context)",
             field.name,
@@ -1577,7 +1594,7 @@ internal fun appendDecodeDeferredPayload(
     body.addStatement(
         "buffer.setLimit(%L - %L)",
         outerLimitVar,
-        field.reservedTrailingBytes,
+        extent.reservedTrailingBytes,
     )
     body.beginControlFlow("val %L = try", field.name)
     body.addStatement("%L.decode(buffer, context)", field.source.codecReceiver())

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterPeek.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterPeek.kt
@@ -239,12 +239,17 @@ internal fun buildPeekFrameFun(shape: CodecShape): FunSpec {
         builder.addStatement("return %T.NoFraming", PEEK_RESULT_CN)
         return builder.build()
     }
-    // Same NoFraming collapse for `@RemainingBytes
-    // @UseCodec val: P`. Body byte count is whatever the user codec
-    // reads against the caller-set limit; 's outer
-    // dispatcher will own peek by reading the fixed header's
-    // remaining-length first.
-    if (shape.fields.any { it is FieldSpec.DeferredPayload }) {
+    // Same NoFraming collapse for `@RemainingBytes @UseCodec val: P`. Body
+    // byte count is whatever the user codec reads against the caller-set
+    // limit; the outer dispatcher will own peek by reading the fixed
+    // header's remaining-length first.
+    //
+    // Extent-aware since #293: this collapse is a property of the *bound*,
+    // not of the payload being codec-deferred. A `@LengthFrom` payload
+    // states its byte count in a sibling the walk can read, so it frames
+    // exactly like `LengthFromString` / `LengthFromMessage` and is handled
+    // in the sequential walk below.
+    if (shape.fields.any { it is FieldSpec.DeferredPayload && it.extent is PayloadExtent.ToLimit }) {
         builder.addStatement("return %T.NoFraming", PEEK_RESULT_CN)
         return builder.build()
     }
@@ -839,10 +844,24 @@ internal fun appendSequentialPeek(
                         "upfront NoFraming short-circuit before reaching the sequential walk.",
                 )
             is FieldSpec.DeferredPayload ->
-                error(
-                    "DeferredPayload should be handled by buildPeekFrameFun's " +
-                        "upfront NoFraming short-circuit before reaching the sequential walk.",
-                )
+                when (val extent = field.extent) {
+                    is PayloadExtent.ToLimit ->
+                        error(
+                            "A to-limit DeferredPayload should be handled by buildPeekFrameFun's " +
+                                "upfront NoFraming short-circuit before reaching the sequential walk.",
+                        )
+                    // (issue #293) Peek shape identical to LengthFromString /
+                    // LengthFromMessage: the sibling states the body byte count,
+                    // and peek never runs the deferred codec — so what the codec
+                    // would do with those bytes is irrelevant to framing.
+                    is PayloadExtent.Sibling ->
+                        appendSequentialPeekLengthFrom(
+                            body = body,
+                            name = field.name,
+                            ownerSimpleName = field.ownerSimpleName,
+                            source = extent.source,
+                        )
+                }
             is FieldSpec.RemainingBytesString ->
                 error(
                     "RemainingBytesString should be handled by buildPeekFrameFun's " +
@@ -918,6 +937,14 @@ internal fun collectPeekStashSources(shape: CodecShape): Set<String> {
             is FieldSpec.LengthFromString -> sources += field.source.siblingName
             is FieldSpec.LengthFromList -> sources += field.source.siblingName
             is FieldSpec.LengthFromMessage -> sources += field.source.siblingName
+            // (issue #293) A sibling-sized payload reads its length carrier in
+            // peek exactly like the other @LengthFrom shapes, so the carrier has
+            // to be stashed. A to-limit payload reads no sibling at all.
+            is FieldSpec.DeferredPayload ->
+                when (val extent = field.extent) {
+                    is PayloadExtent.Sibling -> sources += extent.source.siblingName
+                    is PayloadExtent.ToLimit -> {}
+                }
             else -> { /* not a source */ }
         }
     }

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterPeek.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterPeek.kt
@@ -104,7 +104,7 @@ internal fun buildPeekFrameFun(shape: CodecShape): FunSpec {
     // view to discover the value, then computes total = priorBytes +
     // codec-width + value.toInt() — the user codec does the var-int
     // read against the peek view. Placed BEFORE the
-    // `RemainingBytesProtocolMessageList` / `RemainingBytesPayload`
+    // `RemainingBytesProtocolMessageList` / `DeferredPayload`
     // NoFraming collapses below: a bounding codec gives peek the
     // value-driven byte count that bounds any trailing
     // `@RemainingBytes` body.
@@ -244,7 +244,7 @@ internal fun buildPeekFrameFun(shape: CodecShape): FunSpec {
     // reads against the caller-set limit; 's outer
     // dispatcher will own peek by reading the fixed header's
     // remaining-length first.
-    if (shape.fields.any { it is FieldSpec.RemainingBytesPayload }) {
+    if (shape.fields.any { it is FieldSpec.DeferredPayload }) {
         builder.addStatement("return %T.NoFraming", PEEK_RESULT_CN)
         return builder.build()
     }
@@ -838,9 +838,9 @@ internal fun appendSequentialPeek(
                     "CountPrefixedProtocolMessageList should be handled by buildPeekFrameFun's " +
                         "upfront NoFraming short-circuit before reaching the sequential walk.",
                 )
-            is FieldSpec.RemainingBytesPayload ->
+            is FieldSpec.DeferredPayload ->
                 error(
-                    "RemainingBytesPayload should be handled by buildPeekFrameFun's " +
+                    "DeferredPayload should be handled by buildPeekFrameFun's " +
                         "upfront NoFraming short-circuit before reaching the sequential walk.",
                 )
             is FieldSpec.RemainingBytesString ->

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterWireSize.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterWireSize.kt
@@ -39,7 +39,7 @@ internal fun buildWireSizeFun(
     // unconditionally — promoting to runtime-Exact-via-cast (mirroring
     // LengthPrefixedMessage) is a follow-on once we have a vector
     // where the size optimization actually matters.
-    if (shape.fields.any { it is FieldSpec.RemainingBytesPayload }) {
+    if (shape.fields.any { it is FieldSpec.DeferredPayload }) {
         builder.addStatement("return %T.BackPatch", WIRE_SIZE_CN)
         return builder.build()
     }
@@ -295,9 +295,9 @@ internal fun buildWireSizeFun(
                 bodySizeVar,
             )
         }
-        is FieldSpec.RemainingBytesPayload ->
+        is FieldSpec.DeferredPayload ->
             error(
-                "RemainingBytesPayload terminal shape should be handled by the BackPatch " +
+                "DeferredPayload terminal shape should be handled by the BackPatch " +
                     "early-return at the top of buildWireSizeFun; reaching this branch " +
                     "indicates a missed early return.",
             )

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecIr.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecIr.kt
@@ -295,7 +295,7 @@ internal data class CodecShape(
     /**
      * When the @ProtocolMessage data class
      * carries a `<P : Payload>` type parameter and a
-     * `RemainingBytesPayload` field whose source is
+     * `DeferredPayload` field whose source is
      * `ConstructorInjected`, this is the type-parameter name
      * (`P`) and the constructor-injected codec parameter name
      * (`payloadCodec`). When non-null, the emitter generates
@@ -643,7 +643,7 @@ internal sealed interface FieldSpec {
      * `@RemainingBytes val: String` — UTF-8 string consuming the rest of the
      * buffer. Decode reads `buffer.readString(buffer.remaining(), Charset.UTF8)`;
      * encode writes the value's UTF-8 bytes. Same caller-bounds-buffer contract
-     * as [RemainingBytesPayload]: an outer dispatcher
+     * as [DeferredPayload]: an outer dispatcher
      * sets `buffer.limit()` before this codec runs.
      *
      * Terminal-only (must be the last non-conditional field). The annotation
@@ -671,14 +671,23 @@ internal sealed interface FieldSpec {
     ) : FieldSpec
 
     /**
-     * `@RemainingBytes @UseCodec(C::class) val:
-     * P` where `P` extends `com.ditchoom.buffer.codec.Payload` and
-     * `C` is a Kotlin `object` implementing `Codec<P>`. Decode
-     * delegates to `C.decode(buffer, context)` against the bounded
-     * buffer; encode delegates to `C.encode(buffer, value.<name>,
-     * context)`. Caller-bounds-buffer contract: an outer dispatcher
-     * (for example MQTT) sets `buffer.limit` to bound the
-     * payload region before this codec runs.
+     * A payload field whose decode is *deferred* to a `Codec<P>` the
+     * generated codec does not itself own — either a user `object`
+     * named by `@UseCodec(C::class)` or a codec injected through the
+     * constructor for a `<P : Payload>` type parameter (see
+     * [PayloadCodecSource]). The generated codec's only job is to hand
+     * that codec a correctly bounded region.
+     *
+     * Today the region is always "the rest of the bounded buffer":
+     * `@RemainingBytes @UseCodec(C::class) val: P` where `P` extends
+     * `com.ditchoom.buffer.codec.Payload`. Decode delegates to
+     * `C.decode(buffer, context)` against the bounded buffer; encode
+     * delegates to `C.encode(buffer, value.<name>, context)`.
+     * Caller-bounds-buffer contract: an outer dispatcher (for example
+     * MQTT) sets `buffer.limit` to bound the payload region before this
+     * codec runs. Issue #293 widens the shape to a payload sized by a
+     * sibling length field (`@LengthFrom`), which is why the spec is
+     * named for the deferral rather than for `@RemainingBytes`.
      *
      * Narrow: terminal-only (no fields after the
      * payload), no generics on the outer message,
@@ -688,7 +697,7 @@ internal sealed interface FieldSpec {
      * across platforms (single-platform `object`
      * declaration only).
      */
-    data class RemainingBytesPayload(
+    data class DeferredPayload(
         override val name: String,
         val ownerSimpleName: String,
         val payloadType: TypeName,
@@ -1269,7 +1278,7 @@ internal sealed interface LengthSource {
 
 /**
  * Typed source of a `Codec<T>` instance for a
- * `RemainingBytesPayload` field. Mirrors the `LengthSource`
+ * `DeferredPayload` field. Mirrors the `LengthSource`
  * pattern (doctrine #2: no nullable fields representing form
  * distinction; the type system enforces exhaustive `when`).
  *

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecIr.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecIr.kt
@@ -701,9 +701,10 @@ internal sealed interface FieldSpec {
         override val name: String,
         val ownerSimpleName: String,
         val payloadType: TypeName,
+        /** *Whose* codec decodes the region. */
         val source: PayloadCodecSource,
-        /** See [RemainingBytesString.reservedTrailingBytes]. */
-        val reservedTrailingBytes: Int = 0,
+        /** *How* the region handed to that codec is bounded. */
+        val extent: PayloadExtent,
     ) : FieldSpec
 
     /**
@@ -1307,6 +1308,49 @@ internal sealed interface PayloadCodecSource {
     data class ConstructorInjected(
         val parameterName: String,
     ) : PayloadCodecSource
+}
+
+/**
+ * How the wire region handed to a [FieldSpec.DeferredPayload]'s codec
+ * is bounded — the second of the shape's two axes, fully orthogonal to
+ * [PayloadCodecSource] (which says *whose* codec reads that region).
+ * Every combination of the two is legal; conflating them is what made
+ * `@LengthFrom` payloads unrepresentable before issue #293.
+ *
+ * Same `LengthSource` / [PayloadCodecSource] pattern (doctrine #2): the
+ * form distinction is a type, not a nullable field or a sentinel `Int`,
+ * so every consumer is forced through an exhaustive `when`.
+ *
+ * Wire-significant: the extent is recorded in the schema descriptor and
+ * a change to it is drift, even when a given message's bytes happen to
+ * be identical under both arms. Once the `@LengthFrom` arm lands (#293
+ * phase 3) its length carrier is load-bearing for framing — it can no
+ * longer be resized, reordered, or dropped without breaking decode of
+ * the payload that reads it, which is precisely what the drift gate is
+ * there to catch.
+ */
+internal sealed interface PayloadExtent {
+    /**
+     * The region runs to `buffer.limit()` — the caller-bounds-buffer
+     * contract of `@RemainingBytes`. An outer dispatcher (for example
+     * MQTT's remaining-length) narrowed the limit before this codec ran;
+     * the payload gets whatever is left.
+     */
+    data class ToLimit(
+        /**
+         * Sum of `wireBytes` for trailing FixedSize fields after the
+         * payload — see [FieldSpec.RemainingBytesString.reservedTrailingBytes].
+         * 0 when the payload is terminal.
+         *
+         * This lives here rather than on [FieldSpec.DeferredPayload]
+         * because it exists solely to emulate an explicit length: it is
+         * the only way a to-limit payload can know where it ends when
+         * something follows it. A payload sized by a sibling length
+         * (#293 phase 3) is told its extent outright, so a reservation
+         * would be meaningless there.
+         */
+        val reservedTrailingBytes: Int = 0,
+    ) : PayloadExtent
 }
 
 /**

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecIr.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecIr.kt
@@ -1351,6 +1351,27 @@ internal sealed interface PayloadExtent {
          */
         val reservedTrailingBytes: Int = 0,
     ) : PayloadExtent
+
+    /**
+     * `@LengthFrom("n") val: P` — the region is exactly the `n` bytes
+     * named by a prior sibling field (issue #293). The payload is told
+     * its extent outright, which is what makes the shape framable: peek
+     * can walk the sibling and add its value without running the
+     * deferred codec, so `peekFrameSize` returns a real byte count
+     * instead of collapsing the message to `NoFraming`.
+     *
+     * Unlike [ToLimit] this does not require the payload to be terminal
+     * or to reserve trailing bytes — the bound is explicit, so ordinary
+     * fields may follow it.
+     *
+     * The [source] mirrors `LengthFromString` / `LengthFromList` /
+     * `LengthFromMessage`, so the same sibling forms are accepted (a
+     * peekable unsigned scalar, or a `value class` property returning
+     * `Int`) and the same peek walker applies.
+     */
+    data class Sibling(
+        val source: LengthSource,
+    ) : PayloadExtent
 }
 
 /**

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecSchemaDescriptor.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecSchemaDescriptor.kt
@@ -128,7 +128,7 @@ internal object CodecSchemaDescriptor {
                     "bounding=${field.isBounding} variable=${field.isVariableLength}"
             is FieldSpec.RemainingBytesString ->
                 "string remaining reserved=${field.reservedTrailingBytes}B"
-            is FieldSpec.RemainingBytesPayload ->
+            is FieldSpec.DeferredPayload ->
                 "payload:${field.payloadType} remaining " +
                     "codec=${describePayloadCodecSource(field.source)} " +
                     "reserved=${field.reservedTrailingBytes}B"

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecSchemaDescriptor.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecSchemaDescriptor.kt
@@ -129,9 +129,17 @@ internal object CodecSchemaDescriptor {
             is FieldSpec.RemainingBytesString ->
                 "string remaining reserved=${field.reservedTrailingBytes}B"
             is FieldSpec.DeferredPayload ->
-                "payload:${field.payloadType} remaining " +
-                    "codec=${describePayloadCodecSource(field.source)} " +
-                    "reserved=${field.reservedTrailingBytes}B"
+                // Exhaustive over PayloadExtent: the extent is wire-significant,
+                // so each arm spells out its own token layout rather than sharing
+                // one. `remaining`/`reserved=` are the historical tokens and must
+                // stay exactly where they are — moving them is drift on every
+                // message that already carries this shape.
+                when (val extent = field.extent) {
+                    is PayloadExtent.ToLimit ->
+                        "payload:${field.payloadType} remaining " +
+                            "codec=${describePayloadCodecSource(field.source)} " +
+                            "reserved=${extent.reservedTrailingBytes}B"
+                }
             is FieldSpec.LengthPrefixedUseCodecList ->
                 "list:${field.elementClassName.canonicalName} len-prefix-codec=${field.codecType.canonicalName}"
             is FieldSpec.LengthPrefixedUseCodecPayload ->

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecSchemaDescriptor.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecSchemaDescriptor.kt
@@ -139,6 +139,14 @@ internal object CodecSchemaDescriptor {
                         "payload:${field.payloadType} remaining " +
                             "codec=${describePayloadCodecSource(field.source)} " +
                             "reserved=${extent.reservedTrailingBytes}B"
+                    // Mirrors the `len-from=` token the other @LengthFrom shapes use.
+                    // Deliberately shares no tokens with the ToLimit arm: swapping
+                    // @RemainingBytes for @LengthFrom must read as drift even though
+                    // the bytes can coincide, because the named sibling becomes
+                    // load-bearing for framing the moment the payload reads it.
+                    is PayloadExtent.Sibling ->
+                        "payload:${field.payloadType} len-from=${describeLengthSource(extent.source)} " +
+                            "codec=${describePayloadCodecSource(field.source)}"
                 }
             is FieldSpec.LengthPrefixedUseCodecList ->
                 "list:${field.elementClassName.canonicalName} len-prefix-codec=${field.codecType.canonicalName}"

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/ProtocolMessageProcessor.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/ProtocolMessageProcessor.kt
@@ -1034,9 +1034,11 @@ class ProtocolMessageProcessor(
      * `@LengthFrom` shape validation.
      *
      * Independent from R1 (adjacent-`@LengthFrom` migration suggestion):
-     * Bound field type must be `String` — 's field-type
-     *     universe (row 18). `ByteArray`, nested `@ProtocolMessage`,
-     *     and `@Payload` slots widen this in later stages.
+     * Bound field type must be `String`, `List<@ProtocolMessage>`, a
+     *     nested `@ProtocolMessage`, or a deferred payload — a
+     *     `Payload`-typed field with `@UseCodec`, or the enclosing
+     *     message's `<P : Payload>` type parameter (issue #293).
+     *     `ByteArray` slots widen this in a later stage.
      *   - Referenced sibling must exist as a sibling of the bound
      *     parameter; diagnostics list available numeric siblings
      *     declared before the bound field.
@@ -1052,6 +1054,20 @@ class ProtocolMessageProcessor(
         parameters: List<KSValueParameter>,
     ) {
         val ownerName = owner.qualifiedName?.asString() ?: owner.simpleName.asString()
+        // Names of `<P : Payload>` type parameters on the owner. A field typed
+        // as one of these is resolved by the constructor-injected codec, so it
+        // is a legal `@LengthFrom` bound type even though it is no class at all.
+        val payloadTypeParameterNames =
+            owner.typeParameters
+                .filter { tp ->
+                    val bounds = tp.bounds.toList()
+                    bounds.size == 1 &&
+                        bounds[0]
+                            .resolve()
+                            .declaration.qualifiedName
+                            ?.asString() == PAYLOAD_QNAME
+                }.map { it.name.asString() }
+                .toSet()
         for ((index, param) in parameters.withIndex()) {
             val ann =
                 param.annotations.firstOrNull { a ->
@@ -1088,16 +1104,44 @@ class ProtocolMessageProcessor(
             val isNestedProtocolMessage =
                 nestedProtocolMessageDecl != null &&
                     isNestedProtocolMessageType(nestedProtocolMessageDecl)
-            if (!isStringType && !isListOfProtocolMessage && !isNestedProtocolMessage) {
+            // Deferred payload sized by the sibling (issue #293). Two forms,
+            // matching the two `PayloadCodecSource`s: a `Payload`-typed field
+            // (or a borrowed view opting in via `ViewCodec`) whose codec is
+            // named by `@UseCodec`, or the owner's `<P : Payload>` parameter
+            // whose codec arrives through the constructor. `validateUseCodec`
+            // owns the codec-side checks; this only decides bound-type legality.
+            val hasUseCodec =
+                param.annotations.any { a ->
+                    a.shortName.asString() == USE_CODEC_SHORT &&
+                        a.annotationType
+                            .resolve()
+                            .declaration.qualifiedName
+                            ?.asString() == USE_CODEC_QNAME
+                }
+            val fieldDecl = type.declaration
+            val isInjectedPayloadParameter =
+                !hasUseCodec &&
+                    fieldDecl is com.google.devtools.ksp.symbol.KSTypeParameter &&
+                    fieldDecl.name.asString() in payloadTypeParameterNames
+            val isDeferredPayload =
+                !type.isMarkedNullable &&
+                    (
+                        isInjectedPayloadParameter ||
+                            (hasUseCodec && (type.implementsPayload() || param.hasViewUseCodec()))
+                    )
+            val isSupportedBoundType =
+                isStringType || isListOfProtocolMessage || isNestedProtocolMessage || isDeferredPayload
+            if (!isSupportedBoundType) {
                 val displayed = typeQname ?: "<unresolved>"
                 val nullableSuffix = if (type.isMarkedNullable) "?" else ""
                 logger.error(
                     "@LengthFrom(\"$referenced\") on $ownerName.$fieldName requires the bound " +
                         "field to be a non-nullable `String`, a non-nullable `List<T>` where " +
-                        "`T` is a `@ProtocolMessage data class`, or a non-nullable nested " +
-                        "`@ProtocolMessage` data class / sealed parent, but it is " +
-                        "`$displayed$nullableSuffix`. `ByteArray` and `@Payload` slots are " +
-                        "deferred to later stages.",
+                        "`T` is a `@ProtocolMessage data class`, a non-nullable nested " +
+                        "`@ProtocolMessage` data class / sealed parent, or a deferred payload " +
+                        "(`@UseCodec val: P` where `P : Payload`, or the enclosing message's " +
+                        "`<P : Payload>` type parameter), but it is `$displayed$nullableSuffix`. " +
+                        "`ByteArray` slots are deferred to a later stage.",
                     param,
                 )
                 continue
@@ -1351,13 +1395,23 @@ class ProtocolMessageProcessor(
                 }
             val hasLengthPrefixed =
                 param.annotations.any { ann -> ann.shortName.asString() == "LengthPrefixed" }
-            if (hasLengthFrom) {
+            if (hasLengthFrom && !isPayloadField && !param.hasViewUseCodec()) {
+                // `@LengthFrom @UseCodec` is supported only for the deferred-payload
+                // shape (issue #293) — the sibling gives the byte count, the codec
+                // decodes that region. Other bound types (a list, a scalar) have no
+                // emit path, so they keep the focused diagnostic rather than falling
+                // through to the `Codec<fieldType>` checks below and failing obscurely.
+                val displayed = fieldType.declaration.qualifiedName?.asString() ?: "<unresolved>"
                 logger.error(
-                    "@UseCodec on $ownerName.$fieldName composed with `@LengthFrom` is not yet " +
-                        "supported. Currently emitted compositions are `@RemainingBytes @UseCodec " +
-                        "val: P` (P : Payload), bare `@UseCodec val: <scalar>`, and " +
-                        "`@LengthPrefixed @UseCodec(BoundingLengthCodec) val: List<E>`. " +
-                        "The `@LengthFrom @UseCodec` shape is deferred to a future release.",
+                    "@LengthFrom @UseCodec on $ownerName.$fieldName requires the bound field's " +
+                        "type to extend `com.ditchoom.buffer.codec.Payload`, but it is " +
+                        "`$displayed`. The supported `@UseCodec` compositions are " +
+                        "`@LengthFrom(\"len\") @UseCodec val: P` and `@RemainingBytes @UseCodec " +
+                        "val: P` (both P : Payload), bare `@UseCodec val: <scalar>`, and " +
+                        "`@LengthPrefixed @UseCodec(BoundingLengthCodec) val: List<E>`. Either " +
+                        "wrap the value in a `Payload`-tagged type, or — for a zero-copy " +
+                        "borrowed view whose lifetime is tied to the source buffer — make the " +
+                        "codec implement `com.ditchoom.buffer.codec.ViewCodec`.",
                     param,
                 )
                 continue
@@ -1378,12 +1432,15 @@ class ProtocolMessageProcessor(
                 )
                 continue
             }
-            if (!hasRemainingBytes && isPayloadField) {
+            if (!hasRemainingBytes && !hasLengthFrom && isPayloadField) {
                 logger.error(
                     "@UseCodec on $ownerName.$fieldName must be paired with `@RemainingBytes` " +
-                        "when the field's type extends `com.ditchoom.buffer.codec.Payload`. The " +
-                        "current `@UseCodec` shapes are `@RemainingBytes @UseCodec val: P` " +
-                        "(P : Payload) and bare `@UseCodec val: <scalar>`.",
+                        "or `@LengthFrom` when the field's type extends " +
+                        "`com.ditchoom.buffer.codec.Payload` — the codec is handed a bounded " +
+                        "region, and without one of those the bound is undefined. The current " +
+                        "`@UseCodec` shapes are `@RemainingBytes @UseCodec val: P`, " +
+                        "`@LengthFrom(\"len\") @UseCodec val: P` (both P : Payload), and bare " +
+                        "`@UseCodec val: <scalar>`.",
                     param,
                 )
                 continue
@@ -2148,8 +2205,10 @@ class ProtocolMessageProcessor(
             )
             return
         }
-        // Bound is Payload — confirm at least one parameter has type
-        // P AND `@RemainingBytes`.
+        // Bound is Payload — confirm at least one parameter has type P AND an
+        // annotation that bounds it: `@RemainingBytes` (to the caller's limit)
+        // or `@LengthFrom` (to a sibling byte count, issue #293). Either one
+        // consumes the injected codec, which is what the parameter exists for.
         val anyMatching =
             parameters.any { p ->
                 val ftype = p.type.resolve()
@@ -2158,22 +2217,26 @@ class ProtocolMessageProcessor(
                 if (fdecl !is com.google.devtools.ksp.symbol.KSTypeParameter) return@any false
                 if (fdecl.name.asString() != tpName) return@any false
                 p.annotations.any { ann ->
-                    ann.shortName.asString() == REMAINING_BYTES_SHORT &&
+                    val short = ann.shortName.asString()
+                    val qname =
                         ann.annotationType
                             .resolve()
                             .declaration.qualifiedName
-                            ?.asString() == REMAINING_BYTES_QNAME
+                            ?.asString()
+                    (short == REMAINING_BYTES_SHORT && qname == REMAINING_BYTES_QNAME) ||
+                        (short == LENGTH_FROM_SHORT && qname == LENGTH_FROM_QNAME)
                 }
             }
         if (!anyMatching) {
             logger.error(
                 "@ProtocolMessage `$ownerName` declares type parameter `<$tpName : Payload>` but " +
-                    "no `@RemainingBytes val: $tpName` field uses it. The generic emit path " +
-                    "exists to surface a constructor-injected `Codec<$tpName>` parameter — " +
-                    "without a field consuming it, the parameter is unused. Either add " +
-                    "`@RemainingBytes val payload: $tpName` or drop the " +
-                    "type parameter and use `@UseCodec(...)` against a concrete `Payload` " +
-                    "subtype.",
+                    "no `@RemainingBytes val: $tpName` or `@LengthFrom val: $tpName` field uses " +
+                    "it. The generic emit path exists to surface a constructor-injected " +
+                    "`Codec<$tpName>` parameter — without a field consuming it, the parameter " +
+                    "is unused. Either add `@RemainingBytes val payload: $tpName` (payload runs " +
+                    "to the caller-set limit), `@LengthFrom(\"len\") val payload: $tpName` " +
+                    "(payload is sized by a sibling), or drop the type parameter and use " +
+                    "`@UseCodec(...)` against a concrete `Payload` subtype.",
                 owner,
             )
         }

--- a/buffer-codec-processor/src/test/kotlin/com/ditchoom/buffer/codec/processor/CodecSchemaDescriptorTest.kt
+++ b/buffer-codec-processor/src/test/kotlin/com/ditchoom/buffer/codec/processor/CodecSchemaDescriptorTest.kt
@@ -83,6 +83,34 @@ class CodecSchemaDescriptorTest {
         }
     }
 
+    /**
+     * The extent is wire-significant: two payload fields that differ *only* in how their region is
+     * bounded must not describe identically, or the drift gate would greenlight swapping one for
+     * the other. Issue #293's `@LengthFrom` extent has identical wire bytes to `@RemainingBytes`
+     * whenever the caller's limit already equals the sibling length — but its length carrier
+     * becomes load-bearing for framing, so the change must still be visible.
+     *
+     * With a single extent arm this asserts only exhaustiveness plus a non-empty descriptor; it
+     * starts discriminating the moment a second arm exists.
+     */
+    @Test
+    fun `every PayloadExtent leaf produces a distinct payload descriptor`() {
+        assertExhaustive(PayloadExtent::class, samplePayloadExtents.map { it::class }.toSet())
+        val byDescriptor =
+            samplePayloadExtents.groupBy { extent ->
+                CodecSchemaDescriptor.describeField(payloadFieldWith(extent))
+            }
+        for ((descriptor, extents) in byDescriptor) {
+            assertNonEmptyLine(descriptor, "PayloadExtent ${extents.first()::class.simpleName}")
+            assertEquals(
+                1,
+                extents.size,
+                "extents ${extents.map { it::class.simpleName }} share descriptor \"$descriptor\" — " +
+                    "a schema-invisible extent lets the drift gate miss a framing-relevant change",
+            )
+        }
+    }
+
     // ---- determinism ------------------------------------------------------
 
     @Test
@@ -346,6 +374,21 @@ class CodecSchemaDescriptorTest {
             PayloadCodecSource.ConstructorInjected("payloadCodec"),
         )
 
+    private val samplePayloadExtents: List<PayloadExtent> =
+        listOf(
+            PayloadExtent.ToLimit(0),
+        )
+
+    /** A payload field that varies only in [extent] — the fixture for the distinctness check. */
+    private fun payloadFieldWith(extent: PayloadExtent): FieldSpec.DeferredPayload =
+        FieldSpec.DeferredPayload(
+            name = "payload",
+            ownerSimpleName = "Owner",
+            payloadType = cn,
+            source = PayloadCodecSource.UserCodecObject(codec),
+            extent = extent,
+        )
+
     private val sampleConditionalInners: List<ConditionalInner> =
         listOf(
             ConditionalInner.Scalar(ScalarKind.UInt, Endianness.Big),
@@ -388,7 +431,13 @@ class CodecSchemaDescriptorTest {
             FieldSpec.ProtocolMessageScalar("nested", "Owner", cn, codec),
             FieldSpec.UseCodecScalar("v", "Owner", cn, codec, isBounding = false, isVariableLength = true),
             FieldSpec.RemainingBytesString("rest", "Owner", reservedTrailingBytes = 0),
-            FieldSpec.DeferredPayload("payload", "Owner", cn, PayloadCodecSource.UserCodecObject(codec), 0),
+            FieldSpec.DeferredPayload(
+                "payload",
+                "Owner",
+                cn,
+                PayloadCodecSource.UserCodecObject(codec),
+                PayloadExtent.ToLimit(0),
+            ),
             FieldSpec.LengthPrefixedUseCodecList("props", "Owner", listSpec),
             FieldSpec.LengthPrefixedUseCodecPayload("blob", "Owner", cn, codec, 2, Endianness.Big),
             FieldSpec.RemainingBytesProtocolMessageList("topics", "Owner", cn, codec, elementIsBackPatch = false),

--- a/buffer-codec-processor/src/test/kotlin/com/ditchoom/buffer/codec/processor/CodecSchemaDescriptorTest.kt
+++ b/buffer-codec-processor/src/test/kotlin/com/ditchoom/buffer/codec/processor/CodecSchemaDescriptorTest.kt
@@ -377,6 +377,7 @@ class CodecSchemaDescriptorTest {
     private val samplePayloadExtents: List<PayloadExtent> =
         listOf(
             PayloadExtent.ToLimit(0),
+            PayloadExtent.Sibling(LengthSource.Sibling("len", ScalarKind.UShort)),
         )
 
     /** A payload field that varies only in [extent] — the fixture for the distinctness check. */

--- a/buffer-codec-processor/src/test/kotlin/com/ditchoom/buffer/codec/processor/CodecSchemaDescriptorTest.kt
+++ b/buffer-codec-processor/src/test/kotlin/com/ditchoom/buffer/codec/processor/CodecSchemaDescriptorTest.kt
@@ -388,7 +388,7 @@ class CodecSchemaDescriptorTest {
             FieldSpec.ProtocolMessageScalar("nested", "Owner", cn, codec),
             FieldSpec.UseCodecScalar("v", "Owner", cn, codec, isBounding = false, isVariableLength = true),
             FieldSpec.RemainingBytesString("rest", "Owner", reservedTrailingBytes = 0),
-            FieldSpec.RemainingBytesPayload("payload", "Owner", cn, PayloadCodecSource.UserCodecObject(codec), 0),
+            FieldSpec.DeferredPayload("payload", "Owner", cn, PayloadCodecSource.UserCodecObject(codec), 0),
             FieldSpec.LengthPrefixedUseCodecList("props", "Owner", listSpec),
             FieldSpec.LengthPrefixedUseCodecPayload("blob", "Owner", cn, codec, 2, Endianness.Big),
             FieldSpec.RemainingBytesProtocolMessageList("topics", "Owner", cn, codec, elementIsBackPatch = false),

--- a/buffer-codec-processor/src/test/kotlin/com/ditchoom/buffer/codec/processor/LengthFromValidatorTest.kt
+++ b/buffer-codec-processor/src/test/kotlin/com/ditchoom/buffer/codec/processor/LengthFromValidatorTest.kt
@@ -377,6 +377,110 @@ class LengthFromValidatorTest {
         )
     }
 
+    // ---- deferred payload extent (issue #293) -----------------------------
+
+    @Test
+    fun acceptsLengthFromUseCodecPayload() {
+        val result =
+            compile(
+                """
+                package test
+
+                import com.ditchoom.buffer.ReadBuffer
+                import com.ditchoom.buffer.WriteBuffer
+                import com.ditchoom.buffer.codec.Codec
+                import com.ditchoom.buffer.codec.DecodeContext
+                import com.ditchoom.buffer.codec.EncodeContext
+                import com.ditchoom.buffer.codec.Payload
+                import com.ditchoom.buffer.codec.WireSize
+                import com.ditchoom.buffer.codec.annotations.LengthFrom
+                import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+                import com.ditchoom.buffer.codec.annotations.UseCodec
+
+                data class Blob(val n: Int) : Payload
+
+                object BlobCodec : Codec<Blob> {
+                    override fun decode(buffer: ReadBuffer, context: DecodeContext): Blob = Blob(0)
+                    override fun encode(buffer: WriteBuffer, value: Blob, context: EncodeContext) {}
+                    override fun wireSize(value: Blob, context: EncodeContext): WireSize = WireSize.BackPatch
+                }
+
+                @ProtocolMessage
+                data class Frame(
+                    val length: UShort,
+                    val flags: UByte,
+                    @LengthFrom("length") @UseCodec(BlobCodec::class) val body: Blob,
+                )
+                """.trimIndent(),
+            )
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+    }
+
+    @Test
+    fun acceptsLengthFromOnGenericPayloadTypeParameter() {
+        // The `<P : Payload>` declared-but-unused check keys on a field that
+        // *bounds* P. Before #293 only `@RemainingBytes` counted, so this
+        // otherwise-valid message was rejected as having an unused parameter.
+        val result =
+            compile(
+                """
+                package test
+
+                import com.ditchoom.buffer.codec.Payload
+                import com.ditchoom.buffer.codec.annotations.LengthFrom
+                import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+
+                @ProtocolMessage
+                data class Frame<P : Payload>(
+                    val length: UShort,
+                    val flags: UByte,
+                    @LengthFrom("length") val body: P,
+                )
+                """.trimIndent(),
+            )
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+    }
+
+    @Test
+    fun rejectsLengthFromUseCodecOnNonPayloadBoundType() {
+        val result =
+            compile(
+                """
+                package test
+
+                import com.ditchoom.buffer.ReadBuffer
+                import com.ditchoom.buffer.WriteBuffer
+                import com.ditchoom.buffer.codec.Codec
+                import com.ditchoom.buffer.codec.DecodeContext
+                import com.ditchoom.buffer.codec.EncodeContext
+                import com.ditchoom.buffer.codec.WireSize
+                import com.ditchoom.buffer.codec.annotations.LengthFrom
+                import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+                import com.ditchoom.buffer.codec.annotations.UseCodec
+
+                data class Plain(val n: Int)
+
+                object PlainCodec : Codec<Plain> {
+                    override fun decode(buffer: ReadBuffer, context: DecodeContext): Plain = Plain(0)
+                    override fun encode(buffer: WriteBuffer, value: Plain, context: EncodeContext) {}
+                    override fun wireSize(value: Plain, context: EncodeContext): WireSize = WireSize.BackPatch
+                }
+
+                @ProtocolMessage
+                data class Frame(
+                    val length: UShort,
+                    val flags: UByte,
+                    @LengthFrom("length") @UseCodec(PlainCodec::class) val body: Plain,
+                )
+                """.trimIndent(),
+            )
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode, result.messages)
+        assertTrue(
+            result.messages.contains("@LengthFrom @UseCodec on test.Frame.body requires the bound field's type"),
+            "expected the focused non-Payload diagnostic. Messages:\n${result.messages}",
+        )
+    }
+
     private fun compile(
         @Language("kotlin") source: String,
     ): JvmCompilationResult =

--- a/buffer-codec-processor/src/test/kotlin/com/ditchoom/buffer/codec/processor/UseCodecScalarValidatorTest.kt
+++ b/buffer-codec-processor/src/test/kotlin/com/ditchoom/buffer/codec/processor/UseCodecScalarValidatorTest.kt
@@ -14,9 +14,12 @@ import kotlin.test.assertTrue
 /**
  * `@UseCodec` validator coverage for the bare-scalar shape (no framing
  * annotation). The bare shape unblocks user-supplied length codecs like
- * `MqttRemainingLengthCodec`. The `@RemainingBytes @UseCodec val: P` shape
- * and the deferred `@LengthPrefixed @UseCodec` / `@LengthFrom @UseCodec`
- * shapes still produce the same diagnostics as before.
+ * `MqttRemainingLengthCodec`.
+ *
+ * `@RemainingBytes @UseCodec val: P` is unchanged. `@LengthFrom @UseCodec`
+ * is now the supported deferred-payload shape (issue #293) and is covered in
+ * `LengthFromValidatorTest`; what remains here is the rejection of bound
+ * types that shape does not reach.
  */
 class UseCodecScalarValidatorTest {
     @Test
@@ -699,7 +702,7 @@ class UseCodecScalarValidatorTest {
     }
 
     @Test
-    fun rejectsLengthFromUseCodecAsDeferred() {
+    fun rejectsLengthFromUseCodecOnNonPayloadScalar() {
         val result =
             compile(
                 """
@@ -731,9 +734,12 @@ class UseCodecScalarValidatorTest {
                 """.trimIndent(),
             )
         assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode, result.messages)
+        // Since #293 `@LengthFrom @UseCodec` IS supported — but only for a
+        // deferred payload. A `UInt` bound type has no emit path, so it keeps a
+        // focused diagnostic instead of the old blanket "not yet supported".
         assertTrue(
-            result.messages.contains("not yet supported"),
-            "@LengthFrom @UseCodec should still produce the deferred diagnostic. Messages:\n${result.messages}",
+            result.messages.contains("@LengthFrom @UseCodec on test.HeaderWithLengthFromUseCodec.payload"),
+            "expected the focused non-Payload diagnostic. Messages:\n${result.messages}",
         )
     }
 

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/DeferredDispatchFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/DeferredDispatchFrameCodec.kt
@@ -1,0 +1,85 @@
+package com.ditchoom.buffer.codec.test.protocols.deferredpayload
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.Payload
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public class DeferredDispatchFrameCodec<P : Payload>(
+  private val payloadCodec: Codec<P>,
+) : Codec<DeferredDispatchFrame<P>> {
+  private val commandCodec: DeferredDispatchFrameCommandCodec<P> =
+      DeferredDispatchFrameCommandCodec(payloadCodec)
+
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): DeferredDispatchFrame<P> {
+    val discriminatorPosition = buffer.position()
+    val discriminator = buffer.readUByte().toInt()
+    return when (discriminator) {
+      0x0A -> commandCodec.decode(buffer, context)
+      0xA0 -> DeferredDispatchFrameStatusCodec.decode(buffer, context)
+      else -> {
+        throw DecodeException(fieldPath = "DeferredDispatchFrame.discriminator", bufferPosition = discriminatorPosition, expected = "one of {0x0A, 0xA0}", actual = """0x${discriminator.toString(16).padStart(2, '0').uppercase()}""")
+      }
+    }
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: DeferredDispatchFrame<P>,
+    context: EncodeContext,
+  ) {
+    @Suppress("UNCHECKED_CAST")
+    when (value) {
+      is DeferredDispatchFrame.Command<*> -> {
+        buffer.writeUByte(0x0A.toUByte())
+        commandCodec.encode(buffer, value as DeferredDispatchFrame.Command<P>, context)
+      }
+      is DeferredDispatchFrame.Status -> {
+        buffer.writeUByte(0xA0.toUByte())
+        DeferredDispatchFrameStatusCodec.encode(buffer, value, context)
+      }
+    }
+  }
+
+  override fun wireSize(`value`: DeferredDispatchFrame<P>, context: EncodeContext): WireSize = when (value) {
+    is DeferredDispatchFrame.Command<*> -> WireSize.BackPatch
+    is DeferredDispatchFrame.Status -> WireSize.Exact(2)
+  }
+
+  override fun sizeHint(`value`: DeferredDispatchFrame<P>, context: EncodeContext): Int {
+    @Suppress("UNCHECKED_CAST")
+    return 1 + when (value) {
+      is DeferredDispatchFrame.Command<*> -> commandCodec.sizeHint(value as DeferredDispatchFrame.Command<P>, context)
+      is DeferredDispatchFrame.Status -> DeferredDispatchFrameStatusCodec.sizeHint(value, context)
+    }
+  }
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    if (stream.available() - baseOffset < 1) return PeekResult.NeedsMoreData
+    val discriminator = stream.peekByte(baseOffset).toInt() and 0xFF
+    return when (discriminator) {
+      0x0A -> {
+        when (val inner = commandCodec.peekFrameSize(stream, baseOffset + 1)) {
+          is PeekResult.Complete -> PeekResult.Complete(1 + inner.bytes)
+          else -> inner
+        }
+      }
+      0xA0 -> {
+        when (val inner = DeferredDispatchFrameStatusCodec.peekFrameSize(stream, baseOffset + 1)) {
+          is PeekResult.Complete -> PeekResult.Complete(1 + inner.bytes)
+          else -> inner
+        }
+      }
+      else -> {
+        throw DecodeException(fieldPath = "DeferredDispatchFrame.discriminator", bufferPosition = baseOffset, expected = "one of {0x0A, 0xA0}", actual = """0x${discriminator.toString(16).padStart(2, '0').uppercase()}""")
+      }
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/DeferredDispatchFrameCommandCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/DeferredDispatchFrameCommandCodec.kt
@@ -1,0 +1,137 @@
+package com.ditchoom.buffer.codec.test.protocols.deferredpayload
+
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.Decoder
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.Payload
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.UShort
+
+public class DeferredDispatchFrameCommandCodec<P : Payload>(
+  private val payloadCodec: Codec<P>,
+) : Codec<DeferredDispatchFrame.Command<P>> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): DeferredDispatchFrame.Command<P> {
+    val __batch1 = buffer.readInt()
+    val counter: kotlin.UShort
+    val payloadLength: kotlin.UShort
+    if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) {
+      counter = (__batch1 ushr 16 and 0xFFFF).toUShort()
+      payloadLength = (__batch1 and 0xFFFF).toUShort()
+    } else {
+      counter = (__batch1 and 0xFFFF).toUShort()
+      payloadLength = (__batch1 ushr 16 and 0xFFFF).toUShort()
+    }
+    val payloadBytes = payloadLength.toInt()
+    val payloadOuterLimit = buffer.limit()
+    val payloadEnd = buffer.position() + payloadBytes
+    buffer.setLimit(payloadEnd)
+    val payload = try {
+      payloadCodec.decode(buffer, context)
+    } finally {
+      buffer.setLimit(payloadOuterLimit)
+    }
+    if (buffer.position() != payloadEnd) {
+      throw DecodeException(
+            fieldPath = "Command.payload",
+            bufferPosition = buffer.position(),
+            expected = "the payload codec to consume all " + payloadBytes + " bytes",
+            actual = (payloadEnd - buffer.position()).toString() + " bytes left unread",
+          )
+    }
+    val checksum = buffer.readUShort()
+    return DeferredDispatchFrame.Command<P>(counter = counter, payloadLength = payloadLength, payload = payload, checksum = checksum)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: DeferredDispatchFrame.Command<P>,
+    context: EncodeContext,
+  ) {
+    if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) {
+      buffer.writeInt(((value.counter.toInt() and 0xFFFF) shl 16) or (value.payloadLength.toInt() and 0xFFFF))
+    } else {
+      buffer.writeInt((value.counter.toInt() and 0xFFFF) or ((value.payloadLength.toInt() and 0xFFFF) shl 16))
+    }
+    payloadCodec.encode(buffer, value.payload, context)
+    buffer.writeUShort(value.checksum)
+  }
+
+  override fun wireSize(`value`: DeferredDispatchFrame.Command<P>, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun sizeHint(`value`: DeferredDispatchFrame.Command<P>, context: EncodeContext): Int = 6
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    __offset += 2
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val payloadLengthB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val payloadLengthB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val payloadLength = ((payloadLengthB0 shl 8) or payloadLengthB1).toUInt().toUShort()
+    __offset += 2
+    val payloadBytes = payloadLength.toInt()
+    if (stream.available() - baseOffset < __offset + payloadBytes) return PeekResult.NeedsMoreData
+    __offset += payloadBytes
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    __offset += 2
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+
+  public class Partial<P : Payload> internal constructor(
+    public val counter: UShort,
+    public val payloadLength: UShort,
+    public val checksum: UShort,
+    private val payloadStart: Int,
+    private val payloadEnd: Int,
+    private val buffer: ReadBuffer,
+    private val context: DecodeContext,
+  ) {
+    public fun complete(payloadCodec: Decoder<P>): DeferredDispatchFrame.Command<P> {
+      buffer.position(payloadStart)
+      val __payloadSavedLimit = buffer.limit()
+      buffer.setLimit(payloadEnd)
+      return try {
+        val payload = payloadCodec.decode(buffer, context)
+        if (buffer.position() != payloadEnd) {
+          throw DecodeException(
+                fieldPath = "Command.payload",
+                bufferPosition = buffer.position(),
+                expected = "the payload codec to consume all " + (payloadEnd - payloadStart) + " bytes",
+                actual = (payloadEnd - buffer.position()).toString() + " bytes left unread",
+              )
+        }
+        DeferredDispatchFrame.Command<P>(counter = counter, payloadLength = payloadLength, payload = payload, checksum = checksum)
+      } finally {
+        buffer.setLimit(__payloadSavedLimit)
+      }
+    }
+  }
+
+  public companion object {
+    public fun <P : Payload> partial(buffer: ReadBuffer, context: DecodeContext): Partial<P> {
+      val __batch2 = buffer.readInt()
+      val counter: kotlin.UShort
+      val payloadLength: kotlin.UShort
+      if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) {
+        counter = (__batch2 ushr 16 and 0xFFFF).toUShort()
+        payloadLength = (__batch2 and 0xFFFF).toUShort()
+      } else {
+        counter = (__batch2 and 0xFFFF).toUShort()
+        payloadLength = (__batch2 ushr 16 and 0xFFFF).toUShort()
+      }
+      val __payloadStart = buffer.position()
+      val __payloadEnd = __payloadStart + payloadLength.toInt()
+      buffer.position(__payloadEnd)
+      val checksum = buffer.readUShort()
+      return Partial<P>(counter = counter, payloadLength = payloadLength, checksum = checksum, payloadStart = __payloadStart, payloadEnd = __payloadEnd, buffer = buffer, context = context)
+    }
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/DeferredDispatchFrameCommandCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/DeferredDispatchFrameCommandCodec.kt
@@ -78,6 +78,9 @@ public class DeferredDispatchFrameCommandCodec<P : Payload>(
     val payloadLength = ((payloadLengthB0 shl 8) or payloadLengthB1).toUInt().toUShort()
     __offset += 2
     val payloadBytes = payloadLength.toInt()
+    if (payloadBytes < 0 || payloadBytes > Int.MAX_VALUE - __offset) {
+      throw DecodeException(fieldPath = "Command.payload", bufferPosition = baseOffset + __offset, expected = "__offset + @LengthFrom source in 0..${'$'}{Int.MAX_VALUE}", actual = """${__offset.toLong() + payloadBytes.toLong()}""")
+    }
     if (stream.available() - baseOffset < __offset + payloadBytes) return PeekResult.NeedsMoreData
     __offset += payloadBytes
     if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/DeferredDispatchFrameStatusCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/DeferredDispatchFrameStatusCodec.kt
@@ -1,0 +1,32 @@
+package com.ditchoom.buffer.codec.test.protocols.deferredpayload
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object DeferredDispatchFrameStatusCodec : Codec<DeferredDispatchFrame.Status> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): DeferredDispatchFrame.Status {
+    val code = buffer.readUByte()
+    return DeferredDispatchFrame.Status(code = code)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: DeferredDispatchFrame.Status,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.code)
+  }
+
+  override fun wireSize(`value`: DeferredDispatchFrame.Status, context: EncodeContext): WireSize = WireSize.Exact(1)
+
+  override fun sizeHint(`value`: DeferredDispatchFrame.Status, context: EncodeContext): Int = 1
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult = if (stream.available() - baseOffset >= 1) PeekResult.Complete(1) else PeekResult.NeedsMoreData
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/ShortReadFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/ShortReadFrameCodec.kt
@@ -10,6 +10,7 @@ import com.ditchoom.buffer.codec.PeekResult
 import com.ditchoom.buffer.codec.WireSize
 import com.ditchoom.buffer.stream.StreamProcessor
 import kotlin.Int
+import kotlin.UShort
 
 public object ShortReadFrameCodec : Codec<ShortReadFrame> {
   override fun decode(buffer: ReadBuffer, context: DecodeContext): ShortReadFrame {
@@ -58,5 +59,41 @@ public object ShortReadFrameCodec : Codec<ShortReadFrame> {
     if (stream.available() - baseOffset < __offset + payloadBytes) return PeekResult.NeedsMoreData
     __offset += payloadBytes
     return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+
+  public fun partial(buffer: ReadBuffer, context: DecodeContext): Partial {
+    val payloadLength = buffer.readUShort()
+    val __payloadStart = buffer.position()
+    val __payloadEnd = __payloadStart + payloadLength.toInt()
+    buffer.position(__payloadEnd)
+    return Partial(payloadLength = payloadLength, payloadStart = __payloadStart, payloadEnd = __payloadEnd, buffer = buffer, context = context)
+  }
+
+  public class Partial internal constructor(
+    public val payloadLength: UShort,
+    private val payloadStart: Int,
+    private val payloadEnd: Int,
+    private val buffer: ReadBuffer,
+    private val context: DecodeContext,
+  ) {
+    public fun complete(): ShortReadFrame {
+      buffer.position(payloadStart)
+      val __payloadSavedLimit = buffer.limit()
+      buffer.setLimit(payloadEnd)
+      return try {
+        val payload = ShortReadPayloadCodec.decode(buffer, context)
+        if (buffer.position() != payloadEnd) {
+          throw DecodeException(
+                fieldPath = "ShortReadFrame.payload",
+                bufferPosition = buffer.position(),
+                expected = "the payload codec to consume all " + (payloadEnd - payloadStart) + " bytes",
+                actual = (payloadEnd - buffer.position()).toString() + " bytes left unread",
+              )
+        }
+        ShortReadFrame(payloadLength = payloadLength, payload = payload)
+      } finally {
+        buffer.setLimit(__payloadSavedLimit)
+      }
+    }
   }
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/ShortReadFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/ShortReadFrameCodec.kt
@@ -56,6 +56,9 @@ public object ShortReadFrameCodec : Codec<ShortReadFrame> {
     val payloadLength = ((payloadLengthB0 shl 8) or payloadLengthB1).toUInt().toUShort()
     __offset += 2
     val payloadBytes = payloadLength.toInt()
+    if (payloadBytes < 0 || payloadBytes > Int.MAX_VALUE - __offset) {
+      throw DecodeException(fieldPath = "ShortReadFrame.payload", bufferPosition = baseOffset + __offset, expected = "__offset + @LengthFrom source in 0..${'$'}{Int.MAX_VALUE}", actual = """${__offset.toLong() + payloadBytes.toLong()}""")
+    }
     if (stream.available() - baseOffset < __offset + payloadBytes) return PeekResult.NeedsMoreData
     __offset += payloadBytes
     return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/ShortReadFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/ShortReadFrameCodec.kt
@@ -1,0 +1,62 @@
+package com.ditchoom.buffer.codec.test.protocols.deferredpayload
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object ShortReadFrameCodec : Codec<ShortReadFrame> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): ShortReadFrame {
+    val payloadLength = buffer.readUShort()
+    val payloadBytes = payloadLength.toInt()
+    val payloadOuterLimit = buffer.limit()
+    val payloadEnd = buffer.position() + payloadBytes
+    buffer.setLimit(payloadEnd)
+    val payload = try {
+      ShortReadPayloadCodec.decode(buffer, context)
+    } finally {
+      buffer.setLimit(payloadOuterLimit)
+    }
+    if (buffer.position() != payloadEnd) {
+      throw DecodeException(
+            fieldPath = "ShortReadFrame.payload",
+            bufferPosition = buffer.position(),
+            expected = "the payload codec to consume all " + payloadBytes + " bytes",
+            actual = (payloadEnd - buffer.position()).toString() + " bytes left unread",
+          )
+    }
+    return ShortReadFrame(payloadLength = payloadLength, payload = payload)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: ShortReadFrame,
+    context: EncodeContext,
+  ) {
+    buffer.writeUShort(value.payloadLength)
+    ShortReadPayloadCodec.encode(buffer, value.payload, context)
+  }
+
+  override fun wireSize(`value`: ShortReadFrame, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun sizeHint(`value`: ShortReadFrame, context: EncodeContext): Int = 2
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val payloadLengthB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val payloadLengthB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val payloadLength = ((payloadLengthB0 shl 8) or payloadLengthB1).toUInt().toUShort()
+    __offset += 2
+    val payloadBytes = payloadLength.toInt()
+    if (stream.available() - baseOffset < __offset + payloadBytes) return PeekResult.NeedsMoreData
+    __offset += payloadBytes
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SmpFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SmpFrameCodec.kt
@@ -94,6 +94,9 @@ public object SmpFrameCodec : Codec<SmpFrame> {
     if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
     __offset += 1
     val payloadBytes = payloadLength.toInt()
+    if (payloadBytes < 0 || payloadBytes > Int.MAX_VALUE - __offset) {
+      throw DecodeException(fieldPath = "SmpFrame.payload", bufferPosition = baseOffset + __offset, expected = "__offset + @LengthFrom source in 0..${'$'}{Int.MAX_VALUE}", actual = """${__offset.toLong() + payloadBytes.toLong()}""")
+    }
     if (stream.available() - baseOffset < __offset + payloadBytes) return PeekResult.NeedsMoreData
     __offset += payloadBytes
     return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SmpFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SmpFrameCodec.kt
@@ -12,6 +12,8 @@ import com.ditchoom.buffer.codec.WireSize
 import com.ditchoom.buffer.codec.test.protocols.payload.TextPayloadCodec
 import com.ditchoom.buffer.stream.StreamProcessor
 import kotlin.Int
+import kotlin.UByte
+import kotlin.UShort
 
 public object SmpFrameCodec : Codec<SmpFrame> {
   override fun decode(buffer: ReadBuffer, context: DecodeContext): SmpFrame {
@@ -95,5 +97,67 @@ public object SmpFrameCodec : Codec<SmpFrame> {
     if (stream.available() - baseOffset < __offset + payloadBytes) return PeekResult.NeedsMoreData
     __offset += payloadBytes
     return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+
+  public fun partial(buffer: ReadBuffer, context: DecodeContext): Partial {
+    val __batch2 = buffer.readLong()
+    val op: kotlin.UByte
+    val flags: kotlin.UByte
+    val payloadLength: kotlin.UShort
+    val group: kotlin.UShort
+    val sequence: kotlin.UByte
+    val commandId: kotlin.UByte
+    if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) {
+      op = (__batch2 ushr 56 and 0xFFL).toUByte()
+      flags = (__batch2 ushr 48 and 0xFFL).toUByte()
+      payloadLength = (__batch2 ushr 32 and 0xFFFFL).toUShort()
+      group = (__batch2 ushr 16 and 0xFFFFL).toUShort()
+      sequence = (__batch2 ushr 8 and 0xFFL).toUByte()
+      commandId = (__batch2 and 0xFFL).toUByte()
+    } else {
+      op = (__batch2 and 0xFFL).toUByte()
+      flags = (__batch2 ushr 8 and 0xFFL).toUByte()
+      payloadLength = (__batch2 ushr 16 and 0xFFFFL).toUShort()
+      group = (__batch2 ushr 32 and 0xFFFFL).toUShort()
+      sequence = (__batch2 ushr 48 and 0xFFL).toUByte()
+      commandId = (__batch2 ushr 56 and 0xFFL).toUByte()
+    }
+    val __payloadStart = buffer.position()
+    val __payloadEnd = __payloadStart + payloadLength.toInt()
+    buffer.position(__payloadEnd)
+    return Partial(op = op, flags = flags, payloadLength = payloadLength, group = group, sequence = sequence, commandId = commandId, payloadStart = __payloadStart, payloadEnd = __payloadEnd, buffer = buffer, context = context)
+  }
+
+  public class Partial internal constructor(
+    public val op: UByte,
+    public val flags: UByte,
+    public val payloadLength: UShort,
+    public val group: UShort,
+    public val sequence: UByte,
+    public val commandId: UByte,
+    private val payloadStart: Int,
+    private val payloadEnd: Int,
+    private val buffer: ReadBuffer,
+    private val context: DecodeContext,
+  ) {
+    public fun complete(): SmpFrame {
+      buffer.position(payloadStart)
+      val __payloadSavedLimit = buffer.limit()
+      buffer.setLimit(payloadEnd)
+      return try {
+        val payload = TextPayloadCodec.decode(buffer, context)
+        if (buffer.position() != payloadEnd) {
+          throw DecodeException(
+                fieldPath = "SmpFrame.payload",
+                bufferPosition = buffer.position(),
+                expected = "the payload codec to consume all " + (payloadEnd - payloadStart) + " bytes",
+                actual = (payloadEnd - buffer.position()).toString() + " bytes left unread",
+              )
+        }
+        SmpFrame(op = op, flags = flags, payloadLength = payloadLength, group = group, sequence = sequence, commandId = commandId, payload = payload)
+      } finally {
+        buffer.setLimit(__payloadSavedLimit)
+      }
+    }
   }
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SmpFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SmpFrameCodec.kt
@@ -1,0 +1,99 @@
+package com.ditchoom.buffer.codec.test.protocols.deferredpayload
+
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.codec.test.protocols.payload.TextPayloadCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object SmpFrameCodec : Codec<SmpFrame> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): SmpFrame {
+    val __batch1 = buffer.readLong()
+    val op: kotlin.UByte
+    val flags: kotlin.UByte
+    val payloadLength: kotlin.UShort
+    val group: kotlin.UShort
+    val sequence: kotlin.UByte
+    val commandId: kotlin.UByte
+    if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) {
+      op = (__batch1 ushr 56 and 0xFFL).toUByte()
+      flags = (__batch1 ushr 48 and 0xFFL).toUByte()
+      payloadLength = (__batch1 ushr 32 and 0xFFFFL).toUShort()
+      group = (__batch1 ushr 16 and 0xFFFFL).toUShort()
+      sequence = (__batch1 ushr 8 and 0xFFL).toUByte()
+      commandId = (__batch1 and 0xFFL).toUByte()
+    } else {
+      op = (__batch1 and 0xFFL).toUByte()
+      flags = (__batch1 ushr 8 and 0xFFL).toUByte()
+      payloadLength = (__batch1 ushr 16 and 0xFFFFL).toUShort()
+      group = (__batch1 ushr 32 and 0xFFFFL).toUShort()
+      sequence = (__batch1 ushr 48 and 0xFFL).toUByte()
+      commandId = (__batch1 ushr 56 and 0xFFL).toUByte()
+    }
+    val payloadBytes = payloadLength.toInt()
+    val payloadOuterLimit = buffer.limit()
+    val payloadEnd = buffer.position() + payloadBytes
+    buffer.setLimit(payloadEnd)
+    val payload = try {
+      TextPayloadCodec.decode(buffer, context)
+    } finally {
+      buffer.setLimit(payloadOuterLimit)
+    }
+    if (buffer.position() != payloadEnd) {
+      throw DecodeException(
+            fieldPath = "SmpFrame.payload",
+            bufferPosition = buffer.position(),
+            expected = "the payload codec to consume all " + payloadBytes + " bytes",
+            actual = (payloadEnd - buffer.position()).toString() + " bytes left unread",
+          )
+    }
+    return SmpFrame(op = op, flags = flags, payloadLength = payloadLength, group = group, sequence = sequence, commandId = commandId, payload = payload)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: SmpFrame,
+    context: EncodeContext,
+  ) {
+    if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) {
+      buffer.writeLong(((value.op.toLong() and 0xFFL) shl 56) or ((value.flags.toLong() and 0xFFL) shl 48) or ((value.payloadLength.toLong() and 0xFFFFL) shl 32) or ((value.group.toLong() and 0xFFFFL) shl 16) or ((value.sequence.toLong() and 0xFFL) shl 8) or (value.commandId.toLong() and 0xFFL))
+    } else {
+      buffer.writeLong((value.op.toLong() and 0xFFL) or ((value.flags.toLong() and 0xFFL) shl 8) or ((value.payloadLength.toLong() and 0xFFFFL) shl 16) or ((value.group.toLong() and 0xFFFFL) shl 32) or ((value.sequence.toLong() and 0xFFL) shl 48) or ((value.commandId.toLong() and 0xFFL) shl 56))
+    }
+    TextPayloadCodec.encode(buffer, value.payload, context)
+  }
+
+  override fun wireSize(`value`: SmpFrame, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun sizeHint(`value`: SmpFrame, context: EncodeContext): Int = 8
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    __offset += 1
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    __offset += 1
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val payloadLengthB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val payloadLengthB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val payloadLength = ((payloadLengthB0 shl 8) or payloadLengthB1).toUInt().toUShort()
+    __offset += 2
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    __offset += 2
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    __offset += 1
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    __offset += 1
+    val payloadBytes = payloadLength.toInt()
+    if (stream.available() - baseOffset < __offset + payloadBytes) return PeekResult.NeedsMoreData
+    __offset += payloadBytes
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SmpFrameWithTrailerCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SmpFrameWithTrailerCodec.kt
@@ -84,6 +84,9 @@ public object SmpFrameWithTrailerCodec : Codec<SmpFrameWithTrailer> {
     val payloadLength = ((payloadLengthB0 shl 8) or payloadLengthB1).toUInt().toUShort()
     __offset += 2
     val payloadBytes = payloadLength.toInt()
+    if (payloadBytes < 0 || payloadBytes > Int.MAX_VALUE - __offset) {
+      throw DecodeException(fieldPath = "SmpFrameWithTrailer.payload", bufferPosition = baseOffset + __offset, expected = "__offset + @LengthFrom source in 0..${'$'}{Int.MAX_VALUE}", actual = """${__offset.toLong() + payloadBytes.toLong()}""")
+    }
     if (stream.available() - baseOffset < __offset + payloadBytes) return PeekResult.NeedsMoreData
     __offset += payloadBytes
     if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SmpFrameWithTrailerCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SmpFrameWithTrailerCodec.kt
@@ -13,6 +13,8 @@ import com.ditchoom.buffer.codec.WireSize
 import com.ditchoom.buffer.codec.test.protocols.payload.TextPayloadCodec
 import com.ditchoom.buffer.stream.StreamProcessor
 import kotlin.Int
+import kotlin.String
+import kotlin.UShort
 
 public object SmpFrameWithTrailerCodec : Codec<SmpFrameWithTrailer> {
   override fun decode(buffer: ReadBuffer, context: DecodeContext): SmpFrameWithTrailer {
@@ -95,5 +97,52 @@ public object SmpFrameWithTrailerCodec : Codec<SmpFrameWithTrailer> {
     }
     __offset += 2 + notePrefix.toInt()
     return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+
+  public fun partial(buffer: ReadBuffer, context: DecodeContext): Partial {
+    val payloadLength = buffer.readUShort()
+    val __payloadStart = buffer.position()
+    val __payloadEnd = __payloadStart + payloadLength.toInt()
+    buffer.position(__payloadEnd)
+    val checksum = buffer.readUShort()
+    val notePrefixB0 = buffer.readUByte().toUInt()
+    val notePrefixB1 = buffer.readUByte().toUInt()
+    val notePrefix = ((notePrefixB0 shl 8) or notePrefixB1)
+    if (notePrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "SmpFrameWithTrailer.note", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = notePrefix.toString())
+    }
+    val noteLength = notePrefix.toInt()
+    val note = buffer.readString(noteLength, Charset.UTF8)
+    return Partial(payloadLength = payloadLength, checksum = checksum, note = note, payloadStart = __payloadStart, payloadEnd = __payloadEnd, buffer = buffer, context = context)
+  }
+
+  public class Partial internal constructor(
+    public val payloadLength: UShort,
+    public val checksum: UShort,
+    public val note: String,
+    private val payloadStart: Int,
+    private val payloadEnd: Int,
+    private val buffer: ReadBuffer,
+    private val context: DecodeContext,
+  ) {
+    public fun complete(): SmpFrameWithTrailer {
+      buffer.position(payloadStart)
+      val __payloadSavedLimit = buffer.limit()
+      buffer.setLimit(payloadEnd)
+      return try {
+        val payload = TextPayloadCodec.decode(buffer, context)
+        if (buffer.position() != payloadEnd) {
+          throw DecodeException(
+                fieldPath = "SmpFrameWithTrailer.payload",
+                bufferPosition = buffer.position(),
+                expected = "the payload codec to consume all " + (payloadEnd - payloadStart) + " bytes",
+                actual = (payloadEnd - buffer.position()).toString() + " bytes left unread",
+              )
+        }
+        SmpFrameWithTrailer(payloadLength = payloadLength, payload = payload, checksum = checksum, note = note)
+      } finally {
+        buffer.setLimit(__payloadSavedLimit)
+      }
+    }
   }
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SmpFrameWithTrailerCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SmpFrameWithTrailerCodec.kt
@@ -1,0 +1,99 @@
+package com.ditchoom.buffer.codec.test.protocols.deferredpayload
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.codec.test.protocols.payload.TextPayloadCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public object SmpFrameWithTrailerCodec : Codec<SmpFrameWithTrailer> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): SmpFrameWithTrailer {
+    val payloadLength = buffer.readUShort()
+    val payloadBytes = payloadLength.toInt()
+    val payloadOuterLimit = buffer.limit()
+    val payloadEnd = buffer.position() + payloadBytes
+    buffer.setLimit(payloadEnd)
+    val payload = try {
+      TextPayloadCodec.decode(buffer, context)
+    } finally {
+      buffer.setLimit(payloadOuterLimit)
+    }
+    if (buffer.position() != payloadEnd) {
+      throw DecodeException(
+            fieldPath = "SmpFrameWithTrailer.payload",
+            bufferPosition = buffer.position(),
+            expected = "the payload codec to consume all " + payloadBytes + " bytes",
+            actual = (payloadEnd - buffer.position()).toString() + " bytes left unread",
+          )
+    }
+    val checksum = buffer.readUShort()
+    val notePrefixB0 = buffer.readUByte().toUInt()
+    val notePrefixB1 = buffer.readUByte().toUInt()
+    val notePrefix = ((notePrefixB0 shl 8) or notePrefixB1)
+    if (notePrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "SmpFrameWithTrailer.note", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = notePrefix.toString())
+    }
+    val noteLength = notePrefix.toInt()
+    val note = buffer.readString(noteLength, Charset.UTF8)
+    return SmpFrameWithTrailer(payloadLength = payloadLength, payload = payload, checksum = checksum, note = note)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: SmpFrameWithTrailer,
+    context: EncodeContext,
+  ) {
+    buffer.writeUShort(value.payloadLength)
+    TextPayloadCodec.encode(buffer, value.payload, context)
+    buffer.writeUShort(value.checksum)
+    val noteSizePosition = buffer.position()
+    repeat(2) { buffer.writeUByte(0u) }
+    val noteBodyStart = buffer.position()
+    buffer.writeString(value.note, Charset.UTF8)
+    val noteEndPosition = buffer.position()
+    val noteByteCount = noteEndPosition - noteBodyStart
+    if (noteByteCount > 65_535) {
+      throw EncodeException(fieldPath = "SmpFrameWithTrailer.note", reason = """UTF-8 byte length ${noteByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+    }
+    buffer.position(noteSizePosition)
+    val notePrefix = noteByteCount.toUInt()
+    buffer.writeUByte(((notePrefix shr 8) and 0xFFu).toUByte())
+    buffer.writeUByte((notePrefix and 0xFFu).toUByte())
+    buffer.position(noteEndPosition)
+  }
+
+  override fun wireSize(`value`: SmpFrameWithTrailer, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun sizeHint(`value`: SmpFrameWithTrailer, context: EncodeContext): Int = 6 + value.note.length
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val payloadLengthB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val payloadLengthB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val payloadLength = ((payloadLengthB0 shl 8) or payloadLengthB1).toUInt().toUShort()
+    __offset += 2
+    val payloadBytes = payloadLength.toInt()
+    if (stream.available() - baseOffset < __offset + payloadBytes) return PeekResult.NeedsMoreData
+    __offset += payloadBytes
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    __offset += 2
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val notePrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val notePrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val notePrefix = ((notePrefixB0 shl 8) or notePrefixB1).toUInt()
+    if (notePrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "SmpFrameWithTrailer.note", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + notePrefix.toInt()}""")
+    }
+    __offset += 2 + notePrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SmpGenericFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SmpGenericFrameCodec.kt
@@ -6,12 +6,15 @@ import com.ditchoom.buffer.WriteBuffer
 import com.ditchoom.buffer.codec.Codec
 import com.ditchoom.buffer.codec.DecodeContext
 import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.Decoder
 import com.ditchoom.buffer.codec.EncodeContext
 import com.ditchoom.buffer.codec.Payload
 import com.ditchoom.buffer.codec.PeekResult
 import com.ditchoom.buffer.codec.WireSize
 import com.ditchoom.buffer.stream.StreamProcessor
 import kotlin.Int
+import kotlin.UByte
+import kotlin.UShort
 
 public class SmpGenericFrameCodec<P : Payload>(
   private val payloadCodec: Codec<P>,
@@ -97,5 +100,69 @@ public class SmpGenericFrameCodec<P : Payload>(
     if (stream.available() - baseOffset < __offset + payloadBytes) return PeekResult.NeedsMoreData
     __offset += payloadBytes
     return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+
+  public class Partial<P : Payload> internal constructor(
+    public val op: UByte,
+    public val flags: UByte,
+    public val payloadLength: UShort,
+    public val group: UShort,
+    public val sequence: UByte,
+    public val commandId: UByte,
+    private val payloadStart: Int,
+    private val payloadEnd: Int,
+    private val buffer: ReadBuffer,
+    private val context: DecodeContext,
+  ) {
+    public fun complete(payloadCodec: Decoder<P>): SmpGenericFrame<P> {
+      buffer.position(payloadStart)
+      val __payloadSavedLimit = buffer.limit()
+      buffer.setLimit(payloadEnd)
+      return try {
+        val payload = payloadCodec.decode(buffer, context)
+        if (buffer.position() != payloadEnd) {
+          throw DecodeException(
+                fieldPath = "SmpGenericFrame.payload",
+                bufferPosition = buffer.position(),
+                expected = "the payload codec to consume all " + (payloadEnd - payloadStart) + " bytes",
+                actual = (payloadEnd - buffer.position()).toString() + " bytes left unread",
+              )
+        }
+        SmpGenericFrame<P>(op = op, flags = flags, payloadLength = payloadLength, group = group, sequence = sequence, commandId = commandId, payload = payload)
+      } finally {
+        buffer.setLimit(__payloadSavedLimit)
+      }
+    }
+  }
+
+  public companion object {
+    public fun <P : Payload> partial(buffer: ReadBuffer, context: DecodeContext): Partial<P> {
+      val __batch2 = buffer.readLong()
+      val op: kotlin.UByte
+      val flags: kotlin.UByte
+      val payloadLength: kotlin.UShort
+      val group: kotlin.UShort
+      val sequence: kotlin.UByte
+      val commandId: kotlin.UByte
+      if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) {
+        op = (__batch2 ushr 56 and 0xFFL).toUByte()
+        flags = (__batch2 ushr 48 and 0xFFL).toUByte()
+        payloadLength = (__batch2 ushr 32 and 0xFFFFL).toUShort()
+        group = (__batch2 ushr 16 and 0xFFFFL).toUShort()
+        sequence = (__batch2 ushr 8 and 0xFFL).toUByte()
+        commandId = (__batch2 and 0xFFL).toUByte()
+      } else {
+        op = (__batch2 and 0xFFL).toUByte()
+        flags = (__batch2 ushr 8 and 0xFFL).toUByte()
+        payloadLength = (__batch2 ushr 16 and 0xFFFFL).toUShort()
+        group = (__batch2 ushr 32 and 0xFFFFL).toUShort()
+        sequence = (__batch2 ushr 48 and 0xFFL).toUByte()
+        commandId = (__batch2 ushr 56 and 0xFFL).toUByte()
+      }
+      val __payloadStart = buffer.position()
+      val __payloadEnd = __payloadStart + payloadLength.toInt()
+      buffer.position(__payloadEnd)
+      return Partial<P>(op = op, flags = flags, payloadLength = payloadLength, group = group, sequence = sequence, commandId = commandId, payloadStart = __payloadStart, payloadEnd = __payloadEnd, buffer = buffer, context = context)
+    }
   }
 }

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SmpGenericFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SmpGenericFrameCodec.kt
@@ -1,0 +1,101 @@
+package com.ditchoom.buffer.codec.test.protocols.deferredpayload
+
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.Payload
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+
+public class SmpGenericFrameCodec<P : Payload>(
+  private val payloadCodec: Codec<P>,
+) : Codec<SmpGenericFrame<P>> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): SmpGenericFrame<P> {
+    val __batch1 = buffer.readLong()
+    val op: kotlin.UByte
+    val flags: kotlin.UByte
+    val payloadLength: kotlin.UShort
+    val group: kotlin.UShort
+    val sequence: kotlin.UByte
+    val commandId: kotlin.UByte
+    if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) {
+      op = (__batch1 ushr 56 and 0xFFL).toUByte()
+      flags = (__batch1 ushr 48 and 0xFFL).toUByte()
+      payloadLength = (__batch1 ushr 32 and 0xFFFFL).toUShort()
+      group = (__batch1 ushr 16 and 0xFFFFL).toUShort()
+      sequence = (__batch1 ushr 8 and 0xFFL).toUByte()
+      commandId = (__batch1 and 0xFFL).toUByte()
+    } else {
+      op = (__batch1 and 0xFFL).toUByte()
+      flags = (__batch1 ushr 8 and 0xFFL).toUByte()
+      payloadLength = (__batch1 ushr 16 and 0xFFFFL).toUShort()
+      group = (__batch1 ushr 32 and 0xFFFFL).toUShort()
+      sequence = (__batch1 ushr 48 and 0xFFL).toUByte()
+      commandId = (__batch1 ushr 56 and 0xFFL).toUByte()
+    }
+    val payloadBytes = payloadLength.toInt()
+    val payloadOuterLimit = buffer.limit()
+    val payloadEnd = buffer.position() + payloadBytes
+    buffer.setLimit(payloadEnd)
+    val payload = try {
+      payloadCodec.decode(buffer, context)
+    } finally {
+      buffer.setLimit(payloadOuterLimit)
+    }
+    if (buffer.position() != payloadEnd) {
+      throw DecodeException(
+            fieldPath = "SmpGenericFrame.payload",
+            bufferPosition = buffer.position(),
+            expected = "the payload codec to consume all " + payloadBytes + " bytes",
+            actual = (payloadEnd - buffer.position()).toString() + " bytes left unread",
+          )
+    }
+    return SmpGenericFrame<P>(op = op, flags = flags, payloadLength = payloadLength, group = group, sequence = sequence, commandId = commandId, payload = payload)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: SmpGenericFrame<P>,
+    context: EncodeContext,
+  ) {
+    if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) {
+      buffer.writeLong(((value.op.toLong() and 0xFFL) shl 56) or ((value.flags.toLong() and 0xFFL) shl 48) or ((value.payloadLength.toLong() and 0xFFFFL) shl 32) or ((value.group.toLong() and 0xFFFFL) shl 16) or ((value.sequence.toLong() and 0xFFL) shl 8) or (value.commandId.toLong() and 0xFFL))
+    } else {
+      buffer.writeLong((value.op.toLong() and 0xFFL) or ((value.flags.toLong() and 0xFFL) shl 8) or ((value.payloadLength.toLong() and 0xFFFFL) shl 16) or ((value.group.toLong() and 0xFFFFL) shl 32) or ((value.sequence.toLong() and 0xFFL) shl 48) or ((value.commandId.toLong() and 0xFFL) shl 56))
+    }
+    payloadCodec.encode(buffer, value.payload, context)
+  }
+
+  override fun wireSize(`value`: SmpGenericFrame<P>, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun sizeHint(`value`: SmpGenericFrame<P>, context: EncodeContext): Int = 8
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    __offset += 1
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    __offset += 1
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val payloadLengthB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val payloadLengthB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val payloadLength = ((payloadLengthB0 shl 8) or payloadLengthB1).toUInt().toUShort()
+    __offset += 2
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    __offset += 2
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    __offset += 1
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    __offset += 1
+    val payloadBytes = payloadLength.toInt()
+    if (stream.available() - baseOffset < __offset + payloadBytes) return PeekResult.NeedsMoreData
+    __offset += payloadBytes
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SmpGenericFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SmpGenericFrameCodec.kt
@@ -97,6 +97,9 @@ public class SmpGenericFrameCodec<P : Payload>(
     if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
     __offset += 1
     val payloadBytes = payloadLength.toInt()
+    if (payloadBytes < 0 || payloadBytes > Int.MAX_VALUE - __offset) {
+      throw DecodeException(fieldPath = "SmpGenericFrame.payload", bufferPosition = baseOffset + __offset, expected = "__offset + @LengthFrom source in 0..${'$'}{Int.MAX_VALUE}", actual = """${__offset.toLong() + payloadBytes.toLong()}""")
+    }
     if (stream.available() - baseOffset < __offset + payloadBytes) return PeekResult.NeedsMoreData
     __offset += payloadBytes
     return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/WideLengthDeferredFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/WideLengthDeferredFrameCodec.kt
@@ -1,0 +1,121 @@
+package com.ditchoom.buffer.codec.test.protocols.deferredpayload
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.codec.test.protocols.payload.TextPayloadCodec
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.Int
+import kotlin.UByte
+import kotlin.UInt
+
+public object WideLengthDeferredFrameCodec : Codec<WideLengthDeferredFrame> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): WideLengthDeferredFrame {
+    val payloadLength = buffer.readUInt()
+    val flags = buffer.readUByte()
+    if (payloadLength > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "WideLengthDeferredFrame.payload", bufferPosition = -1, expected = "@LengthFrom source <= ${'$'}{Int.MAX_VALUE}", actual = payloadLength.toString())
+    }
+    val payloadBytes = payloadLength.toInt()
+    val payloadOuterLimit = buffer.limit()
+    val payloadEnd = buffer.position() + payloadBytes
+    buffer.setLimit(payloadEnd)
+    val payload = try {
+      TextPayloadCodec.decode(buffer, context)
+    } finally {
+      buffer.setLimit(payloadOuterLimit)
+    }
+    if (buffer.position() != payloadEnd) {
+      throw DecodeException(
+            fieldPath = "WideLengthDeferredFrame.payload",
+            bufferPosition = buffer.position(),
+            expected = "the payload codec to consume all " + payloadBytes + " bytes",
+            actual = (payloadEnd - buffer.position()).toString() + " bytes left unread",
+          )
+    }
+    return WideLengthDeferredFrame(payloadLength = payloadLength, flags = flags, payload = payload)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: WideLengthDeferredFrame,
+    context: EncodeContext,
+  ) {
+    buffer.writeUInt(value.payloadLength)
+    buffer.writeUByte(value.flags)
+    TextPayloadCodec.encode(buffer, value.payload, context)
+  }
+
+  override fun wireSize(`value`: WideLengthDeferredFrame, context: EncodeContext): WireSize = WireSize.BackPatch
+
+  override fun sizeHint(`value`: WideLengthDeferredFrame, context: EncodeContext): Int = 5
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 4) return PeekResult.NeedsMoreData
+    val payloadLengthB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val payloadLengthB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val payloadLengthB2 = stream.peekByte(baseOffset + __offset + 2).toInt() and 0xFF
+    val payloadLengthB3 = stream.peekByte(baseOffset + __offset + 3).toInt() and 0xFF
+    val payloadLength = ((payloadLengthB0 shl 24) or (payloadLengthB1 shl 16) or (payloadLengthB2 shl 8) or payloadLengthB3).toUInt()
+    __offset += 4
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    __offset += 1
+    if (payloadLength > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "WideLengthDeferredFrame.payload", bufferPosition = -1, expected = "@LengthFrom source <= ${'$'}{Int.MAX_VALUE}", actual = payloadLength.toString())
+    }
+    val payloadBytes = payloadLength.toInt()
+    if (payloadBytes < 0 || payloadBytes > Int.MAX_VALUE - __offset) {
+      throw DecodeException(fieldPath = "WideLengthDeferredFrame.payload", bufferPosition = baseOffset + __offset, expected = "__offset + @LengthFrom source in 0..${'$'}{Int.MAX_VALUE}", actual = """${__offset.toLong() + payloadBytes.toLong()}""")
+    }
+    if (stream.available() - baseOffset < __offset + payloadBytes) return PeekResult.NeedsMoreData
+    __offset += payloadBytes
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+
+  public fun partial(buffer: ReadBuffer, context: DecodeContext): Partial {
+    val payloadLength = buffer.readUInt()
+    val flags = buffer.readUByte()
+    val __payloadStart = buffer.position()
+    if (payloadLength > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "WideLengthDeferredFrame.payload", bufferPosition = -1, expected = "@LengthFrom source <= ${'$'}{Int.MAX_VALUE}", actual = payloadLength.toString())
+    }
+    val __payloadEnd = __payloadStart + payloadLength.toInt()
+    buffer.position(__payloadEnd)
+    return Partial(payloadLength = payloadLength, flags = flags, payloadStart = __payloadStart, payloadEnd = __payloadEnd, buffer = buffer, context = context)
+  }
+
+  public class Partial internal constructor(
+    public val payloadLength: UInt,
+    public val flags: UByte,
+    private val payloadStart: Int,
+    private val payloadEnd: Int,
+    private val buffer: ReadBuffer,
+    private val context: DecodeContext,
+  ) {
+    public fun complete(): WideLengthDeferredFrame {
+      buffer.position(payloadStart)
+      val __payloadSavedLimit = buffer.limit()
+      buffer.setLimit(payloadEnd)
+      return try {
+        val payload = TextPayloadCodec.decode(buffer, context)
+        if (buffer.position() != payloadEnd) {
+          throw DecodeException(
+                fieldPath = "WideLengthDeferredFrame.payload",
+                bufferPosition = buffer.position(),
+                expected = "the payload codec to consume all " + (payloadEnd - payloadStart) + " bytes",
+                actual = (payloadEnd - buffer.position()).toString() + " bytes left unread",
+              )
+        }
+        WideLengthDeferredFrame(payloadLength = payloadLength, flags = flags, payload = payload)
+      } finally {
+        buffer.setLimit(__payloadSavedLimit)
+      }
+    }
+  }
+}

--- a/buffer-codec-test/src/codecSchema/codec-schema.txt
+++ b/buffer-codec-test/src/codecSchema/codec-schema.txt
@@ -180,6 +180,30 @@ message com.ditchoom.buffer.codec.test.protocols.count.CountThenTrailer
   1 trailer scalar:UInt wire=4B order=Big
 message com.ditchoom.buffer.codec.test.protocols.count.CountVariableList
   0 names list:com.ditchoom.buffer.codec.test.protocols.count.CountNamed count-prefixed
+message com.ditchoom.buffer.codec.test.protocols.deferredpayload.ShortReadFrame
+  0 payloadLength scalar:UShort wire=2B order=Default
+  1 payload payload:com.ditchoom.buffer.codec.test.protocols.payload.TextPayload len-from=sibling:payloadLength codec=com.ditchoom.buffer.codec.test.protocols.deferredpayload.ShortReadPayloadCodec
+message com.ditchoom.buffer.codec.test.protocols.deferredpayload.SmpFrame
+  0 op scalar:UByte wire=1B order=Default
+  1 flags scalar:UByte wire=1B order=Default
+  2 payloadLength scalar:UShort wire=2B order=Default
+  3 group scalar:UShort wire=2B order=Default
+  4 sequence scalar:UByte wire=1B order=Default
+  5 commandId scalar:UByte wire=1B order=Default
+  6 payload payload:com.ditchoom.buffer.codec.test.protocols.payload.TextPayload len-from=sibling:payloadLength codec=com.ditchoom.buffer.codec.test.protocols.payload.TextPayloadCodec
+message com.ditchoom.buffer.codec.test.protocols.deferredpayload.SmpFrameWithTrailer
+  0 payloadLength scalar:UShort wire=2B order=Default
+  1 payload payload:com.ditchoom.buffer.codec.test.protocols.payload.TextPayload len-from=sibling:payloadLength codec=com.ditchoom.buffer.codec.test.protocols.payload.TextPayloadCodec
+  2 checksum scalar:UShort wire=2B order=Default
+  3 note string len-prefix=2B/Default
+message com.ditchoom.buffer.codec.test.protocols.deferredpayload.SmpGenericFrame
+  0 op scalar:UByte wire=1B order=Default
+  1 flags scalar:UByte wire=1B order=Default
+  2 payloadLength scalar:UShort wire=2B order=Default
+  3 group scalar:UShort wire=2B order=Default
+  4 sequence scalar:UByte wire=1B order=Default
+  5 commandId scalar:UByte wire=1B order=Default
+  6 payload payload:P len-from=sibling:payloadLength codec=injected:payloadCodec
 message com.ditchoom.buffer.codec.test.protocols.dns.DnsHeader
   0 id scalar:UShort wire=2B order=Big
   1 flags scalar:UShort wire=2B order=Big

--- a/buffer-codec-test/src/codecSchema/codec-schema.txt
+++ b/buffer-codec-test/src/codecSchema/codec-schema.txt
@@ -214,6 +214,10 @@ message com.ditchoom.buffer.codec.test.protocols.deferredpayload.SmpGenericFrame
   4 sequence scalar:UByte wire=1B order=Default
   5 commandId scalar:UByte wire=1B order=Default
   6 payload payload:P len-from=sibling:payloadLength codec=injected:payloadCodec
+message com.ditchoom.buffer.codec.test.protocols.deferredpayload.WideLengthDeferredFrame
+  0 payloadLength scalar:UInt wire=4B order=Default
+  1 flags scalar:UByte wire=1B order=Default
+  2 payload payload:com.ditchoom.buffer.codec.test.protocols.payload.TextPayload len-from=sibling:payloadLength codec=com.ditchoom.buffer.codec.test.protocols.payload.TextPayloadCodec
 message com.ditchoom.buffer.codec.test.protocols.dns.DnsHeader
   0 id scalar:UShort wire=2B order=Big
   1 flags scalar:UShort wire=2B order=Big

--- a/buffer-codec-test/src/codecSchema/codec-schema.txt
+++ b/buffer-codec-test/src/codecSchema/codec-schema.txt
@@ -180,6 +180,16 @@ message com.ditchoom.buffer.codec.test.protocols.count.CountThenTrailer
   1 trailer scalar:UInt wire=4B order=Big
 message com.ditchoom.buffer.codec.test.protocols.count.CountVariableList
   0 names list:com.ditchoom.buffer.codec.test.protocols.count.CountNamed count-prefixed
+sealed com.ditchoom.buffer.codec.test.protocols.deferredpayload.DeferredDispatchFrame dispatch=fixed-byte/1B
+  0x0A Command
+  0xA0 Status
+message com.ditchoom.buffer.codec.test.protocols.deferredpayload.DeferredDispatchFrame.Command
+  0 counter scalar:UShort wire=2B order=Default
+  1 payloadLength scalar:UShort wire=2B order=Default
+  2 payload payload:P len-from=sibling:payloadLength codec=injected:payloadCodec
+  3 checksum scalar:UShort wire=2B order=Default
+message com.ditchoom.buffer.codec.test.protocols.deferredpayload.DeferredDispatchFrame.Status
+  0 code scalar:UByte wire=1B order=Default
 message com.ditchoom.buffer.codec.test.protocols.deferredpayload.ShortReadFrame
   0 payloadLength scalar:UShort wire=2B order=Default
   1 payload payload:com.ditchoom.buffer.codec.test.protocols.payload.TextPayload len-from=sibling:payloadLength codec=com.ditchoom.buffer.codec.test.protocols.deferredpayload.ShortReadPayloadCodec

--- a/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SmpFrame.kt
+++ b/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SmpFrame.kt
@@ -139,6 +139,28 @@ data class ShortReadFrame(
 )
 
 /**
+ * Hostile-length probe for the deferred shape —
+ * [com.ditchoom.buffer.codec.test.protocols.simple.WideLengthFrame]'s
+ * full-width `UInt` carrier with the `String` payload swapped for a
+ * codec-deferred one.
+ *
+ * A full-width carrier is the only shape where a wire-supplied length can
+ * reach `Int.MAX_VALUE` and overflow `peekFrameSize`'s running offset
+ * (`__offset + payloadBytes`). The `UShort` fixtures above cannot express
+ * that value, so without this fixture the overflow guard would exist in
+ * the deferred peeks but never execute. Non-adjacent carrier (`flags`
+ * separates it from the body) for the same reason as `WideLengthFrame`.
+ */
+@ProtocolMessage
+data class WideLengthDeferredFrame(
+    val payloadLength: UInt,
+    val flags: UByte,
+    @LengthFrom("payloadLength")
+    @UseCodec(TextPayloadCodec::class)
+    val payload: TextPayload,
+)
+
+/**
  * The reporter's *second* shape from issue #168, migrated to `@LengthFrom`.
  *
  * #168 asked why `Partial` was generated for `SmpPacket` but not for a sealed

--- a/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SmpFrame.kt
+++ b/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SmpFrame.kt
@@ -10,6 +10,7 @@ import com.ditchoom.buffer.codec.Payload
 import com.ditchoom.buffer.codec.WireSize
 import com.ditchoom.buffer.codec.annotations.LengthFrom
 import com.ditchoom.buffer.codec.annotations.LengthPrefixed
+import com.ditchoom.buffer.codec.annotations.PacketType
 import com.ditchoom.buffer.codec.annotations.ProtocolMessage
 import com.ditchoom.buffer.codec.annotations.UseCodec
 import com.ditchoom.buffer.codec.test.protocols.payload.TextPayload
@@ -136,3 +137,44 @@ data class ShortReadFrame(
     @UseCodec(ShortReadPayloadCodec::class)
     val payload: TextPayload,
 )
+
+/**
+ * The reporter's *second* shape from issue #168, migrated to `@LengthFrom`.
+ *
+ * #168 asked why `Partial` was generated for `SmpPacket` but not for a sealed
+ * `Frame` whose variants carry `counter` / `length` / payload / `checksum`;
+ * #171 answered it by allowing a non-terminal payload with fixed-size
+ * trailers. That shape is the other half of what #293 migrates, so it gets a
+ * fixture: a sealed variant — not a top-level data class — with a
+ * sibling-sized generic payload and a trailer after it.
+ *
+ * Declared with a generic parent (`<out P : Payload>`), which is the form the
+ * processor supports; the raw non-generic parent in #168's original snippet is
+ * rejected by `validateGenericPayloadVariantShape` (issue #176).
+ *
+ * ```text
+ * Command<TextPayload>(counter=1, payloadLength=2, payload="hi", checksum=0xBEEF):
+ *   0A            @PacketType discriminator (consumed by the dispatcher)
+ *   00 01         counter
+ *   00 02         payloadLength
+ *   68 69         payload, exactly payloadLength bytes
+ *   BE EF         checksum
+ * ```
+ */
+@ProtocolMessage
+sealed interface DeferredDispatchFrame<out P : Payload> {
+    @ProtocolMessage
+    @PacketType(0x0A)
+    data class Command<P : Payload>(
+        val counter: UShort,
+        val payloadLength: UShort,
+        @LengthFrom("payloadLength") val payload: P,
+        val checksum: UShort,
+    ) : DeferredDispatchFrame<P>
+
+    @ProtocolMessage
+    @PacketType(0xA0)
+    data class Status(
+        val code: UByte,
+    ) : DeferredDispatchFrame<Nothing>
+}

--- a/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SmpFrame.kt
+++ b/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SmpFrame.kt
@@ -1,0 +1,138 @@
+package com.ditchoom.buffer.codec.test.protocols.deferredpayload
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.Payload
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.codec.annotations.LengthFrom
+import com.ditchoom.buffer.codec.annotations.LengthPrefixed
+import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+import com.ditchoom.buffer.codec.annotations.UseCodec
+import com.ditchoom.buffer.codec.test.protocols.payload.TextPayload
+import com.ditchoom.buffer.codec.test.protocols.payload.TextPayloadCodec
+
+/**
+ * Issue #293 vector — a deferred payload sized by a **sibling length
+ * field** rather than by the caller's buffer limit.
+ *
+ * Modelled on the SMP / mcumgr-over-BLE header that motivated the issue,
+ * because it is the shape the old taxonomy could not express: the length
+ * carrier is non-adjacent (four fixed scalars sit between `payloadLength`
+ * and the body), so `@FramedBy` — which requires the prefix immediately
+ * after the discriminator — does not fit, and `@RemainingBytes` would
+ * throw away the byte count the protocol already states.
+ *
+ * Structurally this is `RemoteHeader` with `String` swapped for a
+ * codec-decoded `Payload`. That swap used to change the *framing* answer
+ * (`peekFrameSize` collapsed to `NoFraming`) even though it changes no
+ * wire byte — the bug #293 is about.
+ *
+ * Wire layout (all multi-byte fields big-endian):
+ * ```text
+ * SmpFrame(op=0, flags=0, payloadLength=2, group=9, sequence=1,
+ *          commandId=3, payload=TextPayload("hi")):
+ *   00            op
+ *   00            flags
+ *   00 02         payloadLength
+ *   00 09         group
+ *   01            sequence
+ *   03            commandId
+ *   68 69         payload, exactly `payloadLength` bytes
+ * ```
+ */
+@ProtocolMessage
+data class SmpFrame(
+    val op: UByte,
+    val flags: UByte,
+    val payloadLength: UShort,
+    val group: UShort,
+    val sequence: UByte,
+    val commandId: UByte,
+    @LengthFrom("payloadLength")
+    @UseCodec(TextPayloadCodec::class)
+    val payload: TextPayload,
+)
+
+/**
+ * The same shape with the payload left generic, so the codec is supplied
+ * by the caller as a constructor-injected `Codec<P>` rather than pinned
+ * by `@UseCodec`. Proves the two axes are independent: the extent
+ * (`@LengthFrom`) composes with either [com.ditchoom.buffer.codec.Payload]
+ * codec source.
+ */
+@ProtocolMessage
+data class SmpGenericFrame<P : Payload>(
+    val op: UByte,
+    val flags: UByte,
+    val payloadLength: UShort,
+    val group: UShort,
+    val sequence: UByte,
+    val commandId: UByte,
+    @LengthFrom("payloadLength") val payload: P,
+)
+
+/**
+ * A sibling-sized payload with fields *after* it, including a
+ * variable-size one.
+ *
+ * `@RemainingBytes` payloads are terminal-or-fixed-size-trailer only:
+ * their end is `limit - <reserved trailing bytes>`, which is computable
+ * only when every trailer has a known width. A sibling states the byte
+ * count outright, so that restriction does not apply and ordinary fields
+ * — of any width — may follow.
+ */
+@ProtocolMessage
+data class SmpFrameWithTrailer(
+    val payloadLength: UShort,
+    @LengthFrom("payloadLength")
+    @UseCodec(TextPayloadCodec::class)
+    val payload: TextPayload,
+    val checksum: UShort,
+    @LengthPrefixed val note: String,
+)
+
+/**
+ * A deliberately misbehaving `Codec<TextPayload>`: it leaves the last
+ * byte of its bounded region unread.
+ *
+ * Under `@RemainingBytes` this is undetectable — the payload's extent is
+ * whatever the codec chooses to read. Under `@LengthFrom` the region is
+ * stated on the wire, so stopping short means every subsequent field
+ * reads from the wrong offset. The generated decode rejects it rather
+ * than silently desynchronising; [ShortReadFrame] is the vector.
+ */
+object ShortReadPayloadCodec : Codec<TextPayload> {
+    override fun decode(
+        buffer: ReadBuffer,
+        context: DecodeContext,
+    ): TextPayload {
+        val short = (buffer.remaining() - 1).coerceAtLeast(0)
+        return TextPayload(buffer.readString(short, Charset.UTF8))
+    }
+
+    override fun encode(
+        buffer: WriteBuffer,
+        value: TextPayload,
+        context: EncodeContext,
+    ) {
+        buffer.writeString(value.text, Charset.UTF8)
+    }
+
+    override fun wireSize(
+        value: TextPayload,
+        context: EncodeContext,
+    ): WireSize = WireSize.BackPatch
+}
+
+/** Carrier for [ShortReadPayloadCodec] — see its docs. */
+@ProtocolMessage
+data class ShortReadFrame(
+    val payloadLength: UShort,
+    @LengthFrom("payloadLength")
+    @UseCodec(ShortReadPayloadCodec::class)
+    val payload: TextPayload,
+)

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SmpFrameCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SmpFrameCodecTest.kt
@@ -217,6 +217,97 @@ class SmpFrameCodecTest {
         }
     }
 
+    // ---- partial / complete deferral --------------------------------------
+
+    /**
+     * The header/payload split the issue is really about: `partial()` decodes
+     * the envelope, the caller picks a `Codec<P>` from what it sees there, and
+     * `complete()` decodes the body. Two actors, two times.
+     *
+     * This is also the migration guarantee. The same message with
+     * `@RemainingBytes val payload: P` already emits a `Partial` (issue #168 /
+     * #171), so moving to `@LengthFrom` must not take it away.
+     */
+    @Test
+    fun partialExposesTheHeaderAndDefersThePayload() {
+        val original =
+            SmpGenericFrame(
+                op = 0u,
+                flags = 0u,
+                payloadLength = 2u,
+                group = 9u,
+                sequence = 1u,
+                commandId = 3u,
+                payload = TextPayload("hi"),
+            )
+        val codec = SmpGenericFrameCodec(TextPayloadCodec)
+        val buf = buildBuffer { codec.encode(it, original, EncodeContext.Empty) }
+        buf.resetForRead()
+
+        val partial = SmpGenericFrameCodec.partial<TextPayload>(buf, DecodeContext.Empty)
+        // Every header field is readable before any payload codec is chosen —
+        // routing on group/commandId is the whole point.
+        assertEquals(9u.toUShort(), partial.group)
+        assertEquals(3u.toUByte(), partial.commandId)
+        assertEquals(2u.toUShort(), partial.payloadLength)
+
+        assertEquals(original, partial.complete(TextPayloadCodec))
+    }
+
+    /**
+     * A `Partial` whose payload is followed by a **variable-width** field.
+     * Impossible under `@RemainingBytes`, where the payload's end is
+     * `limit - <trailer bytes>` and so every trailer must have a known width.
+     * A sibling states the length outright, so the restriction lifts.
+     */
+    @Test
+    fun partialSupportsAVariableWidthTrailer() {
+        val original =
+            SmpFrameWithTrailer(
+                payloadLength = 2u,
+                payload = TextPayload("hi"),
+                checksum = 0xBEEFu,
+                note = "trailing",
+            )
+        val buf = buildBuffer { SmpFrameWithTrailerCodec.encode(it, original, EncodeContext.Empty) }
+        buf.resetForRead()
+
+        val partial = SmpFrameWithTrailerCodec.partial(buf, DecodeContext.Empty)
+        assertEquals(0xBEEFu.toUShort(), partial.checksum, "trailer read eagerly, past the payload")
+        assertEquals("trailing", partial.note)
+        assertEquals(original, partial.complete())
+    }
+
+    /** `complete()` bounds the payload to the sibling region, not to the buffer. */
+    @Test
+    fun completeBoundsThePayloadToTheSiblingRegion() {
+        val original =
+            SmpFrameWithTrailer(
+                payloadLength = 2u,
+                payload = TextPayload("hi"),
+                checksum = 0u,
+                note = "xyz",
+            )
+        val buf = buildBuffer { SmpFrameWithTrailerCodec.encode(it, original, EncodeContext.Empty) }
+        buf.resetForRead()
+        val completed = SmpFrameWithTrailerCodec.partial(buf, DecodeContext.Empty).complete()
+        // TextPayloadCodec reads remaining(); without the bound it would swallow
+        // the checksum and note bytes too.
+        assertEquals(TextPayload("hi"), completed.payload)
+    }
+
+    /** `complete()` enforces the same consumption contract as `decode()`. */
+    @Test
+    fun completeRejectsAnUnderReadingPayloadCodec() {
+        val buf = BufferFactory.Default.allocate(32)
+        buf.writeUShort(4u)
+        buf.writeString("abcd", Charset.UTF8)
+        buf.resetForRead()
+        val partial = ShortReadFrameCodec.partial(buf, DecodeContext.Empty)
+        val failure = assertFailsWith<DecodeException> { partial.complete() }
+        assertEquals("ShortReadFrame.payload", failure.fieldPath)
+    }
+
     private fun frameFor(payload: TextPayload) =
         SmpFrame(
             op = 0u,

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SmpFrameCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SmpFrameCodecTest.kt
@@ -1,0 +1,244 @@
+package com.ditchoom.buffer.codec.test.protocols.deferredpayload
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.test.protocols.payload.TextPayload
+import com.ditchoom.buffer.codec.test.protocols.payload.TextPayloadCodec
+import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Issue #293 — a deferred payload sized by a sibling `@LengthFrom`.
+ *
+ * The load-bearing assertion is [peekFrameSizeCompletesOnceTheBodyArrives]:
+ * before #293 this exact shape returned `PeekResult.NoFraming`, because the
+ * emitter decided framability from the payload field's *decode strategy*
+ * (codec-deferred → unframable) rather than from whether a byte count was
+ * on the wire. The wire format never changed; only the taxonomy did.
+ */
+class SmpFrameCodecTest {
+    private val headerBytes = 8
+
+    @Test
+    fun roundTripsThroughTheSiblingLength() {
+        val payload = TextPayload("hi")
+        val frame = frameFor(payload)
+        val buf = encode(frame)
+        assertEquals(headerBytes + 2, buf.position(), "header + exactly payloadLength body bytes")
+        buf.resetForRead()
+        assertEquals(frame, SmpFrameCodec.decode(buf, DecodeContext.Empty))
+    }
+
+    @Test
+    fun roundTripsMultiByteUtf8Body() {
+        val payload = TextPayload("héllo")
+        val frame = frameFor(payload)
+        val buf = encode(frame)
+        buf.resetForRead()
+        assertEquals(frame, SmpFrameCodec.decode(buf, DecodeContext.Empty))
+    }
+
+    @Test
+    fun roundTripsEmptyBody() {
+        val frame = frameFor(TextPayload(""))
+        val buf = encode(frame)
+        assertEquals(headerBytes, buf.position(), "no body bytes when payloadLength is 0")
+        buf.resetForRead()
+        assertEquals(frame, SmpFrameCodec.decode(buf, DecodeContext.Empty))
+    }
+
+    /**
+     * The point of the issue. `peekFrameSize` walks the fixed header, reads
+     * `payloadLength` out of the stream without consuming it, and reports the
+     * total — so a stream loop can size the frame before buffering it.
+     */
+    @Test
+    fun peekFrameSizeCompletesOnceTheBodyArrives() {
+        val pool = BufferPool()
+        val original = frameFor(TextPayload("hi"))
+        val encoded = encode(original).also { it.resetForRead() }
+        val totalBytes = encoded.remaining()
+        assertEquals(headerBytes + 2, totalBytes)
+
+        val stream = StreamProcessor.create(pool, ByteOrder.BIG_ENDIAN)
+        try {
+            assertEquals(PeekResult.NeedsMoreData, SmpFrameCodec.peekFrameSize(stream))
+            for (i in 0 until totalBytes - 1) {
+                stream.append(singleByte(encoded.readByte()))
+                assertEquals(
+                    PeekResult.NeedsMoreData,
+                    SmpFrameCodec.peekFrameSize(stream),
+                    "after ${i + 1} of $totalBytes bytes",
+                )
+            }
+            stream.append(singleByte(encoded.readByte()))
+            assertEquals(PeekResult.Complete(totalBytes), SmpFrameCodec.peekFrameSize(stream))
+
+            val decoded =
+                stream.readBufferScoped(totalBytes) { SmpFrameCodec.decode(this, DecodeContext.Empty) }
+            assertEquals(original, decoded)
+            assertEquals(0, stream.available(), "frame consumed exactly")
+        } finally {
+            stream.release()
+            pool.clear()
+        }
+    }
+
+    /** Two frames back to back — peek must size the first without reading into the second. */
+    @Test
+    fun peekFrameSizeFramesBackToBackMessages() {
+        val pool = BufferPool()
+        val first = frameFor(TextPayload("one"))
+        val second = frameFor(TextPayload("second"))
+        val stream = StreamProcessor.create(pool, ByteOrder.BIG_ENDIAN)
+        try {
+            for (frame in listOf(first, second)) {
+                val encoded = encode(frame).also { it.resetForRead() }
+                stream.append(encoded)
+            }
+            val firstSize = headerBytes + 3
+            assertEquals(PeekResult.Complete(firstSize), SmpFrameCodec.peekFrameSize(stream))
+            assertEquals(
+                first,
+                stream.readBufferScoped(firstSize) { SmpFrameCodec.decode(this, DecodeContext.Empty) },
+            )
+            val secondSize = headerBytes + 6
+            assertEquals(PeekResult.Complete(secondSize), SmpFrameCodec.peekFrameSize(stream))
+            assertEquals(
+                second,
+                stream.readBufferScoped(secondSize) { SmpFrameCodec.decode(this, DecodeContext.Empty) },
+            )
+            assertEquals(0, stream.available())
+        } finally {
+            stream.release()
+            pool.clear()
+        }
+    }
+
+    /**
+     * The sibling bound must win over the buffer's limit. A payload codec that
+     * reads `remaining()` would swallow the trailing fields if the region were
+     * not narrowed to `payloadLength`.
+     */
+    @Test
+    fun payloadIsBoundedToTheSiblingLengthNotTheBufferLimit() {
+        val original =
+            SmpFrameWithTrailer(
+                payloadLength = 2u,
+                payload = TextPayload("hi"),
+                checksum = 0xBEEFu,
+                note = "trailing",
+            )
+        val buf = buildBuffer { SmpFrameWithTrailerCodec.encode(it, original, EncodeContext.Empty) }
+        buf.resetForRead()
+        val decoded = SmpFrameWithTrailerCodec.decode(buf, DecodeContext.Empty)
+        assertEquals(original, decoded)
+        assertEquals(TextPayload("hi"), decoded.payload, "payload stopped at payloadLength")
+    }
+
+    /**
+     * Strict consumption. A runtime-supplied codec that stops short has
+     * desynchronised everything after it, so the generated decode rejects
+     * rather than trusting it — the `@LengthFrom @ProtocolMessage` path's
+     * trust-and-restore is not extended to arbitrary user codecs.
+     */
+    @Test
+    fun underReadingPayloadCodecIsRejected() {
+        val buf = BufferFactory.Default.allocate(32)
+        buf.writeUShort(4u)
+        buf.writeString("abcd", Charset.UTF8)
+        buf.resetForRead()
+        val failure =
+            assertFailsWith<DecodeException> {
+                ShortReadFrameCodec.decode(buf, DecodeContext.Empty)
+            }
+        assertEquals("ShortReadFrame.payload", failure.fieldPath)
+        assertTrue(
+            failure.actual.contains("1 bytes left unread"),
+            "diagnostic names the shortfall, was: ${failure.actual}",
+        )
+    }
+
+    @Test
+    fun genericFrameRoundTripsWithAnInjectedCodec() {
+        val codec = SmpGenericFrameCodec(TextPayloadCodec)
+        val original =
+            SmpGenericFrame(
+                op = 0u,
+                flags = 0u,
+                payloadLength = 2u,
+                group = 9u,
+                sequence = 1u,
+                commandId = 3u,
+                payload = TextPayload("hi"),
+            )
+        val buf = buildBuffer { codec.encode(it, original, EncodeContext.Empty) }
+        buf.resetForRead()
+        assertEquals(original, codec.decode(buf, DecodeContext.Empty))
+    }
+
+    @Test
+    fun genericFramePeeksWithoutTheInjectedCodec() {
+        val pool = BufferPool()
+        val codec = SmpGenericFrameCodec(TextPayloadCodec)
+        val original =
+            SmpGenericFrame(
+                op = 0u,
+                flags = 0u,
+                payloadLength = 3u,
+                group = 9u,
+                sequence = 1u,
+                commandId = 3u,
+                payload = TextPayload("abc"),
+            )
+        val encoded = buildBuffer { codec.encode(it, original, EncodeContext.Empty) }
+        encoded.resetForRead()
+        val totalBytes = encoded.remaining()
+        val stream = StreamProcessor.create(pool, ByteOrder.BIG_ENDIAN)
+        try {
+            stream.append(encoded)
+            // Framing comes from the wire, not from the payload codec — peek
+            // never runs it, which is exactly why the shape is framable.
+            assertEquals(PeekResult.Complete(totalBytes), codec.peekFrameSize(stream))
+        } finally {
+            stream.release()
+            pool.clear()
+        }
+    }
+
+    private fun frameFor(payload: TextPayload) =
+        SmpFrame(
+            op = 0u,
+            flags = 0u,
+            payloadLength =
+                payload.text
+                    .encodeToByteArray()
+                    .size
+                    .toUShort(),
+            group = 9u,
+            sequence = 1u,
+            commandId = 3u,
+            payload = payload,
+        )
+
+    private fun singleByte(b: Byte) =
+        BufferFactory.Default.allocate(1).also {
+            it.writeByte(b)
+            it.resetForRead()
+        }
+
+    private fun encode(value: SmpFrame) = buildBuffer { SmpFrameCodec.encode(it, value, EncodeContext.Empty) }
+
+    private fun buildBuffer(write: (PlatformBuffer) -> Unit) = BufferFactory.Default.allocate(256).also(write)
+}

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SmpFrameCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SmpFrameCodecTest.kt
@@ -308,6 +308,68 @@ class SmpFrameCodecTest {
         assertEquals("ShortReadFrame.payload", failure.fieldPath)
     }
 
+    // ---- sealed-variant shape (issue #168's second example) ---------------
+
+    /**
+     * A sibling-sized payload inside a **sealed variant**, not a top-level data
+     * class — the `Frame.Command` shape from issue #168, which is the other
+     * message #293 migrates. Exercises the dispatcher path: variant codec,
+     * variant `Partial`, and discriminator-composed framing.
+     */
+    @Test
+    fun sealedVariantRoundTripsAndFrames() {
+        val pool = BufferPool()
+        val codec = DeferredDispatchFrameCodec(TextPayloadCodec)
+        val original =
+            DeferredDispatchFrame.Command(
+                counter = 1u,
+                payloadLength = 2u,
+                payload = TextPayload("hi"),
+                checksum = 0xBEEFu,
+            )
+        val encoded = buildBuffer { codec.encode(it, original, EncodeContext.Empty) }
+        encoded.resetForRead()
+        val totalBytes = encoded.remaining()
+        // 1 discriminator + 2 counter + 2 length + 2 payload + 2 checksum
+        assertEquals(9, totalBytes)
+
+        val stream = StreamProcessor.create(pool, ByteOrder.BIG_ENDIAN)
+        try {
+            stream.append(encoded)
+            // The dispatcher frames by reading the discriminator and delegating to
+            // the variant's peek — no payload codec involved.
+            assertEquals(PeekResult.Complete(totalBytes), codec.peekFrameSize(stream))
+            val decoded =
+                stream.readBufferScoped(totalBytes) { codec.decode(this, DecodeContext.Empty) }
+            assertEquals(original, decoded)
+        } finally {
+            stream.release()
+            pool.clear()
+        }
+    }
+
+    /** The variant keeps its `Partial` — the capability #168/#171 established. */
+    @Test
+    fun sealedVariantStillEmitsPartial() {
+        val original =
+            DeferredDispatchFrame.Command(
+                counter = 7u,
+                payloadLength = 3u,
+                payload = TextPayload("abc"),
+                checksum = 0x1234u,
+            )
+        val buf =
+            buildBuffer {
+                DeferredDispatchFrameCommandCodec(TextPayloadCodec).encode(it, original, EncodeContext.Empty)
+            }
+        buf.resetForRead()
+
+        val partial = DeferredDispatchFrameCommandCodec.partial<TextPayload>(buf, DecodeContext.Empty)
+        assertEquals(7u.toUShort(), partial.counter, "header readable before choosing a payload codec")
+        assertEquals(0x1234u.toUShort(), partial.checksum, "trailer read eagerly, past the payload")
+        assertEquals(original, partial.complete(TextPayloadCodec))
+    }
+
     private fun frameFor(payload: TextPayload) =
         SmpFrame(
             op = 0u,

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/deferredpayload/WideLengthDeferredFramePeekTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/deferredpayload/WideLengthDeferredFramePeekTest.kt
@@ -1,0 +1,90 @@
+package com.ditchoom.buffer.codec.test.protocols.deferredpayload
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.readFrame
+import com.ditchoom.buffer.codec.test.protocols.payload.TextPayload
+import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.buffer.stream.StreamProcessor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * The `@LengthFrom` peek overflow guard, executed on a *deferred* payload.
+ *
+ * Deferred peeks reuse `appendSequentialPeekLengthFrom`, so they inherit the
+ * guard added for the `String` shape ([com.ditchoom.buffer.codec.test.protocols.simple.WideLengthFramePeekTest]
+ * covers that one) — but inheritance is only proven by execution. This drives
+ * [WideLengthDeferredFrame]'s full-width carrier past `Int.MAX_VALUE - __offset`
+ * and asserts the peek rejects it instead of returning a negative `Complete`.
+ */
+class WideLengthDeferredFramePeekTest {
+    /** `payloadLength` big-endian, then `flags` — the 5 fixed header bytes. */
+    private fun headerOf(length: UInt): PlatformBuffer {
+        val buf = BufferFactory.Default.allocate(8, ByteOrder.BIG_ENDIAN)
+        buf.writeUInt(length)
+        buf.writeUByte(0u)
+        return buf
+    }
+
+    private fun streamOf(buf: PlatformBuffer): StreamProcessor {
+        buf.resetForRead()
+        val stream = StreamProcessor.create(BufferPool(), ByteOrder.BIG_ENDIAN)
+        stream.append(buf)
+        return stream
+    }
+
+    @Test
+    fun peekRejectsLengthThatOverflowsTheRunningOffset() {
+        // Int.MAX_VALUE passes the sibling's own `> Int.MAX_VALUE` bound, but
+        // the walk has already advanced 5 bytes: `__offset + payloadBytes`
+        // wraps negative, and without the guard that negative `Complete`
+        // reaches `readBufferScoped`.
+        val stream = streamOf(headerOf(0x7FFFFFFFu))
+        try {
+            assertFailsWith<DecodeException> { WideLengthDeferredFrameCodec.peekFrameSize(stream) }
+        } finally {
+            stream.release()
+        }
+    }
+
+    @Test
+    fun peekReportsCompleteForAWellFormedFrame() {
+        val buf = BufferFactory.Default.allocate(16, ByteOrder.BIG_ENDIAN)
+        buf.writeUInt(2u)
+        buf.writeUByte(0u)
+        buf.writeString("hi")
+        val stream = streamOf(buf)
+        try {
+            assertEquals(PeekResult.Complete(7), WideLengthDeferredFrameCodec.peekFrameSize(stream))
+        } finally {
+            stream.release()
+        }
+    }
+
+    @Test
+    fun roundTripsThroughReadFrame() {
+        val value =
+            WideLengthDeferredFrame(
+                payloadLength = 2u,
+                flags = 0x07u,
+                payload = TextPayload("hi"),
+            )
+        val encoded = BufferFactory.Default.allocate(16, ByteOrder.BIG_ENDIAN)
+        WideLengthDeferredFrameCodec.encode(encoded, value, EncodeContext.Empty)
+        encoded.resetForRead()
+        val stream = StreamProcessor.create(BufferPool(), ByteOrder.BIG_ENDIAN)
+        try {
+            stream.append(encoded)
+            assertEquals(value, WideLengthDeferredFrameCodec.readFrame(stream))
+        } finally {
+            stream.release()
+        }
+    }
+}

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/http2/Http2FrameCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/http2/Http2FrameCodecTest.kt
@@ -546,7 +546,7 @@ class Http2FrameCodecTest {
     @Test
     fun dataVariantWireSizeForwardsToVariantCodec() {
         // The dispatcher's wireSize forwards to the variant codec,
-        // which is BackPatch for any RemainingBytesPayload-bearing
+        // which is BackPatch for any DeferredPayload-bearing
         // shape. Confirms the generic dispatcher's wireSize path
         // correctly routes through the constructed variant codec
         // instance (not a static reference).

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketCodecTest.kt
@@ -535,7 +535,7 @@ class MqttPacketCodecTest {
     fun roundTripsPublishVariantViaDispatcherAtQos1() {
         // The integration test — Publish<P> routes through
         // the dispatcher's generic class with the supplied payload
-        // codec. Confirms @RemainingLength + RemainingBytesPayload
+        // codec. Confirms @RemainingLength + DeferredPayload
         // composition lifts the carve-out correctly. Run
         // at QoS=1 (header byte 0x32) so the packetId slot is on the
         // wire and round-trips through the dispatcher.

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/payload/MqttPublishV3ConcreteCodecTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/payload/MqttPublishV3ConcreteCodecTest.kt
@@ -134,7 +134,7 @@ class MqttPublishV3ConcreteCodecTest {
                 payload = JpegImage(0u, 0u, ByteArray(0)),
             )
         // Unconditionally returns BackPatch when a
-        // RemainingBytesPayload field is present, regardless of whether
+        // DeferredPayload field is present, regardless of whether
         // the user codec itself returns Exact (JpegImageCodec does).
         // Promotion to runtime-Exact is a follow-on with a vector that
         // measurably benefits.

--- a/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/annotations/Annotations.kt
+++ b/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/annotations/Annotations.kt
@@ -294,6 +294,21 @@ annotation class RemainingBytes
  * )
  * ```
  *
+ * ## Bound field types
+ *
+ * `String` (or a value class over `String`), `List<T>` where `T` is a
+ * `@ProtocolMessage` data class, a nested `@ProtocolMessage` data class or
+ * sealed parent, or a **deferred payload** — either
+ * `@UseCodec(C::class) val: P` where `P : Payload`, or the enclosing
+ * message's `<P : Payload>` type parameter, decoded by the
+ * constructor-injected codec. See [UseCodec] for the payload forms.
+ *
+ * The payload form is the framable alternative to [RemainingBytes]: both hand
+ * a bounded region to a codec the generated code does not own, but
+ * `@LengthFrom` takes the bound from the wire instead of from the caller's
+ * buffer limit, so `peekFrameSize` can size the frame and the payload need not
+ * be the last field.
+ *
  * @param field The name of the sibling field that holds the byte length.
  *   Must exist, come before this field, and resolve to either a
  *   non-nullable numeric scalar (`Byte`/`Short`/`Int`/`Long`/`UByte`/
@@ -552,12 +567,20 @@ annotation class When(
  * ```kotlin
  * @ProtocolMessage
  * data class ImageFrame(
- *     val bitmapLength: Int,
+ *     val bitmapLength: UShort,
  *     @UseCodec(PngBitmapCodec::class) @LengthFrom("bitmapLength") val bitmap: ImageBitmap,
  * )
- * // Generated: narrow buffer.limit() by bitmapLength.toInt(), call PngBitmapCodec.decode,
+ * // ImageBitmap : Payload; PngBitmapCodec is an object implementing Codec<ImageBitmap>.
+ * // Generated: narrow buffer.limit() to bitmapLength bytes, call PngBitmapCodec.decode,
  * // restore the outer limit on finally.
  * ```
+ *
+ * Unlike [RemainingBytes], the byte count is on the wire, so this shape stays
+ * framable: `peekFrameSize` walks the sibling and reports the total without
+ * running your codec. The codec **must consume its whole region** — stopping
+ * short desynchronises every field after it, so decode throws
+ * [com.ditchoom.buffer.codec.DecodeException] rather than continuing at the
+ * wrong offset.
  *
  * ## Extension pattern — ship your own per-charset / per-format codec
  *

--- a/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/annotations/Annotations.kt
+++ b/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/annotations/Annotations.kt
@@ -306,8 +306,14 @@ annotation class RemainingBytes
  * The payload form is the framable alternative to [RemainingBytes]: both hand
  * a bounded region to a codec the generated code does not own, but
  * `@LengthFrom` takes the bound from the wire instead of from the caller's
- * buffer limit, so `peekFrameSize` can size the frame and the payload need not
- * be the last field.
+ * buffer limit. Three consequences: `peekFrameSize` can size the frame, the
+ * payload need not be the last field, and the fields that follow it may be any
+ * width (a to-limit payload's trailers must all be fixed-size, since its end is
+ * `limit - <trailer bytes>`).
+ *
+ * The `partial(...)` / `complete(codec)` deferral is generated for this shape
+ * too, so a header can be decoded and routed on before a payload codec is
+ * chosen.
  *
  * @param field The name of the sibling field that holds the byte length.
  *   Must exist, come before this field, and resolve to either a


### PR DESCRIPTION
Closes #293.

`@LengthFrom("n")` now accepts a payload decoded by a codec the generated code does not own — either `@UseCodec(C::class) val: P` where `P : Payload`, or the enclosing message's `<P : Payload>` type parameter resolved through the constructor-injected codec. Until now only `@RemainingBytes` accepted that field shape, and it collapses `peekFrameSize` to `NoFraming`.

```kotlin
@ProtocolMessage(wireOrder = Endianness.Big)
data class SmpPacket<P : Payload>(
    val kind: SmpKind,
    val flags: UByte,
    val length: UShort,      // non-adjacent length carrier
    val group: UShort,
    val sequence: UByte,
    val command: UByte,
    @LengthFrom("length") val payload: P,   // was @RemainingBytes
)
```

`SmpPacketCodec.readFrame(stream)` now works, and the hand-rolled peek arithmetic in the issue can be deleted.

## Why it was blocked

Not because framing was hard. The framing engine already handles this layout — `RemoteHeader` is the same message with `String` in place of `P`, and its generated peek is exactly what the reporter hand-wrote. The blocker was that **framing capability was inferred from the payload field's decode strategy** (codec-deferred → unframable) rather than from whether a byte count is on the wire. Swapping `String` for a codec-decoded `Payload` changes no wire byte, but it changed the framing answer.

So the fix is a taxonomy fix. `FieldSpec.RemainingBytesPayload` named itself after one of its two orthogonal axes — how the region is bounded — when what actually defines the shape is the other one: decode is deferred to a codec the generated code doesn't own. The spec is now `DeferredPayload` with two independent axes:

- `PayloadCodecSource` — *whose* codec decodes the region (`UserCodecObject` | `ConstructorInjected`), unchanged.
- `PayloadExtent` — *how* the region is bounded: `ToLimit(reservedTrailingBytes)` (`@RemainingBytes`) or `Sibling(LengthSource)` (`@LengthFrom`), new.

Every site that branches on the bound is now an exhaustive `when`: analyzer routing, the reservation fill-in, the validator, decode emit, the peek collapse, the sequential peek walk, peek stash sources, the schema descriptor, and the Partial gate.

**Peek is one line.** A sibling-sized payload reuses `appendSequentialPeekLengthFrom` verbatim, because peek never runs the deferred codec and therefore cannot care what that codec would do with the bytes.

## Also in scope

- **`partial()` / `complete(codec)` is generated for the new shape.** #168 (same reporter, same `SmpPacket<P>` message) asked for a `Partial` and #171 shipped one; migrating the payload annotation must not take it away. #293 explicitly asks to keep the deferral, since the header names the `group`/`command` that selects the payload codec — two actors, two times.
- **A Partial may now have a variable-width trailer after the payload.** A to-limit payload ends at `limit - <trailer bytes>`, so all its trailers must be fixed-size; a sibling ends at `start + <sibling>` and needs nothing from the trailer.
- **Strict consumption.** A deferred codec that under-reads its declared region has desynchronised every field after it, so decode throws `DecodeException` instead of continuing at the wrong offset. `@LengthFrom @ProtocolMessage` can trust-and-restore because its codec comes from the same schema; arbitrary user code gets no such benefit of the doubt. `complete()` enforces the same contract via a shared helper.
- **Doc/validator mismatch fixed.** `@UseCodec`'s KDoc has documented `@UseCodec(C) @LengthFrom("n") val: ImageBitmap` as working while the validator rejected it as "deferred to a future release". That shape compiles now; non-`Payload` bound types keep a focused diagnostic instead of the old blanket one. The `<P : Payload>` declared-but-unused check accepts `@LengthFrom val: P` alongside `@RemainingBytes val: P`.

## Migration impact — nothing regresses for the shapes in #168/#293

Both messages the reporter migrates keep everything they have today, and both are now fixtures so CI holds the line:

| their shape | after migrating to `@LengthFrom` |
|---|---|
| `SmpPacket<P>` (#168, #293) — top-level, generic payload, no framing | `partial()`/`complete()` kept, **plus** `peekFrameSize` (`SmpGenericFrame`) |
| `Frame.Command`/`Response` (#168) — sealed variant, generic payload, `checksum` trailer | variant `Partial` kept, **plus** variant peek and discriminator-composed dispatcher framing (`DeferredDispatchFrame`) |

## Deliberately not in scope

- **`wireSize` stays `BackPatch`.** `RuntimeExact` would size an allocation from a user-supplied number — exactly what 17f51778 had to add verification for in `@LengthPrefixed`. Follow-up, gated on the same check. No regression: `@RemainingBytes` payloads are already `BackPatch`.
- **External bounds + sibling extent get no `Partial`.** With `@FramedBy` or a bounding `@UseCodec`, `complete()` would restore a bound it never set, and the terminal `@FramedBy` walk reorders fields around it. This is the carve-out the non-terminal to-limit path already had, not a new one.

  Worth being precise about the one real edge, since it *is* a capability cliff: a message that has an external bound **and** a terminal `@RemainingBytes` payload gets a `Partial` today and would lose it by switching that payload to `@LengthFrom`. Neither shape in #168/#293 is in that class (no `@FramedBy`, no bounding `@UseCodec`), and a message already framed by an outer bound has little reason to also take its payload length from a sibling. If a real one turns up, the fix is to teach `complete()` to restore `outerLimit` alongside the captured region — mechanical, but not worth guessing at without a vector.

## Schema drift

Intentional, and additive in this PR (only the new fixtures). The `Sibling` arm emits `len-from=<source>` and shares no token with `ToLimit`'s `remaining … reserved=NB`, so migrating `@RemainingBytes P` → `@LengthFrom P` reads as drift even though the bytes can coincide — the named sibling becomes load-bearing for framing the moment the payload reads it. A coverage test asserts every extent yields a distinct descriptor; it caught a missing sample while this was being written.

## Verification

Commits 1 and 2 are a pure rename and a pure axis split — **snapshots and the schema baseline are byte-identical across both**, verified by regenerating from the modified processor (`CodecSnapshotTest` + `CodecSchemaDriftGateTest`), not by leaving them untouched. Commit 4's regenerated snapshots touch only the new `deferredpayload` package, so every existing `@RemainingBytes` `Partial` is unchanged.

15 new round-trip / framing / deferral / dispatch / rejection tests green on jvm, jsNode, wasmJsNode, macosArm64 and iosSimulatorArm64; 3 new validator tests; `ktlintCheck`, `detekt` (no new alerts, no baseline additions) and `apiCheck` clean.

## Note for reviewers

#309 patches `appendSequentialPeekLengthFrom`, the exact function this shape's peek reuses, so its `__offset + bytes` overflow guard lands here for free on merge. Until then this shape carries the same UInt-sibling exposure every other `@LengthFrom` shape has on `main` — not a new bug class. Either merge order works.

