### PR TITLE
fix(codec): reject wire-supplied lengths that would widen decode bounds past the enclosing limit

### DIFF
--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitter.kt
@@ -1764,6 +1764,11 @@ internal class CodecEmitter(
                             fieldName = payloadField.name,
                         )
                     }
+                    appendOuterBoundWidenGuard(
+                        body,
+                        extent.source.decodeAccessor(),
+                        "${payloadField.ownerSimpleName}.${payloadField.name}",
+                    )
                     body.addStatement("val __payloadEnd = __payloadStart + %L", extent.source.decodeAccessor())
                 }
             }
@@ -1953,6 +1958,64 @@ internal fun appendFramedBodyTruncationGuard(
         DECODE_EXCEPTION_CN,
         fieldPath,
         lengthLocal,
+    )
+    body.endControlFlow()
+}
+
+/**
+ * Emits the outer-bound widen guard before a narrowing `setLimit`: the
+ * wire-supplied region length must fit inside the current bound.
+ * `ReadBuffer.setLimit` WIDENS unchecked on every platform, so without
+ * this check a codec running under an outer narrowed limit (a sealed
+ * dispatcher's carve, `@FramedBy`, a bounding `@UseCodec` region, or an
+ * enclosing `@LengthPrefixed`/`@LengthFrom` body) would silently read
+ * adjacent bytes past its bound from a lying length field — and still
+ * pass strict consumption, having consumed exactly the lying region.
+ * At the top level the same comparison doubles as a truncation check
+ * against the caller's limit. Decode-side sibling of the #306/#309
+ * encode/peek fixes; `lengthExpr` must be an `Int`-typed expression.
+ */
+internal fun appendOuterBoundWidenGuard(
+    body: CodeBlock.Builder,
+    lengthExpr: String,
+    fieldPath: String,
+) {
+    body.beginControlFlow("if (%L > buffer.remaining())", lengthExpr)
+    body.addStatement(
+        "throw %T(\n  fieldPath = %S,\n  bufferPosition = buffer.position(),\n" +
+            "  expected = \"a \" + %L + \"-byte bounded region within the enclosing limit\",\n" +
+            "  actual = buffer.remaining().toString() + \" bytes available\",\n)",
+        DECODE_EXCEPTION_CN,
+        fieldPath,
+        lengthExpr,
+    )
+    body.endControlFlow()
+}
+
+/**
+ * Emits the post-`applyBound` widen guard for `BoundingLengthCodec`
+ * regions. The narrowing `setLimit` happens inside user code, so the
+ * generated decode verifies the outcome instead of the input: a bound
+ * that lands past the captured outer limit means the decoded length lied
+ * about a region the enclosing bound does not contain. The widened limit
+ * is rolled back before throwing so a catching caller never observes
+ * adjacent bytes exposed past its own bound.
+ */
+internal fun appendApplyBoundWidenGuard(
+    body: CodeBlock.Builder,
+    outerLimitLocal: String,
+    fieldPath: String,
+) {
+    body.beginControlFlow("if (buffer.limit() > %L)", outerLimitLocal)
+    body.addStatement("val __widenedLimit = buffer.limit()")
+    body.addStatement("buffer.setLimit(%L)", outerLimitLocal)
+    body.addStatement(
+        "throw %T(\n  fieldPath = %S,\n  bufferPosition = buffer.position(),\n" +
+            "  expected = \"applyBound to narrow within the enclosing limit \" + %L,\n" +
+            "  actual = \"limit \" + __widenedLimit,\n)",
+        DECODE_EXCEPTION_CN,
+        fieldPath,
+        outerLimitLocal,
     )
     body.endControlFlow()
 }

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterFields.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/CodecEmitterFields.kt
@@ -562,6 +562,7 @@ internal fun appendDecodeConditional(
                 spec = inner.spec,
                 listLocalName = "${field.name}Value",
                 namespacePrefix = field.name,
+                fieldPath = "${field.ownerSimpleName}.${field.name}",
             )
             body.addStatement("%LValue", field.name)
             body.nextControlFlow("else")
@@ -588,6 +589,7 @@ internal fun appendDecodeConditional(
                     prefixWidth = inner.prefixWidth,
                     prefixWireOrder = inner.prefixWireOrder,
                 )
+            appendOuterBoundWidenGuard(body, lengthVar, "${field.ownerSimpleName}.${field.name}")
             val outerLimitVar = "__${field.name}OuterLimit"
             body.addStatement("val %L = buffer.limit()", outerLimitVar)
             body.addStatement("buffer.setLimit(buffer.position() + %L)", lengthVar)
