### PR TITLE
feat(buffer-crypto): Apple Secure Enclave P-256 key agreement

### DIFF
--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeyAgreement.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeyAgreement.apple.kt
@@ -1,0 +1,202 @@
+@file:OptIn(ExperimentalForeignApi::class)
+@file:Suppress("MatchingDeclarationName") // MPP platform-suffixed helper file
+
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.BCKS_ERR_AUTH
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.BCKS_ERR_INPUT
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.BCKS_ERR_PEER
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.BCKS_OK
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.bcks_secure_enclave_p256_ka_agree
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.bcks_secure_enclave_p256_ka_generate
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.value
+import platform.posix.size_tVar
+
+/*
+ * Secure Enclave ECDH P-256 key agreement, plus the durable record framing both Enclave key kinds
+ * share. Split from HardwareKeys.apple.kt, which retains the provider, the signing path, and the
+ * shared generate plumbing.
+ *
+ * The custody model is the signing path's: the Enclave holds the private scalar and runs the
+ * Diffie-Hellman *inside* the element ([bcks_secure_enclave_p256_ka_agree]); only the raw shared
+ * secret crosses back, into a wiped [SecureBuffer] the common [validateRawSecret] / HKDF seam
+ * consumes. So `keyAgreement()` / `hpke()` compose with an Enclave key unchanged, and the scalar
+ * never enters process memory.
+ *
+ * Agreement keys are **advisory**-gated only. CryptoKit would accept a `SecAccessControl` on an
+ * Enclave agreement key, but [UserAuthenticatedKeyProvider] exposes no key-agreement surface — an
+ * OS-bound agreement key would have no caller and no test — so the gate here is the advisory
+ * [ProtectedKeySpec.authorization], evaluated before every derive.
+ */
+
+/** Generates a P-256 key-agreement key inside the Secure Enclave (restore blob + public point). */
+internal fun enclaveGenerateKaP256(): EnclaveP256Key =
+    enclaveGenerate { blobPtr, blobCap, blobLen, pointPtr, pointCap, pointLen ->
+        bcks_secure_enclave_p256_ka_generate(blobPtr, blobCap, blobLen, pointPtr, pointCap, pointLen)
+    }
+
+/**
+ * Runs `DH(enclaveKey, peer)` inside the Enclave — the key restored from [blob], the peer supplied
+ * as its uncompressed SEC1 point — and returns the raw 32-byte shared secret in a wiped
+ * [SecureBuffer] (the common seam applies the KDF / validation above it).
+ *
+ * A rejected peer point (malformed, wrong length, off-curve) surfaces as the uniform
+ * [InvalidPublicKey] with the shim's cause dropped — the same no-oracle contract as the software
+ * agreement glue. A blob this Enclave can no longer restore is [HardwareKeyException.KeyInvalidated].
+ */
+internal fun enclaveAgreeP256(
+    blob: ReadBuffer,
+    peerPoint: ReadBuffer,
+): PlatformBuffer {
+    val cap = KeyAgreementCurve.P256.sharedSecretBytes
+    val out = secureScratch.allocate(cap)
+    var status = -1
+    var written = 0
+    memScoped {
+        val secretLen = alloc<size_tVar>()
+        val peerLen = peerPoint.remaining()
+        blob.withRemainingBytes { blobPtr, blobLen ->
+            peerPoint.withRemainingBytes2(peerLen) { peerPtr ->
+                out.withWritablePointer(cap) { secretPtr ->
+                    status =
+                        bcks_secure_enclave_p256_ka_agree(
+                            blobPtr.reinterpret(),
+                            blobLen.convert(),
+                            peerPtr.reinterpret(),
+                            peerLen.convert(),
+                            secretPtr.reinterpret(),
+                            cap.convert(),
+                            secretLen.ptr,
+                        )
+                }
+            }
+        }
+        written = secretLen.value.toInt()
+    }
+    if (status != BCKS_OK) {
+        out.freeNativeMemory()
+        throw enclaveAgreeFailure(status)
+    }
+    out.position(written)
+    out.resetForRead()
+    return out
+}
+
+/**
+ * The typed failure a non-OK agreement status stands for. Returned rather than thrown so the caller
+ * frees the secret buffer first and keeps a single throw site.
+ */
+private fun enclaveAgreeFailure(status: Int): Throwable =
+    when (status) {
+        // Every peer-point rejection — malformed encoding, wrong length, off-curve — arrives as this
+        // one code, so the exception carries no information about *which* check failed.
+        BCKS_ERR_PEER -> InvalidPublicKey(KeyAgreementCurve.P256)
+        // The Enclave cannot restore this blob (wrong device, or an OS-invalidated key).
+        BCKS_ERR_INPUT -> HardwareKeyException.KeyInvalidated()
+        // Unreachable today (no agreement key is access-controlled), kept typed rather than folded
+        // into the generic hardware failure so an OS-bound key would surface honestly.
+        BCKS_ERR_AUTH -> AuthorizationFailed()
+        else -> HardwareKeyException.TransientHardwareFailure(retryable = false)
+    }
+
+// =============================================================================
+// Durable Enclave key record — `u8 kind | u16 pointLen | point | blob`
+// =============================================================================
+//
+// The public point and the Enclave restore blob together fully describe a persistent key (the point
+// builds the VerifyKey / KeyAgreementPublicKey; the blob reconstructs the key inside the Enclave).
+// They are framed into one opaque buffer the store persists verbatim in a Keychain item.
+//
+// The leading kind byte is what keeps signing and agreement keys from loading as each other: both
+// are (point, blob) pairs, structurally indistinguishable without it. Records written before the
+// agreement kind existed carry no kind byte and begin with the point length's high byte, which is
+// always 0x00 for a 65-byte point — so a leading 0x00 identifies a legacy signing record and is
+// parsed under the old layout.
+
+/** The two persistent Enclave key kinds, tagged in the durable record's first byte. */
+internal enum class EnclaveKeyKind(
+    val tag: Int,
+) {
+    Signing(1),
+    Agreement(2),
+}
+
+/** A parsed durable record: the key [kind] plus freshly-owned restore [blob] and public [point]. */
+internal class EnclaveRecord(
+    val kind: EnclaveKeyKind,
+    val blob: PlatformBuffer,
+    val point: PlatformBuffer,
+)
+
+/** Frames [kind] + [point] + [blob] into a durable record, without disturbing either source's position. */
+internal fun frameEnclaveRecord(
+    kind: EnclaveKeyKind,
+    point: ReadBuffer,
+    blob: ReadBuffer,
+): PlatformBuffer {
+    val pointLen = point.remaining()
+    val out = BufferFactory.Default.allocate(RECORD_HEADER_BYTES + pointLen + blob.remaining())
+    out.writeByte(kind.tag.toByte())
+    out.writeShort(pointLen.toShort())
+    appendPreservingPosition(out, point)
+    appendPreservingPosition(out, blob)
+    out.resetForRead()
+    return out
+}
+
+/** Splits a durable record into its kind and freshly-owned (blob, point) buffers. */
+internal fun parseEnclaveRecord(record: ReadBuffer): EnclaveRecord {
+    val first = record.readByte().toInt() and BYTE_MASK
+    val legacy = first == LEGACY_SIGNING_TAG
+    // Legacy: `first` was the point length's high byte (0x00), so its low byte comes next.
+    val pointLen =
+        if (legacy) record.readByte().toInt() and BYTE_MASK else record.readShort().toInt() and SHORT_MASK
+    val point = copyBuffer(record.readBytes(pointLen), BufferFactory.Default)
+    val blob = copyBuffer(record.readBytes(record.remaining()), BufferFactory.Default)
+    return EnclaveRecord(if (legacy) EnclaveKeyKind.Signing else enclaveKind(first), blob, point)
+}
+
+/**
+ * The [ProtectedKeyAlgorithm] a stored record holds, read without consuming it — the store's
+ * kind check before it hands the record to the matching re-attach path (a mismatch answers `null`
+ * on a load and [KeyStoreException.AliasMismatch] on a get-or-generate).
+ */
+internal fun enclaveRecordAlgorithm(record: ReadBuffer): ProtectedKeyAlgorithm =
+    when (record.get(record.position()).toInt() and BYTE_MASK) {
+        LEGACY_SIGNING_TAG, EnclaveKeyKind.Signing.tag -> ProtectedKeyAlgorithm.EcdsaP256
+        EnclaveKeyKind.Agreement.tag -> ProtectedKeyAlgorithm.EcdhP256
+        else -> throw KeyStoreException.CorruptEntry()
+    }
+
+private fun enclaveKind(tag: Int): EnclaveKeyKind =
+    when (tag) {
+        EnclaveKeyKind.Signing.tag -> EnclaveKeyKind.Signing
+        EnclaveKeyKind.Agreement.tag -> EnclaveKeyKind.Agreement
+        else -> throw KeyStoreException.CorruptEntry()
+    }
+
+/** Appends [src]'s remaining bytes to [dst] without advancing [src]'s position (it may be a live key buffer). */
+private fun appendPreservingPosition(
+    dst: PlatformBuffer,
+    src: ReadBuffer,
+) {
+    if (src.remaining() == 0) return
+    val mark = src.position()
+    dst.write(src)
+    src.position(mark)
+}
+
+private const val RECORD_HEADER_BYTES = 1 + 2 // kind byte + u16 point length
+private const val LEGACY_SIGNING_TAG = 0x00
+private const val BYTE_MASK = 0xFF
+private const val SHORT_MASK = 0xFFFF

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.apple.kt
@@ -31,8 +31,8 @@ import kotlin.time.TimeMark
 import kotlin.time.TimeSource
 
 /*
- * Apple Secure Enclave hardware-backed key provider (CryptoKit `SecureEnclave.P256.Signing`, via the
- * CryptoKitShim).
+ * Apple Secure Enclave hardware-backed key provider (CryptoKit `SecureEnclave.P256.Signing` and
+ * `SecureEnclave.P256.KeyAgreement`, via the CryptoKitShim).
  *
  * The Enclave generates and holds a P-256 private key that never leaves the element; signing routes
  * through the shim, which reconstructs the key from its opaque encrypted blob and signs *inside* the
@@ -41,8 +41,10 @@ import kotlin.time.TimeSource
  * published. All byte transport is buffer-native: the shim reads from / writes into buffer memory
  * directly ([withRemainingBytes] / [withWritablePointer]); no ByteArray round-trips.
  *
- * **Only ECDSA P-256 is backed.** AES-GCM is not eligible: CryptoKit exposes no symmetric Secure
- * Enclave key, and the only "Enclave-tied" AES one could build (ECDH a P-256 Enclave key → derive a
+ * **ECDSA P-256 signing and ECDH P-256 key agreement are backed** (the agreement half lives in
+ * HardwareKeyAgreement.apple.kt and is gated on a real generate-and-agree probe, never inferred).
+ * AES-GCM is not eligible: CryptoKit exposes no symmetric Secure Enclave key, and the only
+ * "Enclave-tied" AES one could build (ECDH a P-256 Enclave key → derive a
  * symmetric key → run AES.GCM in software) would put the AES key in process memory, violating the
  * non-exportable hardware-key contract. (The Enclave *does* contain an AES engine, but Apple exposes
  * no developer API to drive it as an app-controlled non-exportable AEAD key.)
@@ -71,7 +73,23 @@ import kotlin.time.TimeSource
 internal class SecureEnclaveHardwareKeyProvider : HardwareKeyProvider {
     override val dedicatedSecureElement: Boolean get() = true
 
-    override fun eligible(alg: ProtectedKeyAlgorithm): Boolean = alg == ProtectedKeyAlgorithm.EcdsaP256
+    /**
+     * `true` once an Enclave `SecureEnclave.P256.KeyAgreement` key both generates *and* completes one
+     * real agreement against a software peer. Probed (generate-and-agree with a throwaway key)
+     * rather than inferred from OS version or [bcks_secure_enclave_available]: the answer that
+     * matters is whether *this* element performs the DH, which is what an unentitled binary, a
+     * simulator, or a locked device diverge on. Same shape as the signing generate-and-discard probe
+     * in [appleResolution] — a failure routes key agreement to the software floor instead of
+     * over-promising hardware custody.
+     */
+    private val agreementSupported: Boolean by lazy { probeAgreement() }
+
+    override fun eligible(alg: ProtectedKeyAlgorithm): Boolean =
+        when (alg) {
+            ProtectedKeyAlgorithm.EcdsaP256 -> true
+            ProtectedKeyAlgorithm.EcdhP256 -> agreementSupported
+            else -> false
+        }
 
     override suspend fun generateAesGcm(spec: ProtectedKeySpec): AesGcmKey =
         // No app-controlled non-exportable symmetric Enclave key exists on Apple.
