### PR TITLE
feat(buffer-crypto): typed backend resolution + tpm2-pkcs11 JVM hardware key provider

### DIFF
--- a/.github/workflows/crypto-tpm-integration.yaml
+++ b/.github/workflows/crypto-tpm-integration.yaml
@@ -1,0 +1,80 @@
+name: "TPM2 Integration Test (swtpm)"
+
+# Deterministic hardware-free verification of the tpm2-pkcs11-backed JVM key provider:
+# a software TPM (swtpm) + tpm2-abrmd resource broker + an initialized tpm2-pkcs11 token
+# reproduce the exact stack a real Linux TPM 2.0 deployment exercises (where the kernel's
+# /dev/tpmrm0 plays the broker role). The test run is REQUIRED mode: the provider must
+# resolve Available and pass the full sign/agreement contract, so a regression can never
+# hide behind a silent capability refusal.
+
+on:
+  pull_request:
+    paths:
+      - 'buffer-crypto/**'
+      - '.github/workflows/crypto-tpm-integration.yaml'
+
+permissions:
+  contents: read
+
+jobs:
+  swtpm:
+    name: "JVM provider against swtpm token"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+          cache: gradle
+
+      - name: Install swtpm + tpm2-pkcs11 stack
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y swtpm swtpm-tools tpm2-tools tpm2-abrmd \
+            libtpm2-pkcs11-1 libtpm2-pkcs11-tools libtss2-tcti-tabrmd0 dbus
+
+      - name: Start swtpm, session D-Bus, and tpm2-abrmd; initialize the PKCS#11 token
+        run: |
+          RIG="$RUNNER_TEMP/tpm-rig"
+          mkdir -p "$RIG/tpmstate" "$RIG/pkcs11store"
+          swtpm socket --tpm2 --tpmstate dir="$RIG/tpmstate" \
+            --server type=tcp,port=2321 --ctrl type=tcp,port=2322 \
+            --flags not-need-init,startup-clear --daemon
+          dbus-daemon --session --address="unix:path=$RIG/dbus.sock" --fork
+          export DBUS_SESSION_BUS_ADDRESS="unix:path=$RIG/dbus.sock"
+          tpm2-abrmd --tcti=swtpm:host=127.0.0.1,port=2321 --session &
+          sleep 2
+          export TPM2TOOLS_TCTI="tabrmd:bus_type=session"
+          export TPM2_PKCS11_TCTI="tabrmd:bus_type=session"
+          export TPM2_PKCS11_STORE="$RIG/pkcs11store"
+          tpm2_getcap properties-fixed | head -2
+          tpm2_ptool init --path "$TPM2_PKCS11_STORE"
+          tpm2_ptool addtoken --pid 1 --label buffer-crypto \
+            --userpin 1234 --sopin 5678 --path "$TPM2_PKCS11_STORE"
+          # Expose the rig to the test step (fresh Gradle daemon there inherits this env).
+          {
+            echo "DBUS_SESSION_BUS_ADDRESS=unix:path=$RIG/dbus.sock"
+            echo "TPM2_PKCS11_TCTI=tabrmd:bus_type=session"
+            echo "TPM2_PKCS11_STORE=$RIG/pkcs11store"
+          } >> "$GITHUB_ENV"
+
+      - name: Run TPM-required JVM tests
+        run: |
+          ./gradlew :buffer-crypto:jvmTest \
+            --tests "com.ditchoom.buffer.crypto.Tpm2Pkcs11ProviderTest" \
+            --tests "com.ditchoom.buffer.crypto.ProtectedKeyResolutionTest" \
+            -P"buffer.crypto.tpm2.pkcs11.module=/usr/lib/x86_64-linux-gnu/libtpm2_pkcs11.so.1" \
+            -P"buffer.crypto.tpm2.pkcs11.pin=1234" \
+            -P"buffer.crypto.require.tpm2=true"
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: tpm2-jvm-test-results
+          path: buffer-crypto/build/reports/tests/jvmTest/
+          if-no-files-found: ignore

