### PR TITLE
feat(buffer-crypto): Android Keystore ECDH P-256 key agreement

### DIFF
--- a/buffer-crypto/src/androidInstrumentedTest/kotlin/com/ditchoom/buffer/crypto/KeyStoreInstrumentedTest.kt
+++ b/buffer-crypto/src/androidInstrumentedTest/kotlin/com/ditchoom/buffer/crypto/KeyStoreInstrumentedTest.kt
@@ -137,13 +137,74 @@ class KeyStoreInstrumentedTest {
     fun ineligibleAlgorithmsAreRefused() =
         runTest {
             val s = store()
-            // Only ECDSA P-256 signing is hardware-backed here; other schemes / key agreement refuse.
+            // Ed25519 signing and X25519 agreement are never keystore-backed on any API level.
             assertFailsWith<HardwareKeyException.AlgorithmNotEligible> {
                 s.getOrGenerateSigning(alias("ed"), SignatureScheme.Ed25519)
             }
             assertFailsWith<HardwareKeyException.AlgorithmNotEligible> {
-                s.getOrGenerateKeyAgreement(alias("kex"), KeyAgreementCurve.P256)
+                s.getOrGenerateKeyAgreement(alias("x-kex"), KeyAgreementCurve.X25519)
             }
+            // ECDH P-256 is probed (PURPOSE_AGREE_KEY, API 31+): where the device lacks it, the
+            // store must refuse rather than over-promise hardware custody. Where it holds, the
+            // round-trip contract is pinned by keyAgreementIsIdempotentReloadsAcrossRestartAndDerives.
+            if (!s.eligible(ProtectedKeyAlgorithm.EcdhP256)) {
+                assertFailsWith<HardwareKeyException.AlgorithmNotEligible> {
+                    s.getOrGenerateKeyAgreement(alias("kex"), KeyAgreementCurve.P256)
+                }
+            }
+        }
+
+    @Test
+    fun keyAgreementIsIdempotentReloadsAcrossRestartAndDerives() =
+        runTest {
+            val s = store()
+            // API-level-honest gate: pre-31 devices (the API-21 CI leg) exercise the refusal branch
+            // in ineligibleAlgorithmsAreRefused; 31+ devices (the API-35 CI leg) exercise this one.
+            if (!s.eligible(ProtectedKeyAlgorithm.EcdhP256)) return@runTest
+            val a = alias("device-kex")
+            val first = s.getOrGenerateKeyAgreement(a, KeyAgreementCurve.P256)
+            assertEquals(KeyProvenance.Hardware, first.privateKey.provenance)
+            assertEquals(CustodyTier.Hardware, s.custodyFor(ProtectedKeyAlgorithm.EcdhP256).tier)
+            val pub = first.publicKey.exportSpki().toHex()
+
+            // A second get-or-generate over a fresh store returns the SAME key, not a new one.
+            val again = store().getOrGenerateKeyAgreement(a, KeyAgreementCurve.P256)
+            assertEquals(pub, again.publicKey.exportSpki().toHex())
+
+            // Simulated restart: a brand-new store re-attaches, and the reloaded handle derives the
+            // same secret as a software peer does against the persisted public key — the keystore
+            // ECDH is real, standard, and stable across reloads.
+            val reloaded = assertNotNull(store().loadKeyAgreement(a))
+            assertEquals(pub, reloaded.publicKey.exportSpki().toHex())
+            val ops = assertNotNull(keyAgreementAsyncOrNull(KeyAgreementCurve.P256))
+            val peer = ops.generateKeyPair()
+            val info = Info.Of(ascii("keystore-kex"))
+            val viaFirst = ops.deriveSharedSecret(first.privateKey, peer.publicKey, info, length = 32)
+            val viaReloaded = ops.deriveSharedSecret(reloaded.privateKey, peer.publicKey, info, length = 32)
+            val viaPeer = ops.deriveSharedSecret(peer.privateKey, reloaded.publicKey, info, length = 32)
+            assertEquals(viaPeer.toHex(), viaFirst.toHex(), "hw derive must match the peer's derivation")
+            assertEquals(viaPeer.toHex(), viaReloaded.toHex(), "reloaded hw key must derive the same secret")
+        }
+
+    @Test
+    fun agreementAliasNeverSilentlyReplacesAnotherKind() =
+        runTest {
+            val s = store()
+            if (!s.eligible(ProtectedKeyAlgorithm.EcdhP256)) return@runTest
+            val a = alias("mixed-kex")
+            s.getOrGenerateSigning(a, SignatureScheme.EcdsaP256)
+            // Both kinds are keystore PrivateKeyEntries — the purpose-recorded kind must still win.
+            val clash =
+                assertFailsWith<KeyStoreException.AliasMismatch> {
+                    s.getOrGenerateKeyAgreement(a, KeyAgreementCurve.P256)
+                }
+            assertEquals(ProtectedKeyAlgorithm.EcdsaP256, clash.stored)
+            assertEquals(ProtectedKeyAlgorithm.EcdhP256, clash.requested)
+            // And the kind-mismatched loads answer null, never a mistyped handle.
+            assertNull(s.loadKeyAgreement(a))
+            val kex = alias("kex-then-sign")
+            s.getOrGenerateKeyAgreement(kex, KeyAgreementCurve.P256)
+            assertNull(s.loadSigning(kex))
         }
 
     @Test

--- a/buffer-crypto/src/androidMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeyAgreement.android.kt
+++ b/buffer-crypto/src/androidMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeyAgreement.android.kt
@@ -1,0 +1,136 @@
+package com.ditchoom.buffer.crypto
+
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyInfo
+import android.security.keystore.KeyProperties
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import java.math.BigInteger
+import java.security.AlgorithmParameters
+import java.security.GeneralSecurityException
+import java.security.KeyFactory
+import java.security.PrivateKey
+import java.security.PublicKey
+import java.security.spec.ECGenParameterSpec
+import java.security.spec.ECParameterSpec
+import java.security.spec.ECPoint
+import java.security.spec.ECPublicKeySpec
+import javax.crypto.KeyAgreement
+
+/*
+ * ECDH P-256 agreement helpers for [AndroidKeystoreHardwareKeyProvider] — the stateless keystore
+ * spec/op/conversion pieces of the `PURPOSE_AGREE_KEY` path (API 31+, probed). Split from
+ * HardwareKeys.android.kt, which retains the provider, the eligibility probes, and the shared
+ * signing/AES plumbing.
+ */
+
+/**
+ * An ECDH P-256 agreement-key spec, mirroring the signing `ecSpec`. Only reachable on API 31+ (the
+ * probe fails fast pre-31, and every generation path is gated on that eligibility);
+ * `PURPOSE_AGREE_KEY` is a compile-time constant, so referencing it carries no runtime API
+ * requirement of its own.
+ */
+internal fun agreementSpec(
+    alias: String,
+    strongBox: Boolean,
+    policy: ResolvedAndroidPolicy,
+): KeyGenParameterSpec =
+    KeyGenParameterSpec
+        .Builder(alias, KeyProperties.PURPOSE_AGREE_KEY)
+        .setAlgorithmParameterSpec(ECGenParameterSpec(SECP256R1))
+        .setIsStrongBoxBacked(strongBox)
+        .apply { applyUserAuth(policy) }
+        .build()
+
+/**
+ * Runs the keystore ECDH: `DH(privateKey, jcaPeer)` inside the element, returning the raw 32-byte
+ * shared secret in a wiped [SecureBuffer] (the common seam applies the KDF / validation above it).
+ * A peer-point rejection from the provider — checked or unchecked — maps to the uniform
+ * [InvalidPublicKey], never distinguishable by exception type (oracle avoidance, matching the
+ * software JCA glue). `init` stays outside that mapping: a failure there is a *key* problem
+ * (invalidated, unsupported), which `mappingKeystoreFailures` normalizes to a [HardwareKeyException].
+ */
+@Suppress("SwallowedException", "TooGenericExceptionCaught", "ThrowsCount")
+internal fun agreeP256(
+    privateKey: PrivateKey,
+    jcaPeer: PublicKey,
+): PlatformBuffer {
+    val ka = KeyAgreement.getInstance(ECDH, ANDROID_KEY_STORE)
+    ka.init(privateKey)
+    val rawSecretBytes =
+        try {
+            ka.doPhase(jcaPeer, true)
+            ka.generateSecret()
+        } catch (e: GeneralSecurityException) {
+            throw InvalidPublicKey(KeyAgreementCurve.P256)
+        } catch (e: RuntimeException) {
+            throw InvalidPublicKey(KeyAgreementCurve.P256)
+        }
+    if (rawSecretBytes.size != P256_FIELD_BYTES) {
+        rawSecretBytes.fill(0)
+        throw HardwareKeyException.UnsupportedHardwareKey()
+    }
+    val raw = secureScratch.allocate(P256_FIELD_BYTES)
+    raw.writeBytes(rawSecretBytes)
+    rawSecretBytes.fill(0)
+    raw.resetForRead()
+    return raw
+}
+
+/**
+ * Converts a peer's uncompressed SEC1 point (`04 ‖ X ‖ Y`, the pinned [KeyAgreementCurve] encoding)
+ * to a JCA [PublicKey]. Malformed encodings and provider rejections surface as the uniform
+ * [InvalidPublicKey] — same no-oracle contract as the software glue.
+ */
+@Suppress("SwallowedException", "TooGenericExceptionCaught", "ThrowsCount")
+internal fun p256PublicKey(encoded: ReadBuffer): PublicKey {
+    val curve = KeyAgreementCurve.P256
+    val view = encoded.slice()
+    val n = view.remaining()
+    if (n != curve.publicKeyBytes || (view.get(view.position()).toInt() and UBYTE_MASK) != SEC1_UNCOMPRESSED) {
+        throw InvalidPublicKey(curve)
+    }
+    // ByteArray at the unavoidable JCA seam (BigInteger/ECPoint), never a library data structure.
+    val point = ByteArray(n)
+    for (i in 0 until n) point[i] = view.get(view.position() + i)
+    return try {
+        val x = BigInteger(1, point.copyOfRange(1, 1 + P256_FIELD_BYTES))
+        val y = BigInteger(1, point.copyOfRange(1 + P256_FIELD_BYTES, n))
+        val params =
+            AlgorithmParameters
+                .getInstance("EC")
+                .apply { init(ECGenParameterSpec(SECP256R1)) }
+                .getParameterSpec(ECParameterSpec::class.java)
+        KeyFactory.getInstance("EC").generatePublic(ECPublicKeySpec(ECPoint(x, y), params))
+    } catch (e: GeneralSecurityException) {
+        throw InvalidPublicKey(curve)
+    } catch (e: RuntimeException) {
+        throw InvalidPublicKey(curve)
+    }
+}
+
+/**
+ * Distinguishes the two `PrivateKeyEntry` kinds a store can hold — ECDSA signing vs ECDH agreement —
+ * by the keystore-recorded purposes ([KeyInfo.getPurposes], intrinsic to the entry, so no sidecar).
+ * Callers already hold the keystore lock (`entryAlgorithm` / the reattach paths run this inside
+ * `keystoreOp`).
+ */
+internal fun privateEntryAlgorithm(privateKey: PrivateKey): ProtectedKeyAlgorithm {
+    val info =
+        KeyFactory
+            .getInstance(privateKey.algorithm, ANDROID_KEY_STORE)
+            .getKeySpec(privateKey, KeyInfo::class.java) as KeyInfo
+    return if (info.purposes and KeyProperties.PURPOSE_AGREE_KEY != 0) {
+        ProtectedKeyAlgorithm.EcdhP256
+    } else {
+        ProtectedKeyAlgorithm.EcdsaP256
+    }
+}
+
+internal const val ECDH = "ECDH"
+private const val UBYTE_MASK = 0xFF
+
+// File-private copies: same-named private constants exist in other files of this package, so these
+// cannot be shared as internal without a redeclaration conflict.
+private const val P256_FIELD_BYTES = 32
+private const val SEC1_UNCOMPRESSED = 0x04

--- a/buffer-crypto/src/androidMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.android.kt
+++ b/buffer-crypto/src/androidMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.android.kt
@@ -20,20 +20,15 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import java.math.BigInteger
-import java.security.AlgorithmParameters
 import java.security.GeneralSecurityException
 import java.security.KeyFactory
 import java.security.KeyPairGenerator
 import java.security.KeyStore
 import java.security.PrivateKey
 import java.security.ProviderException
-import java.security.PublicKey
 import java.security.Signature
 import java.security.interfaces.ECPublicKey
 import java.security.spec.ECGenParameterSpec
-import java.security.spec.ECParameterSpec
-import java.security.spec.ECPoint
-import java.security.spec.ECPublicKeySpec
 import java.util.UUID
 import javax.crypto.Cipher
 import javax.crypto.KeyAgreement
@@ -353,7 +348,8 @@ internal class AndroidKeystoreHardwareKeyProvider : HardwareKeyProvider {
     ): KeyAgreementKeyPair {
         val policy = ResolvedAndroidPolicy.Advisory(spec.authorization)
         val keyPair = keystoreOp { generateAgreementKeyPair(alias, policy) }
-        val publicKey = KeyAgreementPublicKey.of(KeyAgreementCurve.P256, uncompressedPoint(keyPair.public as ECPublicKey))
+        val publicKey =
+            KeyAgreementPublicKey.of(KeyAgreementCurve.P256, uncompressedPoint(keyPair.public as ECPublicKey))
         return buildKeyAgreementPair(keyPair.private, publicKey, policy.gate, onClose = {})
     }
 
@@ -390,7 +386,8 @@ internal class AndroidKeystoreHardwareKeyProvider : HardwareKeyProvider {
                 (keyStore.getEntry(alias, null) as? KeyStore.PrivateKeyEntry)
                     ?.takeIf { privateEntryAlgorithm(it.privateKey) == ProtectedKeyAlgorithm.EcdhP256 }
             } ?: return null
-        val publicKey = KeyAgreementPublicKey.of(KeyAgreementCurve.P256, uncompressedPoint(entry.certificate.publicKey as ECPublicKey))
+        val point = uncompressedPoint(entry.certificate.publicKey as ECPublicKey)
+        val publicKey = KeyAgreementPublicKey.of(KeyAgreementCurve.P256, point)
         return buildKeyAgreementPair(entry.privateKey, publicKey, spec.authorization, onClose = {})
     }
 