@@ -85,9 +103,73 @@ internal class SecureEnclaveHardwareKeyProvider : HardwareKeyProvider {
     override suspend fun generateKeyAgreement(
         curve: KeyAgreementCurve,
         spec: ProtectedKeySpec,
-    ): KeyAgreementKeyPair =
-        // The Secure Enclave backs no app-controlled ECDH agreement key through this SPI; not eligible.
-        throw HardwareKeyException.AlgorithmNotEligible()
+    ): KeyAgreementKeyPair {
+        // Only ECDH P-256, and only where the probed Enclave agreement support holds. X25519 and the
+        // larger NIST curves have no Secure Enclave backing on any OS version.
+        if (curve != KeyAgreementCurve.P256 || !eligible(ProtectedKeyAlgorithm.EcdhP256)) {
+            throw HardwareKeyException.AlgorithmNotEligible()
+        }
+        val generated = enclaveGenerateKaP256()
+        // Ephemeral: nothing was persisted (the blob is in-process bytes, not a Keychain item), so
+        // there is no out-of-process resource for close to release.
+        return buildKeyAgreementPair(generated.blob, generated.point, spec.authorization)
+    }
+
+    /**
+     * Wraps an Enclave restore [blob] + public [point] as a [KeyAgreementKeyPair] whose DH runs
+     * inside the element. Shared by the ephemeral [generateKeyAgreement] and the persistent
+     * [AppleKeychainKeyStore] paths — the only difference between them is who holds the record.
+     *
+     * The [gate] is the advisory [ProtectedKeySpec.authorization]: agreement keys carry no
+     * `SecAccessControl` (see HardwareKeyAgreement.apple.kt), so the gate is evaluated by library
+     * code before each derive, and the raw secret goes straight to the common validate/HKDF seam.
+     */
+    internal fun buildKeyAgreementPair(
+        blob: PlatformBuffer,
+        point: ReadBuffer,
+        gate: HardwareAuthorization,
+    ): KeyAgreementKeyPair {
+        val curve = KeyAgreementCurve.P256
+        val privateKey =
+            ProtectedKeyAgreementPrivateKey(
+                curve = curve,
+                custody = custody,
+                gatedDh = { peer ->
+                    if (!gate.authorize()) throw AuthorizationFailed()
+                    require(peer.curve == curve) { "private/public key curve mismatch" }
+                    enclaveAgreeP256(blob, peer.encoded)
+                },
+            )
+        return keyAgreementKeyPairOf(curve, privateKey, KeyAgreementPublicKey.of(curve, point))
+    }
+
+    /**
+     * Probes the Enclave's ECDH support end to end: generate a throwaway agreement key, then run one
+     * real agreement against a freshly generated software peer through the production
+     * [enclaveAgreeP256] path. Generation alone would over-promise — an element that mints the key
+     * and then refuses the DH must route to the software floor, not report hardware custody.
+     */
+    private fun probeAgreement(): Boolean =
+        try {
+            val key = enclaveGenerateKaP256()
+            try {
+                val peer = generateKeyPairPlatform(KeyAgreementCurve.P256)
+                try {
+                    val secret = enclaveAgreeP256(key.blob, peer.publicKey.encoded)
+                    val ok = secret.remaining() == KeyAgreementCurve.P256.sharedSecretBytes
+                    secret.freeNativeMemory()
+                    ok
+                } finally {
+                    peer.close()
+                }
+            } finally {
+                key.blob.freeNativeMemory()
+                key.point.freeNativeMemory()
+            }
+        } catch (_: Throwable) {
+            // No Enclave, no entitlement, or an element that declines agreement keys.
+            false
+        }
 
     /** Generates an Enclave P-256 key under [policy] — the shared path for unbound and OS-bound keys. */
     internal suspend fun generateSigningBound(
@@ -198,7 +280,7 @@ internal class SecureEnclaveHardwareKeyProvider : HardwareKeyProvider {
      */
     internal fun generatePersistentSigning(spec: ProtectedKeySpec): Pair<SigningKey, PlatformBuffer> {
         val generated = enclaveGenerateP256()
-        val record = frameEnclaveRecord(generated.point, generated.blob)
+        val record = frameEnclaveRecord(EnclaveKeyKind.Signing, generated.point, generated.blob)
         val key = buildPersistentSigning(generated.blob, generated.point, spec)
         return key to record
     }
@@ -208,8 +290,28 @@ internal class SecureEnclaveHardwareKeyProvider : HardwareKeyProvider {
         record: ReadBuffer,
         spec: ProtectedKeySpec,
     ): SigningKey {
-        val (blob, point) = parseEnclaveRecord(record)
-        return buildPersistentSigning(blob, point, spec)
+        val parsed = parseEnclaveRecord(record)
+        return buildPersistentSigning(parsed.blob, parsed.point, spec)
+    }
+
+    /**
+     * Generates a persistent Enclave P-256 agreement key. Returns the [KeyAgreementKeyPair] plus its
+     * durable record (kind + public point + restore blob) for the store to persist under an alias.
+     */
+    internal fun generatePersistentKeyAgreement(spec: ProtectedKeySpec): Pair<KeyAgreementKeyPair, PlatformBuffer> {
+        val generated = enclaveGenerateKaP256()
+        val record = frameEnclaveRecord(EnclaveKeyKind.Agreement, generated.point, generated.blob)
+        val key = buildKeyAgreementPair(generated.blob, generated.point, spec.authorization)
+        return key to record
+    }
+
+    /** Re-attaches a persistent Enclave agreement key from a durable [record] (see [frameEnclaveRecord]). */
+    internal fun keyAgreementFromRecord(
+        record: ReadBuffer,
+        spec: ProtectedKeySpec,
+    ): KeyAgreementKeyPair {
+        val parsed = parseEnclaveRecord(record)
+        return buildKeyAgreementPair(parsed.blob, parsed.point, spec.authorization)
     }
 
     /** Wraps an Enclave restore [blob] + public [point] as an advisory-gated persistent [SigningKey]. */
@@ -328,16 +430,19 @@ private class SessionWindow(
 }
 
 /** A freshly generated Enclave key: the opaque restore [blob] and its uncompressed SEC1 [point]. */
-private class EnclaveP256Key(
+internal class EnclaveP256Key(
     val blob: PlatformBuffer,
     val point: PlatformBuffer,
 )
 
-// A Secure Enclave P-256 signing key's `dataRepresentation` is ~284 bytes (observed); 1024 gives
-// comfortable margin against OS-version variation. Too-small a buffer makes generate return
-// BCKS_ERR_BUFFER, which would make the provider silently fail to resolve — so keep this generous.
-private const val ENCLAVE_BLOB_CAP = 1024
-private const val P256_POINT_BYTES = 65
+// A Secure Enclave P-256 key's `dataRepresentation` is ~284 bytes (observed); 1024 gives comfortable
+// margin against OS-version variation. Too-small a buffer makes generate return BCKS_ERR_BUFFER,
+// which would make the provider silently fail to resolve — so keep this generous.
+//
+// internal (not private) so the agreement generate in HardwareKeyAgreement.apple.kt shares the same
+// [enclaveGenerate] plumbing; an internal inline function cannot reach private declarations.
+internal const val ENCLAVE_BLOB_CAP = 1024
+internal const val P256_POINT_BYTES = 65
 
 private fun enclaveGenerateP256(): EnclaveP256Key =
     enclaveGenerate { blobPtr, blobCap, blobLen, pointPtr, pointCap, pointLen ->
@@ -356,7 +461,7 @@ private fun enclaveGenerateP256AccessControlled(method: UserAuthenticationMethod
  * [HardwareKeyException.SecureElementUnavailable]: the element would not mint the key (absent,
  * unentitled, or — for the access-controlled variant — no passcode/biometric enrolled).
  */
-private inline fun enclaveGenerate(
+internal inline fun enclaveGenerate(
     call: (
         blobPtr: kotlinx.cinterop.CPointer<kotlinx.cinterop.UByteVar>,
         blobCap: platform.posix.size_t,
@@ -498,46 +603,3 @@ internal actual fun platformProtectedKeyResolution(): ProtectedKeyResolution = a
  * Keychain-backed [AppleKeychainKeyStore], falling back to a software store otherwise.
  */
 internal fun appleEnclaveProviderOrNull(): SecureEnclaveHardwareKeyProvider? = appleProvider as? SecureEnclaveHardwareKeyProvider
-
-// =============================================================================
-// Durable Enclave key record — `u16 pointLen | point | blob`
-// =============================================================================
-//
-// The public point and the Enclave restore blob together fully describe a persistent signing key
-// (the point builds the VerifyKey; the blob reconstructs the signer inside the Enclave). They are
-// framed into one opaque buffer the store persists verbatim in a Keychain item.
-
-private const val RECORD_POINT_LEN_BYTES = 2
-
-/** Frames [point] + [blob] into a durable record, without disturbing either source's position. */
-private fun frameEnclaveRecord(
-    point: ReadBuffer,
-    blob: ReadBuffer,
-): PlatformBuffer {
-    val pointLen = point.remaining()
-    val out = BufferFactory.Default.allocate(RECORD_POINT_LEN_BYTES + pointLen + blob.remaining())
-    out.writeShort(pointLen.toShort())
-    appendPreservingPosition(out, point)
-    appendPreservingPosition(out, blob)
-    out.resetForRead()
-    return out
-}
-
-/** Splits a durable record back into freshly-owned (blob, point) buffers. */
-private fun parseEnclaveRecord(record: ReadBuffer): Pair<PlatformBuffer, PlatformBuffer> {
-    val pointLen = record.readShort().toInt() and 0xFFFF
-    val point = copyBuffer(record.readBytes(pointLen), BufferFactory.Default)
-    val blob = copyBuffer(record.readBytes(record.remaining()), BufferFactory.Default)
-    return blob to point
-}
-
-/** Appends [src]'s remaining bytes to [dst] without advancing [src]'s position (it may be a live key buffer). */
-private fun appendPreservingPosition(
-    dst: PlatformBuffer,
-    src: ReadBuffer,
-) {
-    if (src.remaining() == 0) return
-    val mark = src.position()
-    dst.write(src)
-    src.position(mark)
-}

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/KeyStore.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/KeyStore.apple.kt
@@ -57,10 +57,15 @@ internal actual fun platformKeyStore(config: KeyStoreConfig): KeyStore =
  * persist — a key from [getOrGenerateSigning] / [loadSigning] survives `close()` and process restart
  * until [delete]d (a persistent key's `close()` does not touch the Keychain).
  *
- * Serves only what the Enclave backs non-exportably: ECDSA P-256 signing. A get-or-generate for
- * anything else (other schemes, AES-GCM, key agreement) throws
- * [HardwareKeyException.AlgorithmNotEligible] — consult [custodyFor] / [eligible] first, or supply a
- * software [KeyStoreConfig.storage] for a persistent key the Enclave cannot hold.
+ * Serves what the Enclave backs non-exportably: ECDSA P-256 signing and — where the generate-and-agree
+ * probe holds — ECDH P-256 key agreement. A get-or-generate for anything else (other schemes,
+ * AES-GCM, X25519) throws [HardwareKeyException.AlgorithmNotEligible] — consult [custodyFor] /
+ * [eligible] first, or supply a software [KeyStoreConfig.storage] for a persistent key the Enclave
+ * cannot hold.
+ *
+ * Both key kinds are (public point + restore blob) records, so the record's kind byte is what keeps
+ * them apart: a kind-mismatched load answers `null` and a kind-mismatched get-or-generate raises
+ * [KeyStoreException.AliasMismatch], never a mistyped handle.
  */
 internal class AppleKeychainKeyStore(
     private val provider: SecureEnclaveHardwareKeyProvider,
@@ -96,9 +101,12 @@ internal class AppleKeychainKeyStore(
         return withContext(Dispatchers.Default) {
             keychainGet(alias)?.let { record ->
                 try {
-                    // Only Enclave P-256 signing keys are ever persisted here, so a present record is
-                    // always a signing key of the requested scheme — no AliasMismatch is reachable.
-                    provider.signingFromRecord(record, spec)
+                    // Signing and agreement records are structurally alike; the kind byte decides.
+                    when (val stored = enclaveRecordAlgorithm(record)) {
+                        ProtectedKeyAlgorithm.EcdsaP256 -> provider.signingFromRecord(record, spec)
+                        else ->
+                            throw KeyStoreException.AliasMismatch(alias, stored, scheme.toProtectedKeyAlgorithm())
+                    }
                 } finally {
                     record.freeNativeMemory()
                 }
@@ -129,20 +137,38 @@ internal class AppleKeychainKeyStore(
         spec: ProtectedKeySpec,
     ): KeyAgreementKeyPair {
         requireValidAlias(alias)
-        // The Secure Enclave backs no app-controlled ECDH / X25519 agreement key.
-        throw HardwareKeyException.AlgorithmNotEligible()
+        // Only ECDH P-256, and only where the probed Enclave agreement support holds; X25519 has no
+        // Secure Enclave backing on any OS version.
+        if (curve != KeyAgreementCurve.P256 || !provider.eligible(ProtectedKeyAlgorithm.EcdhP256)) {
+            throw HardwareKeyException.AlgorithmNotEligible()
+        }
+        return withContext(Dispatchers.Default) {
+            keychainGet(alias)?.let { record ->
+                try {
+                    when (val stored = enclaveRecordAlgorithm(record)) {
+                        ProtectedKeyAlgorithm.EcdhP256 -> provider.keyAgreementFromRecord(record, spec)
+                        else ->
+                            throw KeyStoreException.AliasMismatch(alias, stored, curve.toProtectedKeyAlgorithm())
+                    }
+                } finally {
+                    record.freeNativeMemory()
+                }
+            } ?: run {
+                val (key, record) = provider.generatePersistentKeyAgreement(spec)
+                try {
+                    keychainPut(alias, record)
+                } finally {
+                    record.freeNativeMemory()
+                }
+                key
+            }
+        }
     }
 
     override suspend fun loadSigning(alias: String): SigningKey? {
         requireValidAlias(alias)
-        return withContext(Dispatchers.Default) {
-            keychainGet(alias)?.let { record ->
-                try {
-                    provider.signingFromRecord(record, ProtectedKeySpec())
-                } finally {
-                    record.freeNativeMemory()
-                }
-            }
+        return loadRecord(alias, ProtectedKeyAlgorithm.EcdsaP256) { record ->
+            provider.signingFromRecord(record, ProtectedKeySpec())
         }
     }
 
@@ -154,9 +180,30 @@ internal class AppleKeychainKeyStore(
 
     override suspend fun loadKeyAgreement(alias: String): KeyAgreementKeyPair? {
         requireValidAlias(alias)
-        // No agreement key is ever persisted here (see getOrGenerateKeyAgreement).
-        return null
+        return loadRecord(alias, ProtectedKeyAlgorithm.EcdhP256) { record ->
+            provider.keyAgreementFromRecord(record, ProtectedKeySpec())
+        }
     }
+
+    /**
+     * The shared load path: reads the record under [alias] and re-attaches it through [attach] only
+     * when its kind byte says [expected]. A record of the other kind answers `null` — the load
+     * contract is "absent or a different kind", never a mistyped handle.
+     */
+    private suspend fun <T> loadRecord(
+        alias: String,
+        expected: ProtectedKeyAlgorithm,
+        attach: (ReadBuffer) -> T,
+    ): T? =
+        withContext(Dispatchers.Default) {
+            keychainGet(alias)?.let { record ->
+                try {
+                    if (enclaveRecordAlgorithm(record) == expected) attach(record) else null
+                } finally {
+                    record.freeNativeMemory()
+                }
+            }
+        }
 
     override suspend fun contains(alias: String): Boolean {
         requireValidAlias(alias)
@@ -244,7 +291,7 @@ internal class AppleKeychainKeyStore(
         }
 
     private companion object {
-        // A record is `u16 pointLen | point(65) | Enclave blob(~284)` — well under 4 KiB.
+        // A record is `u8 kind | u16 pointLen | point(65) | Enclave blob(~284)` — well under 4 KiB.
         const val RECORD_CAP = 4096
 
         // Newline-joined account names; a device identity store holds few keys, so 64 KiB is ample.

--- a/buffer-crypto/src/appleTest/kotlin/com/ditchoom/buffer/crypto/EnclaveAgreementEligibilityTest.kt
+++ b/buffer-crypto/src/appleTest/kotlin/com/ditchoom/buffer/crypto/EnclaveAgreementEligibilityTest.kt
@@ -1,0 +1,76 @@
+package com.ditchoom.buffer.crypto
+
+import kotlinx.coroutines.test.runTest
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * What the Apple stack must do where the Secure Enclave *cannot* serve ECDH — the other half of
+ * "eligibility is probed, not assumed" (the hardware half is [EnclaveKeyAgreementTest]).
+ *
+ * Three states, each with its own honest answer: a curve the Enclave never backs (X25519) is
+ * refused outright; an element whose generate-and-agree probe fails refuses rather than serving
+ * ECDH at a silently weaker custody; and a target with no Enclave at all (the iOS simulator, an
+ * unentitled binary) degrades to the software store — still functional, never claiming hardware.
+ */
+class EnclaveAgreementEligibilityTest {
+    private val storeName = "bcks-kex-gate-${Random.nextInt(Int.MAX_VALUE)}"
+
+    private fun store(): KeyStore = CryptoCapabilities.keyStore(KeyStoreConfig(name = storeName))
+
+    @Test
+    fun ineligibleCurvesAreRefused() =
+        runTest {
+            val provider = appleEnclaveProviderOrNull() ?: return@runTest
+            // X25519 has no Secure Enclave backing on any OS version, whatever the P-256 probe said.
+            assertTrue(!provider.eligible(ProtectedKeyAlgorithm.X25519), "X25519 is never Enclave-backed")
+            assertFailsWith<HardwareKeyException.AlgorithmNotEligible> {
+                provider.generateKeyAgreement(KeyAgreementCurve.X25519, ProtectedKeySpec())
+            }
+            assertFailsWith<HardwareKeyException.AlgorithmNotEligible> {
+                store().getOrGenerateKeyAgreement("x25519-kex", KeyAgreementCurve.X25519)
+            }
+        }
+
+    @Test
+    fun anElementThatCannotAgreeRefusesRatherThanOverPromising() =
+        runTest {
+            val provider = appleEnclaveProviderOrNull() ?: return@runTest
+            if (provider.eligible(ProtectedKeyAlgorithm.EcdhP256)) return@runTest
+            // Enclave signing resolved but the generate-and-agree probe did not: ECDH must be refused
+            // outright, never served at a silently weaker custody through the hardware store.
+            assertFailsWith<HardwareKeyException.AlgorithmNotEligible> {
+                provider.generateKeyAgreement(KeyAgreementCurve.P256, ProtectedKeySpec())
+            }
+            assertFailsWith<HardwareKeyException.AlgorithmNotEligible> {
+                store().getOrGenerateKeyAgreement("unsupported-kex", KeyAgreementCurve.P256)
+            }
+        }
+
+    @Test
+    fun withoutAnEnclaveTheStoreDegradesToAnHonestSoftwareTier() =
+        runTest {
+            if (appleEnclaveProviderOrNull() != null) return@runTest
+            // iOS simulator / unentitled binary: keyStore() falls back to the software store. Key
+            // agreement still works there — it just must never claim hardware custody.
+            val s = store()
+            val alias = "degraded-kex"
+            val pair = s.getOrGenerateKeyAgreement(alias, KeyAgreementCurve.P256)
+            try {
+                assertEquals(KeyProvenance.Software, pair.privateKey.provenance)
+                assertTrue(
+                    s.custodyFor(ProtectedKeyAlgorithm.EcdhP256).tier < CustodyTier.Hardware,
+                    "a store without an Enclave must not report hardware custody",
+                )
+                assertFailsWith<InsufficientKeyCustody> {
+                    s.requireTier(ProtectedKeyAlgorithm.EcdhP256, CustodyTier.Hardware)
+                }
+            } finally {
+                pair.close()
+                s.delete(alias)
+            }
+        }
+}

--- a/buffer-crypto/src/appleTest/kotlin/com/ditchoom/buffer/crypto/EnclaveKeyAgreementTest.kt
+++ b/buffer-crypto/src/appleTest/kotlin/com/ditchoom/buffer/crypto/EnclaveKeyAgreementTest.kt
@@ -1,0 +1,206 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.crypto.CryptoTestVectors.ascii
+import com.ditchoom.buffer.crypto.CryptoTestVectors.toHex
+import kotlinx.coroutines.test.runTest
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Runtime contract for Secure Enclave ECDH P-256 — the Apple half of hardware-backed key agreement.
+ *
+ * Every test here is **capability-gated, not device-gated by hand**: each asks the provider whether
+ * its generate-and-agree probe held, so an entitled Mac / device runs the real element while the iOS
+ * simulator and an unentitled binary skip to [EnclaveAgreementEligibilityTest] instead. Nothing here
+ * mocks the Enclave: where the gate opens, every derive below is a real in-element Diffie–Hellman.
+ *
+ * Each run uses a random Keychain service name so it never reads an item another binary created
+ * (which would prompt for keychain access), and deletes what it wrote.
+ */
+class EnclaveKeyAgreementTest {
+    private val storeName = "bcks-kex-test-${Random.nextInt(Int.MAX_VALUE)}"
+
+    private fun store(): KeyStore = CryptoCapabilities.keyStore(KeyStoreConfig(name = storeName))
+
+    /** The Enclave provider, but only when its probed ECDH support actually holds. */
+    private fun agreeingEnclave(): SecureEnclaveHardwareKeyProvider? =
+        appleEnclaveProviderOrNull()?.takeIf { it.eligible(ProtectedKeyAlgorithm.EcdhP256) }
+
+    private fun ops() = assertNotNull(keyAgreementAsyncOrNull(KeyAgreementCurve.P256))
+
+    // ---- Persistence: get-or-generate / reload / derive ------------------------------------------
+
+    @Test
+    fun keyAgreementIsIdempotentReloadsAcrossRestartAndDerives() =
+        runTest {
+            if (agreeingEnclave() == null) return@runTest
+            val s = store()
+            val alias = "device-kex"
+            try {
+                val first = s.getOrGenerateKeyAgreement(alias, KeyAgreementCurve.P256)
+                assertEquals(KeyProvenance.Hardware, first.privateKey.provenance)
+                assertEquals(CustodyTier.Hardware, s.custodyFor(ProtectedKeyAlgorithm.EcdhP256).tier)
+                assertFailsWith<UnsupportedOperationException>("an Enclave scalar is never exportable") {
+                    first.privateKey.exportEncoded()
+                }
+                val pub = first.publicKey.exportSpki().toHex()
+
+                // A second get-or-generate over a fresh store returns the SAME key, not a new one.
+                val again = store().getOrGenerateKeyAgreement(alias, KeyAgreementCurve.P256)
+                assertEquals(pub, again.publicKey.exportSpki().toHex())
+
+                // Simulated restart: a brand-new store re-attaches from the Keychain record, and the
+                // reloaded handle derives what a software peer derives against the persisted public
+                // key — the in-Enclave DH is real, standard ECDH, and stable across reloads.
+                val reloaded = assertNotNull(store().loadKeyAgreement(alias))
+                assertEquals(pub, reloaded.publicKey.exportSpki().toHex())
+                val ops = ops()
+                val peer = ops.generateKeyPair()
+                try {
+                    val info = Info.Of(ascii("enclave-kex"))
+                    val viaFirst = ops.deriveSharedSecret(first.privateKey, peer.publicKey, info, length = 32)
+                    val viaReloaded = ops.deriveSharedSecret(reloaded.privateKey, peer.publicKey, info, length = 32)
+                    val viaPeer = ops.deriveSharedSecret(peer.privateKey, reloaded.publicKey, info, length = 32)
+                    assertEquals(viaPeer.toHex(), viaFirst.toHex(), "hw derive must match the peer's derivation")
+                    assertEquals(viaPeer.toHex(), viaReloaded.toHex(), "reloaded hw key must derive the same secret")
+                } finally {
+                    peer.close()
+                }
+            } finally {
+                s.delete(alias)
+            }
+        }
+
+    @Test
+    fun agreementAliasNeverSilentlyReplacesAnotherKind() =
+        runTest {
+            if (agreeingEnclave() == null) return@runTest
+            val s = store()
+            val signAlias = "mixed-sign"
+            val kexAlias = "mixed-kex"
+            try {
+                // Both kinds are (public point + Enclave blob) records — only the record's kind byte
+                // tells them apart, so this is the test that the byte is load-bearing.
+                s.getOrGenerateSigning(signAlias, SignatureScheme.EcdsaP256)
+                val clash =
+                    assertFailsWith<KeyStoreException.AliasMismatch> {
+                        s.getOrGenerateKeyAgreement(signAlias, KeyAgreementCurve.P256)
+                    }
+                assertEquals(ProtectedKeyAlgorithm.EcdsaP256, clash.stored)
+                assertEquals(ProtectedKeyAlgorithm.EcdhP256, clash.requested)
+                assertNull(s.loadKeyAgreement(signAlias), "a signing alias must not load as an agreement key")
+
+                s.getOrGenerateKeyAgreement(kexAlias, KeyAgreementCurve.P256)
+                val reverse =
+                    assertFailsWith<KeyStoreException.AliasMismatch> {
+                        s.getOrGenerateSigning(kexAlias, SignatureScheme.EcdsaP256)
+                    }
+                assertEquals(ProtectedKeyAlgorithm.EcdhP256, reverse.stored)
+                assertEquals(ProtectedKeyAlgorithm.EcdsaP256, reverse.requested)
+                assertNull(s.loadSigning(kexAlias), "an agreement alias must not load as a signing key")
+            } finally {
+                s.delete(signAlias)
+                s.delete(kexAlias)
+            }
+        }
+
+    @Test
+    fun persistedSigningKeysStillRoundTripUnderTheKindTaggedRecord() =
+        runTest {
+            if (appleEnclaveProviderOrNull() == null) return@runTest
+            val s = store()
+            val alias = "sign-roundtrip"
+            try {
+                val first = s.getOrGenerateSigning(alias, SignatureScheme.EcdsaP256)
+                val pub = first.verifyKey.exportSpki().toHex()
+                val reloaded = assertNotNull(store().loadSigning(alias))
+                assertEquals(pub, reloaded.verifyKey.exportSpki().toHex())
+                val ops = assertNotNull(signatureAsyncOrNull(SignatureScheme.EcdsaP256))
+                val message = ascii("record format change must not break signing")
+                val signature = ops.sign(reloaded, message)
+                assertTrue(ops.verify(first.verifyKey, message, signature), "reloaded Enclave key must still sign")
+            } finally {
+                s.delete(alias)
+            }
+        }
+
+    // ---- Ephemeral provider keys: real in-element DH, gate, peer rejection -----------------------
+
+    @Test
+    fun ephemeralEnclaveKeyAgreesWithASoftwarePeer() =
+        runTest {
+            val provider = agreeingEnclave() ?: return@runTest
+            val pair = provider.generateKeyAgreement(KeyAgreementCurve.P256, ProtectedKeySpec())
+            val ops = ops()
+            val peer = ops.generateKeyPair()
+            try {
+                assertEquals(KeyProvenance.Hardware, pair.privateKey.provenance)
+                val info = Info.Of(ascii("ephemeral-enclave-kex"))
+                val viaHardware = ops.deriveSharedSecret(pair.privateKey, peer.publicKey, info, length = 32)
+                val viaPeer = ops.deriveSharedSecret(peer.privateKey, pair.publicKey, info, length = 32)
+                assertEquals(viaPeer.toHex(), viaHardware.toHex(), "in-Enclave DH must be standard ECDH")
+            } finally {
+                peer.close()
+                pair.close()
+            }
+        }
+
+    @Test
+    fun offCurvePeerPointsAreRejectedUniformly() =
+        runTest {
+            val provider = agreeingEnclave() ?: return@runTest
+            val pair = provider.generateKeyAgreement(KeyAgreementCurve.P256, ProtectedKeySpec())
+            val ops = ops()
+            val peer = ops.generateKeyPair()
+            try {
+                // A valid encoding whose X coordinate was perturbed: right length, right 0x04 prefix,
+                // not on the curve. The element's rejection must arrive as InvalidPublicKey — the
+                // same answer a malformed encoding gets, with no detail about which check failed.
+                val bogus = KeyAgreementPublicKey.of(KeyAgreementCurve.P256, perturbed(peer.publicKey.encoded))
+                assertFailsWith<InvalidPublicKey> {
+                    ops.deriveSharedSecret(pair.privateKey, bogus, Info.Of(ascii("bad-peer")), length = 32)
+                }
+            } finally {
+                peer.close()
+                pair.close()
+            }
+        }
+
+    @Test
+    fun aDeniedAdvisoryGateRefusesTheDeriveBeforeTheElementIsTouched() =
+        runTest {
+            val provider = agreeingEnclave() ?: return@runTest
+            val spec = ProtectedKeySpec(authorization = HardwareAuthorization { false })
+            val pair = provider.generateKeyAgreement(KeyAgreementCurve.P256, spec)
+            val ops = ops()
+            val peer = ops.generateKeyPair()
+            try {
+                assertFailsWith<AuthorizationFailed> {
+                    ops.deriveSharedSecret(pair.privateKey, peer.publicKey, Info.Of(ascii("denied")), length = 32)
+                }
+            } finally {
+                peer.close()
+                pair.close()
+            }
+        }
+
+    /** A copy of [point] with one X-coordinate byte flipped — same length and 0x04 prefix, off-curve. */
+    private fun perturbed(point: ReadBuffer): ReadBuffer {
+        val out = copyBuffer(point, BufferFactory.Default)
+        val target = out.position() + 1
+        out.set(target, (out.get(target).toInt() xor X_FLIP_MASK).toByte())
+        return out
+    }
+
+    private companion object {
+        const val X_FLIP_MASK = 0x5A
+    }
+}

--- a/buffer-crypto/src/appleTest/kotlin/com/ditchoom/buffer/crypto/EnclaveRecordFormatTest.kt
+++ b/buffer-crypto/src/appleTest/kotlin/com/ditchoom/buffer/crypto/EnclaveRecordFormatTest.kt
@@ -1,0 +1,63 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.crypto.CryptoTestVectors.ascii
+import com.ditchoom.buffer.crypto.CryptoTestVectors.toHex
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The durable Enclave key record — `u8 kind | u16 pointLen | point | blob` — as pure parsing, with
+ * no Enclave involved, so it runs on every Apple target including the simulator.
+ *
+ * Signing and agreement keys are both (public point + restore blob) pairs, structurally identical;
+ * the kind byte is the only thing that keeps them from loading as each other. It also has to stay
+ * backward compatible with records written before the agreement kind existed.
+ */
+class EnclaveRecordFormatTest {
+    private val point = ascii("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef!")
+    private val blob = ascii("an opaque Enclave restore blob")
+
+    @Test
+    fun legacyRecordsWithoutAKindByteStillReadAsSigningKeys() {
+        // A pre-kind record is `u16 pointLen | point | blob`, so its first byte is the length's high
+        // byte — always 0x00 for a 65-byte point. That is what the parse falls back on, so a key
+        // persisted by an earlier release keeps loading as the signing key it is.
+        val record = BufferFactory.Default.allocate(LEGACY_HEADER_BYTES + point.remaining() + blob.remaining())
+        record.writeShort(point.remaining().toShort())
+        record.write(point)
+        record.write(blob)
+        record.resetForRead()
+        point.position(0)
+        blob.position(0)
+
+        assertEquals(ProtectedKeyAlgorithm.EcdsaP256, enclaveRecordAlgorithm(record))
+        val parsed = parseEnclaveRecord(record)
+        assertEquals(EnclaveKeyKind.Signing, parsed.kind)
+        assertEquals(point.toHex(), parsed.point.toHex())
+        assertEquals(blob.toHex(), parsed.blob.toHex())
+    }
+
+    @Test
+    fun kindTaggedRecordsRoundTripAndStayDistinguishable() {
+        for (kind in EnclaveKeyKind.entries) {
+            val record = frameEnclaveRecord(kind, point, blob)
+            val expected =
+                if (kind == EnclaveKeyKind.Signing) {
+                    ProtectedKeyAlgorithm.EcdsaP256
+                } else {
+                    ProtectedKeyAlgorithm.EcdhP256
+                }
+            assertEquals(expected, enclaveRecordAlgorithm(record), "$kind must report its own algorithm")
+            val parsed = parseEnclaveRecord(record)
+            assertEquals(kind, parsed.kind)
+            assertEquals(point.toHex(), parsed.point.toHex())
+            assertEquals(blob.toHex(), parsed.blob.toHex())
+        }
+    }
+
+    private companion object {
+        const val LEGACY_HEADER_BYTES = 2
+    }
+}

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.kt
@@ -29,7 +29,8 @@ import kotlin.time.Duration.Companion.seconds
  * [HardwareSupport.Unavailable] — but the machinery (SPI, gated keys, witness dispatch) is real and
  * exercised by a fake provider in the test suite. The families a secure element actually holds are
  * wired: **AES-GCM**, **signatures**, and — where the element backs it (Android Keystore
- * `PURPOSE_AGREE_KEY`, API 31+) — **ECDH key agreement**. ChaCha20-Poly1305 is excluded
+ * `PURPOSE_AGREE_KEY` on API 31+, Apple `SecureEnclave.P256.KeyAgreement`, both probed rather than
+ * inferred) — **ECDH key agreement**. ChaCha20-Poly1305 is excluded
  * (Enclave/StrongBox do not implement it) and verify keys are public (no secret to protect), so
  * neither gets a hardware variant; their sealed types are nonetheless already shaped to accept one
  * without a break.

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/HardwareKeyConformanceTest.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/HardwareKeyConformanceTest.kt
@@ -87,8 +87,9 @@ class HardwareKeyConformanceTest {
             }
         }
 
-        // ECDH P-256 key agreement is probed per device (Android API 31+ Keystore) — gate on
-        // eligibility. Where it holds, a real element-held key must agree with a software peer:
+        // ECDH P-256 key agreement is probed per device (Android API 31+ Keystore, Apple Secure
+        // Enclave) — gate on eligibility. Where it holds, a real element-held key must agree with a
+        // software peer:
         // both sides derive the same secret, proving the keystore DH produced standard ECDH.
         if (provider.eligible(ProtectedKeyAlgorithm.EcdhP256)) {
             val pair = provider.generateKeyAgreement(KeyAgreementCurve.P256, grant)

--- a/buffer-crypto/src/nativeInterop/swift/CryptoKitShim.h
+++ b/buffer-crypto/src/nativeInterop/swift/CryptoKitShim.h
@@ -20,6 +20,7 @@
 #define BCKS_ERR_AUTH (-2)
 #define BCKS_ERR_BUFFER (-3)
 #define BCKS_ERR_INTERNAL (-4)
+#define BCKS_ERR_PEER (-5)
 
 // ChaCha20-Poly1305.
 int32_t bcks_chachapoly_seal(
@@ -144,6 +145,28 @@ int32_t bcks_secure_enclave_p256_sign_ctx(
     const uint8_t *msgPtr, size_t msgLen,
     uint8_t *sigOut, size_t sigCap,
     size_t *sigLenOut);
+
+// Secure Enclave key agreement (hardware-backed P-256 ECDH). Same custody model as the signing
+// keys: the Enclave holds the private scalar, the blob is an encrypted representation only that
+// Enclave can restore, and the Diffie-Hellman runs inside the element — only the raw shared secret
+// crosses back. No SecAccessControl variant exists: the user-authenticated SPI exposes no key
+// agreement, so agreement keys carry the library's advisory gate only.
+
+// Generates a P-256 key-agreement key inside the Secure Enclave. Outputs match
+// bcks_secure_enclave_p256_generate (encrypted blob + uncompressed SEC1 public point).
+int32_t bcks_secure_enclave_p256_ka_generate(
+    uint8_t *blobOut, size_t blobCap, size_t *blobLenOut,
+    uint8_t *pointOut, size_t pointCap, size_t *pointLenOut);
+
+// Computes DH(enclaveKey, peer) inside the Enclave, emitting the raw 32-byte shared secret. `peer`
+// is the uncompressed SEC1 point (04 || X || Y), validated on-curve by CryptoKit. BCKS_ERR_PEER when
+// the peer point is malformed / off-curve / rejected (one uniform code — no oracle), BCKS_ERR_INPUT
+// when the blob is not restorable by this Enclave, BCKS_ERR_AUTH on a denied user authentication.
+int32_t bcks_secure_enclave_p256_ka_agree(
+    const uint8_t *blobPtr, size_t blobLen,
+    const uint8_t *peerPtr, size_t peerLen,
+    uint8_t *secretOut, size_t secretCap,
+    size_t *secretLenOut);
 
 // Keychain persistence — durable generic-password items for the alias-addressable key store.
 // `service` and `account` are NUL-terminated UTF-8 C strings (account == the caller's alias). The

--- a/buffer-crypto/src/nativeInterop/swift/CryptoKitShim.swift
+++ b/buffer-crypto/src/nativeInterop/swift/CryptoKitShim.swift
@@ -29,6 +29,7 @@ private let BCKS_ERR_INPUT: Int32 = -1 // malformed key / nonce / point / signat
 private let BCKS_ERR_AUTH: Int32 = -2 // AEAD tag mismatch / signature did not verify
 private let BCKS_ERR_BUFFER: Int32 = -3 // output buffer too small
 private let BCKS_ERR_INTERNAL: Int32 = -4 // unexpected CryptoKit failure
+private let BCKS_ERR_PEER: Int32 = -5 // peer public key rejected (malformed / off-curve)
 
 // Copy a CryptoKit Data result into a caller-provided output buffer, writing the length out.
 private func emit(_ data: Data, _ out: UnsafeMutablePointer<UInt8>?, _ outCap: Int, _ outLen: UnsafeMutablePointer<Int>?) -> Int32 {
@@ -542,6 +543,70 @@ public func bcks_secure_enclave_p256_sign_ctx(
         return emit(sig.derRepresentation, sigOut, sigCap, sigLenOut)
     } catch {
         return classifySignFailure(error)
+    }
+}
+
+// =============================================================================
+// Secure Enclave key agreement (hardware-backed P-256 ECDH) — CryptoKit
+// SecureEnclave.P256.KeyAgreement
+// =============================================================================
+//
+// The same custody model as the signing keys above: the Enclave generates and holds the P-256
+// private scalar, `dataRepresentation` is an *encrypted* blob only this Enclave can restore, and the
+// Diffie–Hellman itself runs inside the element. Only the raw 32-byte shared secret crosses back —
+// the caller runs the all-zero check / HKDF above it, so the scalar never enters process memory.
+//
+// No access-controlled (`SecAccessControl`) variant is offered, deliberately: the module's
+// user-authenticated SPI exposes no key-agreement surface, so an OS-bound agreement key would have
+// no caller and no test. Agreement keys therefore carry only the library's advisory gate.
+
+// Generate a P-256 *key agreement* key inside the Secure Enclave. Writes the persistent encrypted
+// key blob into blobOut and the uncompressed SEC1 public point (04 ‖ X ‖ Y) into pointOut.
+@_cdecl("bcks_secure_enclave_p256_ka_generate")
+public func bcks_secure_enclave_p256_ka_generate(
+    _ blobOut: UnsafeMutablePointer<UInt8>?, _ blobCap: Int,
+    _ blobLenOut: UnsafeMutablePointer<Int>?,
+    _ pointOut: UnsafeMutablePointer<UInt8>?, _ pointCap: Int,
+    _ pointLenOut: UnsafeMutablePointer<Int>?
+) -> Int32 {
+    guard SecureEnclave.isAvailable else { return BCKS_ERR_INTERNAL }
+    guard let key = try? SecureEnclave.P256.KeyAgreement.PrivateKey() else { return BCKS_ERR_INTERNAL }
+    let s = emit(key.dataRepresentation, blobOut, blobCap, blobLenOut)
+    if s != BCKS_OK { return s }
+    return emit(key.publicKey.x963Representation, pointOut, pointCap, pointLenOut)
+}
+
+// Classify a failure of the agreement itself (the peer point already decoded, so it is on-curve).
+// A CryptoKit parameter rejection is still peer-shaped; anything else is an auth denial or an
+// element failure, per classifySignFailure.
+private func classifyAgreeFailure(_ error: Error) -> Int32 {
+    if error is CryptoKitError { return BCKS_ERR_PEER }
+    return classifySignFailure(error)
+}
+
+// Compute DH(enclaveKey, peer) inside the Secure Enclave, emitting the raw 32-byte shared secret.
+// The peer point is the uncompressed SEC1 encoding (04 ‖ X ‖ Y); CryptoKit validates it is on-curve.
+// BCKS_ERR_PEER: peer point malformed / off-curve / rejected. BCKS_ERR_INPUT: the blob is not
+// restorable by this Enclave. BCKS_ERR_AUTH: user authentication denied.
+@_cdecl("bcks_secure_enclave_p256_ka_agree")
+public func bcks_secure_enclave_p256_ka_agree(
+    _ blobPtr: UnsafePointer<UInt8>?, _ blobLen: Int,
+    _ peerPtr: UnsafePointer<UInt8>?, _ peerLen: Int,
+    _ secretOut: UnsafeMutablePointer<UInt8>?, _ secretCap: Int,
+    _ secretLenOut: UnsafeMutablePointer<Int>?
+) -> Int32 {
+    guard let key = try? SecureEnclave.P256.KeyAgreement.PrivateKey(
+        dataRepresentation: bytes(blobPtr, blobLen)
+    ) else { return BCKS_ERR_INPUT }
+    guard let peer = try? P256.KeyAgreement.PublicKey(x963Representation: bytes(peerPtr, peerLen)) else {
+        return BCKS_ERR_PEER
+    }
+    do {
+        let shared = try key.sharedSecretFromKeyAgreement(with: peer)
+        let raw = shared.withUnsafeBytes { Data($0) }
+        return emit(raw, secretOut, secretCap, secretLenOut)
+    } catch {
+        return classifyAgreeFailure(error)
     }
 }
 


### PR DESCRIPTION
## Summary

Implements the **Apple half of #312**: `HardwareKeyProvider.generateKeyAgreement` and the persistent
`KeyStore.getOrGenerateKeyAgreement` / `loadKeyAgreement` are now real on Apple, backed by CryptoKit
`SecureEnclave.P256.KeyAgreement`. Mirrors the Android design from #316 point for point.

Two new shim functions (`bcks_secure_enclave_p256_ka_generate`, `bcks_secure_enclave_p256_ka_agree`)
plus one new status code (`BCKS_ERR_PEER`) so a peer-point rejection is distinguishable from an
unrestorable key blob *at the shim boundary* while staying one uniform code above it.

### Design

- **Probed eligibility, not capability inference.** `eligible(EcdhP256)` generates a throwaway
  Enclave agreement key and runs one full DH against a freshly generated software peer, lazily —
  the same shape as the existing signing generate-and-discard probe. `SecureEnclave.isAvailable`
  and OS version are not trusted on their own: an element that mints the key and then declines the
  agreement is routed to the software floor instead of over-promising hardware custody.
- **Gated-DH closure.** The private scalar never enters process memory: `DH(sk, peer)` runs inside
  the Enclave and only the raw shared secret comes back, into a wiped `SecureBuffer` handed to the
  common `validateRawSecret` / HKDF seam. `hpke()` / `keyAgreement()` witnesses compose unchanged,
  and `exportEncoded()` on the agreement key throws by construction.
- **Uniform peer rejection.** Malformed, wrong-length and off-curve peer points are all rejected by
  the one `P256.KeyAgreement.PublicKey(x963Representation:)` decode and arrive as a single shim
  status, surfacing as `InvalidPublicKey` with the cause dropped — same no-oracle contract as the
  software glue. An unrestorable blob stays typed as `KeyInvalidated`.
- **Purpose-disambiguated persistence.** Both Enclave key kinds are (public point + restore blob)
  records, structurally identical, so the durable Keychain record gains a leading kind byte:
  `u8 kind | u16 pointLen | point | blob`. A kind-mismatched load answers `null`; a kind-mismatched
  get-or-generate raises `AliasMismatch` (in both directions). Records written by earlier releases
  have no kind byte and begin with the point length's high byte — always `0x00` for a 65-byte
  point — so a leading `0x00` is parsed under the old layout and keeps loading as a signing key.
- **Advisory gate only.** CryptoKit *would* accept a `SecAccessControl` on an Enclave agreement key,
  but `UserAuthenticatedKeyProvider` exposes no key-agreement surface, so an OS-bound agreement key
  would have no caller and no test. No `_ac` / `_ctx` shim variant is added; agreement keys carry
  the advisory `ProtectedKeySpec.authorization` gate, evaluated before every derive.

### What was verified where

**Real Secure Enclave hardware** — `:buffer-crypto:macosArm64Test`, **335 tests, 0 failures**. This
Mac's test binary resolves a usable Enclave (`bcks_secure_enclave_available() == 1`, resolution
`Available(AppleSecureEnclave)`) *and* the new generate-and-agree probe holds, confirmed by
instrumenting the gate during development. So these ran against the real element, not a fallback:

- `HardwareKeyConformanceTest.hardwareCapabilityReflectsThePlatformBackend` →
  `assertRealProviderWorks` drove the real provider's ECDH branch (hardware key ↔ software peer,
  both sides deriving the same secret).
- `EnclaveKeyAgreementTest` — persist / reload-across-simulated-restart / derive round-trip against
  a software peer; alias-kind mismatch both directions (`AliasMismatch` + `null` loads); signing
  keys still round-tripping under the kind-tagged record; ephemeral in-element DH matching a
  software peer; off-curve peer point → `InvalidPublicKey`; denied advisory gate → `AuthorizationFailed`.
- `EnclaveAgreementEligibilityTest.ineligibleCurvesAreRefused` — X25519 refused by the real provider
  and the Keychain store.

**iOS simulator (no Enclave)** — `:buffer-crypto:iosSimulatorArm64Test`, **335 tests, 0 failures**.
The resolution is `Refused(AppleSecureEnclave, NotPresent)` and `keyStore()` falls back to the
software store, so the eligibility probe degrades without throwing and
`EnclaveAgreementEligibilityTest.withoutAnEnclaveTheStoreDegradesToAnHonestSoftwareTier` ran its
real body there: agreement still works, provenance is `Software`, custody is below `Hardware`, and
`requireTier(Hardware)` raises `InsufficientKeyCustody`. The Enclave-gated tests skip there by
capability, as intended.

**Software / no-hardware paths** — `EnclaveRecordFormatTest` (record framing + the legacy no-kind-byte
fallback) is pure parsing and ran on both targets. `FakeHardware` in commonTest already covers the
witness / KDF machinery on every platform; it needed no change.

The Swift shim was force-recompiled for `tvos_arm64`, `watchos_x64` and `ios_arm64` in addition to
`macos_arm64` — `SecureEnclave.P256.KeyAgreement` compiles on every Apple target.

`apiCheck` green (public ABI unchanged — all additions `internal`), `ktlintCheck` green, `detekt`
clean (zero findings on the module, baseline untouched).

Closes #312 — Android landed in #316 and this was the remaining half.