@@ -1038,6 +1040,7 @@ internal fun appendDecodeLengthPrefixed(
     body.endControlFlow()
     val resolvedVar = "${field.name}Length"
     body.addStatement("val %L = %L.toInt()", resolvedVar, prefixVar)
+    appendOuterBoundWidenGuard(body, resolvedVar, "${field.ownerSimpleName}.${field.name}")
     val outerVar = "${field.name}OuterLimit"
     body.addStatement("val %L = buffer.limit()", outerVar)
     body.addStatement("buffer.setLimit(buffer.position() + %L)", resolvedVar)
@@ -1455,6 +1458,7 @@ internal fun appendDecodeLengthFromList(
     val bytesVar = "${field.name}Bytes"
     val outerLimitVar = "${field.name}OuterLimit"
     body.addStatement("val %L = %L", bytesVar, field.source.decodeAccessor())
+    appendOuterBoundWidenGuard(body, bytesVar, "${field.ownerSimpleName}.${field.name}")
     body.addStatement("val %L = buffer.limit()", outerLimitVar)
     body.addStatement("buffer.setLimit(buffer.position() + %L)", bytesVar)
     body.addStatement("val %L = mutableListOf<%T>()", field.name, field.elementClassName)
@@ -1521,6 +1525,7 @@ internal fun appendDecodeLengthFromMessage(
     val bytesVar = "${field.name}Bytes"
     val outerLimitVar = "${field.name}OuterLimit"
     body.addStatement("val %L = %L", bytesVar, field.source.decodeAccessor())
+    appendOuterBoundWidenGuard(body, bytesVar, "${field.ownerSimpleName}.${field.name}")
     body.addStatement("val %L = buffer.limit()", outerLimitVar)
     body.addStatement("buffer.setLimit(buffer.position() + %L)", bytesVar)
     body.beginControlFlow("val %L = try", field.name)
@@ -1652,6 +1657,7 @@ private fun appendDecodeDeferredPayloadSibling(
     val outerLimitVar = "${field.name}OuterLimit"
     val endVar = "${field.name}End"
     body.addStatement("val %L = %L", bytesVar, extent.source.decodeAccessor())
+    appendOuterBoundWidenGuard(body, bytesVar, "${field.ownerSimpleName}.${field.name}")
     body.addStatement("val %L = buffer.limit()", outerLimitVar)
     body.addStatement("val %L = buffer.position() + %L", endVar, bytesVar)
     body.addStatement("buffer.setLimit(%L)", endVar)
@@ -1895,6 +1901,11 @@ internal fun appendDecodeUseCodecScalar(
     body.addStatement("val %L = %T.decode(buffer, context)", field.name, field.codecType)
     if (field.isBounding) {
         body.addStatement("%T.applyBound(buffer, %L)", field.codecType, field.name)
+        appendApplyBoundWidenGuard(
+            body,
+            "__${field.name}OuterLimit",
+            "${field.ownerSimpleName}.${field.name}",
+        )
     }
 }
 
@@ -2009,6 +2020,7 @@ internal fun appendDecodeLengthPrefixedUseCodecList(
         spec = field.spec,
         listLocalName = field.name,
         namespacePrefix = field.name,
+        fieldPath = "${field.ownerSimpleName}.${field.name}",
     )
 }
 
@@ -2045,6 +2057,7 @@ internal fun appendDecodeLengthPrefixedUseCodecPayload(
             prefixWidth = field.prefixWidth,
             prefixWireOrder = field.prefixWireOrder,
         )
+    appendOuterBoundWidenGuard(body, lengthVar, "${field.ownerSimpleName}.${field.name}")
     val outerLimitVar = "__${field.name}OuterLimit"
     body.addStatement("val %L = buffer.limit()", outerLimitVar)
     body.addStatement("buffer.setLimit(buffer.position() + %L)", lengthVar)
@@ -2080,12 +2093,14 @@ internal fun appendDecodeLengthPrefixedListBody(
     spec: LengthPrefixedListSpec,
     listLocalName: String,
     namespacePrefix: String,
+    fieldPath: String,
 ) {
     val outerLimitVar = "__${namespacePrefix}OuterLimit"
     val lengthVar = "__${namespacePrefix}Length"
     body.addStatement("val %L = buffer.limit()", outerLimitVar)
     body.addStatement("val %L = %T.decode(buffer, context)", lengthVar, spec.codecType)
     body.addStatement("%T.applyBound(buffer, %L)", spec.codecType, lengthVar)
+    appendApplyBoundWidenGuard(body, outerLimitVar, fieldPath)
     body.addStatement("val %L = mutableListOf<%T>()", listLocalName, spec.elementClassName)
     body.beginControlFlow("try")
     body.beginControlFlow("while (buffer.position() < buffer.limit())")

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/asciistring/AsciiGreetingCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/asciistring/AsciiGreetingCodec.kt
@@ -22,6 +22,14 @@ public object AsciiGreetingCodec : Codec<AsciiGreeting> {
       throw DecodeException(fieldPath = "AsciiGreeting.command", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = commandPrefix.toString())
     }
     val commandLength = commandPrefix.toInt()
+    if (commandLength > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "AsciiGreeting.command",
+            bufferPosition = buffer.position(),
+            expected = "a " + commandLength + "-byte bounded region within the enclosing limit",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     val __commandOuterLimit = buffer.limit()
     buffer.setLimit(buffer.position() + commandLength)
     val command = try {

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/HonestHostCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/HonestHostCodec.kt
@@ -22,6 +22,14 @@ public object HonestHostCodec : Codec<HonestHost> {
       throw DecodeException(fieldPath = "HonestHost.inner", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = innerPrefix.toString())
     }
     val innerLength = innerPrefix.toInt()
+    if (innerLength > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "HonestHost.inner",
+            bufferPosition = buffer.position(),
+            expected = "a " + innerLength + "-byte bounded region within the enclosing limit",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     val innerOuterLimit = buffer.limit()
     buffer.setLimit(buffer.position() + innerLength)
     val inner = try {

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/LpByteWrappedTailCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/LpByteWrappedTailCodec.kt
@@ -19,6 +19,14 @@ public object LpByteWrappedTailCodec : Codec<LpByteWrappedTail> {
       throw DecodeException(fieldPath = "LpByteWrappedTail.body", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = bodyPrefix.toString())
     }
     val bodyLength = bodyPrefix.toInt()
+    if (bodyLength > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "LpByteWrappedTail.body",
+            bufferPosition = buffer.position(),
+            expected = "a " + bodyLength + "-byte bounded region within the enclosing limit",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     val bodyOuterLimit = buffer.limit()
     buffer.setLimit(buffer.position() + bodyLength)
     val body = try {

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/LpWrappedTailCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/LpWrappedTailCodec.kt
@@ -22,6 +22,14 @@ public object LpWrappedTailCodec : Codec<LpWrappedTail> {
       throw DecodeException(fieldPath = "LpWrappedTail.body", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = bodyPrefix.toString())
     }
     val bodyLength = bodyPrefix.toInt()
+    if (bodyLength > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "LpWrappedTail.body",
+            bufferPosition = buffer.position(),
+            expected = "a " + bodyLength + "-byte bounded region within the enclosing limit",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     val bodyOuterLimit = buffer.limit()
     buffer.setLimit(buffer.position() + bodyLength)
     val body = try {

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/MisdeclaredHostCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/boundary/MisdeclaredHostCodec.kt
@@ -22,6 +22,14 @@ public object MisdeclaredHostCodec : Codec<MisdeclaredHost> {
       throw DecodeException(fieldPath = "MisdeclaredHost.inner", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = innerPrefix.toString())
     }
     val innerLength = innerPrefix.toInt()
+    if (innerLength > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "MisdeclaredHost.inner",
+            bufferPosition = buffer.position(),
+            expected = "a " + innerLength + "-byte bounded region within the enclosing limit",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     val innerOuterLimit = buffer.limit()
     buffer.setLimit(buffer.position() + innerLength)
     val inner = try {

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/DeferredDispatchFrameCommandCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/DeferredDispatchFrameCommandCodec.kt
@@ -30,6 +30,14 @@ public class DeferredDispatchFrameCommandCodec<P : Payload>(
       payloadLength = (__batch1 ushr 16 and 0xFFFF).toUShort()
     }
     val payloadBytes = payloadLength.toInt()
+    if (payloadBytes > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "Command.payload",
+            bufferPosition = buffer.position(),
+            expected = "a " + payloadBytes + "-byte bounded region within the enclosing limit",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     val payloadOuterLimit = buffer.limit()
     val payloadEnd = buffer.position() + payloadBytes
     buffer.setLimit(payloadEnd)
@@ -131,6 +139,14 @@ public class DeferredDispatchFrameCommandCodec<P : Payload>(
         payloadLength = (__batch2 ushr 16 and 0xFFFF).toUShort()
       }
       val __payloadStart = buffer.position()
+      if (payloadLength.toInt() > buffer.remaining()) {
+        throw DecodeException(
+              fieldPath = "Command.payload",
+              bufferPosition = buffer.position(),
+              expected = "a " + payloadLength.toInt() + "-byte bounded region within the enclosing limit",
+              actual = buffer.remaining().toString() + " bytes available",
+            )
+      }
       val __payloadEnd = __payloadStart + payloadLength.toInt()
       buffer.position(__payloadEnd)
       val checksum = buffer.readUShort()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/ShortReadFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/ShortReadFrameCodec.kt
@@ -16,6 +16,14 @@ public object ShortReadFrameCodec : Codec<ShortReadFrame> {
   override fun decode(buffer: ReadBuffer, context: DecodeContext): ShortReadFrame {
     val payloadLength = buffer.readUShort()
     val payloadBytes = payloadLength.toInt()
+    if (payloadBytes > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "ShortReadFrame.payload",
+            bufferPosition = buffer.position(),
+            expected = "a " + payloadBytes + "-byte bounded region within the enclosing limit",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     val payloadOuterLimit = buffer.limit()
     val payloadEnd = buffer.position() + payloadBytes
     buffer.setLimit(payloadEnd)
@@ -67,6 +75,14 @@ public object ShortReadFrameCodec : Codec<ShortReadFrame> {
   public fun partial(buffer: ReadBuffer, context: DecodeContext): Partial {
     val payloadLength = buffer.readUShort()
     val __payloadStart = buffer.position()
+    if (payloadLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "ShortReadFrame.payload",
+            bufferPosition = buffer.position(),
+            expected = "a " + payloadLength.toInt() + "-byte bounded region within the enclosing limit",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     val __payloadEnd = __payloadStart + payloadLength.toInt()
     buffer.position(__payloadEnd)
     return Partial(payloadLength = payloadLength, payloadStart = __payloadStart, payloadEnd = __payloadEnd, buffer = buffer, context = context)

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SmpFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SmpFrameCodec.kt
@@ -40,6 +40,14 @@ public object SmpFrameCodec : Codec<SmpFrame> {
       commandId = (__batch1 ushr 56 and 0xFFL).toUByte()
     }
     val payloadBytes = payloadLength.toInt()
+    if (payloadBytes > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "SmpFrame.payload",
+            bufferPosition = buffer.position(),
+            expected = "a " + payloadBytes + "-byte bounded region within the enclosing limit",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     val payloadOuterLimit = buffer.limit()
     val payloadEnd = buffer.position() + payloadBytes
     buffer.setLimit(payloadEnd)
@@ -126,6 +134,14 @@ public object SmpFrameCodec : Codec<SmpFrame> {
       commandId = (__batch2 ushr 56 and 0xFFL).toUByte()
     }
     val __payloadStart = buffer.position()
+    if (payloadLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "SmpFrame.payload",
+            bufferPosition = buffer.position(),
+            expected = "a " + payloadLength.toInt() + "-byte bounded region within the enclosing limit",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     val __payloadEnd = __payloadStart + payloadLength.toInt()
     buffer.position(__payloadEnd)
     return Partial(op = op, flags = flags, payloadLength = payloadLength, group = group, sequence = sequence, commandId = commandId, payloadStart = __payloadStart, payloadEnd = __payloadEnd, buffer = buffer, context = context)

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SmpFrameWithTrailerCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SmpFrameWithTrailerCodec.kt
@@ -20,6 +20,14 @@ public object SmpFrameWithTrailerCodec : Codec<SmpFrameWithTrailer> {
   override fun decode(buffer: ReadBuffer, context: DecodeContext): SmpFrameWithTrailer {
     val payloadLength = buffer.readUShort()
     val payloadBytes = payloadLength.toInt()
+    if (payloadBytes > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "SmpFrameWithTrailer.payload",
+            bufferPosition = buffer.position(),
+            expected = "a " + payloadBytes + "-byte bounded region within the enclosing limit",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     val payloadOuterLimit = buffer.limit()
     val payloadEnd = buffer.position() + payloadBytes
     buffer.setLimit(payloadEnd)
@@ -105,6 +113,14 @@ public object SmpFrameWithTrailerCodec : Codec<SmpFrameWithTrailer> {
   public fun partial(buffer: ReadBuffer, context: DecodeContext): Partial {
     val payloadLength = buffer.readUShort()
     val __payloadStart = buffer.position()
+    if (payloadLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "SmpFrameWithTrailer.payload",
+            bufferPosition = buffer.position(),
+            expected = "a " + payloadLength.toInt() + "-byte bounded region within the enclosing limit",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     val __payloadEnd = __payloadStart + payloadLength.toInt()
     buffer.position(__payloadEnd)
     val checksum = buffer.readUShort()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SmpGenericFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SmpGenericFrameCodec.kt
@@ -43,6 +43,14 @@ public class SmpGenericFrameCodec<P : Payload>(
       commandId = (__batch1 ushr 56 and 0xFFL).toUByte()
     }
     val payloadBytes = payloadLength.toInt()
+    if (payloadBytes > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "SmpGenericFrame.payload",
+            bufferPosition = buffer.position(),
+            expected = "a " + payloadBytes + "-byte bounded region within the enclosing limit",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     val payloadOuterLimit = buffer.limit()
     val payloadEnd = buffer.position() + payloadBytes
     buffer.setLimit(payloadEnd)
@@ -163,6 +171,14 @@ public class SmpGenericFrameCodec<P : Payload>(
         commandId = (__batch2 ushr 56 and 0xFFL).toUByte()
       }
       val __payloadStart = buffer.position()
+      if (payloadLength.toInt() > buffer.remaining()) {
+        throw DecodeException(
+              fieldPath = "SmpGenericFrame.payload",
+              bufferPosition = buffer.position(),
+              expected = "a " + payloadLength.toInt() + "-byte bounded region within the enclosing limit",
+              actual = buffer.remaining().toString() + " bytes available",
+            )
+      }
       val __payloadEnd = __payloadStart + payloadLength.toInt()
       buffer.position(__payloadEnd)
       return Partial<P>(op = op, flags = flags, payloadLength = payloadLength, group = group, sequence = sequence, commandId = commandId, payloadStart = __payloadStart, payloadEnd = __payloadEnd, buffer = buffer, context = context)

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/WideLengthDeferredFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/deferredpayload/WideLengthDeferredFrameCodec.kt
@@ -22,6 +22,14 @@ public object WideLengthDeferredFrameCodec : Codec<WideLengthDeferredFrame> {
       throw DecodeException(fieldPath = "WideLengthDeferredFrame.payload", bufferPosition = -1, expected = "@LengthFrom source <= ${'$'}{Int.MAX_VALUE}", actual = payloadLength.toString())
     }
     val payloadBytes = payloadLength.toInt()
+    if (payloadBytes > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "WideLengthDeferredFrame.payload",
+            bufferPosition = buffer.position(),
+            expected = "a " + payloadBytes + "-byte bounded region within the enclosing limit",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     val payloadOuterLimit = buffer.limit()
     val payloadEnd = buffer.position() + payloadBytes
     buffer.setLimit(payloadEnd)
@@ -84,6 +92,14 @@ public object WideLengthDeferredFrameCodec : Codec<WideLengthDeferredFrame> {
     val __payloadStart = buffer.position()
     if (payloadLength > Int.MAX_VALUE.toUInt()) {
       throw DecodeException(fieldPath = "WideLengthDeferredFrame.payload", bufferPosition = -1, expected = "@LengthFrom source <= ${'$'}{Int.MAX_VALUE}", actual = payloadLength.toString())
+    }
+    if (payloadLength.toInt() > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "WideLengthDeferredFrame.payload",
+            bufferPosition = buffer.position(),
+            expected = "a " + payloadLength.toInt() + "-byte bounded region within the enclosing limit",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
     }
     val __payloadEnd = __payloadStart + payloadLength.toInt()
     buffer.position(__payloadEnd)

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/grpc/GrpcLengthPrefixedMessageCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/grpc/GrpcLengthPrefixedMessageCodec.kt
@@ -24,6 +24,14 @@ public object GrpcLengthPrefixedMessageCodec : Codec<GrpcLengthPrefixedMessage> 
       throw DecodeException(fieldPath = "GrpcLengthPrefixedMessage.message", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = messagePrefix.toString())
     }
     val messageLength = messagePrefix.toInt()
+    if (messageLength > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "GrpcLengthPrefixedMessage.message",
+            bufferPosition = buffer.position(),
+            expected = "a " + messageLength + "-byte bounded region within the enclosing limit",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     val __messageOuterLimit = buffer.limit()
     buffer.setLimit(buffer.position() + messageLength)
     val message = try {

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2FrameSettingsCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2FrameSettingsCodec.kt
@@ -20,6 +20,14 @@ public object Http2FrameSettingsCodec : Codec<Http2Frame.Settings> {
     val flags = buffer.readUByte()
     val streamId = Http2StreamId(buffer.readUInt())
     val entriesBytes = header.length
+    if (entriesBytes > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "Settings.entries",
+            bufferPosition = buffer.position(),
+            expected = "a " + entriesBytes + "-byte bounded region within the enclosing limit",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     val entriesOuterLimit = buffer.limit()
     buffer.setLimit(buffer.position() + entriesBytes)
     val entries = mutableListOf<Http2Setting>()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2SettingsFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http2/Http2SettingsFrameCodec.kt
@@ -29,6 +29,14 @@ public object Http2SettingsFrameCodec : Codec<Http2SettingsFrame> {
       throw DecodeException(fieldPath = "Http2SettingsFrame.entries", bufferPosition = -1, expected = "@LengthFrom source <= ${'$'}{Int.MAX_VALUE}", actual = length.toString())
     }
     val entriesBytes = length.toInt()
+    if (entriesBytes > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "Http2SettingsFrame.entries",
+            bufferPosition = buffer.position(),
+            expected = "a " + entriesBytes + "-byte bounded region within the enclosing limit",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     val entriesOuterLimit = buffer.limit()
     buffer.setLimit(buffer.position() + entriesBytes)
     val entries = mutableListOf<Http2Setting>()

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameDataCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameDataCodec.kt
@@ -5,6 +5,7 @@ import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.WriteBuffer
 import com.ditchoom.buffer.codec.Codec
 import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
 import com.ditchoom.buffer.codec.EncodeContext
 import com.ditchoom.buffer.codec.PeekResult
 import com.ditchoom.buffer.codec.WireSize
@@ -20,6 +21,16 @@ public object Http3FrameDataCodec : Codec<Http3Frame.Data> {
     val __lengthOuterLimit = buffer.limit()
     val length = Http3LengthCodec.decode(buffer, context)
     Http3LengthCodec.applyBound(buffer, length)
+    if (buffer.limit() > __lengthOuterLimit) {
+      val __widenedLimit = buffer.limit()
+      buffer.setLimit(__lengthOuterLimit)
+      throw DecodeException(
+            fieldPath = "Data.length",
+            bufferPosition = buffer.position(),
+            expected = "applyBound to narrow within the enclosing limit " + __lengthOuterLimit,
+            actual = "limit " + __widenedLimit,
+          )
+    }
     return try {
       val payload = BinaryDataCodec.decode(buffer, context)
       Http3Frame.Data(frameType = frameType, length = length, payload = payload)
@@ -74,6 +85,16 @@ public object Http3FrameDataCodec : Codec<Http3Frame.Data> {
     val __lengthOuterLimit = buffer.limit()
     val length = Http3LengthCodec.decode(buffer, context)
     Http3LengthCodec.applyBound(buffer, length)
+    if (buffer.limit() > __lengthOuterLimit) {
+      val __widenedLimit = buffer.limit()
+      buffer.setLimit(__lengthOuterLimit)
+      throw DecodeException(
+            fieldPath = "Data.length",
+            bufferPosition = buffer.position(),
+            expected = "applyBound to narrow within the enclosing limit " + __lengthOuterLimit,
+            actual = "limit " + __widenedLimit,
+          )
+    }
     return Partial(frameType = frameType, length = length, outerLimit = __lengthOuterLimit, buffer = buffer, context = context)
   }
 

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameExtensionCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameExtensionCodec.kt
@@ -5,6 +5,7 @@ import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.WriteBuffer
 import com.ditchoom.buffer.codec.Codec
 import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
 import com.ditchoom.buffer.codec.EncodeContext
 import com.ditchoom.buffer.codec.PeekResult
 import com.ditchoom.buffer.codec.WireSize
@@ -20,6 +21,16 @@ public object Http3FrameExtensionCodec : Codec<Http3Frame.Extension> {
     val __lengthOuterLimit = buffer.limit()
     val length = Http3LengthCodec.decode(buffer, context)
     Http3LengthCodec.applyBound(buffer, length)
+    if (buffer.limit() > __lengthOuterLimit) {
+      val __widenedLimit = buffer.limit()
+      buffer.setLimit(__lengthOuterLimit)
+      throw DecodeException(
+            fieldPath = "Extension.length",
+            bufferPosition = buffer.position(),
+            expected = "applyBound to narrow within the enclosing limit " + __lengthOuterLimit,
+            actual = "limit " + __widenedLimit,
+          )
+    }
     return try {
       val payload = BinaryDataCodec.decode(buffer, context)
       Http3Frame.Extension(frameType = frameType, length = length, payload = payload)
@@ -74,6 +85,16 @@ public object Http3FrameExtensionCodec : Codec<Http3Frame.Extension> {
     val __lengthOuterLimit = buffer.limit()
     val length = Http3LengthCodec.decode(buffer, context)
     Http3LengthCodec.applyBound(buffer, length)
+    if (buffer.limit() > __lengthOuterLimit) {
+      val __widenedLimit = buffer.limit()
+      buffer.setLimit(__lengthOuterLimit)
+      throw DecodeException(
+            fieldPath = "Extension.length",
+            bufferPosition = buffer.position(),
+            expected = "applyBound to narrow within the enclosing limit " + __lengthOuterLimit,
+            actual = "limit " + __widenedLimit,
+          )
+    }
     return Partial(frameType = frameType, length = length, outerLimit = __lengthOuterLimit, buffer = buffer, context = context)
   }
 

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameHeadersCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameHeadersCodec.kt
@@ -5,6 +5,7 @@ import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.WriteBuffer
 import com.ditchoom.buffer.codec.Codec
 import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
 import com.ditchoom.buffer.codec.EncodeContext
 import com.ditchoom.buffer.codec.PeekResult
 import com.ditchoom.buffer.codec.WireSize
@@ -20,6 +21,16 @@ public object Http3FrameHeadersCodec : Codec<Http3Frame.Headers> {
     val __lengthOuterLimit = buffer.limit()
     val length = Http3LengthCodec.decode(buffer, context)
     Http3LengthCodec.applyBound(buffer, length)
+    if (buffer.limit() > __lengthOuterLimit) {
+      val __widenedLimit = buffer.limit()
+      buffer.setLimit(__lengthOuterLimit)
+      throw DecodeException(
+            fieldPath = "Headers.length",
+            bufferPosition = buffer.position(),
+            expected = "applyBound to narrow within the enclosing limit " + __lengthOuterLimit,
+            actual = "limit " + __widenedLimit,
+          )
+    }
     return try {
       val fieldSection = BinaryDataCodec.decode(buffer, context)
       Http3Frame.Headers(frameType = frameType, length = length, fieldSection = fieldSection)
@@ -74,6 +85,16 @@ public object Http3FrameHeadersCodec : Codec<Http3Frame.Headers> {
     val __lengthOuterLimit = buffer.limit()
     val length = Http3LengthCodec.decode(buffer, context)
     Http3LengthCodec.applyBound(buffer, length)
+    if (buffer.limit() > __lengthOuterLimit) {
+      val __widenedLimit = buffer.limit()
+      buffer.setLimit(__lengthOuterLimit)
+      throw DecodeException(
+            fieldPath = "Headers.length",
+            bufferPosition = buffer.position(),
+            expected = "applyBound to narrow within the enclosing limit " + __lengthOuterLimit,
+            actual = "limit " + __widenedLimit,
+          )
+    }
     return Partial(frameType = frameType, length = length, outerLimit = __lengthOuterLimit, buffer = buffer, context = context)
   }
 

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameSettingsCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/http3/Http3FrameSettingsCodec.kt
@@ -5,6 +5,7 @@ import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.WriteBuffer
 import com.ditchoom.buffer.codec.Codec
 import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
 import com.ditchoom.buffer.codec.EncodeContext
 import com.ditchoom.buffer.codec.PeekResult
 import com.ditchoom.buffer.codec.WireSize
@@ -20,6 +21,16 @@ public object Http3FrameSettingsCodec : Codec<Http3Frame.Settings> {
     val __lengthOuterLimit = buffer.limit()
     val length = Http3LengthCodec.decode(buffer, context)
     Http3LengthCodec.applyBound(buffer, length)
+    if (buffer.limit() > __lengthOuterLimit) {
+      val __widenedLimit = buffer.limit()
+      buffer.setLimit(__lengthOuterLimit)
+      throw DecodeException(
+            fieldPath = "Settings.length",
+            bufferPosition = buffer.position(),
+            expected = "applyBound to narrow within the enclosing limit " + __lengthOuterLimit,
+            actual = "limit " + __widenedLimit,
+          )
+    }
     return try {
       val parameters = BinaryDataCodec.decode(buffer, context)
       Http3Frame.Settings(frameType = frameType, length = length, parameters = parameters)
@@ -74,6 +85,16 @@ public object Http3FrameSettingsCodec : Codec<Http3Frame.Settings> {
     val __lengthOuterLimit = buffer.limit()
     val length = Http3LengthCodec.decode(buffer, context)
     Http3LengthCodec.applyBound(buffer, length)
+    if (buffer.limit() > __lengthOuterLimit) {
+      val __widenedLimit = buffer.limit()
+      buffer.setLimit(__lengthOuterLimit)
+      throw DecodeException(
+            fieldPath = "Settings.length",
+            bufferPosition = buffer.position(),
+            expected = "applyBound to narrow within the enclosing limit " + __lengthOuterLimit,
+            actual = "limit " + __widenedLimit,
+          )
+    }
     return Partial(frameType = frameType, length = length, outerLimit = __lengthOuterLimit, buffer = buffer, context = context)
   }
 

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/PropertyBagFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/PropertyBagFrameCodec.kt
@@ -7,6 +7,7 @@ import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.WriteBuffer
 import com.ditchoom.buffer.codec.Codec
 import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
 import com.ditchoom.buffer.codec.EncodeContext
 import com.ditchoom.buffer.codec.LengthPrefixedListEncoder
 import com.ditchoom.buffer.codec.PeekResult
@@ -21,6 +22,16 @@ public object PropertyBagFrameCodec : Codec<PropertyBagFrame> {
     val __propertiesOuterLimit = buffer.limit()
     val __propertiesLength = MqttRemainingLengthCodec.decode(buffer, context)
     MqttRemainingLengthCodec.applyBound(buffer, __propertiesLength)
+    if (buffer.limit() > __propertiesOuterLimit) {
+      val __widenedLimit = buffer.limit()
+      buffer.setLimit(__propertiesOuterLimit)
+      throw DecodeException(
+            fieldPath = "PropertyBagFrame.properties",
+            bufferPosition = buffer.position(),
+            expected = "applyBound to narrow within the enclosing limit " + __propertiesOuterLimit,
+            actual = "limit " + __widenedLimit,
+          )
+    }
     val properties = mutableListOf<PropertyEntry>()
     try {
       while (buffer.position() < buffer.limit()) {

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/StringTaggedPropertyBagCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/StringTaggedPropertyBagCodec.kt
@@ -7,6 +7,7 @@ import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.WriteBuffer
 import com.ditchoom.buffer.codec.Codec
 import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
 import com.ditchoom.buffer.codec.EncodeContext
 import com.ditchoom.buffer.codec.LengthPrefixedListEncoder
 import com.ditchoom.buffer.codec.PeekResult
@@ -21,6 +22,16 @@ public object StringTaggedPropertyBagCodec : Codec<StringTaggedPropertyBag> {
     val __propertiesOuterLimit = buffer.limit()
     val __propertiesLength = MqttRemainingLengthCodec.decode(buffer, context)
     MqttRemainingLengthCodec.applyBound(buffer, __propertiesLength)
+    if (buffer.limit() > __propertiesOuterLimit) {
+      val __widenedLimit = buffer.limit()
+      buffer.setLimit(__propertiesOuterLimit)
+      throw DecodeException(
+            fieldPath = "StringTaggedPropertyBag.properties",
+            bufferPosition = buffer.position(),
+            expected = "applyBound to narrow within the enclosing limit " + __propertiesOuterLimit,
+            actual = "limit " + __widenedLimit,
+          )
+    }
     val properties = mutableListOf<StringTaggedProperty>()
     try {
       while (buffer.position() < buffer.limit()) {

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/TaggedPropertyBagCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/lengthprefixedusecodec/TaggedPropertyBagCodec.kt
@@ -7,6 +7,7 @@ import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.WriteBuffer
 import com.ditchoom.buffer.codec.Codec
 import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
 import com.ditchoom.buffer.codec.EncodeContext
 import com.ditchoom.buffer.codec.LengthPrefixedListEncoder
 import com.ditchoom.buffer.codec.PeekResult
@@ -22,6 +23,16 @@ public object TaggedPropertyBagCodec : Codec<TaggedPropertyBag> {
     val __propertiesOuterLimit = buffer.limit()
     val __propertiesLength = MqttRemainingLengthCodec.decode(buffer, context)
     MqttRemainingLengthCodec.applyBound(buffer, __propertiesLength)
+    if (buffer.limit() > __propertiesOuterLimit) {
+      val __widenedLimit = buffer.limit()
+      buffer.setLimit(__propertiesOuterLimit)
+      throw DecodeException(
+            fieldPath = "TaggedPropertyBag.properties",
+            bufferPosition = buffer.position(),
+            expected = "applyBound to narrow within the enclosing limit " + __propertiesOuterLimit,
+            actual = "limit " + __widenedLimit,
+          )
+    }
     val properties = mutableListOf<PropertyEntry>()
     try {
       while (buffer.position() < buffer.limit()) {

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketConnectCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqtt/MqttPacketConnectCodec.kt
@@ -84,6 +84,14 @@ public object MqttPacketConnectCodec {
           throw DecodeException(fieldPath = "Connect.willPayload", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = willPayloadPrefix.toString())
         }
         val willPayloadLength = willPayloadPrefix.toInt()
+        if (willPayloadLength > buffer.remaining()) {
+          throw DecodeException(
+                fieldPath = "Connect.willPayload",
+                bufferPosition = buffer.position(),
+                expected = "a " + willPayloadLength + "-byte bounded region within the enclosing limit",
+                actual = buffer.remaining().toString() + " bytes available",
+              )
+        }
         val __willPayloadOuterLimit = buffer.limit()
         buffer.setLimit(buffer.position() + willPayloadLength)
         try {
@@ -114,6 +122,14 @@ public object MqttPacketConnectCodec {
           throw DecodeException(fieldPath = "Connect.password", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = passwordPrefix.toString())
         }
         val passwordLength = passwordPrefix.toInt()
+        if (passwordLength > buffer.remaining()) {
+          throw DecodeException(
+                fieldPath = "Connect.password",
+                bufferPosition = buffer.position(),
+                expected = "a " + passwordLength + "-byte bounded region within the enclosing limit",
+                actual = buffer.remaining().toString() + " bytes available",
+              )
+        }
         val __passwordOuterLimit = buffer.limit()
         buffer.setLimit(buffer.position() + passwordLength)
         try {

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketConnectCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PacketConnectCodec.kt
@@ -81,6 +81,14 @@ public object MqttV5PacketConnectCodec {
           throw DecodeException(fieldPath = "Connect.willPayload", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = willPayloadPrefix.toString())
         }
         val willPayloadLength = willPayloadPrefix.toInt()
+        if (willPayloadLength > buffer.remaining()) {
+          throw DecodeException(
+                fieldPath = "Connect.willPayload",
+                bufferPosition = buffer.position(),
+                expected = "a " + willPayloadLength + "-byte bounded region within the enclosing limit",
+                actual = buffer.remaining().toString() + " bytes available",
+              )
+        }
         val __willPayloadOuterLimit = buffer.limit()
         buffer.setLimit(buffer.position() + willPayloadLength)
         try {
@@ -111,6 +119,14 @@ public object MqttV5PacketConnectCodec {
           throw DecodeException(fieldPath = "Connect.password", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = passwordPrefix.toString())
         }
         val passwordLength = passwordPrefix.toInt()
+        if (passwordLength > buffer.remaining()) {
+          throw DecodeException(
+                fieldPath = "Connect.password",
+                bufferPosition = buffer.position(),
+                expected = "a " + passwordLength + "-byte bounded region within the enclosing limit",
+                actual = buffer.remaining().toString() + " bytes available",
+              )
+        }
         val __passwordOuterLimit = buffer.limit()
         buffer.setLimit(buffer.position() + passwordLength)
         try {

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyAuthenticationDataCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyAuthenticationDataCodec.kt
@@ -23,6 +23,14 @@ public object MqttV5PropertyAuthenticationDataCodec : Codec<MqttV5Property.Authe
       throw DecodeException(fieldPath = "AuthenticationData.data", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = dataPrefix.toString())
     }
     val dataLength = dataPrefix.toInt()
+    if (dataLength > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "AuthenticationData.data",
+            bufferPosition = buffer.position(),
+            expected = "a " + dataLength + "-byte bounded region within the enclosing limit",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     val __dataOuterLimit = buffer.limit()
     buffer.setLimit(buffer.position() + dataLength)
     val data = try {

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyCorrelationDataCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/mqttv5/MqttV5PropertyCorrelationDataCodec.kt
@@ -23,6 +23,14 @@ public object MqttV5PropertyCorrelationDataCodec : Codec<MqttV5Property.Correlat
       throw DecodeException(fieldPath = "CorrelationData.data", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = dataPrefix.toString())
     }
     val dataLength = dataPrefix.toInt()
+    if (dataLength > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "CorrelationData.data",
+            bufferPosition = buffer.position(),
+            expected = "a " + dataLength + "-byte bounded region within the enclosing limit",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     val __dataOuterLimit = buffer.limit()
     buffer.setLimit(buffer.position() + dataLength)
     val data = try {

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/riff/WavFmtChunkCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/riff/WavFmtChunkCodec.kt
@@ -27,6 +27,14 @@ public object WavFmtChunkCodec : Codec<WavFmtChunk> {
       throw DecodeException(fieldPath = "WavFmtChunk.body", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = bodyPrefix.toString())
     }
     val bodyLength = bodyPrefix.toInt()
+    if (bodyLength > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "WavFmtChunk.body",
+            bufferPosition = buffer.position(),
+            expected = "a " + bodyLength + "-byte bounded region within the enclosing limit",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     val bodyOuterLimit = buffer.limit()
     buffer.setLimit(buffer.position() + bodyLength)
     val body = try {

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice15a/Slice15aLengthPrefixedPayloadCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/slice15a/Slice15aLengthPrefixedPayloadCodec.kt
@@ -22,6 +22,14 @@ public object Slice15aLengthPrefixedPayloadCodec : Codec<Slice15aLengthPrefixedP
       throw DecodeException(fieldPath = "Slice15aLengthPrefixedPayload.data", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = dataPrefix.toString())
     }
     val dataLength = dataPrefix.toInt()
+    if (dataLength > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "Slice15aLengthPrefixedPayload.data",
+            bufferPosition = buffer.position(),
+            expected = "a " + dataLength + "-byte bounded region within the enclosing limit",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     val __dataOuterLimit = buffer.limit()
     buffer.setLimit(buffer.position() + dataLength)
     val data = try {

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeCodec.kt
@@ -23,6 +23,14 @@ public object TlsHandshakeCodec : Codec<TlsHandshake> {
       throw DecodeException(fieldPath = "TlsHandshake.body", bufferPosition = -1, expected = "@LengthFrom source <= ${'$'}{Int.MAX_VALUE}", actual = length.toString())
     }
     val bodyBytes = length.toInt()
+    if (bodyBytes > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "TlsHandshake.body",
+            bufferPosition = buffer.position(),
+            expected = "a " + bodyBytes + "-byte bounded region within the enclosing limit",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     val bodyOuterLimit = buffer.limit()
     buffer.setLimit(buffer.position() + bodyBytes)
     val body = try {

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeWithSealedBodyCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshakeWithSealedBodyCodec.kt
@@ -23,6 +23,14 @@ public object TlsHandshakeWithSealedBodyCodec : Codec<TlsHandshakeWithSealedBody
       throw DecodeException(fieldPath = "TlsHandshakeWithSealedBody.body", bufferPosition = -1, expected = "@LengthFrom source <= ${'$'}{Int.MAX_VALUE}", actual = length.toString())
     }
     val bodyBytes = length.toInt()
+    if (bodyBytes > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "TlsHandshakeWithSealedBody.body",
+            bufferPosition = buffer.position(),
+            expected = "a " + bodyBytes + "-byte bounded region within the enclosing limit",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
     val bodyOuterLimit = buffer.limit()
     buffer.setLimit(buffer.position() + bodyBytes)
     val body = try {

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsRecordCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/tls/TlsRecordCodec.kt
@@ -1,0 +1,112 @@
+package com.ditchoom.buffer.codec.test.protocols.tls
+
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.Codec
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.EncodeException
+import com.ditchoom.buffer.codec.PeekResult
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.stream.StreamProcessor
+import com.ditchoom.buffer.swapBytes
+import kotlin.Int
+
+public object TlsRecordCodec : Codec<TlsRecord> {
+  override fun decode(buffer: ReadBuffer, context: DecodeContext): TlsRecord {
+    val contentType = buffer.readUByte()
+    val legacyRecordVersionRaw = buffer.readShort()
+    val legacyRecordVersion = (if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) legacyRecordVersionRaw else swapBytes(legacyRecordVersionRaw)).toUShort()
+    val fragmentPrefixB0 = buffer.readUByte().toUInt()
+    val fragmentPrefixB1 = buffer.readUByte().toUInt()
+    val fragmentPrefix = ((fragmentPrefixB0 shl 8) or fragmentPrefixB1)
+    if (fragmentPrefix > Int.MAX_VALUE.toUInt()) {
+      throw DecodeException(fieldPath = "TlsRecord.fragment", bufferPosition = -1, expected = "length prefix <= ${'$'}{Int.MAX_VALUE}", actual = fragmentPrefix.toString())
+    }
+    val fragmentLength = fragmentPrefix.toInt()
+    if (fragmentLength > buffer.remaining()) {
+      throw DecodeException(
+            fieldPath = "TlsRecord.fragment",
+            bufferPosition = buffer.position(),
+            expected = "a " + fragmentLength + "-byte bounded region within the enclosing limit",
+            actual = buffer.remaining().toString() + " bytes available",
+          )
+    }
+    val fragmentOuterLimit = buffer.limit()
+    buffer.setLimit(buffer.position() + fragmentLength)
+    val fragment = try {
+      TlsHandshakeCodec.decode(buffer, context)
+    } finally {
+      buffer.setLimit(fragmentOuterLimit)
+    }
+    return TlsRecord(contentType = contentType, legacyRecordVersion = legacyRecordVersion, fragment = fragment)
+  }
+
+  override fun encode(
+    buffer: WriteBuffer,
+    `value`: TlsRecord,
+    context: EncodeContext,
+  ) {
+    buffer.writeUByte(value.contentType)
+    val legacyRecordVersionRaw = value.legacyRecordVersion.toShort()
+    buffer.writeShort(if (buffer.byteOrder == ByteOrder.BIG_ENDIAN) legacyRecordVersionRaw else swapBytes(legacyRecordVersionRaw))
+    when (val fragmentWireSize = TlsHandshakeCodec.wireSize(value.fragment, context)) {
+      is WireSize.Exact -> {
+        val fragmentByteCount = fragmentWireSize.bytes
+        if (fragmentByteCount > 65_535) {
+          throw EncodeException(fieldPath = "TlsRecord.fragment", reason = """encoded message byte length ${fragmentByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+        }
+        val fragmentPrefix = fragmentByteCount.toUInt()
+        buffer.writeUByte(((fragmentPrefix shr 8) and 0xFFu).toUByte())
+        buffer.writeUByte((fragmentPrefix and 0xFFu).toUByte())
+        val fragmentBodyStart = buffer.position()
+        TlsHandshakeCodec.encode(buffer, value.fragment, context)
+        if (buffer.position() - fragmentBodyStart != fragmentByteCount) {
+          throw EncodeException(fieldPath = "TlsRecord.fragment", reason = """wireSize declared ${fragmentByteCount} bytes but encode wrote ${buffer.position() - fragmentBodyStart} — the codec's wireSize and encode disagree""")
+        }
+      }
+      WireSize.BackPatch -> {
+        val fragmentSizePosition = buffer.position()
+        repeat(2) { buffer.writeUByte(0u) }
+        val fragmentBodyStart = buffer.position()
+        TlsHandshakeCodec.encode(buffer, value.fragment, context)
+        val fragmentEndPosition = buffer.position()
+        val fragmentPatchByteCount = fragmentEndPosition - fragmentBodyStart
+        if (fragmentPatchByteCount > 65_535) {
+          throw EncodeException(fieldPath = "TlsRecord.fragment", reason = """encoded message byte length ${fragmentPatchByteCount} exceeds @LengthPrefixed(LengthPrefix.Short) max 65535""")
+        }
+        buffer.position(fragmentSizePosition)
+        val fragmentPatchPrefix = fragmentPatchByteCount.toUInt()
+        buffer.writeUByte(((fragmentPatchPrefix shr 8) and 0xFFu).toUByte())
+        buffer.writeUByte((fragmentPatchPrefix and 0xFFu).toUByte())
+        buffer.position(fragmentEndPosition)
+      }
+    }
+  }
+
+  override fun wireSize(`value`: TlsRecord, context: EncodeContext): WireSize = when (val fragmentSize = TlsHandshakeCodec.wireSize(value.fragment, context)) {
+    is WireSize.Exact -> WireSize.Exact(5 + fragmentSize.bytes)
+    WireSize.BackPatch -> WireSize.BackPatch
+  }
+
+  override fun sizeHint(`value`: TlsRecord, context: EncodeContext): Int = 5 + TlsHandshakeCodec.sizeHint(value.fragment, context)
+
+  override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+    var __offset = 0
+    if (stream.available() - baseOffset < __offset + 1) return PeekResult.NeedsMoreData
+    __offset += 1
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    __offset += 2
+    if (stream.available() - baseOffset < __offset + 2) return PeekResult.NeedsMoreData
+    val fragmentPrefixB0 = stream.peekByte(baseOffset + __offset).toInt() and 0xFF
+    val fragmentPrefixB1 = stream.peekByte(baseOffset + __offset + 1).toInt() and 0xFF
+    val fragmentPrefix = ((fragmentPrefixB0 shl 8) or fragmentPrefixB1).toUInt()
+    if (fragmentPrefix > (Int.MAX_VALUE - __offset - 2).toUInt()) {
+      throw DecodeException(fieldPath = "TlsRecord.fragment", bufferPosition = baseOffset + __offset, expected = "__offset + 2 + length prefix <= ${'$'}{Int.MAX_VALUE}", actual = """${__offset + 2 + fragmentPrefix.toInt()}""")
+    }
+    __offset += 2 + fragmentPrefix.toInt()
+    return if (stream.available() - baseOffset >= __offset) PeekResult.Complete(__offset) else PeekResult.NeedsMoreData
+  }
+}

--- a/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/BoundedFrameCodec.kt
+++ b/buffer-codec-test/codec-snapshots/com/ditchoom/buffer/codec/test/protocols/usecodecscalar/BoundedFrameCodec.kt
@@ -5,6 +5,7 @@ import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.WriteBuffer
 import com.ditchoom.buffer.codec.Codec
 import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
 import com.ditchoom.buffer.codec.EncodeContext
 import com.ditchoom.buffer.codec.PeekResult
 import com.ditchoom.buffer.codec.WireSize
@@ -21,6 +22,16 @@ public object BoundedFrameCodec : Codec<BoundedFrame> {
     val __lengthOuterLimit = buffer.limit()
     val length = Le32LengthCodec.decode(buffer, context)
     Le32LengthCodec.applyBound(buffer, length)
+    if (buffer.limit() > __lengthOuterLimit) {
+      val __widenedLimit = buffer.limit()
+      buffer.setLimit(__lengthOuterLimit)
+      throw DecodeException(
+            fieldPath = "BoundedFrame.length",
+            bufferPosition = buffer.position(),
+            expected = "applyBound to narrow within the enclosing limit " + __lengthOuterLimit,
+            actual = "limit " + __widenedLimit,
+          )
+    }
     return try {
       val payload = BinaryDataCodec.decode(buffer, context)
       BoundedFrame(tag = tag, length = length, payload = payload)
@@ -69,6 +80,16 @@ public object BoundedFrameCodec : Codec<BoundedFrame> {
     val __lengthOuterLimit = buffer.limit()
     val length = Le32LengthCodec.decode(buffer, context)
     Le32LengthCodec.applyBound(buffer, length)
+    if (buffer.limit() > __lengthOuterLimit) {
+      val __widenedLimit = buffer.limit()
+      buffer.setLimit(__lengthOuterLimit)
+      throw DecodeException(
+            fieldPath = "BoundedFrame.length",
+            bufferPosition = buffer.position(),
+            expected = "applyBound to narrow within the enclosing limit " + __lengthOuterLimit,
+            actual = "limit " + __widenedLimit,
+          )
+    }
     return Partial(tag = tag, length = length, outerLimit = __lengthOuterLimit, buffer = buffer, context = context)
   }
 

--- a/buffer-codec-test/src/codecSchema/codec-schema.txt
+++ b/buffer-codec-test/src/codecSchema/codec-schema.txt
@@ -1161,6 +1161,10 @@ message com.ditchoom.buffer.codec.test.protocols.tls.TlsHandshakeWithSealedBody
   0 msgType scalar:UByte wire=1B order=Big
   1 length scalar:UInt wire=3B order=Big
   2 body msg:com.ditchoom.buffer.codec.test.protocols.tls.TlsHandshakeSealedBody len-from=sibling:length
+message com.ditchoom.buffer.codec.test.protocols.tls.TlsRecord
+  0 contentType scalar:UByte wire=1B order=Big
+  1 legacyRecordVersion scalar:UShort wire=2B order=Big
+  2 fragment msg:com.ditchoom.buffer.codec.test.protocols.tls.TlsHandshake len-prefix=2B/Big
 message com.ditchoom.buffer.codec.test.protocols.usecodecscalar.BoundedFrame
   0 tag scalar:Short wire=2B order=Default
   1 length codec:com.ditchoom.buffer.codec.test.protocols.usecodecscalar.Le32LengthCodec bounding=true variable=false

--- a/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshake.kt
+++ b/buffer-codec-test/src/commonMain/kotlin/com/ditchoom/buffer/codec/test/protocols/tls/TlsHandshake.kt
@@ -2,6 +2,7 @@ package com.ditchoom.buffer.codec.test.protocols.tls
 
 import com.ditchoom.buffer.codec.annotations.Endianness
 import com.ditchoom.buffer.codec.annotations.LengthFrom
+import com.ditchoom.buffer.codec.annotations.LengthPrefixed
 import com.ditchoom.buffer.codec.annotations.PacketType
 import com.ditchoom.buffer.codec.annotations.ProtocolMessage
 import com.ditchoom.buffer.codec.annotations.RemainingBytes
@@ -66,6 +67,21 @@ data class TlsHandshakeWithSealedBody(
     val msgType: UByte,
     @WireBytes(3) val length: UInt,
     @LengthFrom("length") val body: TlsHandshakeSealedBody,
+)
+
+/**
+ * RFC 8446 §5.1 record envelope (minimal): the handshake fragment is
+ * bounded by the record's own uint16 length. Nesting [TlsHandshake]
+ * under this outer bound is the hostile-length vector: the inner
+ * `@LengthFrom("length")` region must never widen `buffer.limit()`
+ * past the record's `@LengthPrefixed` bound, no matter what the inner
+ * uint24 claims.
+ */
+@ProtocolMessage(wireOrder = Endianness.Big)
+data class TlsRecord(
+    val contentType: UByte,
+    val legacyRecordVersion: UShort,
+    @LengthPrefixed val fragment: TlsHandshake,
 )
 
 @ProtocolMessage(wireOrder = Endianness.Big)

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/boundary/OuterBoundWidenGuardTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/boundary/OuterBoundWidenGuardTest.kt
@@ -1,0 +1,93 @@
+package com.ditchoom.buffer.codec.test.protocols.boundary
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.test.protocols.http2.Http2SettingsFrameCodec
+import com.ditchoom.buffer.codec.test.protocols.lengthprefixedusecodec.PropertyBagFrameCodec
+import com.ditchoom.buffer.codec.test.protocols.usecodecscalar.BoundedFrameCodec
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * Widen-guard audit for the remaining narrowing decode sites — every
+ * wire-supplied length that narrows `buffer.limit()` must be rejected when
+ * it exceeds the enclosing bound, since `setLimit` widens unchecked on
+ * every platform (same decode-side hole as the `@LengthFrom` message
+ * shapes; see `TlsRecordWidenGuardTest`).
+ *
+ * Covered here:
+ *  - `@LengthFrom("sibling") List<T>` — [Http2SettingsFrameCodec]
+ *  - `BoundingLengthCodec.applyBound` on a `@UseCodec` scalar — [BoundedFrameCodec]
+ *  - `BoundingLengthCodec.applyBound` on a `@LengthPrefixed @UseCodec` list — [PropertyBagFrameCodec]
+ */
+class OuterBoundWidenGuardTest {
+    /** SETTINGS frame whose uint24 claims 60 entry bytes; the carve leaves 6. */
+    @Test
+    fun lengthFromListCannotWidenPastTheOuterBound() {
+        val buf = BufferFactory.Default.allocate(128, ByteOrder.BIG_ENDIAN)
+        buf.writeUByte(0u) // uint24 length = 60, LIES
+        buf.writeUByte(0u)
+        buf.writeUByte(60u)
+        buf.writeUByte(4u) // type = SETTINGS
+        buf.writeUByte(0u) // flags
+        buf.writeUInt(0u) // streamId
+        buf.writeUShort(1u) // one honest 6-byte entry
+        buf.writeUInt(4096u)
+        carveAndPad(buf)
+        val failure =
+            assertFailsWith<DecodeException> {
+                Http2SettingsFrameCodec.decode(buf, DecodeContext.Empty)
+            }
+        assertEquals("Http2SettingsFrame.entries", failure.fieldPath)
+    }
+
+    /** Bounding `@UseCodec` scalar whose `applyBound` would land past the carve. */
+    @Test
+    fun boundingUseCodecScalarCannotWidenPastTheOuterBound() {
+        val buf = BufferFactory.Default.allocate(128, ByteOrder.BIG_ENDIAN)
+        buf.writeShort(0x0102) // tag
+        buf.writeByte(50) // length = 50 little-endian, LIES: the carve leaves 2
+        buf.writeByte(0)
+        buf.writeByte(0)
+        buf.writeByte(0)
+        buf.writeByte(0x68) // payload "hi"
+        buf.writeByte(0x69)
+        carveAndPad(buf)
+        val failure =
+            assertFailsWith<DecodeException> {
+                BoundedFrameCodec.decode(buf, DecodeContext.Empty)
+            }
+        assertEquals("BoundedFrame.length", failure.fieldPath)
+    }
+
+    /** VBI-prefixed property list whose remaining-length claims 50; the carve leaves 10. */
+    @Test
+    fun boundingPrefixedListCannotWidenPastTheOuterBound() {
+        val buf = BufferFactory.Default.allocate(128, ByteOrder.BIG_ENDIAN)
+        buf.writeByte(50) // MQTT var-byte-int = 50, LIES
+        repeat(2) { i ->
+            buf.writeUByte((i + 1).toUByte()) // property id
+            buf.writeUInt(0xCAFEu) // property value
+        }
+        carveAndPad(buf)
+        val failure =
+            assertFailsWith<DecodeException> {
+                PropertyBagFrameCodec.decode(buf, DecodeContext.Empty)
+            }
+        assertEquals("PropertyBagFrame.properties", failure.fieldPath)
+    }
+
+    /** Carve the outer bound at the honest frame end, with adjacent bytes beyond it. */
+    private fun carveAndPad(buf: PlatformBuffer) {
+        val frameEnd = buf.position()
+        repeat(100) { buf.writeByte(0x5A) }
+        buf.setLimit(buf.position())
+        buf.position(0)
+        buf.setLimit(frameEnd)
+    }
+}

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SiblingBoundWidenGuardTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/deferredpayload/SiblingBoundWidenGuardTest.kt
@@ -1,0 +1,155 @@
+package com.ditchoom.buffer.codec.test.protocols.deferredpayload
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.test.protocols.payload.TextPayload
+import com.ditchoom.buffer.codec.test.protocols.payload.TextPayloadCodec
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * Hostile sibling lengths for the deferred-payload shapes (#310) running
+ * under an outer narrowed limit — a sealed dispatcher, `@FramedBy`
+ * envelope, or bounding `@UseCodec` region upstream. The sibling-derived
+ * `setLimit` must never widen past that bound: a lying `payloadLength`
+ * would otherwise read the *next* frame's bytes as payload and still pass
+ * strict consumption, because the codec consumed exactly the lying region.
+ *
+ * The outer bound is simulated with a caller-carved `setLimit`, which is
+ * byte-for-byte what a dispatcher does before delegating.
+ */
+class SiblingBoundWidenGuardTest {
+    private val headerBytes = 8
+
+    /** `@LengthFrom @UseCodec` deferred payload — [SmpFrameCodec]. */
+    @Test
+    fun deferredUseCodecPayloadCannotWidenPastTheOuterBound() {
+        val buf = hostileSmpFrame()
+        val failure =
+            assertFailsWith<DecodeException> {
+                SmpFrameCodec.decode(buf, DecodeContext.Empty)
+            }
+        assertEquals("SmpFrame.payload", failure.fieldPath)
+    }
+
+    /** Constructor-injected generic payload codec — [SmpGenericFrameCodec]. */
+    @Test
+    fun constructorInjectedPayloadCannotWidenPastTheOuterBound() {
+        val buf = hostileSmpFrame() // SmpGenericFrame shares SmpFrame's wire layout
+        val failure =
+            assertFailsWith<DecodeException> {
+                SmpGenericFrameCodec(TextPayloadCodec).decode(buf, DecodeContext.Empty)
+            }
+        assertEquals("SmpGenericFrame.payload", failure.fieldPath)
+    }
+
+    /** `partial()` computes the payload region from the sibling — same guard, same failure. */
+    @Test
+    fun partialRejectsALyingSiblingLength() {
+        val buf = hostileSmpFrame()
+        val failure =
+            assertFailsWith<DecodeException> {
+                SmpGenericFrameCodec.partial<TextPayload>(buf, DecodeContext.Empty)
+            }
+        assertEquals("SmpGenericFrame.payload", failure.fieldPath)
+    }
+
+    /**
+     * The eager-trailer `Partial` (payload followed by more fields) seeks
+     * past the payload region before reading the trailer — with a lying
+     * sibling that seek would land in the next frame's bytes.
+     */
+    @Test
+    fun eagerTrailerPartialRejectsALyingSiblingLength() {
+        val buf = hostileTrailerFrame()
+        val failure =
+            assertFailsWith<DecodeException> {
+                SmpFrameWithTrailerCodec.partial(buf, DecodeContext.Empty)
+            }
+        assertEquals("SmpFrameWithTrailer.payload", failure.fieldPath)
+    }
+
+    /** The inline decode of the same trailer shape hits the same guard. */
+    @Test
+    fun trailerFrameDecodeRejectsALyingSiblingLength() {
+        val buf = hostileTrailerFrame()
+        val failure =
+            assertFailsWith<DecodeException> {
+                SmpFrameWithTrailerCodec.decode(buf, DecodeContext.Empty)
+            }
+        assertEquals("SmpFrameWithTrailer.payload", failure.fieldPath)
+    }
+
+    /** Control: a sibling length that exactly fills the carved region still decodes. */
+    @Test
+    fun honestLengthAtTheExactBoundStillDecodes() {
+        val buf = BufferFactory.Default.allocate(64, ByteOrder.BIG_ENDIAN)
+        writeSmpHeader(buf, payloadLength = 2u)
+        buf.writeString("hi", Charset.UTF8)
+        val frameEnd = buf.position()
+        repeat(40) { buf.writeByte(0x5A) }
+        buf.setLimit(buf.position())
+        buf.position(0)
+        buf.setLimit(frameEnd)
+
+        val decoded = SmpFrameCodec.decode(buf, DecodeContext.Empty)
+        assertEquals(TextPayload("hi"), decoded.payload)
+        assertEquals(frameEnd, buf.position(), "frame consumed exactly")
+    }
+
+    /**
+     * An SMP frame carved to its honest 10 bytes whose `payloadLength`
+     * claims 20 — the extra bytes belong to the next frame. `TextPayload`'s
+     * codec reads `remaining()`, so a widened limit would return the
+     * sentinel bytes as payload text with no error at all.
+     */
+    private fun hostileSmpFrame(): PlatformBuffer {
+        val buf = BufferFactory.Default.allocate(64, ByteOrder.BIG_ENDIAN)
+        writeSmpHeader(buf, payloadLength = 20u) // LIES: the carve leaves 2
+        buf.writeString("hi", Charset.UTF8)
+        val frameEnd = buf.position()
+        repeat(40) { buf.writeByte(0x5A) } // next frame's bytes
+        buf.setLimit(buf.position())
+        buf.position(0)
+        buf.setLimit(frameEnd) // outer carve: this frame is exactly 10 bytes
+        return buf
+    }
+
+    private fun writeSmpHeader(
+        buf: PlatformBuffer,
+        payloadLength: UShort,
+    ) {
+        buf.writeUByte(0u) // op
+        buf.writeUByte(0u) // flags
+        buf.writeUShort(payloadLength)
+        buf.writeUShort(9u) // group
+        buf.writeUByte(1u) // sequence
+        buf.writeUByte(3u) // commandId
+    }
+
+    /**
+     * `SmpFrameWithTrailer` wire: `payloadLength(2) | payload | checksum(2) |
+     * note(2-byte prefix + bytes)`. Honest frame is 2 + 2 + 2 + 2 + 1 = 9
+     * bytes; the sibling claims 20.
+     */
+    private fun hostileTrailerFrame(): PlatformBuffer {
+        val buf = BufferFactory.Default.allocate(64, ByteOrder.BIG_ENDIAN)
+        buf.writeUShort(20u) // payloadLength LIES: the carve leaves 2
+        buf.writeString("hi", Charset.UTF8)
+        buf.writeUShort(0xBEEFu) // checksum
+        buf.writeUShort(1u) // note length prefix
+        buf.writeString("x", Charset.UTF8)
+        val frameEnd = buf.position()
+        repeat(40) { buf.writeByte(0x5A) }
+        buf.setLimit(buf.position())
+        buf.position(0)
+        buf.setLimit(frameEnd)
+        return buf
+    }
+}

--- a/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/tls/TlsRecordWidenGuardTest.kt
+++ b/buffer-codec-test/src/commonTest/kotlin/com/ditchoom/buffer/codec/test/protocols/tls/TlsRecordWidenGuardTest.kt
@@ -1,0 +1,132 @@
+package com.ditchoom.buffer.codec.test.protocols.tls
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.DecodeException
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.test.protocols.payload.BinaryData
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * Hostile-length guard for nested narrowing `setLimit` — a codec running
+ * under an outer narrowed limit must never WIDEN `buffer.limit()` from a
+ * lying wire-supplied length. `ReadBuffer.setLimit` widens unchecked on
+ * every platform, so without a decode-side guard an inner region can
+ * silently read adjacent bytes past its enclosing bound and still pass
+ * strict-consumption (it consumed exactly the lying region). Same bug
+ * class as the encode-side/peek fixes in #306/#309.
+ *
+ * [TlsRecord] is the end-to-end vector: the record's `@LengthPrefixed`
+ * bound narrows the buffer, then the nested [TlsHandshake]'s
+ * `@LengthFrom("length")` uint24 lies past it.
+ */
+class TlsRecordWidenGuardTest {
+    @Test
+    fun recordWithHonestNestedHandshakeRoundTrips() {
+        val body =
+            TlsHandshakeBody(
+                legacyVersion = 0x0303u,
+                random = BinaryData(byteArrayOf(0x0A, 0x0B, 0x0C)),
+            )
+        // body = 2 (legacyVersion) + 3 (random) = 5
+        val original =
+            TlsRecord(
+                contentType = 0x16u,
+                legacyRecordVersion = 0x0303u,
+                fragment = TlsHandshake(msgType = 0x01u, length = 5u, body = body),
+            )
+        val buf = BufferFactory.Default.allocate(64, ByteOrder.BIG_ENDIAN)
+        TlsRecordCodec.encode(buf, original, EncodeContext.Empty)
+        buf.resetForRead()
+        val decoded = TlsRecordCodec.decode(buf, DecodeContext.Empty)
+        assertEquals(original.contentType, decoded.contentType)
+        assertEquals(original.fragment.length, decoded.fragment.length)
+        assertEquals(original.fragment.body.legacyVersion, decoded.fragment.body.legacyVersion)
+    }
+
+    /**
+     * The inner handshake's uint24 claims 100 body bytes but the record's
+     * own bound only leaves 3. Widening would silently swallow the bytes
+     * of whatever follows the record in the same buffer.
+     */
+    @Test
+    fun lyingInnerLengthCannotWidenPastTheRecordBound() {
+        val buf = hostileRecord()
+        val failure =
+            assertFailsWith<DecodeException> {
+                TlsRecordCodec.decode(buf, DecodeContext.Empty)
+            }
+        assertEquals("TlsHandshake.body", failure.fieldPath)
+        assertContains(failure.actual, "3 bytes")
+    }
+
+    /** The guard must not disturb the outer restore: limit is back at the caller's bound. */
+    @Test
+    fun outerLimitSurvivesTheRejectedDecode() {
+        val buf = hostileRecord()
+        val outerLimit = buf.limit()
+        assertFailsWith<DecodeException> { TlsRecordCodec.decode(buf, DecodeContext.Empty) }
+        assertEquals(outerLimit, buf.limit(), "outer limit restored by the try/finally chain")
+    }
+
+    /**
+     * The record's own `@LengthPrefixed` prefix lying past a caller-narrowed
+     * limit is the same hole one level up ("@LengthPrefixed message bodies").
+     */
+    @Test
+    fun lyingRecordPrefixUnderNarrowedLimitIsRejected() {
+        val buf = BufferFactory.Default.allocate(256, ByteOrder.BIG_ENDIAN)
+        buf.writeUByte(0x16u) // contentType
+        buf.writeUShort(0x0303u) // legacyRecordVersion
+        buf.writeUShort(200u) // fragment prefix LIES: the carve below only leaves 7
+        writeHonestFragment(buf, bodyByteCount = 3)
+        val recordEnd = buf.position()
+        repeat(220) { buf.writeByte(0x5A) } // adjacent bytes owned by the next record
+        buf.setLimit(buf.position())
+        buf.position(0)
+        buf.setLimit(recordEnd) // outer carve, e.g. a record-layer dispatcher
+
+        val failure =
+            assertFailsWith<DecodeException> {
+                TlsRecordCodec.decode(buf, DecodeContext.Empty)
+            }
+        assertEquals("TlsRecord.fragment", failure.fieldPath)
+    }
+
+    /**
+     * One record whose inner uint24 claims 100 bytes, followed by adjacent
+     * bytes that a widened limit would expose. The record itself is
+     * well-formed at the envelope layer: prefix = 7 = actual fragment bytes.
+     */
+    private fun hostileRecord(): PlatformBuffer {
+        val buf = BufferFactory.Default.allocate(256, ByteOrder.BIG_ENDIAN)
+        buf.writeUByte(0x16u) // contentType
+        buf.writeUShort(0x0303u) // legacyRecordVersion
+        buf.writeUShort(7u) // fragment prefix: honest (1 msgType + 3 length + 3 body)
+        writeHonestFragment(buf, bodyByteCount = 3, lyingLength = 100u)
+        repeat(200) { buf.writeByte(0x5A) } // bytes past the record a widen would read
+        buf.setLimit(buf.position())
+        buf.position(0)
+        return buf
+    }
+
+    private fun writeHonestFragment(
+        buf: PlatformBuffer,
+        bodyByteCount: Int,
+        lyingLength: UInt? = null,
+    ) {
+        buf.writeUByte(0x01u) // msgType
+        val declared = lyingLength ?: bodyByteCount.toUInt()
+        buf.writeUByte(((declared shr 16) and 0xFFu).toUByte()) // uint24 length
+        buf.writeUByte(((declared shr 8) and 0xFFu).toUByte())
+        buf.writeUByte((declared and 0xFFu).toUByte())
+        buf.writeUShort(0x0303u) // body.legacyVersion
+        repeat(bodyByteCount - 2) { buf.writeByte(0x42) } // body.random
+    }
+}


### PR DESCRIPTION
## The hole

Generated decode narrows `buffer.limit()` from wire-supplied lengths — `buffer.setLimit(buffer.position() + siblingLength)` and friends — with no check that the new limit fits under the current one. `ReadBuffer.setLimit` **widens** unchecked on every platform (`BaseJvmBuffer` delegates to `ByteBuffer.limit()`, `BaseWebBuffer.setLimit` assigns unchecked).

Top-level `readFrame` loops are safe because `peekFrameSize` carves the exact frame. The vector is a codec running **nested under an outer narrowed limit** — a sealed dispatcher's carve, `@FramedBy`, a bounding `@UseCodec` region, or an enclosing `@LengthPrefixed`/`@LengthFrom` body. A lying length field widens past the outer bound, silently reads adjacent bytes from the same buffer, and the strict-consumption check *passes* because the codec consumed exactly the lying region. On JVM the position-clamp in `ByteBuffer.limit()` sometimes trips the consumption check by accident (with a misleading diagnostic); on JS/WASM the read succeeds silently. Same bug class as #306/#309, which fixed encode-side verification and peek but not decode-side widening.

## The fix

Audited every narrowing decode emit; each now rejects a length that exceeds the enclosing bound with a `DecodeException` before the `setLimit`:

- `@LengthPrefixed` nested message bodies
- `@LengthPrefixed @UseCodec` payloads (plain and `@When`-conditional)
- `@LengthFrom` nested messages and lists
- sibling-sized deferred payloads (#310) — both `decode()` and the `partial()` region capture that `complete()` later re-seeks
- `BoundingLengthCodec` regions (`@UseCodec` scalar and `@LengthPrefixed @UseCodec` list): the narrow happens inside user `applyBound` code, so the generated decode verifies the outcome afterwards and rolls the widened limit back before throwing, so a catching caller never observes bytes exposed past its own bound

Already safe, unchanged: `@FramedBy` / `@ForwardCompatible` (framed-body truncation guard) and the reserved-trailer `setLimit(outerLimit - N)` (subtraction cannot widen). At the top level the new guard doubles as a truncation check against the caller's limit.

## Tests

New `TlsRecord` fixture (RFC 8446 §5.1 record envelope) nests `TlsHandshake`'s uint24 `@LengthFrom` region under a record-layer `@LengthPrefixed` bound as the end-to-end vector. Hostile-length tests cover every guarded shape — nested message, deferred `@UseCodec`, constructor-injected generic, `partial()`, `@LengthFrom` list, and both `applyBound` shapes — plus exact-bound controls, on JVM, JS, and WASM.

The snapshot diff is added guard lines only (+382, no deletions); that diff is the migration note. Schema deltas are SAFE additions (the new fixture).

Out of scope (deliberate): teaching `Partial` to compose with external bounds (`shouldEmitPartial`'s Sibling carve-out) — this guard answers the design question that work needs, but it's a separate PR.