@@ -643,15 +640,16 @@ private fun requireValidAesSize(sizeBits: Int) {
     if (!valid) throw HardwareKeyException.UnsupportedHardwareKey()
 }
 
-private const val ANDROID_KEY_STORE = "AndroidKeyStore"
+// ANDROID_KEY_STORE / SECP256R1 are shared with the agreement helpers in
+// HardwareKeyAgreement.android.kt (internal, not private); the SEC1/field-width constants stay
+// private because same-named private constants already exist in other files of this package.
+internal const val ANDROID_KEY_STORE = "AndroidKeyStore"
 private const val AES_GCM_TRANSFORM = "AES/GCM/NoPadding"
 private const val ECDSA_SHA256 = "SHA256withECDSA"
-private const val ECDH = "ECDH"
-private const val SECP256R1 = "secp256r1"
+internal const val SECP256R1 = "secp256r1"
 private const val ALIAS_PREFIX = "com.ditchoom.buffer.crypto.hw."
 private const val P256_FIELD_BYTES = 32
 private const val SEC1_UNCOMPRESSED = 0x04
-private const val UBYTE_MASK = 0xFF
 
 // --- stateless keystore helpers (file-level: no provider state, kept off the class) --------------
 
@@ -690,108 +688,6 @@ private fun ecSpec(
         .setIsStrongBoxBacked(strongBox)
         .apply { applyUserAuth(policy) }
         .build()
-
-/**
- * An ECDH P-256 agreement-key spec, mirroring [ecSpec]. Only reachable on API 31+ (the probe fails
- * fast pre-31, and every generation path is gated on that eligibility); `PURPOSE_AGREE_KEY` is a
- * compile-time constant, so referencing it carries no runtime API requirement of its own.
- */
-private fun agreementSpec(
-    alias: String,
-    strongBox: Boolean,
-    policy: ResolvedAndroidPolicy,
-): KeyGenParameterSpec =
-    KeyGenParameterSpec
-        .Builder(alias, KeyProperties.PURPOSE_AGREE_KEY)
-        .setAlgorithmParameterSpec(ECGenParameterSpec(SECP256R1))
-        .setIsStrongBoxBacked(strongBox)
-        .apply { applyUserAuth(policy) }
-        .build()
-
-/**
- * Runs the keystore ECDH: `DH(privateKey, jcaPeer)` inside the element, returning the raw 32-byte
- * shared secret in a wiped [SecureBuffer] (the common seam applies the KDF / validation above it).
- * A peer-point rejection from the provider — checked or unchecked — maps to the uniform
- * [InvalidPublicKey], never distinguishable by exception type (oracle avoidance, matching the
- * software JCA glue). `init` stays outside that mapping: a failure there is a *key* problem
- * (invalidated, unsupported), which [mappingKeystoreFailures] normalizes to a [HardwareKeyException].
- */
-@Suppress("SwallowedException", "TooGenericExceptionCaught")
-private fun agreeP256(
-    privateKey: PrivateKey,
-    jcaPeer: PublicKey,
-): PlatformBuffer {
-    val ka = KeyAgreement.getInstance(ECDH, ANDROID_KEY_STORE)
-    ka.init(privateKey)
-    val rawSecretBytes =
-        try {
-            ka.doPhase(jcaPeer, true)
-            ka.generateSecret()
-        } catch (e: GeneralSecurityException) {
-            throw InvalidPublicKey(KeyAgreementCurve.P256)
-        } catch (e: RuntimeException) {
-            throw InvalidPublicKey(KeyAgreementCurve.P256)
-        }
-    if (rawSecretBytes.size != P256_FIELD_BYTES) {
-        rawSecretBytes.fill(0)
-        throw HardwareKeyException.UnsupportedHardwareKey()
-    }
-    val raw = secureScratch.allocate(P256_FIELD_BYTES)
-    raw.writeBytes(rawSecretBytes)
-    rawSecretBytes.fill(0)
-    raw.resetForRead()
-    return raw
-}
-
-/**
- * Converts a peer's uncompressed SEC1 point (`04 ‖ X ‖ Y`, the pinned [KeyAgreementCurve] encoding)
- * to a JCA [PublicKey]. Malformed encodings and provider rejections surface as the uniform
- * [InvalidPublicKey] — same no-oracle contract as the software glue.
- */
-@Suppress("SwallowedException", "TooGenericExceptionCaught", "ThrowsCount")
-private fun p256PublicKey(encoded: ReadBuffer): PublicKey {
-    val curve = KeyAgreementCurve.P256
-    val view = encoded.slice()
-    val n = view.remaining()
-    if (n != curve.publicKeyBytes || (view.get(view.position()).toInt() and UBYTE_MASK) != SEC1_UNCOMPRESSED) {
-        throw InvalidPublicKey(curve)
-    }
-    // ByteArray at the unavoidable JCA seam (BigInteger/ECPoint), never a library data structure.
-    val point = ByteArray(n)
-    for (i in 0 until n) point[i] = view.get(view.position() + i)
-    return try {
-        val x = BigInteger(1, point.copyOfRange(1, 1 + P256_FIELD_BYTES))
-        val y = BigInteger(1, point.copyOfRange(1 + P256_FIELD_BYTES, n))
-        val params =
-            AlgorithmParameters
-                .getInstance("EC")
-                .apply { init(ECGenParameterSpec(SECP256R1)) }
-                .getParameterSpec(ECParameterSpec::class.java)
-        KeyFactory.getInstance("EC").generatePublic(ECPublicKeySpec(ECPoint(x, y), params))
-    } catch (e: GeneralSecurityException) {
-        throw InvalidPublicKey(curve)
-    } catch (e: RuntimeException) {
-        throw InvalidPublicKey(curve)
-    }
-}
-
-/**
- * Distinguishes the two `PrivateKeyEntry` kinds a store can hold — ECDSA signing vs ECDH agreement —
- * by the keystore-recorded purposes ([KeyInfo.getPurposes], intrinsic to the entry, so no sidecar).
- * Callers already hold the keystore lock ([entryAlgorithm] / the reattach paths run this inside
- * `keystoreOp`).
- */
-private fun privateEntryAlgorithm(privateKey: PrivateKey): ProtectedKeyAlgorithm {
-    val info =
-        KeyFactory
-            .getInstance(privateKey.algorithm, ANDROID_KEY_STORE)
-            .getKeySpec(privateKey, KeyInfo::class.java) as KeyInfo
-    return if (info.purposes and KeyProperties.PURPOSE_AGREE_KEY != 0) {
-        ProtectedKeyAlgorithm.EcdhP256
-    } else {
-        ProtectedKeyAlgorithm.EcdsaP256
-    }
-}
 
 /**
  * Runs [block], normalizing any keystore-originated failure to a [HardwareKeyException]. A

--- a/buffer-crypto/src/androidMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.android.kt
+++ b/buffer-crypto/src/androidMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.android.kt
@@ -20,17 +20,23 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import java.math.BigInteger
+import java.security.AlgorithmParameters
 import java.security.GeneralSecurityException
 import java.security.KeyFactory
 import java.security.KeyPairGenerator
 import java.security.KeyStore
 import java.security.PrivateKey
 import java.security.ProviderException
+import java.security.PublicKey
 import java.security.Signature
 import java.security.interfaces.ECPublicKey
 import java.security.spec.ECGenParameterSpec
+import java.security.spec.ECParameterSpec
+import java.security.spec.ECPoint
+import java.security.spec.ECPublicKeySpec
 import java.util.UUID
 import javax.crypto.Cipher
+import javax.crypto.KeyAgreement
 import javax.crypto.KeyGenerator
 import javax.crypto.SecretKey
 import javax.crypto.SecretKeyFactory
@@ -46,8 +52,9 @@ import javax.crypto.spec.GCMParameterSpec
  * signature bytes cross the JCA boundary as arrays — the payload itself streams buffer→cipher→buffer
  * through the shared [finalInto] / [openInto] plumbing, identical to the in-memory AES-GCM path.
  *
- * Eligibility mirrors what a secure element actually backs: AES-256/128-GCM and ECDSA P-256.
- * (Ed25519 / P-384 / P-521 are not offered — see [eligible].)
+ * Eligibility mirrors what a secure element actually backs: AES-256/128-GCM, ECDSA P-256, and — on
+ * API 31+ where the keystore honors `PURPOSE_AGREE_KEY` (probed, not inferred from the API level) —
+ * ECDH P-256 key agreement. (Ed25519 / P-384 / P-521 / X25519 are not offered — see [eligible].)
  *
  * **Robustness shape (all driven by real device behaviour):**
  *  - **StrongBox fallback is exception-broad.** A device that lacks (or under-provisions) a secure
@@ -106,9 +113,19 @@ internal class AndroidKeystoreHardwareKeyProvider : HardwareKeyProvider {
      */
     override val dedicatedSecureElement: Boolean by lazy { probeStrongBox() }
 
+    /**
+     * `true` once a `PURPOSE_AGREE_KEY` generation *and* a full keystore ECDH against a software
+     * peer succeed. Probed (generate-and-agree with a throwaway key) rather than inferred from the
+     * API level: `PURPOSE_AGREE_KEY` exists from API 31, but whether the device's Keymaster/KeyMint
+     * actually implements agreement is exactly the kind of claim cheap-device implementations and
+     * the emulator diverge on — so the answer comes from the keystore itself, like [probeStrongBox].
+     */
+    private val agreementSupported: Boolean by lazy { probeAgreement() }
+
     override fun eligible(alg: ProtectedKeyAlgorithm): Boolean =
         when (alg) {
             ProtectedKeyAlgorithm.AesGcm, ProtectedKeyAlgorithm.EcdsaP256 -> true
+            ProtectedKeyAlgorithm.EcdhP256 -> agreementSupported
             else -> false
         }
 
@@ -123,9 +140,58 @@ internal class AndroidKeystoreHardwareKeyProvider : HardwareKeyProvider {
     override suspend fun generateKeyAgreement(
         curve: KeyAgreementCurve,
         spec: ProtectedKeySpec,
-    ): KeyAgreementKeyPair =
-        // Android Keystore backs no app-controlled ECDH/X25519 agreement key here; not eligible.
-        throw HardwareKeyException.AlgorithmNotEligible()
+    ): KeyAgreementKeyPair {
+        // Only ECDH P-256, and only where the keystore-probed PURPOSE_AGREE_KEY support holds
+        // (API 31+). X25519 has no AndroidKeyStore agreement backing on any API level.
+        if (curve != KeyAgreementCurve.P256 || !eligible(ProtectedKeyAlgorithm.EcdhP256)) {
+            throw HardwareKeyException.AlgorithmNotEligible()
+        }
+        val policy = ResolvedAndroidPolicy.Advisory(spec.authorization)
+        val alias = newAlias("ecdh")
+        val keyPair = keystoreOp { generateAgreementKeyPair(alias, policy) }
+        val publicKey = KeyAgreementPublicKey.of(curve, uncompressedPoint(keyPair.public as ECPublicKey))
+        // Ephemeral: the scratch alias is deleted when the returned pair (or its private key) is closed.
+        return buildKeyAgreementPair(
+            keyPair.private,
+            publicKey,
+            policy.gate,
+            onClose = { runCatching { keyStore.deleteEntry(alias) } },
+        )
+    }
+
+    /**
+     * Wraps an AndroidKeystore ECDH private-key handle as a [KeyAgreementKeyPair]. Shared by the
+     * ephemeral provider ([generateKeyAgreement], a scratch alias deleted on close) and the
+     * persistent [AndroidKeystoreKeyStore] (a named alias whose [onClose] is a no-op).
+     *
+     * Agreement keys are only ever **advisory**-gated: [UserAuthenticatedKeyProvider] exposes no key
+     * agreement, and `BiometricPrompt.CryptoObject` cannot wrap a JCA `KeyAgreement` on the API
+     * levels this module supports — so the [gate] here is the advisory
+     * [ProtectedKeySpec.authorization], evaluated before every derive (outside the keystore lock).
+     */
+    internal fun buildKeyAgreementPair(
+        privateKey: PrivateKey,
+        publicKey: KeyAgreementPublicKey,
+        gate: HardwareAuthorization,
+        onClose: () -> Unit,
+    ): KeyAgreementKeyPair {
+        val curve = publicKey.curve
+        val agreementPrivateKey =
+            ProtectedKeyAgreementPrivateKey(
+                curve = curve,
+                custody = custody,
+                gatedDh = { peer ->
+                    if (!gate.authorize()) throw AuthorizationFailed()
+                    require(peer.curve == curve) { "private/public key curve mismatch" }
+                    // Peer-point conversion happens outside the keystore lock; a malformed or
+                    // off-curve point is rejected before the element is ever touched.
+                    val jcaPeer = p256PublicKey(peer.encoded)
+                    keystoreOp { agreeP256(privateKey, jcaPeer) }
+                },
+                onClose = onClose,
+            )
+        return keyAgreementKeyPairOf(curve, agreementPrivateKey, publicKey)
+    }
 
     /** Generates an AES-GCM keystore key under [policy] — the shared path for unbound and OS-bound keys. */
     internal suspend fun generateAesGcmBound(
@@ -280,17 +346,52 @@ internal class AndroidKeystoreHardwareKeyProvider : HardwareKeyProvider {
         return buildAesGcmKey(key, spec.aesKeySizeBits, policy, onClose = {})
     }
 
+    /** Generates a persistent ECDH P-256 agreement key under [alias]; onClose is a no-op (the stored key survives). */
+    internal suspend fun generatePersistentKeyAgreement(
+        alias: String,
+        spec: ProtectedKeySpec,
+    ): KeyAgreementKeyPair {
+        val policy = ResolvedAndroidPolicy.Advisory(spec.authorization)
+        val keyPair = keystoreOp { generateAgreementKeyPair(alias, policy) }
+        val publicKey = KeyAgreementPublicKey.of(KeyAgreementCurve.P256, uncompressedPoint(keyPair.public as ECPublicKey))
+        return buildKeyAgreementPair(keyPair.private, publicKey, policy.gate, onClose = {})
+    }
+
     /**
      * Re-attaches to a persisted signing key under [alias], or `null` if the alias is absent or holds
-     * a key of a different kind. The gate is [spec]'s advisory authorization; onClose is a no-op.
+     * a key of a different kind (an AES entry, or an agreement key — both signing and agreement keys
+     * are `PrivateKeyEntry`s, so the keystore-recorded purposes disambiguate). The gate is [spec]'s
+     * advisory authorization; onClose is a no-op.
      */
     internal suspend fun reattachSigning(
         alias: String,
         spec: ProtectedKeySpec,
     ): SigningKey? {
-        val entry = keystoreOp { keyStore.getEntry(alias, null) } as? KeyStore.PrivateKeyEntry ?: return null
+        val entry =
+            keystoreOp {
+                (keyStore.getEntry(alias, null) as? KeyStore.PrivateKeyEntry)
+                    ?.takeIf { privateEntryAlgorithm(it.privateKey) == ProtectedKeyAlgorithm.EcdsaP256 }
+            } ?: return null
         val verifyKey = VerifyKey.ecdsaP256(uncompressedPoint(entry.certificate.publicKey as ECPublicKey))
         return buildSigningKey(entry.privateKey, verifyKey, ResolvedAndroidPolicy.Advisory(spec.authorization), onClose = {})
+    }
+
+    /**
+     * Re-attaches to a persisted agreement key under [alias], or `null` if the alias is absent or
+     * holds a key of a different kind (purpose-checked, mirroring [reattachSigning]). The gate is
+     * [spec]'s advisory authorization; onClose is a no-op.
+     */
+    internal suspend fun reattachKeyAgreement(
+        alias: String,
+        spec: ProtectedKeySpec,
+    ): KeyAgreementKeyPair? {
+        val entry =
+            keystoreOp {
+                (keyStore.getEntry(alias, null) as? KeyStore.PrivateKeyEntry)
+                    ?.takeIf { privateEntryAlgorithm(it.privateKey) == ProtectedKeyAlgorithm.EcdhP256 }
+            } ?: return null
+        val publicKey = KeyAgreementPublicKey.of(KeyAgreementCurve.P256, uncompressedPoint(entry.certificate.publicKey as ECPublicKey))
+        return buildKeyAgreementPair(entry.privateKey, publicKey, spec.authorization, onClose = {})
     }
 
     /** Re-attaches to a persisted AES-GCM key under [alias], or `null` if absent / a different kind. */
@@ -309,8 +410,8 @@ internal class AndroidKeystoreHardwareKeyProvider : HardwareKeyProvider {
             if (!keyStore.containsAlias(alias)) {
                 null
             } else {
-                when (keyStore.getEntry(alias, null)) {
-                    is KeyStore.PrivateKeyEntry -> ProtectedKeyAlgorithm.EcdsaP256
+                when (val entry = keyStore.getEntry(alias, null)) {
+                    is KeyStore.PrivateKeyEntry -> privateEntryAlgorithm(entry.privateKey)
                     is KeyStore.SecretKeyEntry -> ProtectedKeyAlgorithm.AesGcm
                     else -> null
                 }
@@ -426,6 +527,18 @@ internal class AndroidKeystoreHardwareKeyProvider : HardwareKeyProvider {
                 }.generateKeyPair()
         }
 
+    private fun generateAgreementKeyPair(
+        alias: String,
+        policy: ResolvedAndroidPolicy,
+    ): java.security.KeyPair =
+        generateWithStrongBoxFallback { strongBox ->
+            KeyPairGenerator
+                .getInstance(KeyProperties.KEY_ALGORITHM_EC, ANDROID_KEY_STORE)
+                .apply {
+                    initialize(agreementSpec(alias, strongBox, policy))
+                }.generateKeyPair()
+        }
+
     /**
      * Builds a key with `setIsStrongBoxBacked(true)`, falling back to the TEE on *any* StrongBox
      * rejection. Crucially this is not gated on [StrongBoxUnavailableException]: real devices reject
@@ -478,6 +591,46 @@ internal class AndroidKeystoreHardwareKeyProvider : HardwareKeyProvider {
                 runCatching { keyStore.deleteEntry(alias) }
             }
         }
+
+    /**
+     * Probes whether the keystore actually backs ECDH P-256 agreement keys: generates a throwaway
+     * `PURPOSE_AGREE_KEY` key and runs a full keystore ECDH against a fresh software peer. The
+     * end-to-end agreement matters — a device may accept the generation spec and still fail the
+     * `KeyAgreement` op (support claims and Keymaster reality diverge on exactly this purpose), so
+     * generation alone would over-promise. Pre-31 the purpose does not exist; fail fast.
+     */
+    private fun probeAgreement(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return false
+        return synchronized(keystoreMonitor) {
+            val alias = newAlias("probe-ecdh")
+            try {
+                val keyPair =
+                    KeyPairGenerator
+                        .getInstance(KeyProperties.KEY_ALGORITHM_EC, ANDROID_KEY_STORE)
+                        .apply {
+                            initialize(agreementSpec(alias, strongBox = false, policy = probeAdvisoryPolicy))
+                        }.generateKeyPair()
+                val peer =
+                    KeyPairGenerator
+                        .getInstance("EC")
+                        .apply { initialize(ECGenParameterSpec(SECP256R1)) }
+                        .generateKeyPair()
+                val ka = KeyAgreement.getInstance(ECDH, ANDROID_KEY_STORE)
+                ka.init(keyPair.private)
+                ka.doPhase(peer.public, true)
+                val secret = ka.generateSecret()
+                val ok = secret.size == P256_FIELD_BYTES
+                secret.fill(0)
+                ok
+            } catch (_: Throwable) {
+                // Purpose rejected, agreement unimplemented, or any provisioning failure ⇒ route
+                // key agreement to the software floor instead of over-promising hardware custody.
+                false
+            } finally {
+                runCatching { keyStore.deleteEntry(alias) }
+            }
+        }
+    }
 }
 
 private fun newAlias(kind: String): String = "$ALIAS_PREFIX$kind-${UUID.randomUUID()}"
@@ -493,10 +646,12 @@ private fun requireValidAesSize(sizeBits: Int) {
 private const val ANDROID_KEY_STORE = "AndroidKeyStore"
 private const val AES_GCM_TRANSFORM = "AES/GCM/NoPadding"
 private const val ECDSA_SHA256 = "SHA256withECDSA"
+private const val ECDH = "ECDH"
 private const val SECP256R1 = "secp256r1"
 private const val ALIAS_PREFIX = "com.ditchoom.buffer.crypto.hw."
 private const val P256_FIELD_BYTES = 32
 private const val SEC1_UNCOMPRESSED = 0x04
+private const val UBYTE_MASK = 0xFF
 
 // --- stateless keystore helpers (file-level: no provider state, kept off the class) --------------
 
@@ -535,6 +690,108 @@ private fun ecSpec(
         .setIsStrongBoxBacked(strongBox)
         .apply { applyUserAuth(policy) }
         .build()
+
+/**
+ * An ECDH P-256 agreement-key spec, mirroring [ecSpec]. Only reachable on API 31+ (the probe fails
+ * fast pre-31, and every generation path is gated on that eligibility); `PURPOSE_AGREE_KEY` is a
+ * compile-time constant, so referencing it carries no runtime API requirement of its own.
+ */
+private fun agreementSpec(
+    alias: String,
+    strongBox: Boolean,
+    policy: ResolvedAndroidPolicy,
+): KeyGenParameterSpec =
+    KeyGenParameterSpec
+        .Builder(alias, KeyProperties.PURPOSE_AGREE_KEY)
+        .setAlgorithmParameterSpec(ECGenParameterSpec(SECP256R1))
+        .setIsStrongBoxBacked(strongBox)
+        .apply { applyUserAuth(policy) }
+        .build()
+
+/**
+ * Runs the keystore ECDH: `DH(privateKey, jcaPeer)` inside the element, returning the raw 32-byte
+ * shared secret in a wiped [SecureBuffer] (the common seam applies the KDF / validation above it).
+ * A peer-point rejection from the provider — checked or unchecked — maps to the uniform
+ * [InvalidPublicKey], never distinguishable by exception type (oracle avoidance, matching the
+ * software JCA glue). `init` stays outside that mapping: a failure there is a *key* problem
+ * (invalidated, unsupported), which [mappingKeystoreFailures] normalizes to a [HardwareKeyException].
+ */
+@Suppress("SwallowedException", "TooGenericExceptionCaught")
+private fun agreeP256(
+    privateKey: PrivateKey,
+    jcaPeer: PublicKey,
+): PlatformBuffer {
+    val ka = KeyAgreement.getInstance(ECDH, ANDROID_KEY_STORE)
+    ka.init(privateKey)
+    val rawSecretBytes =
+        try {
+            ka.doPhase(jcaPeer, true)
+            ka.generateSecret()
+        } catch (e: GeneralSecurityException) {
+            throw InvalidPublicKey(KeyAgreementCurve.P256)
+        } catch (e: RuntimeException) {
+            throw InvalidPublicKey(KeyAgreementCurve.P256)
+        }
+    if (rawSecretBytes.size != P256_FIELD_BYTES) {
+        rawSecretBytes.fill(0)
+        throw HardwareKeyException.UnsupportedHardwareKey()
+    }
+    val raw = secureScratch.allocate(P256_FIELD_BYTES)
+    raw.writeBytes(rawSecretBytes)
+    rawSecretBytes.fill(0)
+    raw.resetForRead()
+    return raw
+}
+
+/**
+ * Converts a peer's uncompressed SEC1 point (`04 ‖ X ‖ Y`, the pinned [KeyAgreementCurve] encoding)
+ * to a JCA [PublicKey]. Malformed encodings and provider rejections surface as the uniform
+ * [InvalidPublicKey] — same no-oracle contract as the software glue.
+ */
+@Suppress("SwallowedException", "TooGenericExceptionCaught", "ThrowsCount")
+private fun p256PublicKey(encoded: ReadBuffer): PublicKey {
+    val curve = KeyAgreementCurve.P256
+    val view = encoded.slice()
+    val n = view.remaining()
+    if (n != curve.publicKeyBytes || (view.get(view.position()).toInt() and UBYTE_MASK) != SEC1_UNCOMPRESSED) {
+        throw InvalidPublicKey(curve)
+    }
+    // ByteArray at the unavoidable JCA seam (BigInteger/ECPoint), never a library data structure.
+    val point = ByteArray(n)
+    for (i in 0 until n) point[i] = view.get(view.position() + i)
+    return try {
+        val x = BigInteger(1, point.copyOfRange(1, 1 + P256_FIELD_BYTES))
+        val y = BigInteger(1, point.copyOfRange(1 + P256_FIELD_BYTES, n))
+        val params =
+            AlgorithmParameters
+                .getInstance("EC")
+                .apply { init(ECGenParameterSpec(SECP256R1)) }
+                .getParameterSpec(ECParameterSpec::class.java)
+        KeyFactory.getInstance("EC").generatePublic(ECPublicKeySpec(ECPoint(x, y), params))
+    } catch (e: GeneralSecurityException) {
+        throw InvalidPublicKey(curve)
+    } catch (e: RuntimeException) {
+        throw InvalidPublicKey(curve)
+    }
+}
+
+/**
+ * Distinguishes the two `PrivateKeyEntry` kinds a store can hold — ECDSA signing vs ECDH agreement —
+ * by the keystore-recorded purposes ([KeyInfo.getPurposes], intrinsic to the entry, so no sidecar).
+ * Callers already hold the keystore lock ([entryAlgorithm] / the reattach paths run this inside
+ * `keystoreOp`).
+ */
+private fun privateEntryAlgorithm(privateKey: PrivateKey): ProtectedKeyAlgorithm {
+    val info =
+        KeyFactory
+            .getInstance(privateKey.algorithm, ANDROID_KEY_STORE)
+            .getKeySpec(privateKey, KeyInfo::class.java) as KeyInfo
+    return if (info.purposes and KeyProperties.PURPOSE_AGREE_KEY != 0) {
+        ProtectedKeyAlgorithm.EcdhP256
+    } else {
+        ProtectedKeyAlgorithm.EcdsaP256
+    }
+}
 
 /**
  * Runs [block], normalizing any keystore-originated failure to a [HardwareKeyException]. A

--- a/buffer-crypto/src/androidMain/kotlin/com/ditchoom/buffer/crypto/KeyStore.android.kt
+++ b/buffer-crypto/src/androidMain/kotlin/com/ditchoom/buffer/crypto/KeyStore.android.kt
@@ -29,8 +29,9 @@ internal actual fun platformKeyStore(config: KeyStoreConfig): KeyStore =
  * alias methods persist — a key from [getOrGenerateSigning] / [loadSigning] survives `close()` and
  * process restart until [delete]d.
  *
- * Serves only the algorithms an AndroidKeystore backs non-exportably: ECDSA P-256 signing and
- * AES-GCM. A get-or-generate for anything else (Ed25519 / P-384 / P-521 / key agreement) throws
+ * Serves only the algorithms an AndroidKeystore backs non-exportably: ECDSA P-256 signing, AES-GCM,
+ * and — on API 31+ where the keystore-probed `PURPOSE_AGREE_KEY` support holds — ECDH P-256 key
+ * agreement. A get-or-generate for anything else (Ed25519 / P-384 / P-521 / X25519) throws
  * [HardwareKeyException.AlgorithmNotEligible] — consult [custodyFor] / [eligible] first, or supply a
  * software [KeyStoreConfig.storage] for a persistent key the element cannot hold.
  */
@@ -92,8 +93,17 @@ internal class AndroidKeystoreKeyStore(
         spec: ProtectedKeySpec,
     ): KeyAgreementKeyPair {
         requireValidAlias(alias)
-        // An AndroidKeystore backs no app-controlled ECDH / X25519 agreement key.
-        throw HardwareKeyException.AlgorithmNotEligible()
+        // Only ECDH P-256, and only where the keystore-probed PURPOSE_AGREE_KEY support holds
+        // (API 31+); X25519 has no AndroidKeystore agreement backing on any API level.
+        if (curve != KeyAgreementCurve.P256 || !provider.eligible(ProtectedKeyAlgorithm.EcdhP256)) {
+            throw HardwareKeyException.AlgorithmNotEligible()
+        }
+        val ns = namespaced(alias)
+        return when (val stored = provider.entryAlgorithm(ns)) {
+            null -> provider.generatePersistentKeyAgreement(ns, spec)
+            ProtectedKeyAlgorithm.EcdhP256 -> requireNotNull(provider.reattachKeyAgreement(ns, spec))
+            else -> throw KeyStoreException.AliasMismatch(alias, stored, curve.toProtectedKeyAlgorithm())
+        }
     }
 
     override suspend fun loadSigning(alias: String): SigningKey? {
@@ -108,8 +118,7 @@ internal class AndroidKeystoreKeyStore(
 
     override suspend fun loadKeyAgreement(alias: String): KeyAgreementKeyPair? {
         requireValidAlias(alias)
-        // No agreement key is ever persisted here (see getOrGenerateKeyAgreement).
-        return null
+        return provider.reattachKeyAgreement(namespaced(alias), ProtectedKeySpec())
     }
 
     override suspend fun contains(alias: String): Boolean {

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.kt
@@ -27,10 +27,12 @@ import kotlin.time.Duration.Companion.seconds
  *
  * In 6.0 no platform constructs a hardware key — [CryptoCapabilities.hardware] is always
  * [HardwareSupport.Unavailable] — but the machinery (SPI, gated keys, witness dispatch) is real and
- * exercised by a fake provider in the test suite. Only the two families a secure element actually
- * holds are wired: **AES-GCM** and **signatures**. ChaCha20-Poly1305 is excluded (Enclave/StrongBox
- * do not implement it) and verify keys are public (no secret to protect), so neither gets a hardware
- * variant; their sealed types are nonetheless already shaped to accept one without a break.
+ * exercised by a fake provider in the test suite. The families a secure element actually holds are
+ * wired: **AES-GCM**, **signatures**, and — where the element backs it (Android Keystore
+ * `PURPOSE_AGREE_KEY`, API 31+) — **ECDH key agreement**. ChaCha20-Poly1305 is excluded
+ * (Enclave/StrongBox do not implement it) and verify keys are public (no secret to protect), so
+ * neither gets a hardware variant; their sealed types are nonetheless already shaped to accept one
+ * without a break.
  */
 
 /**

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/FakeHardware.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/FakeHardware.kt
@@ -14,8 +14,9 @@ import kotlin.time.TimeSource
  *    successful op produces standard ciphertext / signatures (proving the seam wires through).
  *  - Each use is gated on [ProtectedKeySpec.authorization]; a denying gate raises [AuthorizationFailed],
  *    exactly as a refused biometric / keystore unlock would.
- *  - Eligibility is a realistic subset: AES-GCM and ECDSA P-256 only. ChaCha20-Poly1305 and Ed25519
- *    are rejected (Enclave/StrongBox do not back them), matching the no-hardware-variant decision.
+ *  - Eligibility is a realistic subset: AES-GCM, ECDSA P-256, and ECDH P-256 only (the Android
+ *    Keystore subset). ChaCha20-Poly1305, Ed25519, and X25519 are rejected (Enclave/StrongBox do
+ *    not back them), matching the no-hardware-variant decision.
  *  - Keys are generated, never imported: AES material is fresh CSPRNG bytes; the ECDSA key uses a
  *    fixed NIST P-256 test keypair (buffer-crypto exposes no ECDSA keypair generation, so a known
  *    keypair is used so the test can build the matching public [VerifyKey] — verify keys are public).
@@ -95,7 +96,9 @@ internal class FakeHardware(
     )
 
     override fun eligible(alg: ProtectedKeyAlgorithm): Boolean =
-        alg == ProtectedKeyAlgorithm.AesGcm || alg == ProtectedKeyAlgorithm.EcdsaP256
+        alg == ProtectedKeyAlgorithm.AesGcm ||
+            alg == ProtectedKeyAlgorithm.EcdsaP256 ||
+            alg == ProtectedKeyAlgorithm.EcdhP256
 
     override suspend fun generateAesGcm(spec: ProtectedKeySpec): AesGcmKey = aesGcmPair(spec).hardware
 
@@ -110,10 +113,14 @@ internal class FakeHardware(
     override suspend fun generateKeyAgreement(
         curve: KeyAgreementCurve,
         spec: ProtectedKeySpec,
-    ): KeyAgreementKeyPair =
-        // The fake secure element backs only AES-GCM + ECDSA P-256, matching Enclave/StrongBox; a
-        // key-agreement request is not eligible, exactly as on the real hardware providers.
-        throw HardwareKeyException.AlgorithmNotEligible()
+    ): KeyAgreementKeyPair {
+        // The fake element backs ECDH P-256 only (mirroring the Android Keystore subset); X25519 /
+        // P-384 / P-521 refuse with the same typed error as any ineligible algorithm.
+        if (curve != KeyAgreementCurve.P256 || !eligible(curve.toProtectedKeyAlgorithm())) {
+            throw HardwareKeyException.AlgorithmNotEligible()
+        }
+        return keyAgreementPair(spec).hardware
+    }
 
     /** Richer result for the conformance test: the hardware key and a software twin with the same key. */
     fun aesGcmPair(
@@ -156,6 +163,40 @@ internal class FakeHardware(
                 },
             )
         return AesGcmPair(hardware, twin)
+    }
+
+    /** A hardware agreement pair plus the software twin (same scalar) tests can derive against directly. */
+    class AgreementPair(
+        val hardware: KeyAgreementKeyPair,
+        val softwareTwin: KeyAgreementKeyPair,
+    )
+
+    /**
+     * Richer result for the conformance test: the "element"-held key pair driven through the gated
+     * DH closure, plus the in-memory twin it wraps. The gated closure computes the raw `DH(sk, peer)`
+     * through the module's own seam — proving the [ProtectedKeyAgreementPrivateKey] machinery routes
+     * a non-exportable key's derive through [dhRawSecret] and the shared KDF, not a stub.
+     */
+    suspend fun keyAgreementPair(
+        spec: ProtectedKeySpec,
+        policy: UserAuthenticationPolicy? = null,
+    ): AgreementPair {
+        val inner = keyAgreementAsyncOps(KeyAgreementCurve.P256).generateKeyPair()
+        val auth = FakeAuthPolicy(spec.authorization, policy)
+        val hardware =
+            keyAgreementKeyPairOf(
+                KeyAgreementCurve.P256,
+                ProtectedKeyAgreementPrivateKey(
+                    curve = KeyAgreementCurve.P256,
+                    custody = custody,
+                    gatedDh = { peer ->
+                        auth.beforeOp()
+                        dhRawSecret(inner.privateKey, peer)
+                    },
+                ),
+                inner.publicKey,
+            )
+        return AgreementPair(hardware, inner)
     }
 
     /** Richer result for the conformance test: the hardware signing key and its public verify key. */

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/HardwareKeyConformanceTest.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/HardwareKeyConformanceTest.kt
@@ -104,7 +104,11 @@ class HardwareKeyConformanceTest {
                         val info = Info.Of(ascii("hw-ka-conformance"))
                         val viaHardware = ops.deriveSharedSecret(pair.privateKey, peer.publicKey, info, length = 32)
                         val viaPeer = ops.deriveSharedSecret(peer.privateKey, pair.publicKey, info, length = 32)
-                        assertEquals(viaPeer.toHex(), viaHardware.toHex(), "real hw ECDH must agree with a software peer")
+                        assertEquals(
+                            viaPeer.toHex(),
+                            viaHardware.toHex(),
+                            "real hw ECDH must agree with a software peer",
+                        )
                     } finally {
                         peer.close()
                     }
@@ -233,7 +237,7 @@ class HardwareKeyConformanceTest {
         runTest {
             val pair = provider.generateKeyAgreement(KeyAgreementCurve.P256, grant)
             assertEquals(KeyProvenance.Hardware, pair.privateKey.provenance)
-            assertFailsWith<UnsupportedOperationException>("a non-exportable agreement key has no exportable material") {
+            assertFailsWith<UnsupportedOperationException>("a non-exportable agreement key must not export") {
                 pair.privateKey.exportEncoded()
             }
         }

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/HardwareKeyConformanceTest.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/HardwareKeyConformanceTest.kt
@@ -18,7 +18,7 @@ import kotlin.time.TestTimeSource
  * under test (witness → gated closure, blocking-seam safety net, the auth gate) is the production
  * code, not the fake.
  *
- * Proves, for the two families a secure element backs (AES-GCM + ECDSA P-256):
+ * Proves, for the families a secure element backs (AES-GCM + ECDSA P-256 + ECDH P-256):
  *  - the public `CryptoCapabilities.hardware` witness is [HardwareSupport.Unavailable] on every
  *    platform in 6.0 (no backend ships yet);
  *  - hardware keys carry [KeyProvenance.Hardware] and a realistic eligibility subset;
@@ -86,16 +86,45 @@ class HardwareKeyConformanceTest {
                 aes.close()
             }
         }
+
+        // ECDH P-256 key agreement is probed per device (Android API 31+ Keystore) — gate on
+        // eligibility. Where it holds, a real element-held key must agree with a software peer:
+        // both sides derive the same secret, proving the keystore DH produced standard ECDH.
+        if (provider.eligible(ProtectedKeyAlgorithm.EcdhP256)) {
+            val pair = provider.generateKeyAgreement(KeyAgreementCurve.P256, grant)
+            try {
+                assertEquals(KeyProvenance.Hardware, pair.privateKey.provenance)
+                assertFailsWith<UnsupportedOperationException>("a hardware agreement key has no exportable scalar") {
+                    pair.privateKey.exportEncoded()
+                }
+                val ops = keyAgreementAsyncOrNull(KeyAgreementCurve.P256)
+                if (ops != null) {
+                    val peer = ops.generateKeyPair()
+                    try {
+                        val info = Info.Of(ascii("hw-ka-conformance"))
+                        val viaHardware = ops.deriveSharedSecret(pair.privateKey, peer.publicKey, info, length = 32)
+                        val viaPeer = ops.deriveSharedSecret(peer.privateKey, pair.publicKey, info, length = 32)
+                        assertEquals(viaPeer.toHex(), viaHardware.toHex(), "real hw ECDH must agree with a software peer")
+                    } finally {
+                        peer.close()
+                    }
+                }
+            } finally {
+                pair.close()
+            }
+        }
     }
 
     @Test
     fun eligibilityIsARealisticSubset() {
         assertTrue(provider.eligible(ProtectedKeyAlgorithm.AesGcm), "AES-GCM is eligible")
         assertTrue(provider.eligible(ProtectedKeyAlgorithm.EcdsaP256), "ECDSA P-256 is eligible")
-        // A secure element backs neither ChaCha20-Poly1305 nor Ed25519 (nor P-384/P-521 here).
+        assertTrue(provider.eligible(ProtectedKeyAlgorithm.EcdhP256), "ECDH P-256 is eligible")
+        // A secure element backs neither ChaCha20-Poly1305 nor Ed25519 (nor P-384/P-521/X25519 here).
         assertTrue(!provider.eligible(ProtectedKeyAlgorithm.Ed25519), "Ed25519 not eligible")
         assertTrue(!provider.eligible(ProtectedKeyAlgorithm.EcdsaP384), "P-384 not eligible")
         assertTrue(!provider.eligible(ProtectedKeyAlgorithm.EcdsaP521), "P-521 not eligible")
+        assertTrue(!provider.eligible(ProtectedKeyAlgorithm.X25519), "X25519 not eligible")
     }
 
     @Test
@@ -180,13 +209,53 @@ class HardwareKeyConformanceTest {
         }
     }
 
+    // ---- Key agreement (ECDH P-256) ----
+
     @Test
-    fun generateKeyAgreementIsNotEligibleOnHardware() =
+    fun hardwareKeyAgreementDerivesTheSameSecretAsItsSoftwareTwin() =
         runTest {
-            // The hardware providers back no app-controlled agreement key; the request is refused with
-            // the same typed error as any ineligible algorithm.
+            val keys = provider.keyAgreementPair(grant)
+            val ops = keyAgreementAsyncOrNull(KeyAgreementCurve.P256) ?: return@runTest
+            val peer = ops.generateKeyPair()
+            val info = Info.Of(ascii("hw-ka"))
+            // The hardware key derives through its gated closure; the software twin (same scalar)
+            // and the peer's own derivation must all land on identical key material — the
+            // ProtectedKeyAgreementPrivateKey seam wires through to real ECDH + the shared KDF.
+            val viaHardware = ops.deriveSharedSecret(keys.hardware.privateKey, peer.publicKey, info, length = 32)
+            val viaTwin = ops.deriveSharedSecret(keys.softwareTwin.privateKey, peer.publicKey, info, length = 32)
+            val viaPeer = ops.deriveSharedSecret(peer.privateKey, keys.hardware.publicKey, info, length = 32)
+            assertEquals(viaTwin.toHex(), viaHardware.toHex(), "hw derive must match its software twin")
+            assertEquals(viaPeer.toHex(), viaHardware.toHex(), "hw derive must match the peer's derivation")
+        }
+
+    @Test
+    fun hardwareKeyAgreementReportsHardwareProvenanceAndNoExport() =
+        runTest {
+            val pair = provider.generateKeyAgreement(KeyAgreementCurve.P256, grant)
+            assertEquals(KeyProvenance.Hardware, pair.privateKey.provenance)
+            assertFailsWith<UnsupportedOperationException>("a non-exportable agreement key has no exportable material") {
+                pair.privateKey.exportEncoded()
+            }
+        }
+
+    @Test
+    fun hardwareKeyAgreementDeniedAuthorizationFails() =
+        runTest {
+            val keys = provider.keyAgreementPair(deny)
+            val ops = keyAgreementAsyncOrNull(KeyAgreementCurve.P256) ?: return@runTest
+            val peer = ops.generateKeyPair()
+            assertFailsWith<AuthorizationFailed> {
+                ops.deriveSharedSecret(keys.hardware.privateKey, peer.publicKey, Info.Of(ascii("denied")), length = 32)
+            }
+        }
+
+    @Test
+    fun generateKeyAgreementRejectsIneligibleCurve() =
+        runTest {
+            // The element backs no X25519 agreement key; refused with the same typed error as any
+            // ineligible algorithm.
             assertFailsWith<HardwareKeyException.AlgorithmNotEligible> {
-                provider.generateKeyAgreement(KeyAgreementCurve.P256, grant)
+                provider.generateKeyAgreement(KeyAgreementCurve.X25519, grant)
             }
         }
 


### PR DESCRIPTION
## Summary

Implements the **Android half of #312**: `HardwareKeyProvider.generateKeyAgreement` and the persistent `KeyStore.getOrGenerateKeyAgreement` / `loadKeyAgreement` are now real on Android, backed by `AndroidKeyStore` `PURPOSE_AGREE_KEY` (API 31+). The Apple half is tracked separately (needs a new Secure Enclave shim function and Mac verification).

### Design
- **Probed eligibility, not API-level inference.** `eligible(EcdhP256)` generates a throwaway `PURPOSE_AGREE_KEY` key and runs a full keystore ECDH against a software peer once (lazily, mirroring `probeStrongBox`). Devices whose Keymaster/KeyMint accepts the generation spec but fails the agreement op are routed to the software floor instead of over-promising hardware custody.
- **Gated-DH closure.** The keystore-held scalar never enters process memory: `DH(sk, peer)` runs inside `AndroidKeyStore` via `KeyAgreement.getInstance("ECDH", "AndroidKeyStore")`, and the raw secret is handed to the common `validateRawSecret`/HKDF seam in a wiped `SecureBuffer`. `hpke()` / `keyAgreement()` witnesses compose unchanged.
- **Uniform peer rejection.** Malformed/off-curve peer points map to `InvalidPublicKey` with the cause dropped — same no-oracle contract as the software JCA glue.
- **Advisory gating only.** `BiometricPrompt.CryptoObject` cannot wrap a JCA `KeyAgreement` on supported API levels, and `UserAuthenticatedKeyProvider` exposes no agreement surface — so agreement keys carry the advisory `ProtectedKeySpec.authorization` gate, evaluated per derive outside the keystore lock.
- **Purpose-disambiguated persistence.** Signing and agreement keys are both `PrivateKeyEntry`s; `entryAlgorithm`/`reattach*` now read the keystore-recorded purposes, so kind-mismatched loads answer `null` and get-or-generate raises `AliasMismatch` instead of returning a mistyped handle.

### Testing (deterministic, CI-covered)
- `FakeHardware` now implements `generateKeyAgreement`, so the `ProtectedKeyAgreementPrivateKey` machinery (witness dispatch, gated closure, KDF composition, denied-auth) runs in **commonTest on every platform**.
- The conformance test's `assertRealProviderWorks` drives the **real keystore ECDH** wherever a provider resolves — on the CI emulator matrix the API 35 leg exercises the full path (hardware↔software peer agreement) and new instrumented tests pin persist/reload/derive round-trips and alias-kind mismatches. The API 21 leg skips the module (minSdk 28); pre-31 refusal is covered by the eligibility gate tests.
- Verified locally on an API 35 emulator: **333 instrumented tests, 0 failures**.
- `apiCheck` green — public ABI unchanged (all additions `internal`); JVM/JS/Linux/WASM test sources compile; ktlint clean.

Closes nothing outright — #312 stays open for the Apple half.