--- a/buffer-crypto/api/android/buffer-crypto.api
+++ b/buffer-crypto/api/android/buffer-crypto.api
@@ -198,6 +198,112 @@ public final class com/ditchoom/buffer/crypto/BiometricPromptAuthenticator : com
 	public fun authorize (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public abstract interface class com/ditchoom/buffer/crypto/CapabilityFinding {
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/CapabilityFinding$Enclave : com/ditchoom/buffer/crypto/CapabilityFinding {
+}
+
+public final class com/ditchoom/buffer/crypto/CapabilityFinding$Enclave$NotPresent : com/ditchoom/buffer/crypto/CapabilityFinding$Enclave {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/CapabilityFinding$Enclave$NotPresent;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/CapabilityFinding$Enclave$ProbeFailed : com/ditchoom/buffer/crypto/CapabilityFinding$Enclave {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/CapabilityFinding$Enclave$ProbeFailed;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/CapabilityFinding$Keystore : com/ditchoom/buffer/crypto/CapabilityFinding {
+}
+
+public final class com/ditchoom/buffer/crypto/CapabilityFinding$Keystore$ProviderMissing : com/ditchoom/buffer/crypto/CapabilityFinding$Keystore {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/CapabilityFinding$Keystore$ProviderMissing;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/CapabilityFinding$Tpm2 : com/ditchoom/buffer/crypto/CapabilityFinding {
+}
+
+public final class com/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$AuthNotConfigured : com/ditchoom/buffer/crypto/CapabilityFinding$Tpm2 {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$AuthNotConfigured;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$ModuleNotFound : com/ditchoom/buffer/crypto/CapabilityFinding$Tpm2 {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$ModuleNotFound;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$ProbeOpFailed : com/ditchoom/buffer/crypto/CapabilityFinding$Tpm2 {
+	public fun <init> (Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;Lcom/ditchoom/buffer/crypto/CkrClass;)V
+	public final fun component1 ()Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
+	public final fun component2 ()Lcom/ditchoom/buffer/crypto/CkrClass;
+	public final fun copy (Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;Lcom/ditchoom/buffer/crypto/CkrClass;)Lcom/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$ProbeOpFailed;
+	public static synthetic fun copy$default (Lcom/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$ProbeOpFailed;Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;Lcom/ditchoom/buffer/crypto/CkrClass;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$ProbeOpFailed;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlg ()Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
+	public final fun getCkr ()Lcom/ditchoom/buffer/crypto/CkrClass;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$ProbeOpFailedOpaque : com/ditchoom/buffer/crypto/CapabilityFinding$Tpm2 {
+	public fun <init> (Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;)V
+	public final fun component1 ()Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
+	public final fun copy (Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;)Lcom/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$ProbeOpFailedOpaque;
+	public static synthetic fun copy$default (Lcom/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$ProbeOpFailedOpaque;Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$ProbeOpFailedOpaque;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlg ()Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$RuntimeUnsupported : com/ditchoom/buffer/crypto/CapabilityFinding$Tpm2 {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$RuntimeUnsupported;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$TokenRejected : com/ditchoom/buffer/crypto/CapabilityFinding$Tpm2 {
+	public fun <init> (Lcom/ditchoom/buffer/crypto/CkrClass;)V
+	public final fun component1 ()Lcom/ditchoom/buffer/crypto/CkrClass;
+	public final fun copy (Lcom/ditchoom/buffer/crypto/CkrClass;)Lcom/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$TokenRejected;
+	public static synthetic fun copy$default (Lcom/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$TokenRejected;Lcom/ditchoom/buffer/crypto/CkrClass;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$TokenRejected;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCkr ()Lcom/ditchoom/buffer/crypto/CkrClass;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$TokenRejectedOpaque : com/ditchoom/buffer/crypto/CapabilityFinding$Tpm2 {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$TokenRejectedOpaque;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/CapabilityFinding$Web : com/ditchoom/buffer/crypto/CapabilityFinding {
+}
+
+public final class com/ditchoom/buffer/crypto/CapabilityFinding$Web$SubtleCryptoUnavailable : com/ditchoom/buffer/crypto/CapabilityFinding$Web {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/CapabilityFinding$Web$SubtleCryptoUnavailable;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface class com/ditchoom/buffer/crypto/ChaChaPolyKey : com/ditchoom/buffer/crypto/AeadKey, java/lang/AutoCloseable {
 	public static final field Companion Lcom/ditchoom/buffer/crypto/ChaChaPolyKey$Companion;
 	public abstract fun getProvenance ()Lcom/ditchoom/buffer/crypto/KeyProvenance;
@@ -206,6 +312,87 @@ public abstract interface class com/ditchoom/buffer/crypto/ChaChaPolyKey : com/d
 public final class com/ditchoom/buffer/crypto/ChaChaPolyKey$Companion {
 	public final fun of (Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;)Lcom/ditchoom/buffer/crypto/ChaChaPolyKey;
 	public static synthetic fun of$default (Lcom/ditchoom/buffer/crypto/ChaChaPolyKey$Companion;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/ChaChaPolyKey;
+}
+
+public final class com/ditchoom/buffer/crypto/Ckr {
+	public static final field CKR_DEVICE_ERROR J
+	public static final field CKR_MECHANISM_INVALID J
+	public static final field CKR_PIN_INCORRECT J
+	public static final field CKR_PIN_LOCKED J
+	public static final field CKR_TOKEN_NOT_PRESENT J
+	public static final field CKR_VENDOR_DEFINED J
+	public static final synthetic fun box-impl (J)Lcom/ditchoom/buffer/crypto/Ckr;
+	public static final fun classify-impl (J)Lcom/ditchoom/buffer/crypto/CkrClass;
+	public static fun constructor-impl (J)J
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (JLjava/lang/Object;)Z
+	public static final fun equals-impl0 (JJ)Z
+	public final fun getRaw-s-VKNKU ()J
+	public fun hashCode ()I
+	public static fun hashCode-impl (J)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (J)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()J
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/CkrClass {
+}
+
+public final class com/ditchoom/buffer/crypto/CkrClass$DeviceError : com/ditchoom/buffer/crypto/CkrClass {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/CkrClass$DeviceError;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/CkrClass$MechanismInvalid : com/ditchoom/buffer/crypto/CkrClass {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/CkrClass$MechanismInvalid;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/CkrClass$PinIncorrect : com/ditchoom/buffer/crypto/CkrClass {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/CkrClass$PinIncorrect;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/CkrClass$PinLocked : com/ditchoom/buffer/crypto/CkrClass {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/CkrClass$PinLocked;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/CkrClass$TokenNotPresent : com/ditchoom/buffer/crypto/CkrClass {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/CkrClass$TokenNotPresent;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/CkrClass$Unrecognized : com/ditchoom/buffer/crypto/CkrClass {
+	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-KCHEO4w ()J
+	public final fun copy-XCQIlFk (J)Lcom/ditchoom/buffer/crypto/CkrClass$Unrecognized;
+	public static synthetic fun copy-XCQIlFk$default (Lcom/ditchoom/buffer/crypto/CkrClass$Unrecognized;JILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/CkrClass$Unrecognized;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCkr-KCHEO4w ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/CkrClass$VendorDefined : com/ditchoom/buffer/crypto/CkrClass {
+	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-KCHEO4w ()J
+	public final fun copy-XCQIlFk (J)Lcom/ditchoom/buffer/crypto/CkrClass$VendorDefined;
+	public static synthetic fun copy-XCQIlFk$default (Lcom/ditchoom/buffer/crypto/CkrClass$VendorDefined;JILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/CkrClass$VendorDefined;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCkr-KCHEO4w ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class com/ditchoom/buffer/crypto/ConcreteKeyProvider : com/ditchoom/buffer/crypto/KeyProvider {
@@ -1184,6 +1371,37 @@ public final class com/ditchoom/buffer/crypto/ProtectedKeyAlgorithm : java/lang/
 	public static fun values ()[Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
 }
 
+public abstract interface class com/ditchoom/buffer/crypto/ProtectedKeyBackend {
+}
+
+public final class com/ditchoom/buffer/crypto/ProtectedKeyBackend$AndroidKeystore : com/ditchoom/buffer/crypto/ProtectedKeyBackend {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/ProtectedKeyBackend$AndroidKeystore;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/ProtectedKeyBackend$AppleSecureEnclave : com/ditchoom/buffer/crypto/ProtectedKeyBackend {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/ProtectedKeyBackend$AppleSecureEnclave;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/ProtectedKeyBackend$Tpm2Pkcs11 : com/ditchoom/buffer/crypto/ProtectedKeyBackend {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/ProtectedKeyBackend$Tpm2Pkcs11;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/ProtectedKeyBackend$WebCrypto : com/ditchoom/buffer/crypto/ProtectedKeyBackend {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/ProtectedKeyBackend$WebCrypto;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface class com/ditchoom/buffer/crypto/ProtectedKeyProvider : com/ditchoom/buffer/crypto/ConcreteKeyProvider {
 	public abstract fun getCustody ()Lcom/ditchoom/buffer/crypto/KeyCustody$NonExportable;
 	public synthetic fun getCustody ()Lcom/ditchoom/buffer/crypto/KeyCustody;
@@ -1191,6 +1409,46 @@ public abstract interface class com/ditchoom/buffer/crypto/ProtectedKeyProvider 
 
 public final class com/ditchoom/buffer/crypto/ProtectedKeyProvider$DefaultImpls {
 	public static fun custodyFor (Lcom/ditchoom/buffer/crypto/ProtectedKeyProvider;Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;)Lcom/ditchoom/buffer/crypto/KeyCustody;
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/ProtectedKeyResolution {
+}
+
+public final class com/ditchoom/buffer/crypto/ProtectedKeyResolution$Available : com/ditchoom/buffer/crypto/ProtectedKeyResolution {
+	public fun <init> (Lcom/ditchoom/buffer/crypto/ProtectedKeyBackend;Lcom/ditchoom/buffer/crypto/ProtectedKeyProvider;)V
+	public final fun component1 ()Lcom/ditchoom/buffer/crypto/ProtectedKeyBackend;
+	public final fun component2 ()Lcom/ditchoom/buffer/crypto/ProtectedKeyProvider;
+	public final fun copy (Lcom/ditchoom/buffer/crypto/ProtectedKeyBackend;Lcom/ditchoom/buffer/crypto/ProtectedKeyProvider;)Lcom/ditchoom/buffer/crypto/ProtectedKeyResolution$Available;
+	public static synthetic fun copy$default (Lcom/ditchoom/buffer/crypto/ProtectedKeyResolution$Available;Lcom/ditchoom/buffer/crypto/ProtectedKeyBackend;Lcom/ditchoom/buffer/crypto/ProtectedKeyProvider;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/ProtectedKeyResolution$Available;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBackend ()Lcom/ditchoom/buffer/crypto/ProtectedKeyBackend;
+	public final fun getProvider ()Lcom/ditchoom/buffer/crypto/ProtectedKeyProvider;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/ProtectedKeyResolution$None : com/ditchoom/buffer/crypto/ProtectedKeyResolution {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/ProtectedKeyResolution$None;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/ProtectedKeyResolution$Refused : com/ditchoom/buffer/crypto/ProtectedKeyResolution {
+	public fun <init> (Lcom/ditchoom/buffer/crypto/ProtectedKeyBackend;Lcom/ditchoom/buffer/crypto/CapabilityFinding;)V
+	public final fun component1 ()Lcom/ditchoom/buffer/crypto/ProtectedKeyBackend;
+	public final fun component2 ()Lcom/ditchoom/buffer/crypto/CapabilityFinding;
+	public final fun copy (Lcom/ditchoom/buffer/crypto/ProtectedKeyBackend;Lcom/ditchoom/buffer/crypto/CapabilityFinding;)Lcom/ditchoom/buffer/crypto/ProtectedKeyResolution$Refused;
+	public static synthetic fun copy$default (Lcom/ditchoom/buffer/crypto/ProtectedKeyResolution$Refused;Lcom/ditchoom/buffer/crypto/ProtectedKeyBackend;Lcom/ditchoom/buffer/crypto/CapabilityFinding;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/ProtectedKeyResolution$Refused;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBackend ()Lcom/ditchoom/buffer/crypto/ProtectedKeyBackend;
+	public final fun getFinding ()Lcom/ditchoom/buffer/crypto/CapabilityFinding;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/ProtectedKeyResolutionKt {
+	public static final fun getProtectedKeyResolution (Lcom/ditchoom/buffer/crypto/CryptoCapabilities;)Lcom/ditchoom/buffer/crypto/ProtectedKeyResolution;
 }
 
 public final class com/ditchoom/buffer/crypto/ProtectedKeySpec {

--- a/buffer-crypto/api/jvm/buffer-crypto.api
+++ b/buffer-crypto/api/jvm/buffer-crypto.api
@@ -183,6 +183,112 @@ public final class com/ditchoom/buffer/crypto/AesGcmKey$DefaultImpls {
 public final class com/ditchoom/buffer/crypto/AuthorizationFailed : com/ditchoom/buffer/crypto/CryptoMisuseException {
 }
 
+public abstract interface class com/ditchoom/buffer/crypto/CapabilityFinding {
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/CapabilityFinding$Enclave : com/ditchoom/buffer/crypto/CapabilityFinding {
+}
+
+public final class com/ditchoom/buffer/crypto/CapabilityFinding$Enclave$NotPresent : com/ditchoom/buffer/crypto/CapabilityFinding$Enclave {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/CapabilityFinding$Enclave$NotPresent;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/CapabilityFinding$Enclave$ProbeFailed : com/ditchoom/buffer/crypto/CapabilityFinding$Enclave {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/CapabilityFinding$Enclave$ProbeFailed;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/CapabilityFinding$Keystore : com/ditchoom/buffer/crypto/CapabilityFinding {
+}
+
+public final class com/ditchoom/buffer/crypto/CapabilityFinding$Keystore$ProviderMissing : com/ditchoom/buffer/crypto/CapabilityFinding$Keystore {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/CapabilityFinding$Keystore$ProviderMissing;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/CapabilityFinding$Tpm2 : com/ditchoom/buffer/crypto/CapabilityFinding {
+}
+
+public final class com/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$AuthNotConfigured : com/ditchoom/buffer/crypto/CapabilityFinding$Tpm2 {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$AuthNotConfigured;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$ModuleNotFound : com/ditchoom/buffer/crypto/CapabilityFinding$Tpm2 {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$ModuleNotFound;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$ProbeOpFailed : com/ditchoom/buffer/crypto/CapabilityFinding$Tpm2 {
+	public fun <init> (Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;Lcom/ditchoom/buffer/crypto/CkrClass;)V
+	public final fun component1 ()Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
+	public final fun component2 ()Lcom/ditchoom/buffer/crypto/CkrClass;
+	public final fun copy (Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;Lcom/ditchoom/buffer/crypto/CkrClass;)Lcom/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$ProbeOpFailed;
+	public static synthetic fun copy$default (Lcom/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$ProbeOpFailed;Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;Lcom/ditchoom/buffer/crypto/CkrClass;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$ProbeOpFailed;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlg ()Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
+	public final fun getCkr ()Lcom/ditchoom/buffer/crypto/CkrClass;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$ProbeOpFailedOpaque : com/ditchoom/buffer/crypto/CapabilityFinding$Tpm2 {
+	public fun <init> (Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;)V
+	public final fun component1 ()Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
+	public final fun copy (Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;)Lcom/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$ProbeOpFailedOpaque;
+	public static synthetic fun copy$default (Lcom/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$ProbeOpFailedOpaque;Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$ProbeOpFailedOpaque;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlg ()Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$RuntimeUnsupported : com/ditchoom/buffer/crypto/CapabilityFinding$Tpm2 {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$RuntimeUnsupported;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$TokenRejected : com/ditchoom/buffer/crypto/CapabilityFinding$Tpm2 {
+	public fun <init> (Lcom/ditchoom/buffer/crypto/CkrClass;)V
+	public final fun component1 ()Lcom/ditchoom/buffer/crypto/CkrClass;
+	public final fun copy (Lcom/ditchoom/buffer/crypto/CkrClass;)Lcom/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$TokenRejected;
+	public static synthetic fun copy$default (Lcom/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$TokenRejected;Lcom/ditchoom/buffer/crypto/CkrClass;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$TokenRejected;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCkr ()Lcom/ditchoom/buffer/crypto/CkrClass;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$TokenRejectedOpaque : com/ditchoom/buffer/crypto/CapabilityFinding$Tpm2 {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/CapabilityFinding$Tpm2$TokenRejectedOpaque;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/CapabilityFinding$Web : com/ditchoom/buffer/crypto/CapabilityFinding {
+}
+
+public final class com/ditchoom/buffer/crypto/CapabilityFinding$Web$SubtleCryptoUnavailable : com/ditchoom/buffer/crypto/CapabilityFinding$Web {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/CapabilityFinding$Web$SubtleCryptoUnavailable;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface class com/ditchoom/buffer/crypto/ChaChaPolyKey : com/ditchoom/buffer/crypto/AeadKey, java/lang/AutoCloseable {
 	public static final field Companion Lcom/ditchoom/buffer/crypto/ChaChaPolyKey$Companion;
 	public abstract fun getProvenance ()Lcom/ditchoom/buffer/crypto/KeyProvenance;
@@ -191,6 +297,87 @@ public abstract interface class com/ditchoom/buffer/crypto/ChaChaPolyKey : com/d
 public final class com/ditchoom/buffer/crypto/ChaChaPolyKey$Companion {
 	public final fun of (Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;)Lcom/ditchoom/buffer/crypto/ChaChaPolyKey;
 	public static synthetic fun of$default (Lcom/ditchoom/buffer/crypto/ChaChaPolyKey$Companion;Lcom/ditchoom/buffer/ReadBuffer;Lcom/ditchoom/buffer/BufferFactory;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/ChaChaPolyKey;
+}
+
+public final class com/ditchoom/buffer/crypto/Ckr {
+	public static final field CKR_DEVICE_ERROR J
+	public static final field CKR_MECHANISM_INVALID J
+	public static final field CKR_PIN_INCORRECT J
+	public static final field CKR_PIN_LOCKED J
+	public static final field CKR_TOKEN_NOT_PRESENT J
+	public static final field CKR_VENDOR_DEFINED J
+	public static final synthetic fun box-impl (J)Lcom/ditchoom/buffer/crypto/Ckr;
+	public static final fun classify-impl (J)Lcom/ditchoom/buffer/crypto/CkrClass;
+	public static fun constructor-impl (J)J
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (JLjava/lang/Object;)Z
+	public static final fun equals-impl0 (JJ)Z
+	public final fun getRaw-s-VKNKU ()J
+	public fun hashCode ()I
+	public static fun hashCode-impl (J)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (J)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()J
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/CkrClass {
+}
+
+public final class com/ditchoom/buffer/crypto/CkrClass$DeviceError : com/ditchoom/buffer/crypto/CkrClass {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/CkrClass$DeviceError;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/CkrClass$MechanismInvalid : com/ditchoom/buffer/crypto/CkrClass {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/CkrClass$MechanismInvalid;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/CkrClass$PinIncorrect : com/ditchoom/buffer/crypto/CkrClass {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/CkrClass$PinIncorrect;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/CkrClass$PinLocked : com/ditchoom/buffer/crypto/CkrClass {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/CkrClass$PinLocked;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/CkrClass$TokenNotPresent : com/ditchoom/buffer/crypto/CkrClass {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/CkrClass$TokenNotPresent;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/CkrClass$Unrecognized : com/ditchoom/buffer/crypto/CkrClass {
+	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-KCHEO4w ()J
+	public final fun copy-XCQIlFk (J)Lcom/ditchoom/buffer/crypto/CkrClass$Unrecognized;
+	public static synthetic fun copy-XCQIlFk$default (Lcom/ditchoom/buffer/crypto/CkrClass$Unrecognized;JILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/CkrClass$Unrecognized;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCkr-KCHEO4w ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/CkrClass$VendorDefined : com/ditchoom/buffer/crypto/CkrClass {
+	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-KCHEO4w ()J
+	public final fun copy-XCQIlFk (J)Lcom/ditchoom/buffer/crypto/CkrClass$VendorDefined;
+	public static synthetic fun copy-XCQIlFk$default (Lcom/ditchoom/buffer/crypto/CkrClass$VendorDefined;JILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/CkrClass$VendorDefined;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCkr-KCHEO4w ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class com/ditchoom/buffer/crypto/ConcreteKeyProvider : com/ditchoom/buffer/crypto/KeyProvider {
@@ -1169,6 +1356,37 @@ public final class com/ditchoom/buffer/crypto/ProtectedKeyAlgorithm : java/lang/
 	public static fun values ()[Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
 }
 
+public abstract interface class com/ditchoom/buffer/crypto/ProtectedKeyBackend {
+}
+
+public final class com/ditchoom/buffer/crypto/ProtectedKeyBackend$AndroidKeystore : com/ditchoom/buffer/crypto/ProtectedKeyBackend {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/ProtectedKeyBackend$AndroidKeystore;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/ProtectedKeyBackend$AppleSecureEnclave : com/ditchoom/buffer/crypto/ProtectedKeyBackend {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/ProtectedKeyBackend$AppleSecureEnclave;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/ProtectedKeyBackend$Tpm2Pkcs11 : com/ditchoom/buffer/crypto/ProtectedKeyBackend {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/ProtectedKeyBackend$Tpm2Pkcs11;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/ProtectedKeyBackend$WebCrypto : com/ditchoom/buffer/crypto/ProtectedKeyBackend {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/ProtectedKeyBackend$WebCrypto;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface class com/ditchoom/buffer/crypto/ProtectedKeyProvider : com/ditchoom/buffer/crypto/ConcreteKeyProvider {
 	public abstract fun getCustody ()Lcom/ditchoom/buffer/crypto/KeyCustody$NonExportable;
 	public synthetic fun getCustody ()Lcom/ditchoom/buffer/crypto/KeyCustody;
@@ -1176,6 +1394,46 @@ public abstract interface class com/ditchoom/buffer/crypto/ProtectedKeyProvider 
 
 public final class com/ditchoom/buffer/crypto/ProtectedKeyProvider$DefaultImpls {
 	public static fun custodyFor (Lcom/ditchoom/buffer/crypto/ProtectedKeyProvider;Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;)Lcom/ditchoom/buffer/crypto/KeyCustody;
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/ProtectedKeyResolution {
+}
+
+public final class com/ditchoom/buffer/crypto/ProtectedKeyResolution$Available : com/ditchoom/buffer/crypto/ProtectedKeyResolution {
+	public fun <init> (Lcom/ditchoom/buffer/crypto/ProtectedKeyBackend;Lcom/ditchoom/buffer/crypto/ProtectedKeyProvider;)V
+	public final fun component1 ()Lcom/ditchoom/buffer/crypto/ProtectedKeyBackend;
+	public final fun component2 ()Lcom/ditchoom/buffer/crypto/ProtectedKeyProvider;
+	public final fun copy (Lcom/ditchoom/buffer/crypto/ProtectedKeyBackend;Lcom/ditchoom/buffer/crypto/ProtectedKeyProvider;)Lcom/ditchoom/buffer/crypto/ProtectedKeyResolution$Available;
+	public static synthetic fun copy$default (Lcom/ditchoom/buffer/crypto/ProtectedKeyResolution$Available;Lcom/ditchoom/buffer/crypto/ProtectedKeyBackend;Lcom/ditchoom/buffer/crypto/ProtectedKeyProvider;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/ProtectedKeyResolution$Available;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBackend ()Lcom/ditchoom/buffer/crypto/ProtectedKeyBackend;
+	public final fun getProvider ()Lcom/ditchoom/buffer/crypto/ProtectedKeyProvider;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/ProtectedKeyResolution$None : com/ditchoom/buffer/crypto/ProtectedKeyResolution {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/ProtectedKeyResolution$None;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/ProtectedKeyResolution$Refused : com/ditchoom/buffer/crypto/ProtectedKeyResolution {
+	public fun <init> (Lcom/ditchoom/buffer/crypto/ProtectedKeyBackend;Lcom/ditchoom/buffer/crypto/CapabilityFinding;)V
+	public final fun component1 ()Lcom/ditchoom/buffer/crypto/ProtectedKeyBackend;
+	public final fun component2 ()Lcom/ditchoom/buffer/crypto/CapabilityFinding;
+	public final fun copy (Lcom/ditchoom/buffer/crypto/ProtectedKeyBackend;Lcom/ditchoom/buffer/crypto/CapabilityFinding;)Lcom/ditchoom/buffer/crypto/ProtectedKeyResolution$Refused;
+	public static synthetic fun copy$default (Lcom/ditchoom/buffer/crypto/ProtectedKeyResolution$Refused;Lcom/ditchoom/buffer/crypto/ProtectedKeyBackend;Lcom/ditchoom/buffer/crypto/CapabilityFinding;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/ProtectedKeyResolution$Refused;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBackend ()Lcom/ditchoom/buffer/crypto/ProtectedKeyBackend;
+	public final fun getFinding ()Lcom/ditchoom/buffer/crypto/CapabilityFinding;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/ProtectedKeyResolutionKt {
+	public static final fun getProtectedKeyResolution (Lcom/ditchoom/buffer/crypto/CryptoCapabilities;)Lcom/ditchoom/buffer/crypto/ProtectedKeyResolution;
 }
 
 public final class com/ditchoom/buffer/crypto/ProtectedKeySpec {

--- a/buffer-crypto/build.gradle.kts
+++ b/buffer-crypto/build.gradle.kts
@@ -556,3 +556,21 @@ dokka {
         reportUndocumented.set(false)
     }
 }
+
+// Forward the tpm2-pkcs11 harness configuration into the JVM test process, so the TPM-backed
+// provider tests can reach a real (or swtpm-emulated) token. Gradle -P properties become the
+// library's system properties (fresh per invocation, immune to daemon-env staleness); the
+// TPM2_PKCS11_* / DBUS_* environment is what the native tpm2-pkcs11 module itself reads.
+tasks.withType<Test>().configureEach {
+    listOf(
+        "buffer.crypto.tpm2.pkcs11.module",
+        "buffer.crypto.tpm2.pkcs11.pin",
+        "buffer.crypto.tpm2.pkcs11.slotIndex",
+        "buffer.crypto.require.tpm2",
+    ).forEach { key ->
+        (project.findProperty(key) as? String)?.let { systemProperty(key, it) }
+    }
+    listOf("TPM2_PKCS11_TCTI", "TPM2_PKCS11_STORE", "DBUS_SESSION_BUS_ADDRESS").forEach { key ->
+        System.getenv(key)?.let { environment(key, it) }
+    }
+}

--- a/buffer-crypto/src/androidMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.android.kt
+++ b/buffer-crypto/src/androidMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.android.kt
@@ -635,7 +635,10 @@ private val androidResolution: ProtectedKeyResolution by lazy {
         ?.let { ProtectedKeyResolution.Available(ProtectedKeyBackend.AndroidKeystore, it) }
         // Construction only fails where there is no AndroidKeyStore JCA provider at all — a host-JVM
         // unit-test run, never a device or emulator.
-        ?: ProtectedKeyResolution.Refused(ProtectedKeyBackend.AndroidKeystore, CapabilityFinding.Keystore.ProviderMissing)
+        ?: ProtectedKeyResolution.Refused(
+            ProtectedKeyBackend.AndroidKeystore,
+            CapabilityFinding.Keystore.ProviderMissing,
+        )
 }
 
 internal actual fun platformProtectedKeyResolution(): ProtectedKeyResolution = androidResolution

--- a/buffer-crypto/src/androidMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.android.kt
+++ b/buffer-crypto/src/androidMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.android.kt
@@ -630,7 +630,15 @@ private val androidProvider: HardwareKeyProvider? by lazy {
     }
 }
 
-internal actual fun platformProtectedKeyProvider(): ProtectedKeyProvider? = androidProvider
+private val androidResolution: ProtectedKeyResolution by lazy {
+    androidProvider
+        ?.let { ProtectedKeyResolution.Available(ProtectedKeyBackend.AndroidKeystore, it) }
+        // Construction only fails where there is no AndroidKeyStore JCA provider at all — a host-JVM
+        // unit-test run, never a device or emulator.
+        ?: ProtectedKeyResolution.Refused(ProtectedKeyBackend.AndroidKeystore, CapabilityFinding.Keystore.ProviderMissing)
+}
+
+internal actual fun platformProtectedKeyResolution(): ProtectedKeyResolution = androidResolution
 
 /**
  * The AndroidKeystore provider narrowed to its concrete type, or `null` off-device (a host-JVM unit

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.apple.kt
@@ -458,9 +458,10 @@ private fun enclaveSignP256Into(
  * fails closed on an unentitled/unsigned binary (e.g. the macOS CLI test runner) or the simulator,
  * keeping [CryptoCapabilities.hardware] honestly [HardwareSupport.Unavailable] there.
  */
-private val appleProvider: HardwareKeyProvider? by lazy {
+private val appleResolution: ProtectedKeyResolution by lazy {
     if (bcks_secure_enclave_available() == 0) {
-        null
+        // CryptoKit reports no Enclave on this hardware (or the simulator).
+        ProtectedKeyResolution.Refused(ProtectedKeyBackend.AppleSecureEnclave, CapabilityFinding.Enclave.NotPresent)
     } else {
         val usable =
             try {
@@ -469,11 +470,21 @@ private val appleProvider: HardwareKeyProvider? by lazy {
             } catch (_: Throwable) {
                 false
             }
-        if (usable) SecureEnclaveHardwareKeyProvider() else null
+        if (usable) {
+            ProtectedKeyResolution.Available(ProtectedKeyBackend.AppleSecureEnclave, SecureEnclaveHardwareKeyProvider())
+        } else {
+            // Present but the generate-and-discard probe failed — typically an unentitled binary
+            // (the macOS CLI test runner).
+            ProtectedKeyResolution.Refused(ProtectedKeyBackend.AppleSecureEnclave, CapabilityFinding.Enclave.ProbeFailed)
+        }
     }
 }
 
-internal actual fun platformProtectedKeyProvider(): ProtectedKeyProvider? = appleProvider
+private val appleProvider: HardwareKeyProvider? by lazy {
+    (appleResolution as? ProtectedKeyResolution.Available)?.provider as? HardwareKeyProvider
+}
+
+internal actual fun platformProtectedKeyResolution(): ProtectedKeyResolution = appleResolution
 
 /**
  * The Secure Enclave provider narrowed to its concrete type, or `null` where the Enclave is

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.apple.kt
@@ -478,7 +478,10 @@ private val appleResolution: ProtectedKeyResolution by lazy {
         } else {
             // Present but the generate-and-discard probe failed — typically an unentitled binary
             // (the macOS CLI test runner).
-            ProtectedKeyResolution.Refused(ProtectedKeyBackend.AppleSecureEnclave, CapabilityFinding.Enclave.ProbeFailed)
+            ProtectedKeyResolution.Refused(
+                ProtectedKeyBackend.AppleSecureEnclave,
+                CapabilityFinding.Enclave.ProbeFailed,
+            )
         }
     }
 }

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.apple.kt
@@ -461,7 +461,10 @@ private fun enclaveSignP256Into(
 private val appleResolution: ProtectedKeyResolution by lazy {
     if (bcks_secure_enclave_available() == 0) {
         // CryptoKit reports no Enclave on this hardware (or the simulator).
-        ProtectedKeyResolution.Refused(ProtectedKeyBackend.AppleSecureEnclave, CapabilityFinding.Enclave.NotPresent)
+        ProtectedKeyResolution.Refused(
+            ProtectedKeyBackend.AppleSecureEnclave,
+            CapabilityFinding.Enclave.NotPresent,
+        )
     } else {
         val usable =
             try {

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/KeyProvider.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/KeyProvider.kt
@@ -75,12 +75,14 @@ sealed interface ProtectedKeySupport {
 }
 
 /**
- * The platform's strongest non-exportable key provider, or `null` when this platform wires none.
- * `internal` + `expect`/`actual` so it stays out of the public ABI while the public accessors
- * ([CryptoCapabilities.protectedKeys], [CryptoCapabilities.hardware]) keep their frozen signatures.
- * This one internal seam replaces the 6.0 `platformHardwareKeyProvider()`.
+ * The platform's strongest non-exportable key provider, or `null` when none is usable. Derived from
+ * the typed [platformProtectedKeyResolution] seam — the `null` here is a *derivation* for the frozen
+ * accessors ([CryptoCapabilities.protectedKeys], [CryptoCapabilities.hardware]), not a state of its
+ * own: the distinction between "no backend wired" and "wired but refused (and why)" lives in
+ * [ProtectedKeyResolution], never overloaded onto this nullable.
  */
-internal expect fun platformProtectedKeyProvider(): ProtectedKeyProvider?
+internal fun platformProtectedKeyProvider(): ProtectedKeyProvider? =
+    (platformProtectedKeyResolution() as? ProtectedKeyResolution.Available)?.provider
 
 /**
  * The non-exportable key capability on this platform: [ProtectedKeySupport.Available] where either a

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/ProtectedKeyResolution.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/ProtectedKeyResolution.kt
@@ -1,0 +1,214 @@
+package com.ditchoom.buffer.crypto
+
+import kotlin.jvm.JvmInline
+
+/*
+ * Typed backend resolution — the "why", not just the "whether".
+ *
+ * The frozen witnesses ([CryptoCapabilities.protectedKeys] / [CryptoCapabilities.hardware]) answer
+ * *whether* a non-exportable backend is usable; they deliberately collapse every failure to
+ * [ProtectedKeySupport.Unavailable]. That is the right shape for routing — fail closed, no detail a
+ * consumer could mis-branch on — but it conflates three genuinely different facts: "this platform
+ * wires no backend at all", "a backend is wired but refused at runtime (and here is the typed
+ * reason)", and "available". [ProtectedKeyResolution] reifies those three states so nothing is
+ * overloaded onto `null` and nothing is a string a consumer would have to parse:
+ *
+ *  - the backend identity is a closed [ProtectedKeyBackend] sealed set (exhaustive `when`, the
+ *    compiler flags every consumer when a backend is added — never a name to compare);
+ *  - a refusal carries a [CapabilityFinding], a per-backend sealed hierarchy whose variants are the
+ *    operationally distinct failures (install the module vs. configure the PIN vs. the token lacks
+ *    the mechanism);
+ *  - where a foreign error code is genuinely open-ended (PKCS#11 `CKR_*`, which includes a
+ *    vendor-defined range), it rides as a typed value ([Ckr]) classified into the small branchable
+ *    [CkrClass] set with an explicit [CkrClass.Unrecognized] tail — openness is reified in the type,
+ *    never as a nullable field or free text;
+ *  - "no code was surfaced at all" is its own variant (`*Opaque`), not a `null` code.
+ *
+ * Human-readable rendering is `toString()` of the sealed values — diagnostics/telemetry only. The
+ * resolution is for *reporting*; **routing decisions should stay on the witnesses and custody
+ * tiers**, which cannot over-promise. Findings never carry secrets (no PINs, no key material).
+ */
+
+/**
+ * The closed set of non-exportable key backends this library ships. A `when` over it is exhaustive;
+ * adding a backend is a source-visible event at every consumer site, not a new magic string.
+ */
+sealed interface ProtectedKeyBackend {
+    /** The Android Keystore (StrongBox / TEE). */
+    data object AndroidKeystore : ProtectedKeyBackend
+
+    /** The Apple Secure Enclave (CryptoKit, entitled processes on Apple silicon / A-series). */
+    data object AppleSecureEnclave : ProtectedKeyBackend
+
+    /** WebCrypto `extractable:false` software keys (browser / Node / WASM engines). */
+    data object WebCrypto : ProtectedKeyBackend
+
+    /** A TPM 2.0 reached through the `tpm2-pkcs11` module on the desktop JVM. */
+    data object Tpm2Pkcs11 : ProtectedKeyBackend
+}
+
+/**
+ * A raw PKCS#11 return code (`CKR_*`) as a typed value — never a bare integer in the API, never a
+ * message to parse. The CKR space is open by spec (a `CKR_VENDOR_DEFINED` range exists and real
+ * tokens use it), so this is deliberately **not** a sealed enumeration of every code: [classify]
+ * yields the small set of outcomes a consumer can act on, with the open tail reified as
+ * [CkrClass.VendorDefined] / [CkrClass.Unrecognized].
+ */
+@JvmInline
+value class Ckr(
+    val raw: ULong,
+) {
+    /** The semantically distinct outcome class of this code. */
+    fun classify(): CkrClass =
+        when {
+            raw == CKR_TOKEN_NOT_PRESENT -> CkrClass.TokenNotPresent
+            raw == CKR_PIN_INCORRECT -> CkrClass.PinIncorrect
+            raw == CKR_PIN_LOCKED -> CkrClass.PinLocked
+            raw == CKR_MECHANISM_INVALID -> CkrClass.MechanismInvalid
+            raw == CKR_DEVICE_ERROR -> CkrClass.DeviceError
+            raw >= CKR_VENDOR_DEFINED -> CkrClass.VendorDefined(this)
+            else -> CkrClass.Unrecognized(this)
+        }
+
+    private companion object {
+        const val CKR_MECHANISM_INVALID: ULong = 0x70u
+        const val CKR_PIN_INCORRECT: ULong = 0xA0u
+        const val CKR_PIN_LOCKED: ULong = 0xA4u
+        const val CKR_DEVICE_ERROR: ULong = 0x30u
+        const val CKR_TOKEN_NOT_PRESENT: ULong = 0xE0u
+        const val CKR_VENDOR_DEFINED: ULong = 0x80000000u
+    }
+}
+
+/**
+ * The branchable classification of a [Ckr]. Small on purpose: these are the outcomes with distinct
+ * *remediations* (fix the PIN config, initialize the token, accept that the token lacks the
+ * mechanism). Everything else lands in the typed open tail, which still forces a consumer's `when`
+ * to handle the unknown — by the compiler, not by convention.
+ */
+sealed interface CkrClass {
+    /** No token in the slot ([Ckr] `CKR_TOKEN_NOT_PRESENT`) — the token was never initialized. */
+    data object TokenNotPresent : CkrClass
+
+    /** The configured user PIN is wrong. Fix configuration; never retry in a loop (see [PinLocked]). */
+    data object PinIncorrect : CkrClass
+
+    /** The token has locked the PIN after repeated failures; operator intervention required. */
+    data object PinLocked : CkrClass
+
+    /** The token does not implement the requested mechanism (e.g. no `CKM_ECDH1_DERIVE`). */
+    data object MechanismInvalid : CkrClass
+
+    /** The device reported a hardware-level error. */
+    data object DeviceError : CkrClass
+
+    /** A code in the PKCS#11 vendor-defined range; [ckr] carries the raw value. */
+    data class VendorDefined(
+        val ckr: Ckr,
+    ) : CkrClass
+
+    /** A standard-range code outside the classified set; [ckr] carries the raw value. */
+    data class Unrecognized(
+        val ckr: Ckr,
+    ) : CkrClass
+}
+
+/**
+ * Why a wired backend refused at runtime — per-backend sealed hierarchies, so each backend's failure
+ * vocabulary stays quarantined to its branch (PKCS#11 codes never leak into the Keystore branch) and
+ * a `when` within a branch is exhaustive over that backend's real failure modes.
+ */
+sealed interface CapabilityFinding {
+    /** [ProtectedKeyBackend.AndroidKeystore] findings. */
+    sealed interface Keystore : CapabilityFinding {
+        /** No `AndroidKeyStore` JCA provider in this runtime (a host-JVM unit-test run, not a device). */
+        data object ProviderMissing : Keystore
+    }
+
+    /** [ProtectedKeyBackend.AppleSecureEnclave] findings. */
+    sealed interface Enclave : CapabilityFinding {
+        /** CryptoKit reports no Secure Enclave on this hardware (or the simulator). */
+        data object NotPresent : Enclave
+
+        /** The Enclave exists but the generate-and-discard probe failed (typically an unentitled binary). */
+        data object ProbeFailed : Enclave
+    }
+
+    /** [ProtectedKeyBackend.WebCrypto] findings. */
+    sealed interface Web : CapabilityFinding {
+        /** `crypto.subtle.generateKey` is absent in this engine (insecure context / bare runtime). */
+        data object SubtleCryptoUnavailable : Web
+    }
+
+    /** [ProtectedKeyBackend.Tpm2Pkcs11] findings. */
+    sealed interface Tpm2 : CapabilityFinding {
+        /** The runtime predates `Provider.configure` (JVM 9+); the PKCS#11 bridge cannot be built. */
+        data object RuntimeUnsupported : Tpm2
+
+        /** No `tpm2-pkcs11` module was found (configured path or the well-known locations). */
+        data object ModuleNotFound : Tpm2
+
+        /** A module exists but no user PIN is configured, so the token cannot be logged into. */
+        data object AuthNotConfigured : Tpm2
+
+        /** Configuring/logging into the token failed with a PKCS#11 code, classified. */
+        data class TokenRejected(
+            val ckr: CkrClass,
+        ) : Tpm2
+
+        /** Configuring/logging into the token failed and no PKCS#11 code was surfaced. */
+        data object TokenRejectedOpaque : Tpm2
+
+        /** The end-to-end probe op for [alg] failed with a PKCS#11 code, classified. */
+        data class ProbeOpFailed(
+            val alg: ProtectedKeyAlgorithm,
+            val ckr: CkrClass,
+        ) : Tpm2
+
+        /** The end-to-end probe op for [alg] failed and no PKCS#11 code was surfaced. */
+        data class ProbeOpFailedOpaque(
+            val alg: ProtectedKeyAlgorithm,
+        ) : Tpm2
+    }
+}
+
+/**
+ * The full, typed answer to "what non-exportable key backend does this platform have, and if none
+ * is usable, why". Three states that must never be conflated (and previously were, onto `null`):
+ * [Available], [Refused] (wired, probed, refused — with the typed reason), and [None] (this library
+ * build wires no backend for the platform — a fact about the build, not the device).
+ *
+ * Reached via [CryptoCapabilities.protectedKeyResolution]. The frozen witnesses derive from it:
+ * [Available] ⇒ [ProtectedKeySupport.Available]; everything else ⇒ [ProtectedKeySupport.Unavailable].
+ */
+sealed interface ProtectedKeyResolution {
+    /** [backend] probed end-to-end on this device and [provider] is usable. */
+    data class Available(
+        val backend: ProtectedKeyBackend,
+        val provider: ProtectedKeyProvider,
+    ) : ProtectedKeyResolution
+
+    /** [backend] is wired for this platform but its runtime probe refused, for the typed [finding]. */
+    data class Refused(
+        val backend: ProtectedKeyBackend,
+        val finding: CapabilityFinding,
+    ) : ProtectedKeyResolution
+
+    /** This platform wires no non-exportable backend in this library version. */
+    data object None : ProtectedKeyResolution
+}
+
+/**
+ * The per-platform resolution seam. Internal so the platform actuals stay out of the public ABI;
+ * the public surface is [CryptoCapabilities.protectedKeyResolution] plus the frozen witnesses.
+ * Actuals must cache (the probes are expensive and the answer is stable for the process lifetime).
+ */
+internal expect fun platformProtectedKeyResolution(): ProtectedKeyResolution
+
+/**
+ * The typed backend resolution for this platform — diagnostics, telemetry, and operator-facing
+ * "why is hardware unavailable" surfaces. For *routing*, prefer the witnesses
+ * ([CryptoCapabilities.protectedKeys], [CryptoCapabilities.hardware]) and custody assertions
+ * ([KeyProvider.requireTier]): they fail closed and cannot over-promise.
+ */
+val CryptoCapabilities.protectedKeyResolution: ProtectedKeyResolution get() = platformProtectedKeyResolution()

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/ProtectedKeyResolutionTest.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/ProtectedKeyResolutionTest.kt
@@ -1,0 +1,71 @@
+package com.ditchoom.buffer.crypto
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Conformance for the typed backend resolution ([CryptoCapabilities.protectedKeyResolution]):
+ * three states that must never be conflated (Available / Refused-with-typed-finding / None), no
+ * `null` anywhere, and strict agreement with the frozen witnesses it derives. Runs on every target —
+ * each platform lands in a different arm, and all arms are compile-time exhaustive.
+ */
+class ProtectedKeyResolutionTest {
+    @Test
+    fun resolutionAndFrozenWitnessesAgree() {
+        when (val resolution = CryptoCapabilities.protectedKeyResolution) {
+            is ProtectedKeyResolution.Available -> {
+                val support = CryptoCapabilities.protectedKeys
+                assertTrue(support is ProtectedKeySupport.Available, "Available resolution must surface in the witness")
+                assertSame(resolution.provider, support.provider, "the witness must expose the resolved provider")
+            }
+            is ProtectedKeyResolution.Refused ->
+                assertEquals(ProtectedKeySupport.Unavailable, CryptoCapabilities.protectedKeys)
+            ProtectedKeyResolution.None ->
+                assertEquals(ProtectedKeySupport.Unavailable, CryptoCapabilities.protectedKeys)
+        }
+    }
+
+    @Test
+    fun refusalFindingStaysInItsBackendBranch() {
+        val resolution = CryptoCapabilities.protectedKeyResolution
+        if (resolution !is ProtectedKeyResolution.Refused) return
+        val matches =
+            when (resolution.backend) {
+                ProtectedKeyBackend.AndroidKeystore -> resolution.finding is CapabilityFinding.Keystore
+                ProtectedKeyBackend.AppleSecureEnclave -> resolution.finding is CapabilityFinding.Enclave
+                ProtectedKeyBackend.WebCrypto -> resolution.finding is CapabilityFinding.Web
+                ProtectedKeyBackend.Tpm2Pkcs11 -> resolution.finding is CapabilityFinding.Tpm2
+            }
+        assertTrue(matches, "a refusal's finding must come from its own backend's branch, got ${resolution.finding}")
+    }
+
+    @Test
+    fun hardwareWitnessOnlySurfacesHardwareBackends() {
+        // The secure-element refinement: hardware Available implies an Available resolution whose
+        // provider IS the hardware provider; a software non-exportable backend (WebCrypto) must not
+        // surface there.
+        when (val hw = CryptoCapabilities.hardware) {
+            is HardwareSupport.Unavailable -> Unit
+            is HardwareSupport.Available -> {
+                val resolution = CryptoCapabilities.protectedKeyResolution
+                assertTrue(resolution is ProtectedKeyResolution.Available)
+                assertSame(resolution.provider, hw.provider)
+            }
+        }
+    }
+
+    @Test
+    fun ckrClassificationIsTypedWithAnExplicitOpenTail() {
+        assertEquals(CkrClass.PinIncorrect, Ckr(0xA0u).classify())
+        assertEquals(CkrClass.PinLocked, Ckr(0xA4u).classify())
+        assertEquals(CkrClass.TokenNotPresent, Ckr(0xE0u).classify())
+        assertEquals(CkrClass.MechanismInvalid, Ckr(0x70u).classify())
+        assertEquals(CkrClass.DeviceError, Ckr(0x30u).classify())
+        // The open ranges are reified, not nullable and not collapsed: vendor codes and
+        // standard-range codes outside the classified set each carry their raw value.
+        assertEquals(CkrClass.VendorDefined(Ckr(0x80000001u)), Ckr(0x80000001u).classify())
+        assertEquals(CkrClass.Unrecognized(Ckr(0x191u)), Ckr(0x191u).classify())
+    }
+}

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.jsAndWasmJs.kt
@@ -193,12 +193,16 @@ internal fun buildWebCryptoKeyAgreementPair(
 
 /**
  * Browser/Node and WASM expose non-exportable WebCrypto software keys but no dedicated secure element,
- * so [platformProtectedKeyProvider] returns the [WebCryptoProtectedKeyProvider] (a
- * [ProtectedKeyProvider], **not** a [HardwareKeyProvider]) only when `subtle.generateKey` is present;
- * [CryptoCapabilities.hardware] stays [HardwareSupport.Unavailable].
+ * so the resolution offers [WebCryptoProtectedKeyProvider] (a [ProtectedKeyProvider], **not** a
+ * [HardwareKeyProvider]) only when `subtle.generateKey` is present; [CryptoCapabilities.hardware]
+ * stays [HardwareSupport.Unavailable] either way.
  */
-internal actual fun platformProtectedKeyProvider(): ProtectedKeyProvider? =
-    if (subtleGenerateKeyAvailable) WebCryptoProtectedKeyProvider else null
+internal actual fun platformProtectedKeyResolution(): ProtectedKeyResolution =
+    if (subtleGenerateKeyAvailable) {
+        ProtectedKeyResolution.Available(ProtectedKeyBackend.WebCrypto, WebCryptoProtectedKeyProvider)
+    } else {
+        ProtectedKeyResolution.Refused(ProtectedKeyBackend.WebCrypto, CapabilityFinding.Web.SubtleCryptoUnavailable)
+    }
 
 // =============================================================================
 // helpers (shared js/wasmJs)

--- a/buffer-crypto/src/jvmMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.jvm.kt
+++ b/buffer-crypto/src/jvmMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.jvm.kt
@@ -168,7 +168,7 @@ private val jvmResolution: ProtectedKeyResolution by lazy { resolveTpm2Pkcs11() 
 
 internal actual fun platformProtectedKeyResolution(): ProtectedKeyResolution = jvmResolution
 
-@Suppress("SwallowedException", "TooGenericExceptionCaught", "ReturnCount")
+@Suppress("SwallowedException", "TooGenericExceptionCaught", "ReturnCount", "CyclomaticComplexMethod")
 private fun resolveTpm2Pkcs11(): ProtectedKeyResolution {
     val explicitModule = configured(MODULE_PROP, MODULE_ENV)
     val os = System.getProperty("os.name")?.lowercase() ?: ""
@@ -254,6 +254,7 @@ private fun probeFailure(
  * and converts that one JCA artifact into the typed value at the boundary - the string never leaves
  * this function, and consumers only ever see [Ckr]/[CkrClass].
  */
+@Suppress("ReturnCount")
 private fun ckrOf(failure: Throwable): Ckr? {
     var cur: Throwable? = failure
     while (cur != null) {

--- a/buffer-crypto/src/jvmMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.jvm.kt
+++ b/buffer-crypto/src/jvmMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.jvm.kt
@@ -50,6 +50,15 @@ import java.security.spec.X509EncodedKeySpec
  * reliable way to distinguish a discrete TPM from a firmware TPM, so the claim stays at
  * "hardware-isolated, non-exportable" - the same conservative posture as a TEE-only Android device.
  *
+ * **Custody trust boundary (operator-delegated):** unlike the Android/Apple backends, where the OS
+ * pins which element backs a key, the hardware-custody claim here is exactly as trustworthy as the
+ * *configured module*. Pointing the module path at a software PKCS#11 implementation (e.g. SoftHSM)
+ * yields software keys labeled [KeyCustody.NonExportable.Hardware] - the JCA bridge cannot read
+ * `CK_TOKEN_INFO` to verify the token is a TPM. Deployments that rely on the custody tier MUST
+ * treat the module path/PIN configuration as security-sensitive, same-integrity-domain state.
+ * The PIN additionally arrives as an immutable system-property/environment `String`; only the
+ * `char[]` copy handed to the login is wiped - an inherent limit of env-based configuration.
+ *
  * `ByteArray` appears at the unavoidable JCA seam (X509EncodedKeySpec / generateSecret / BigInteger),
  * never as a library data structure; secret-bearing arrays are wiped after use.
  */
@@ -59,7 +68,12 @@ internal class Tpm2Pkcs11HardwareKeyProvider(
     /** PKCS#11 cannot confirm a discrete element, so this never over-claims. See the file KDoc. */
     override val dedicatedSecureElement: Boolean get() = false
 
-    /** Serializes token ops (TPM round-trips are slow and strictly ordered) off the calling thread. */
+    /**
+     * Serializes suspend token ops (TPM round-trips are slow) off the calling thread. The lazy
+     * [agreementSupported] probe is the one exception: [eligible] is non-suspend so the probe cannot
+     * take this Mutex and may overlap an in-flight op - safe because SunPKCS11 pools sessions and
+     * the resource manager (tpm2-abrmd / kernel `/dev/tpmrm0`) serializes at the TPM boundary.
+     */
     private val tokenLock = Mutex()
 
     /**

--- a/buffer-crypto/src/jvmMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.jvm.kt
+++ b/buffer-crypto/src/jvmMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.jvm.kt
@@ -1,8 +1,315 @@
+@file:Suppress("MatchingDeclarationName") // MPP platform-suffixed actual file
+
 package com.ditchoom.buffer.crypto
 
-/**
- * The desktop JVM wires no secure-element backend: the host has no Android Keystore and no Secure
- * Enclave reachable from this runtime, so [CryptoCapabilities.hardware] stays
- * [HardwareSupport.Unavailable]. (The Android target supplies its own actual.)
+import com.ditchoom.buffer.PlatformBuffer
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import java.security.GeneralSecurityException
+import java.security.KeyFactory
+import java.security.Provider
+import java.security.ProviderException
+import java.security.Security
+import java.security.Signature
+import java.security.interfaces.ECPublicKey
+import java.security.spec.X509EncodedKeySpec
+
+/*
+ * Desktop-JVM non-exportable key backend: a TPM 2.0 reached through the standard `tpm2-pkcs11`
+ * module via the JCA `SunPKCS11` provider.
+ *
+ * Keys are *generated inside* the TPM-backed PKCS#11 token and never leave it: the gated closures
+ * drive a JCA `Signature` / `KeyAgreement` over the token key handle, so the private scalar is never
+ * in process memory. This is the same shape as the Android Keystore backend - advisory-gated ops,
+ * serialized off the calling thread, failures normalized to [HardwareKeyException] - with PKCS#11 in
+ * place of the keystore.
+ *
+ * **Resolution is probed end-to-end, never inferred** (see [platformProtectedKeyResolution]): the
+ * module must exist, the token must accept a login, and a full generate -> sign -> software-verify
+ * round-trip must succeed before [ProtectedKeyResolution.Available] is reported. Every refusal is a
+ * typed [CapabilityFinding.Tpm2] - module missing vs. PIN unconfigured vs. token rejection are
+ * distinct states, not one `null`.
+ *
+ * **Configuration** (system property, falling back to the environment variable):
+ *  - `buffer.crypto.tpm2.pkcs11.module` / `BUFFER_CRYPTO_TPM2_PKCS11_MODULE` - module path;
+ *    otherwise the well-known distro locations are tried.
+ *  - `buffer.crypto.tpm2.pkcs11.pin` / `BUFFER_CRYPTO_TPM2_PKCS11_PIN` - the token user PIN
+ *    (required; without it the resolution is [CapabilityFinding.Tpm2.AuthNotConfigured]).
+ *  - `buffer.crypto.tpm2.pkcs11.slotIndex` / `BUFFER_CRYPTO_TPM2_PKCS11_SLOT_INDEX` - the
+ *    `slotListIndex` handed to SunPKCS11 (default 0, the first initialized token).
+ *
+ * **Eligibility mirrors what the stack actually backs.** ECDSA P-256 is the proven baseline (it is
+ * the resolution probe). ECDH P-256 is probed lazily end-to-end - as of tpm2-pkcs11 1.9 the module
+ * does not advertise `CKM_ECDH1_DERIVE`, so the probe honestly fails and agreement routes to the
+ * software floor; when the module gains the mechanism, eligibility lights up with no library change.
+ * AES-GCM is not offered (the SunPKCS11 + tpm2-pkcs11 combination does not usably back it).
+ *
+ * **Custody honesty:** the provider reports `dedicatedSecureElement = false`. PKCS#11 exposes no
+ * reliable way to distinguish a discrete TPM from a firmware TPM, so the claim stays at
+ * "hardware-isolated, non-exportable" - the same conservative posture as a TEE-only Android device.
+ *
+ * `ByteArray` appears at the unavoidable JCA seam (X509EncodedKeySpec / generateSecret / BigInteger),
+ * never as a library data structure; secret-bearing arrays are wiped after use.
  */
-internal actual fun platformProtectedKeyProvider(): ProtectedKeyProvider? = null
+internal class Tpm2Pkcs11HardwareKeyProvider(
+    private val p11: Provider,
+) : HardwareKeyProvider {
+    /** PKCS#11 cannot confirm a discrete element, so this never over-claims. See the file KDoc. */
+    override val dedicatedSecureElement: Boolean get() = false
+
+    /** Serializes token ops (TPM round-trips are slow and strictly ordered) off the calling thread. */
+    private val tokenLock = Mutex()
+
+    /**
+     * `true` once a full token ECDH against a software peer matches the software-side derivation.
+     * Lazily probed: tpm2-pkcs11 1.9 lacks `CKM_ECDH1_DERIVE` (SunPKCS11 then registers no `ECDH`
+     * service, and the probe fails on `NoSuchAlgorithmException`), but a module that gains the
+     * mechanism passes with no library change.
+     */
+    private val agreementSupported: Boolean by lazy { probeAgreement(p11) }
+
+    override fun eligible(alg: ProtectedKeyAlgorithm): Boolean =
+        when (alg) {
+            ProtectedKeyAlgorithm.EcdsaP256 -> true
+            ProtectedKeyAlgorithm.EcdhP256 -> agreementSupported
+            else -> false
+        }
+
+    override suspend fun generateSigning(
+        scheme: SignatureScheme,
+        spec: ProtectedKeySpec,
+    ): SigningKey {
+        if (!eligible(scheme.toProtectedKeyAlgorithm())) throw HardwareKeyException.AlgorithmNotEligible()
+        val keyPair = tokenOp { generateP256KeyPair(p11) }
+        val verifyKey = VerifyKey.ecdsaP256(uncompressedP256Point(keyPair.public as ECPublicKey))
+        val gate = spec.authorization
+        return ProtectedSigningKey(
+            scheme = SignatureScheme.EcdsaP256,
+            custody = custody,
+            gatedSign = { message, factory ->
+                if (!gate.authorize()) throw AuthorizationFailed()
+                tokenOp {
+                    val signer = Signature.getInstance(ECDSA_SHA256, p11).apply { initSign(keyPair.private) }
+                    signer.update(message.slice().remainingBytes())
+                    val der = signer.sign()
+                    val out: PlatformBuffer = factory.allocate(der.size)
+                    out.writeBytes(der)
+                    out.resetForRead()
+                    out
+                }
+            },
+            verifyKey = verifyKey,
+            // Session objects: the token drops the key with the process; nothing to delete here.
+            onClose = {},
+        )
+    }
+
+    override suspend fun generateAesGcm(spec: ProtectedKeySpec): AesGcmKey =
+        // The SunPKCS11 + tpm2-pkcs11 combination does not usably back AES-GCM; see eligible().
+        throw HardwareKeyException.AlgorithmNotEligible()
+
+    override suspend fun generateKeyAgreement(
+        curve: KeyAgreementCurve,
+        spec: ProtectedKeySpec,
+    ): KeyAgreementKeyPair {
+        // Only ECDH P-256, and only where the end-to-end probe holds (see agreementSupported).
+        if (curve != KeyAgreementCurve.P256 || !eligible(ProtectedKeyAlgorithm.EcdhP256)) {
+            throw HardwareKeyException.AlgorithmNotEligible()
+        }
+        val keyPair = tokenOp { generateP256KeyPair(p11) }
+        val publicKey = KeyAgreementPublicKey.of(curve, uncompressedP256Point(keyPair.public as ECPublicKey))
+        val gate = spec.authorization
+        val privateKey =
+            ProtectedKeyAgreementPrivateKey(
+                curve = curve,
+                custody = custody,
+                gatedDh = { peer ->
+                    if (!gate.authorize()) throw AuthorizationFailed()
+                    require(peer.curve == curve) { "private/public key curve mismatch" }
+                    // Peer-point conversion happens outside the token lock; a malformed or
+                    // off-curve point is rejected before the TPM is ever touched.
+                    val jcaPeer = p256PublicKeyFromSec1(peer.encoded)
+                    tokenOp { agreeP256OnToken(p11, keyPair.private, jcaPeer) }
+                },
+                onClose = {},
+            )
+        return keyAgreementKeyPairOf(curve, privateKey, publicKey)
+    }
+
+    /**
+     * Runs a token [block] serialized and on [Dispatchers.IO] (PKCS#11 calls block), normalizing any
+     * provider-originated failure to a [HardwareKeyException]. A [CryptoException] thrown inside
+     * (e.g. [AuthorizationFailed], [InvalidPublicKey]) passes through untouched.
+     */
+    @Suppress("SwallowedException")
+    private suspend fun <T> tokenOp(block: () -> T): T =
+        tokenLock.withLock {
+            withContext(Dispatchers.IO) {
+                try {
+                    block()
+                } catch (e: CryptoException) {
+                    throw e
+                } catch (e: GeneralSecurityException) {
+                    throw HardwareKeyException.UnsupportedHardwareKey()
+                } catch (e: ProviderException) {
+                    throw HardwareKeyException.UnsupportedHardwareKey()
+                }
+            }
+        }
+}
+
+// =============================================================================
+// Resolution - every step's refusal is a distinct typed finding, never a bare null
+// =============================================================================
+
+private val jvmResolution: ProtectedKeyResolution by lazy { resolveTpm2Pkcs11() }
+
+internal actual fun platformProtectedKeyResolution(): ProtectedKeyResolution = jvmResolution
+
+@Suppress("SwallowedException", "TooGenericExceptionCaught", "ReturnCount")
+private fun resolveTpm2Pkcs11(): ProtectedKeyResolution {
+    val explicitModule = configured(MODULE_PROP, MODULE_ENV)
+    val os = System.getProperty("os.name")?.lowercase() ?: ""
+    // Without an explicit module, only Linux is worth probing (the module is a Linux stack); a
+    // macOS/Windows JVM wires no backend in this version - None, a build fact, not a device refusal.
+    if (explicitModule == null && !os.contains("linux")) return ProtectedKeyResolution.None
+
+    val modulePath =
+        explicitModule ?: WELL_KNOWN_MODULE_PATHS.firstOrNull { java.io.File(it).exists() }
+            ?: return refused(CapabilityFinding.Tpm2.ModuleNotFound)
+    if (!java.io.File(modulePath).exists()) return refused(CapabilityFinding.Tpm2.ModuleNotFound)
+
+    val pin = configured(PIN_PROP, PIN_ENV) ?: return refused(CapabilityFinding.Tpm2.AuthNotConfigured)
+    val slotIndex = configured(SLOT_PROP, SLOT_ENV)?.toIntOrNull() ?: 0
+
+    // Configure SunPKCS11 + login. Provider.configure is JVM 9+; a JVM 8 runtime is a typed refusal.
+    val p11 =
+        try {
+            val base =
+                Security.getProvider(SUN_PKCS11)
+                    ?: return refused(CapabilityFinding.Tpm2.TokenRejectedOpaque)
+            val conf = "--name=$PROVIDER_NAME\nlibrary=$modulePath\nslotListIndex=$slotIndex\n"
+            val configured = base.configure(conf)
+            val keyStore = java.security.KeyStore.getInstance(PKCS11_KEYSTORE, configured)
+            val pinChars = pin.toCharArray()
+            try {
+                keyStore.load(null, pinChars)
+            } finally {
+                pinChars.fill(' ')
+            }
+            configured
+        } catch (e: NoSuchMethodError) {
+            return refused(CapabilityFinding.Tpm2.RuntimeUnsupported)
+        } catch (e: Throwable) {
+            return refused(tokenRejection(e))
+        }
+
+    // End-to-end probe: generate -> sign on token -> verify in software. Only a full round-trip
+    // upgrades the resolution to Available; anything less would over-promise.
+    return try {
+        val keyPair = generateP256KeyPair(p11)
+        val message = PROBE_MESSAGE.encodeToByteArray()
+        val signer = Signature.getInstance(ECDSA_SHA256, p11).apply { initSign(keyPair.private) }
+        signer.update(message)
+        val der = signer.sign()
+        val softPub =
+            KeyFactory.getInstance(EC).generatePublic(X509EncodedKeySpec(keyPair.public.encoded))
+        val verifier = Signature.getInstance(ECDSA_SHA256).apply { initVerify(softPub) }
+        verifier.update(message)
+        if (verifier.verify(der)) {
+            ProtectedKeyResolution.Available(ProtectedKeyBackend.Tpm2Pkcs11, Tpm2Pkcs11HardwareKeyProvider(p11))
+        } else {
+            refused(probeFailure(ProtectedKeyAlgorithm.EcdsaP256, cause = null))
+        }
+    } catch (e: Throwable) {
+        refused(probeFailure(ProtectedKeyAlgorithm.EcdsaP256, cause = e))
+    }
+}
+
+private fun refused(finding: CapabilityFinding.Tpm2): ProtectedKeyResolution =
+    ProtectedKeyResolution.Refused(ProtectedKeyBackend.Tpm2Pkcs11, finding)
+
+/** A configure/login failure as a typed finding - classified when a CKR is recoverable, opaque otherwise. */
+private fun tokenRejection(failure: Throwable): CapabilityFinding.Tpm2 =
+    ckrOf(failure)?.let { CapabilityFinding.Tpm2.TokenRejected(it.classify()) }
+        ?: CapabilityFinding.Tpm2.TokenRejectedOpaque
+
+/** A probe-op failure as a typed finding - classified when a CKR is recoverable, opaque otherwise. */
+private fun probeFailure(
+    alg: ProtectedKeyAlgorithm,
+    cause: Throwable?,
+): CapabilityFinding.Tpm2 =
+    cause?.let { ckrOf(it) }?.let { CapabilityFinding.Tpm2.ProbeOpFailed(alg, it.classify()) }
+        ?: CapabilityFinding.Tpm2.ProbeOpFailedOpaque(alg)
+
+/**
+ * Recovers the PKCS#11 `CKR_*` code from a SunPKCS11 failure as a typed [Ckr], or `null` when none
+ * was surfaced (the `*Opaque` findings make that absence a state, not a nullable field downstream).
+ *
+ * Bridge note: `PKCS11Exception.getErrorCode()` lives in the non-exported `sun.security.pkcs11`
+ * package, unreachable under JPMS without `--add-opens`. The exception's *message* carries the code
+ * (`"CKR_PIN_INCORRECT"` for named codes, `"0x..."` for unnamed ones), so this walks the cause chain
+ * and converts that one JCA artifact into the typed value at the boundary - the string never leaves
+ * this function, and consumers only ever see [Ckr]/[CkrClass].
+ */
+private fun ckrOf(failure: Throwable): Ckr? {
+    var cur: Throwable? = failure
+    while (cur != null) {
+        if (cur.javaClass.name == PKCS11_EXCEPTION_CLASS) {
+            val message = cur.message ?: return null
+            CKR_NAME_TO_CODE[message.trim()]?.let { return Ckr(it) }
+            val hex = HEX_CODE_REGEX.find(message)?.value ?: return null
+            return hex.removePrefix("0x").toULongOrNull(HEX_RADIX)?.let { Ckr(it) }
+        }
+        cur = cur.cause
+    }
+    return null
+}
+
+/** System property first, then the environment; blank answers count as absent. */
+private fun configured(
+    prop: String,
+    env: String,
+): String? = System.getProperty(prop)?.takeIf { it.isNotBlank() } ?: System.getenv(env)?.takeIf { it.isNotBlank() }
+
+private const val MODULE_PROP = "buffer.crypto.tpm2.pkcs11.module"
+private const val MODULE_ENV = "BUFFER_CRYPTO_TPM2_PKCS11_MODULE"
+private const val PIN_PROP = "buffer.crypto.tpm2.pkcs11.pin"
+private const val PIN_ENV = "BUFFER_CRYPTO_TPM2_PKCS11_PIN"
+private const val SLOT_PROP = "buffer.crypto.tpm2.pkcs11.slotIndex"
+private const val SLOT_ENV = "BUFFER_CRYPTO_TPM2_PKCS11_SLOT_INDEX"
+
+private val WELL_KNOWN_MODULE_PATHS =
+    listOf(
+        "/usr/lib/x86_64-linux-gnu/libtpm2_pkcs11.so.1",
+        "/usr/lib/x86_64-linux-gnu/libtpm2_pkcs11.so",
+        "/usr/lib/aarch64-linux-gnu/libtpm2_pkcs11.so.1",
+        "/usr/lib64/libtpm2_pkcs11.so.1",
+        "/usr/lib/libtpm2_pkcs11.so.1",
+        "/usr/local/lib/libtpm2_pkcs11.so.1",
+    )
+
+private const val SUN_PKCS11 = "SunPKCS11"
+private const val PKCS11_KEYSTORE = "PKCS11"
+private const val PROVIDER_NAME = "buffer-crypto-tpm2"
+private const val PKCS11_EXCEPTION_CLASS = "sun.security.pkcs11.wrapper.PKCS11Exception"
+private const val ECDSA_SHA256 = "SHA256withECDSA"
+private const val EC = "EC"
+private const val PROBE_MESSAGE = "buffer-crypto tpm2-pkcs11 resolution probe"
+private const val HEX_RADIX = 16
+private val HEX_CODE_REGEX = Regex("0x[0-9a-fA-F]+")
+
+/** The named `CKR_*` codes SunPKCS11 prints, mapped back to their numeric values (typed at the boundary). */
+private val CKR_NAME_TO_CODE: Map<String, ULong> =
+    mapOf(
+        "CKR_TOKEN_NOT_PRESENT" to 0xE0u,
+        "CKR_PIN_INCORRECT" to 0xA0u,
+        "CKR_PIN_LOCKED" to 0xA4u,
+        "CKR_MECHANISM_INVALID" to 0x70u,
+        "CKR_DEVICE_ERROR" to 0x30u,
+        "CKR_SLOT_ID_INVALID" to 0x3u,
+        "CKR_GENERAL_ERROR" to 0x5u,
+        "CKR_FUNCTION_FAILED" to 0x6u,
+    )

--- a/buffer-crypto/src/jvmMain/kotlin/com/ditchoom/buffer/crypto/Tpm2Pkcs11Token.jvm.kt
+++ b/buffer-crypto/src/jvmMain/kotlin/com/ditchoom/buffer/crypto/Tpm2Pkcs11Token.jvm.kt
@@ -1,0 +1,166 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import java.math.BigInteger
+import java.security.AlgorithmParameters
+import java.security.GeneralSecurityException
+import java.security.KeyFactory
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.PrivateKey
+import java.security.Provider
+import java.security.PublicKey
+import java.security.interfaces.ECPublicKey
+import java.security.spec.ECGenParameterSpec
+import java.security.spec.ECParameterSpec
+import java.security.spec.ECPoint
+import java.security.spec.ECPublicKeySpec
+import java.security.spec.X509EncodedKeySpec
+import javax.crypto.KeyAgreement
+
+/*
+ * Stateless PKCS#11 token primitives for [Tpm2Pkcs11HardwareKeyProvider] — key generation, the
+ * on-token ECDH, the end-to-end agreement probe, and the SEC1/JCA conversions. Split from
+ * HardwareKeys.jvm.kt, which retains the provider class and the typed resolution pipeline.
+ */
+
+internal fun generateP256KeyPair(p11: Provider): KeyPair =
+    KeyPairGenerator
+        .getInstance(EC_ALGORITHM, p11)
+        .apply { initialize(ECGenParameterSpec(SECP256R1_CURVE)) }
+        .generateKeyPair()
+
+/**
+ * Runs the token ECDH: `DH(privateKey, jcaPeer)` inside the TPM, returning the raw 32-byte shared
+ * secret in a wiped `SecureBuffer` (the common seam applies the KDF / validation above it). A
+ * peer-point rejection — checked or unchecked — maps to the uniform [InvalidPublicKey], never
+ * distinguishable by exception type (oracle avoidance, matching the software JCA glue).
+ */
+@Suppress("SwallowedException", "TooGenericExceptionCaught", "ThrowsCount")
+internal fun agreeP256OnToken(
+    p11: Provider,
+    privateKey: PrivateKey,
+    jcaPeer: PublicKey,
+): PlatformBuffer {
+    val ka = KeyAgreement.getInstance(ECDH_ALGORITHM, p11)
+    ka.init(privateKey)
+    val rawSecretBytes =
+        try {
+            ka.doPhase(jcaPeer, true)
+            ka.generateSecret()
+        } catch (e: GeneralSecurityException) {
+            throw InvalidPublicKey(KeyAgreementCurve.P256)
+        } catch (e: RuntimeException) {
+            throw InvalidPublicKey(KeyAgreementCurve.P256)
+        }
+    if (rawSecretBytes.size != P256_FIELD_BYTES) {
+        rawSecretBytes.fill(0)
+        throw HardwareKeyException.UnsupportedHardwareKey()
+    }
+    val raw = secureScratch.allocate(P256_FIELD_BYTES)
+    raw.writeBytes(rawSecretBytes)
+    rawSecretBytes.fill(0)
+    raw.resetForRead()
+    return raw
+}
+
+/** End-to-end ECDH probe: a token key must agree with a software peer, both directions matching. */
+@Suppress("SwallowedException", "TooGenericExceptionCaught")
+internal fun probeAgreement(p11: Provider): Boolean =
+    try {
+        val tokenPair = generateP256KeyPair(p11)
+        val peer =
+            KeyPairGenerator
+                .getInstance(EC_ALGORITHM)
+                .apply { initialize(ECGenParameterSpec(SECP256R1_CURVE)) }
+                .generateKeyPair()
+
+        val hw = KeyAgreement.getInstance(ECDH_ALGORITHM, p11)
+        hw.init(tokenPair.private)
+        hw.doPhase(peer.public, true)
+        val hwSecret = hw.generateSecret()
+
+        val sw = KeyAgreement.getInstance(ECDH_ALGORITHM)
+        sw.init(peer.private)
+        sw.doPhase(
+            KeyFactory.getInstance(EC_ALGORITHM).generatePublic(X509EncodedKeySpec(tokenPair.public.encoded)),
+            true,
+        )
+        val swSecret = sw.generateSecret()
+
+        val match = hwSecret.contentEquals(swSecret)
+        hwSecret.fill(0)
+        swSecret.fill(0)
+        match
+    } catch (e: Throwable) {
+        // NoSuchAlgorithmException (no CKM_ECDH1_DERIVE on the token) or any op failure: route
+        // agreement to the software floor instead of over-promising hardware custody.
+        false
+    }
+
+/**
+ * Converts a peer's uncompressed SEC1 point (`04 || X || Y`, the pinned [KeyAgreementCurve]
+ * encoding) to a JCA [PublicKey] via the default software provider. Malformed encodings and provider
+ * rejections surface as the uniform [InvalidPublicKey] — same no-oracle contract as the software glue.
+ */
+@Suppress("SwallowedException", "TooGenericExceptionCaught", "ThrowsCount")
+internal fun p256PublicKeyFromSec1(encoded: ReadBuffer): PublicKey {
+    val curve = KeyAgreementCurve.P256
+    val view = encoded.slice()
+    val n = view.remaining()
+    if (n != curve.publicKeyBytes || (view.get(view.position()).toInt() and UBYTE_MASK) != SEC1_UNCOMPRESSED) {
+        throw InvalidPublicKey(curve)
+    }
+    // ByteArray at the unavoidable JCA seam (BigInteger/ECPoint), never a library data structure.
+    val point = ByteArray(n)
+    for (i in 0 until n) point[i] = view.get(view.position() + i)
+    return try {
+        val x = BigInteger(1, point.copyOfRange(1, 1 + P256_FIELD_BYTES))
+        val y = BigInteger(1, point.copyOfRange(1 + P256_FIELD_BYTES, n))
+        val params =
+            AlgorithmParameters
+                .getInstance(EC_ALGORITHM)
+                .apply { init(ECGenParameterSpec(SECP256R1_CURVE)) }
+                .getParameterSpec(ECParameterSpec::class.java)
+        KeyFactory.getInstance(EC_ALGORITHM).generatePublic(ECPublicKeySpec(ECPoint(x, y), params))
+    } catch (e: GeneralSecurityException) {
+        throw InvalidPublicKey(curve)
+    } catch (e: RuntimeException) {
+        throw InvalidPublicKey(curve)
+    }
+}
+
+/** Encodes an EC public key as an uncompressed SEC1 point (`04 || X || Y`), read-ready. */
+internal fun uncompressedP256Point(pub: ECPublicKey): ReadBuffer {
+    val out = ByteArray(1 + 2 * P256_FIELD_BYTES)
+    out[0] = SEC1_UNCOMPRESSED.toByte()
+    fixedBe(pub.w.affineX, P256_FIELD_BYTES).copyInto(out, 1)
+    fixedBe(pub.w.affineY, P256_FIELD_BYTES).copyInto(out, 1 + P256_FIELD_BYTES)
+    return BufferFactory.Default.wrap(out)
+}
+
+/** A nonnegative [BigInteger] as exactly [n] big-endian bytes (left-padded / sign-byte stripped). */
+private fun fixedBe(
+    value: BigInteger,
+    n: Int,
+): ByteArray {
+    val be = value.toByteArray()
+    return when {
+        be.size == n -> be
+        be.size == n + 1 && be[0].toInt() == 0 -> be.copyOfRange(1, be.size)
+        be.size < n -> ByteArray(n - be.size) + be
+        else -> be.copyOfRange(be.size - n, be.size)
+    }
+}
+
+// Distinct names on purpose: same-named private constants ("EC", "secp256r1", field widths) exist in
+// other files of this package, and these must be internal-visible to HardwareKeys.jvm.kt.
+internal const val EC_ALGORITHM = "EC"
+internal const val SECP256R1_CURVE = "secp256r1"
+private const val ECDH_ALGORITHM = "ECDH"
+private const val P256_FIELD_BYTES = 32
+private const val SEC1_UNCOMPRESSED = 0x04
+private const val UBYTE_MASK = 0xFF

--- a/buffer-crypto/src/jvmTest/kotlin/com/ditchoom/buffer/crypto/Tpm2Pkcs11ProviderTest.kt
+++ b/buffer-crypto/src/jvmTest/kotlin/com/ditchoom/buffer/crypto/Tpm2Pkcs11ProviderTest.kt
@@ -1,0 +1,108 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.crypto.CryptoTestVectors.ascii
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * On-token conformance for the tpm2-pkcs11-backed [HardwareKeyProvider] — the desktop-JVM hardware
+ * tier that only runs against a real TPM or the swtpm CI harness.
+ *
+ * Two modes, selected by the `buffer.crypto.require.tpm2` system property (forwarded from the
+ * Gradle `-P` property of the same name):
+ *  - **required** (the swtpm CI job, or a locally configured rig): the resolution MUST be
+ *    [ProtectedKeyResolution.Available] for [ProtectedKeyBackend.Tpm2Pkcs11], and the full contract
+ *    is pinned — sign → verify round-trip, hardware custody, denied-gate, honest ECDH refusal
+ *    (tpm2-pkcs11 1.9 advertises no `CKM_ECDH1_DERIVE`), and software-floor routing.
+ *  - **unconfigured** (a plain dev machine / non-TPM CI leg): the resolution must still be a
+ *    *typed* state that agrees with the frozen witnesses (covered in ProtectedKeyResolutionTest);
+ *    the required-mode assertions are skipped, never silently faked.
+ */
+class Tpm2Pkcs11ProviderTest {
+    private val required = System.getProperty("buffer.crypto.require.tpm2") == "true"
+
+    @Test
+    fun tpmBackendResolvesAndSignsWhenRequired() =
+        runTest {
+            if (!required) return@runTest
+            val resolution =
+                assertIs<ProtectedKeyResolution.Available>(
+                    CryptoCapabilities.protectedKeyResolution,
+                    "the swtpm harness is configured, so resolution must be Available",
+                )
+            assertEquals(ProtectedKeyBackend.Tpm2Pkcs11, resolution.backend)
+            val provider = assertIs<HardwareKeyProvider>(resolution.provider)
+
+            // The secure-element witness surfaces the TPM (issue: hardware never Available on JVM).
+            val hw = assertIs<HardwareSupport.Available>(CryptoCapabilities.hardware)
+            assertEquals(provider, hw.provider)
+
+            // Sign on the token, verify under the captured public key via the ordinary witness ops.
+            assertTrue(provider.eligible(ProtectedKeyAlgorithm.EcdsaP256))
+            val signing = provider.generateSigning(SignatureScheme.EcdsaP256, ProtectedKeySpec())
+            try {
+                assertEquals(KeyProvenance.Hardware, signing.provenance)
+                val custody = signing.custody
+                assertIs<KeyCustody.NonExportable.Hardware>(custody)
+                // PKCS#11 cannot confirm a discrete vs. firmware TPM; the claim stays conservative.
+                assertFalse(custody.dedicatedSecureElement, "the TPM backend must not claim a confirmed dedicated element")
+                val ops = assertNotNull(signatureAsyncOrNull(SignatureScheme.EcdsaP256))
+                val message = ascii("tpm2-backed identity signature")
+                val signature = ops.sign(signing, message)
+                assertTrue(ops.verify(signing.verifyKey, message, signature), "token-sign must verify under its public key")
+            } finally {
+                signing.close()
+            }
+
+            // A denying advisory gate surfaces as AuthorizationFailed, exactly like the other backends.
+            val denied =
+                provider.generateSigning(
+                    SignatureScheme.EcdsaP256,
+                    ProtectedKeySpec(authorization = HardwareAuthorization { false }),
+                )
+            try {
+                val ops = assertNotNull(signatureAsyncOrNull(SignatureScheme.EcdsaP256))
+                assertFailsWith<AuthorizationFailed> { ops.sign(denied, ascii("denied")) }
+            } finally {
+                denied.close()
+            }
+        }
+
+    @Test
+    fun agreementIsHonestlyRefusedAndRoutedToTheSoftwareFloor() =
+        runTest {
+            if (!required) return@runTest
+            val resolution = assertIs<ProtectedKeyResolution.Available>(CryptoCapabilities.protectedKeyResolution)
+            val provider = resolution.provider
+
+            // tpm2-pkcs11 1.9 advertises no CKM_ECDH1_DERIVE: the end-to-end probe must fail closed,
+            // never over-promise. (When the module gains the mechanism, this flips via the probe —
+            // at which point these assertions are the thing to update.)
+            assertFalse(provider.eligible(ProtectedKeyAlgorithm.EcdhP256))
+            assertFailsWith<HardwareKeyException.AlgorithmNotEligible> {
+                provider.generateKeyAgreement(KeyAgreementCurve.P256, ProtectedKeySpec())
+            }
+
+            // The total resolver still serves agreement — from the software floor, with honest custody.
+            val resolver = CryptoCapabilities.keyProvider()
+            assertEquals(KeyCustody.ExportableSoftware, resolver.custodyFor(ProtectedKeyAlgorithm.EcdhP256))
+            val routed = resolver.generateKeyAgreement(KeyAgreementCurve.P256, ProtectedKeySpec())
+            try {
+                assertEquals(KeyProvenance.Software, routed.privateKey.provenance)
+            } finally {
+                routed.close()
+            }
+
+            // requireTier: hardware signing holds; hardware agreement refuses with the typed custody error.
+            resolver.requireTier(ProtectedKeyAlgorithm.EcdsaP256, CustodyTier.Hardware)
+            assertFailsWith<InsufficientKeyCustody> {
+                resolver.requireTier(ProtectedKeyAlgorithm.EcdhP256, CustodyTier.Hardware)
+            }
+        }
+}

--- a/buffer-crypto/src/jvmTest/kotlin/com/ditchoom/buffer/crypto/Tpm2Pkcs11ProviderTest.kt
+++ b/buffer-crypto/src/jvmTest/kotlin/com/ditchoom/buffer/crypto/Tpm2Pkcs11ProviderTest.kt
@@ -51,11 +51,17 @@ class Tpm2Pkcs11ProviderTest {
                 val custody = signing.custody
                 assertIs<KeyCustody.NonExportable.Hardware>(custody)
                 // PKCS#11 cannot confirm a discrete vs. firmware TPM; the claim stays conservative.
-                assertFalse(custody.dedicatedSecureElement, "the TPM backend must not claim a confirmed dedicated element")
+                assertFalse(
+                    custody.dedicatedSecureElement,
+                    "the TPM backend must not claim a confirmed dedicated element",
+                )
                 val ops = assertNotNull(signatureAsyncOrNull(SignatureScheme.EcdsaP256))
                 val message = ascii("tpm2-backed identity signature")
                 val signature = ops.sign(signing, message)
-                assertTrue(ops.verify(signing.verifyKey, message, signature), "token-sign must verify under its public key")
+                assertTrue(
+                    ops.verify(signing.verifyKey, message, signature),
+                    "token-sign must verify under its public key",
+                )
             } finally {
                 signing.close()
             }

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.linux.kt
@@ -1,7 +1,10 @@
 package com.ditchoom.buffer.crypto
 
 /**
- * Linux (BoringSSL-backed) wires no secure-element key provider, so [CryptoCapabilities.hardware]
- * stays [HardwareSupport.Unavailable].
+ * Kotlin/Native Linux (BoringSSL-backed) wires no non-exportable key backend in this version, so the
+ * resolution is honestly [ProtectedKeyResolution.None] — a fact about this library build, distinct
+ * (by type, not by `null`) from a wired-but-refused backend. A TPM 2.0 reached through PKCS#11
+ * cinterop is the natural future backend here; the **JVM-on-Linux** target already provides one via
+ * `tpm2-pkcs11` (see `HardwareKeys.jvm.kt`).
  */
-internal actual fun platformProtectedKeyProvider(): ProtectedKeyProvider? = null
+internal actual fun platformProtectedKeyResolution(): ProtectedKeyResolution = ProtectedKeyResolution.None


### PR DESCRIPTION
## Summary

Two tightly coupled changes:

1. **Typed capability resolution — no more overloaded `null`.** The internal seam `platformProtectedKeyProvider(): ProtectedKeyProvider?` conflated *"this platform wires no backend"* with *"a backend is wired but its probe refused"*. It is replaced by `platformProtectedKeyResolution(): ProtectedKeyResolution` — a sealed three-state answer (`Available` / `Refused(backend, finding)` / `None`) with:
   - `ProtectedKeyBackend` — closed sealed set (AndroidKeystore / AppleSecureEnclave / WebCrypto / Tpm2Pkcs11); exhaustive `when`, nothing to string-match.
   - `CapabilityFinding` — per-backend sealed failure hierarchies (install-the-module vs configure-the-PIN vs token-lacks-the-mechanism are distinct typed states; `*Opaque` variants reify "no code surfaced" instead of a nullable field).
   - `Ckr` (`@JvmInline value class`) + `CkrClass` — PKCS#11 return codes as typed values with a small branchable classification and an explicit open tail (`VendorDefined`/`Unrecognized`), honoring that the CKR space is open by spec.
   - The frozen witnesses (`protectedKeys`/`hardware`) are byte-identical and now *derive* from the resolution; the new `CryptoCapabilities.protectedKeyResolution` accessor is a diagnostics/telemetry surface — routing stays on the witnesses, which fail closed.

2. **Linux/JVM half of #313: a real TPM 2.0 backend.** `Tpm2Pkcs11HardwareKeyProvider` reaches a TPM through the standard `tpm2-pkcs11` module via JCA `SunPKCS11`. `CryptoCapabilities.hardware` now reports `Available` on a TPM-equipped Linux JVM.
   - **Probed end-to-end, never inferred**: module present → token login → generate → sign-on-token → software-verify must all succeed before `Available` is reported; every refusal is a typed `CapabilityFinding.Tpm2`.
   - Config via system properties/env: `buffer.crypto.tpm2.pkcs11.module|pin|slotIndex` (`BUFFER_CRYPTO_TPM2_PKCS11_*`).
   - Eligibility is honest: **ECDSA P-256** (the identity-key use case) is the proven baseline. **ECDH P-256** is probed lazily — tpm2-pkcs11 1.9 does not advertise `CKM_ECDH1_DERIVE` (verified against the module), so it refuses and the resolver routes agreement to the software floor; when the module gains the mechanism, eligibility lights up with no library change. AES-GCM not offered. `dedicatedSecureElement=false` (PKCS#11 cannot distinguish discrete vs firmware TPM — never over-claims).

## Deterministic CI (no hardware)

New `crypto-tpm-integration.yaml`: **swtpm** (software TPM) + **tpm2-abrmd** broker + an initialized tpm2-pkcs11 token on `ubuntu-24.04`, then the JVM tests in **required mode** — the provider MUST resolve `Available` and pass the sign/agreement contract, so regressions can't hide behind a silent capability refusal. (Real deployments use the kernel's `/dev/tpmrm0` resource manager; the broker dance is test-rig-only.)

Verified locally against a live swtpm rig: required-mode tests green; negative control (wrong PIN) fails the required assertions as designed.

## Notes
- Additive minor: `apiCheck` green after `apiDump` (all new types are new; frozen witnesses untouched).
- Apple actual is a mechanical rewrite of the existing probe into the typed states (`Enclave.NotPresent` vs `Enclave.ProbeFailed`) — compiled/exercised by Mac CI as usual.
- Kotlin/Native `linuxMain` stays `None` (typed): a PKCS#11 cinterop backend is the natural follow-up; the issue's stated use case (pure-JVM background processes) is covered by the JVM target.
- Persistent `KeyStore` aliases for TPM keys (get-or-generate/reload) are a follow-up — SunPKCS11's KeyStore view requires certificate-wrapped entries, which deserves its own PR.

Progresses #313 (Linux TPM half; the macOS-Keychain-from-JVM half remains).

## Security note: custody trust boundary

Unlike the Android/Apple backends (where the OS pins which element backs a key), the hardware-custody claim of this backend is **delegated to the operator's module configuration**: pointing `BUFFER_CRYPTO_TPM2_PKCS11_MODULE` at a software PKCS#11 implementation (e.g. SoftHSM) yields software keys labeled `NonExportable.Hardware` — the JCA bridge cannot read `CK_TOKEN_INFO` to verify the token is a TPM. Deployments relying on the custody tier must treat the module path/PIN configuration as security-sensitive state (documented in the provider KDoc). A future hardening could verify token identity through a thin PKCS#11 wrapper.
