### PR TITLE
feat(buffer-crypto): user-authentication-bound hardware ECDH key agreement

### DIFF
--- a/buffer-crypto/api/android/buffer-crypto.api
+++ b/buffer-crypto/api/android/buffer-crypto.api
@@ -1356,6 +1356,10 @@ public final class com/ditchoom/buffer/crypto/OptionalAead$Unavailable : com/dit
 	public fun toString ()Ljava/lang/String;
 }
 
+public abstract interface class com/ditchoom/buffer/crypto/PerUseAgreementCapable : com/ditchoom/buffer/crypto/UserAuthenticatedKeyProvider {
+	public abstract fun generateKeyAgreement (Lcom/ditchoom/buffer/crypto/KeyAgreementCurve;Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy$PerUse;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class com/ditchoom/buffer/crypto/ProtectedKeyAlgorithm : java/lang/Enum {
 	public static final field AesGcm Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
 	public static final field EcdhP256 Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
@@ -1848,6 +1852,7 @@ public abstract interface class com/ditchoom/buffer/crypto/UserAuthenticatedKeyP
 	public abstract fun eligible (Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;)Z
 	public abstract fun generateAesGcm (Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun generateAesGcm$default (Lcom/ditchoom/buffer/crypto/UserAuthenticatedKeyProvider;Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun generateKeyAgreement (Lcom/ditchoom/buffer/crypto/KeyAgreementCurve;Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy$Windowed;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun generateSigning (Lcom/ditchoom/buffer/crypto/SignatureScheme;Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -1879,7 +1884,7 @@ public final class com/ditchoom/buffer/crypto/UserAuthenticationPolicy$PerUse : 
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/ditchoom/buffer/crypto/UserAuthenticationPolicy$Session : com/ditchoom/buffer/crypto/UserAuthenticationPolicy {
+public final class com/ditchoom/buffer/crypto/UserAuthenticationPolicy$Session : com/ditchoom/buffer/crypto/UserAuthenticationPolicy$Windowed {
 	public synthetic fun <init> (JLcom/ditchoom/buffer/crypto/UserAuthenticationMethod;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (JLcom/ditchoom/buffer/crypto/UserAuthenticationMethod;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-UwyO8pc ()J
@@ -1891,6 +1896,9 @@ public final class com/ditchoom/buffer/crypto/UserAuthenticationPolicy$Session :
 	public final fun getValidity-UwyO8pc ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/UserAuthenticationPolicy$Windowed : com/ditchoom/buffer/crypto/UserAuthenticationPolicy {
 }
 
 public final class com/ditchoom/buffer/crypto/VerificationFailed : com/ditchoom/buffer/crypto/CryptoException {

--- a/buffer-crypto/api/jvm/buffer-crypto.api
+++ b/buffer-crypto/api/jvm/buffer-crypto.api
@@ -1341,6 +1341,10 @@ public final class com/ditchoom/buffer/crypto/OptionalAead$Unavailable : com/dit
 	public fun toString ()Ljava/lang/String;
 }
 
+public abstract interface class com/ditchoom/buffer/crypto/PerUseAgreementCapable : com/ditchoom/buffer/crypto/UserAuthenticatedKeyProvider {
+	public abstract fun generateKeyAgreement (Lcom/ditchoom/buffer/crypto/KeyAgreementCurve;Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy$PerUse;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class com/ditchoom/buffer/crypto/ProtectedKeyAlgorithm : java/lang/Enum {
 	public static final field AesGcm Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
 	public static final field EcdhP256 Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
@@ -1831,6 +1835,7 @@ public abstract interface class com/ditchoom/buffer/crypto/UserAuthenticatedKeyP
 	public abstract fun eligible (Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;)Z
 	public abstract fun generateAesGcm (Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun generateAesGcm$default (Lcom/ditchoom/buffer/crypto/UserAuthenticatedKeyProvider;Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun generateKeyAgreement (Lcom/ditchoom/buffer/crypto/KeyAgreementCurve;Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy$Windowed;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun generateSigning (Lcom/ditchoom/buffer/crypto/SignatureScheme;Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -1862,7 +1867,7 @@ public final class com/ditchoom/buffer/crypto/UserAuthenticationPolicy$PerUse : 
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/ditchoom/buffer/crypto/UserAuthenticationPolicy$Session : com/ditchoom/buffer/crypto/UserAuthenticationPolicy {
+public final class com/ditchoom/buffer/crypto/UserAuthenticationPolicy$Session : com/ditchoom/buffer/crypto/UserAuthenticationPolicy$Windowed {
 	public synthetic fun <init> (JLcom/ditchoom/buffer/crypto/UserAuthenticationMethod;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (JLcom/ditchoom/buffer/crypto/UserAuthenticationMethod;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-UwyO8pc ()J
@@ -1874,6 +1879,9 @@ public final class com/ditchoom/buffer/crypto/UserAuthenticationPolicy$Session :
 	public final fun getValidity-UwyO8pc ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/UserAuthenticationPolicy$Windowed : com/ditchoom/buffer/crypto/UserAuthenticationPolicy {
 }
 
 public final class com/ditchoom/buffer/crypto/VerificationFailed : com/ditchoom/buffer/crypto/CryptoException {

--- a/buffer-crypto/src/androidInstrumentedTest/kotlin/com/ditchoom/buffer/crypto/UserAuthBindingInstrumentedTest.kt
+++ b/buffer-crypto/src/androidInstrumentedTest/kotlin/com/ditchoom/buffer/crypto/UserAuthBindingInstrumentedTest.kt
@@ -11,6 +11,7 @@ import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -74,6 +75,46 @@ class UserAuthBindingInstrumentedTest {
                 key.close()
             }
         }
+
+    @Test
+    fun sessionBoundAgreementIsRefusedByTheKeystoreWithoutAuthentication() =
+        runTest {
+            assumeTrue("requires a secure lock screen", keyguard.isDeviceSecure)
+            val provider = authenticatedProvider()
+            assumeTrue("device KeyMint must back PURPOSE_AGREE_KEY", provider.eligible(ProtectedKeyAlgorithm.EcdhP256))
+            val pair =
+                provider.generateKeyAgreement(KeyAgreementCurve.P256, UserAuthenticationPolicy.Session(5.seconds))
+            try {
+                val ops = assertNotNull(keyAgreementAsyncOrNull(KeyAgreementCurve.P256))
+                val peer = ops.generateKeyPair()
+                try {
+                    // The stale-window derive throws UserAuthenticationRequired; the gate re-prompts
+                    // once via the LyingPrompt (which never really authenticates), so the retry is
+                    // refused again and the terminal state propagates — proving the keystore, not the
+                    // library, enforces the binding on ECDH.
+                    assertFailsWith<HardwareKeyException.UserAuthenticationRequired>(
+                        "an auth-bound agreement key must be unusable without a real device unlock",
+                    ) {
+                        ops.deriveSharedSecret(pair.privateKey, peer.publicKey, Info.Of(ascii("nope")), length = 32)
+                    }
+                } finally {
+                    peer.close()
+                }
+            } finally {
+                pair.close()
+            }
+        }
+
+    @Test
+    fun androidProviderIsNotPerUseAgreementCapable() {
+        // The type-level guarantee, checked on real silicon: Android has no CryptoObject overload for
+        // KeyAgreement, so its provider must NOT advertise per-derive agreement — a caller's
+        // `is PerUseAgreementCapable` narrowing correctly falls through to the Session path here.
+        assertTrue(
+            authenticatedProvider() !is PerUseAgreementCapable,
+            "the Android keystore provider cannot bind per-derive agreement",
+        )
+    }
 
     @Test
     fun perUseKeyIsRefusedWhenTheCryptoObjectWasNeverAuthorized() =

--- a/buffer-crypto/src/androidMain/kotlin/com/ditchoom/buffer/crypto/BiometricAuth.android.kt
+++ b/buffer-crypto/src/androidMain/kotlin/com/ditchoom/buffer/crypto/BiometricAuth.android.kt
@@ -180,6 +180,19 @@ internal class AndroidUserAuthenticatedKeyProvider(
         policy: UserAuthenticationPolicy,
     ): SigningKey = base.generateSigningBound(policy.resolve(), scheme)
 
+    // Deliberately NOT a PerUseAgreementCapable: Android's keystore has no CryptoObject overload for
+    // KeyAgreement, so it can gate ECDH by the auth window (Session) but never per-derive (PerUse).
+    // The Windowed parameter type makes that limit a compile-time fact rather than a runtime throw.
+    override suspend fun generateKeyAgreement(
+        curve: KeyAgreementCurve,
+        policy: UserAuthenticationPolicy.Windowed,
+    ): KeyAgreementKeyPair {
+        if (curve != KeyAgreementCurve.P256 || !base.eligible(ProtectedKeyAlgorithm.EcdhP256)) {
+            throw HardwareKeyException.AlgorithmNotEligible()
+        }
+        return base.generateKeyAgreementBound(policy.resolve())
+    }
+
     private fun UserAuthenticationPolicy.resolve(): ResolvedAndroidPolicy =
         when (this) {
             is UserAuthenticationPolicy.Session -> ResolvedAndroidPolicy.Session(validity, method, prompt)

--- a/buffer-crypto/src/androidMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.android.kt
+++ b/buffer-crypto/src/androidMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.android.kt
@@ -155,19 +155,31 @@ internal class AndroidKeystoreHardwareKeyProvider : HardwareKeyProvider {
     }
 
     /**
-     * Wraps an AndroidKeystore ECDH private-key handle as a [KeyAgreementKeyPair]. Shared by the
-     * ephemeral provider ([generateKeyAgreement], a scratch alias deleted on close) and the
-     * persistent [AndroidKeystoreKeyStore] (a named alias whose [onClose] is a no-op).
-     *
-     * Agreement keys are only ever **advisory**-gated: [UserAuthenticatedKeyProvider] exposes no key
-     * agreement, and `BiometricPrompt.CryptoObject` cannot wrap a JCA `KeyAgreement` on the API
-     * levels this module supports — so the [gate] here is the advisory
-     * [ProtectedKeySpec.authorization], evaluated before every derive (outside the keystore lock).
+     * Wraps an AndroidKeystore ECDH private-key handle as an **advisory**-gated [KeyAgreementKeyPair]
+     * — the [gate] is [ProtectedKeySpec.authorization], evaluated before every derive. This is the
+     * path the unbound provider and the persistent store use; the OS-bound path takes the
+     * [ResolvedAndroidPolicy] overload below.
      */
     internal fun buildKeyAgreementPair(
         privateKey: PrivateKey,
         publicKey: KeyAgreementPublicKey,
         gate: HardwareAuthorization,
+        onClose: () -> Unit,
+    ): KeyAgreementKeyPair = buildKeyAgreementPair(privateKey, publicKey, ResolvedAndroidPolicy.Advisory(gate), onClose)
+
+    /**
+     * Wraps an AndroidKeystore ECDH private-key handle as a [KeyAgreementKeyPair] gated by
+     * [policy]. The [ResolvedAndroidPolicy.Session] arm is the only OS-bound one reachable for key
+     * agreement: `BiometricPrompt.CryptoObject` has no `KeyAgreement` overload, so a per-derive
+     * (`PerUse`) agreement key cannot be bound on Android — the type system already prevents it (the
+     * `UserAuthenticatedKeyProvider.generateKeyAgreement` surface takes only
+     * [UserAuthenticationPolicy.Windowed], and this provider is not a [PerUseAgreementCapable]), and
+     * [gatedAgreementDh] rejects a stray `PerUse` defensively.
+     */
+    internal fun buildKeyAgreementPair(
+        privateKey: PrivateKey,
+        publicKey: KeyAgreementPublicKey,
+        policy: ResolvedAndroidPolicy,
         onClose: () -> Unit,
     ): KeyAgreementKeyPair {
         val curve = publicKey.curve
@@ -176,16 +188,67 @@ internal class AndroidKeystoreHardwareKeyProvider : HardwareKeyProvider {
                 curve = curve,
                 custody = custody,
                 gatedDh = { peer ->
-                    if (!gate.authorize()) throw AuthorizationFailed()
                     require(peer.curve == curve) { "private/public key curve mismatch" }
                     // Peer-point conversion happens outside the keystore lock; a malformed or
                     // off-curve point is rejected before the element is ever touched.
                     val jcaPeer = p256PublicKey(peer.encoded)
-                    keystoreOp { agreeP256(privateKey, jcaPeer) }
+                    gatedAgreementDh(policy) { keystoreOp { agreeP256(privateKey, jcaPeer) } }
                 },
                 onClose = onClose,
             )
         return keyAgreementKeyPairOf(curve, agreementPrivateKey, publicKey)
+    }
+
+    /**
+     * Runs one keystore ECDH [dh] under the key's [policy] — the agreement analogue of [gatedOp],
+     * minus the `CryptoObject` path (a `KeyAgreement` cannot be wrapped, and no per-derive agreement
+     * key exists here):
+     *  - [ResolvedAndroidPolicy.Advisory]: gate first, then one shot.
+     *  - [ResolvedAndroidPolicy.Session]: one shot; on a stale keystore auth window
+     *    ([HardwareKeyException.UserAuthenticationRequired]), prompt once (no `CryptoObject`) and
+     *    retry once — the derive re-runs [agreeP256] fresh.
+     *  - [ResolvedAndroidPolicy.PerUse]: unreachable for agreement; refused rather than silently
+     *    downgraded to an unbound derive.
+     */
+    private suspend fun <T> gatedAgreementDh(
+        policy: ResolvedAndroidPolicy,
+        dh: suspend () -> T,
+    ): T =
+        when (policy) {
+            is ResolvedAndroidPolicy.Advisory -> {
+                if (!policy.gate.authorize()) throw AuthorizationFailed()
+                dh()
+            }
+
+            is ResolvedAndroidPolicy.Session ->
+                try {
+                    dh()
+                } catch (_: HardwareKeyException.UserAuthenticationRequired) {
+                    if (!policy.unlock()) throw AuthorizationFailed()
+                    dh()
+                }
+
+            is ResolvedAndroidPolicy.PerUse -> throw HardwareKeyException.AlgorithmNotEligible()
+        }
+
+    /**
+     * Generates an OS-bound ECDH P-256 agreement key under [policy] (a [UserAuthenticationPolicy.Windowed]
+     * → [ResolvedAndroidPolicy.Session] binding). Ephemeral: the scratch alias is deleted on close.
+     * The `Windowed` bound at the [UserAuthenticatedKeyProvider] surface is what keeps a `PerUse`
+     * agreement request from ever reaching here.
+     */
+    internal suspend fun generateKeyAgreementBound(policy: ResolvedAndroidPolicy): KeyAgreementKeyPair {
+        if (!eligible(ProtectedKeyAlgorithm.EcdhP256)) throw HardwareKeyException.AlgorithmNotEligible()
+        val alias = newAlias("ecdh")
+        val keyPair = keystoreOp { generateAgreementKeyPair(alias, policy) }
+        val publicKey =
+            KeyAgreementPublicKey.of(KeyAgreementCurve.P256, uncompressedPoint(keyPair.public as ECPublicKey))
+        return buildKeyAgreementPair(
+            keyPair.private,
+            publicKey,
+            policy,
+            onClose = { runCatching { keyStore.deleteEntry(alias) } },
+        )
     }
 
     /** Generates an AES-GCM keystore key under [policy] — the shared path for unbound and OS-bound keys. */

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeyAgreement.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeyAgreement.apple.kt
@@ -11,8 +11,9 @@ import com.ditchoom.buffer.crypto.cinterop.cryptokit.BCKS_ERR_AUTH
 import com.ditchoom.buffer.crypto.cinterop.cryptokit.BCKS_ERR_INPUT
 import com.ditchoom.buffer.crypto.cinterop.cryptokit.BCKS_ERR_PEER
 import com.ditchoom.buffer.crypto.cinterop.cryptokit.BCKS_OK
-import com.ditchoom.buffer.crypto.cinterop.cryptokit.bcks_secure_enclave_p256_ka_agree
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.bcks_secure_enclave_p256_ka_agree_ctx
 import com.ditchoom.buffer.crypto.cinterop.cryptokit.bcks_secure_enclave_p256_ka_generate
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.bcks_secure_enclave_p256_ka_generate_ac
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.alloc
 import kotlinx.cinterop.convert
@@ -39,25 +40,49 @@ import platform.posix.size_tVar
  * [ProtectedKeySpec.authorization], evaluated before every derive.
  */
 
-/** Generates a P-256 key-agreement key inside the Secure Enclave (restore blob + public point). */
+/** Generates an advisory-gated P-256 key-agreement key inside the Secure Enclave (blob + point). */
 internal fun enclaveGenerateKaP256(): EnclaveP256Key =
     enclaveGenerate { blobPtr, blobCap, blobLen, pointPtr, pointCap, pointLen ->
         bcks_secure_enclave_p256_ka_generate(blobPtr, blobCap, blobLen, pointPtr, pointCap, pointLen)
     }
 
 /**
- * Runs `DH(enclaveKey, peer)` inside the Enclave — the key restored from [blob], the peer supplied
- * as its uncompressed SEC1 point — and returns the raw 32-byte shared secret in a wiped
- * [SecureBuffer] (the common seam applies the KDF / validation above it).
+ * Generates an **access-controlled** P-256 key-agreement key inside the Secure Enclave — the element
+ * itself refuses a derive without a satisfied [SecAccessControl] authentication ([method]: userPresence
+ * or biometryCurrentSet). Used for [UserAuthenticationPolicy] agreement keys; the returned blob
+ * restores only under an authenticated LAContext (see [enclaveAgreeP256]).
+ */
+internal fun enclaveGenerateKaP256AccessControlled(method: UserAuthenticationMethod): EnclaveP256Key =
+    enclaveGenerate { blobPtr, blobCap, blobLen, pointPtr, pointCap, pointLen ->
+        // The shim's authReq selector matches laMethod(): 1 = userPresence, 2 = biometryCurrentSet.
+        bcks_secure_enclave_p256_ka_generate_ac(
+            method.laMethod(),
+            blobPtr,
+            blobCap,
+            blobLen,
+            pointPtr,
+            pointCap,
+            pointLen,
+        )
+    }
+
+/**
+ * Runs `DH(enclaveKey, peer)` inside the Enclave — the key restored from [blob], authorized through
+ * the LAContext behind [laHandle] (`0` = none), the peer supplied as its uncompressed SEC1 point —
+ * and returns the raw 32-byte shared secret in a wiped [SecureBuffer] (the common seam applies the
+ * KDF / validation above it).
  *
  * A rejected peer point (malformed, wrong length, off-curve) surfaces as the uniform
  * [InvalidPublicKey] with the shim's cause dropped — the same no-oracle contract as the software
- * agreement glue. A blob this Enclave can no longer restore is [HardwareKeyException.KeyInvalidated].
+ * agreement glue. Returns `null` when the OS denied user authentication (the caller maps it to the
+ * policy-appropriate typed exception). A blob this Enclave can no longer restore is
+ * [HardwareKeyException.KeyInvalidated].
  */
 internal fun enclaveAgreeP256(
     blob: ReadBuffer,
     peerPoint: ReadBuffer,
-): PlatformBuffer {
+    laHandle: Long = 0L,
+): PlatformBuffer? {
     val cap = KeyAgreementCurve.P256.sharedSecretBytes
     val out = secureScratch.allocate(cap)
     var status = -1
@@ -69,9 +94,10 @@ internal fun enclaveAgreeP256(
             peerPoint.withRemainingBytes2(peerLen) { peerPtr ->
                 out.withWritablePointer(cap) { secretPtr ->
                     status =
-                        bcks_secure_enclave_p256_ka_agree(
+                        bcks_secure_enclave_p256_ka_agree_ctx(
                             blobPtr.reinterpret(),
                             blobLen.convert(),
+                            laHandle,
                             peerPtr.reinterpret(),
                             peerLen.convert(),
                             secretPtr.reinterpret(),
@@ -83,18 +109,21 @@ internal fun enclaveAgreeP256(
         }
         written = secretLen.value.toInt()
     }
-    if (status != BCKS_OK) {
-        out.freeNativeMemory()
-        throw enclaveAgreeFailure(status)
+    if (status == BCKS_OK) {
+        out.position(written)
+        out.resetForRead()
+        return out
     }
-    out.position(written)
-    out.resetForRead()
-    return out
+    out.freeNativeMemory()
+    // A denied user authentication is `null`, not a throw: the gated closure decides the typed
+    // outcome (session re-prompt vs terminal), exactly as the signing path does.
+    if (status == BCKS_ERR_AUTH) return null
+    throw enclaveAgreeFailure(status)
 }
 
 /**
- * The typed failure a non-OK agreement status stands for. Returned rather than thrown so the caller
- * frees the secret buffer first and keeps a single throw site.
+ * The typed failure a non-OK, non-auth agreement status stands for. Returned rather than thrown so
+ * the caller frees the secret buffer first and keeps a single throw site.
  */
 private fun enclaveAgreeFailure(status: Int): Throwable =
     when (status) {
@@ -103,9 +132,6 @@ private fun enclaveAgreeFailure(status: Int): Throwable =
         BCKS_ERR_PEER -> InvalidPublicKey(KeyAgreementCurve.P256)
         // The Enclave cannot restore this blob (wrong device, or an OS-invalidated key).
         BCKS_ERR_INPUT -> HardwareKeyException.KeyInvalidated()
-        // Unreachable today (no agreement key is access-controlled), kept typed rather than folded
-        // into the generic hardware failure so an OS-bound key would surface honestly.
-        BCKS_ERR_AUTH -> AuthorizationFailed()
         else -> HardwareKeyException.TransientHardwareFailure(retryable = false)
     }
 

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.apple.kt
@@ -116,36 +116,130 @@ internal class SecureEnclaveHardwareKeyProvider : HardwareKeyProvider {
     }
 
     /**
-     * Wraps an Enclave restore [blob] + public [point] as a [KeyAgreementKeyPair] whose DH runs
-     * inside the element. Shared by the ephemeral [generateKeyAgreement] and the persistent
-     * [AppleKeychainKeyStore] paths — the only difference between them is who holds the record.
-     *
-     * The [gate] is the advisory [ProtectedKeySpec.authorization]: agreement keys carry no
-     * `SecAccessControl` (see HardwareKeyAgreement.apple.kt), so the gate is evaluated by library
-     * code before each derive, and the raw secret goes straight to the common validate/HKDF seam.
+     * Wraps an Enclave restore [blob] + public [point] as an **advisory**-gated [KeyAgreementKeyPair]
+     * whose DH runs inside the element. Shared by the ephemeral [generateKeyAgreement] and the
+     * persistent [AppleKeychainKeyStore] paths. The [gate] is the advisory
+     * [ProtectedKeySpec.authorization]; the key carries no `SecAccessControl`, so the OS never
+     * prompts and an auth-denied status is unreachable (surfaced as the closest structured outcome).
+     * OS-bound agreement keys take [buildBoundKeyAgreement] instead.
      */
     internal fun buildKeyAgreementPair(
         blob: PlatformBuffer,
         point: ReadBuffer,
         gate: HardwareAuthorization,
+    ): KeyAgreementKeyPair = buildBoundKeyAgreement(ResolvedApplePolicy.Advisory(gate), blob, point)
+
+    /**
+     * Wraps an Enclave restore [blob] + public [point] as a [KeyAgreementKeyPair] gated by [policy].
+     * The gated DH dispatches exactly like [gatedSign]: advisory (library gate, `laHandle = 0`),
+     * session (a library-enforced validity window over one long-lived LAContext, re-prompting once on
+     * an OS-invalidated window), or per-use (a fresh LAContext per derive). The raw secret goes
+     * straight to the common validate/HKDF seam; the scalar never enters process memory.
+     */
+    internal fun buildBoundKeyAgreement(
+        policy: ResolvedApplePolicy,
+        blob: PlatformBuffer,
+        point: ReadBuffer,
     ): KeyAgreementKeyPair {
         val curve = KeyAgreementCurve.P256
         val privateKey =
             ProtectedKeyAgreementPrivateKey(
                 curve = curve,
                 custody = custody,
-                gatedDh = { peer ->
-                    if (!gate.authorize()) throw AuthorizationFailed()
-                    require(peer.curve == curve) { "private/public key curve mismatch" }
-                    enclaveAgreeP256(blob, peer.encoded)
-                },
+                gatedDh = gatedAgreementDh(policy, blob),
             )
         return keyAgreementKeyPairOf(curve, privateKey, KeyAgreementPublicKey.of(curve, point))
     }
 
+    /** The [HardwareDh] closure for [policy] — the agreement analogue of [gatedSign]. */
+    private fun gatedAgreementDh(
+        policy: ResolvedApplePolicy,
+        blob: PlatformBuffer,
+    ): HardwareDh =
+        when (policy) {
+            is ResolvedApplePolicy.Advisory -> advisoryAgree(policy.gate, blob)
+            is ResolvedApplePolicy.Session -> sessionAgree(policy, blob)
+            is ResolvedApplePolicy.PerUse -> perUseAgree(policy.authenticator, blob)
+        }
+
+    private fun advisoryAgree(
+        gate: HardwareAuthorization,
+        blob: PlatformBuffer,
+    ): HardwareDh =
+        { peer ->
+            if (!gate.authorize()) throw AuthorizationFailed()
+            requireP256(peer)
+            // No SecAccessControl, so an auth-denied status is unreachable; the impossible `null`
+            // surfaces as the closest structured outcome rather than a silent success.
+            enclaveAgreeP256(blob, peer.encoded, laHandle = 0L) ?: throw AuthorizationFailed()
+        }
+
+    private fun sessionAgree(
+        policy: ResolvedApplePolicy.Session,
+        blob: PlatformBuffer,
+    ): HardwareDh {
+        val authenticator = policy.authenticator
+        val window = SessionWindow(policy.validity, policy.method, authenticator)
+        return { peer ->
+            requireP256(peer)
+            // A closed authenticator has released its LAContext; refuse before handing the shim a
+            // stale handle (which the derive would otherwise misreport as KeyInvalidated).
+            if (!authenticator.available) throw AuthorizationFailed()
+            window.ensureAuthenticated()
+            val first =
+                withContext(Dispatchers.Default) {
+                    enclaveAgreeP256(blob, peer.encoded, authenticator.contextHandle)
+                }
+            first ?: run {
+                // The OS refused a derive on a window we believed fresh — the LAContext was
+                // invalidated out from under us. Reset, re-prompt exactly once, retry; only a second
+                // refusal is the terminal state. Mirrors [sessionSign].
+                window.invalidate()
+                window.ensureAuthenticated()
+                withContext(Dispatchers.Default) {
+                    enclaveAgreeP256(blob, peer.encoded, authenticator.contextHandle)
+                } ?: throw HardwareKeyException.UserAuthenticationRequired()
+            }
+        }
+    }
+
+    private fun perUseAgree(
+        authenticator: LocalAuthAuthenticator,
+        blob: PlatformBuffer,
+    ): HardwareDh =
+        { peer ->
+            requireP256(peer)
+            // A fresh, un-evaluated context per derive: the OS prompts during the agreement itself,
+            // binding the authentication to exactly this operation. Blocking prompt ⇒ off-thread.
+            val fresh = authenticator.newContextHandle()
+            try {
+                withContext(Dispatchers.Default) {
+                    enclaveAgreeP256(blob, peer.encoded, fresh)
+                } ?: throw AuthorizationFailed()
+            } finally {
+                releaseContextHandle(fresh)
+            }
+        }
+
     /**
-     * Probes the Enclave's ECDH support end to end: generate a throwaway agreement key, then run one
-     * real agreement against a freshly generated software peer through the production
+     * Generates an OS-bound Enclave P-256 agreement key under [policy] (access-controlled: the
+     * element refuses an unauthenticated derive). Ephemeral — the blob is in-process bytes, not a
+     * Keychain item, so close releases nothing out of process.
+     */
+    internal fun generateKeyAgreementBound(policy: ResolvedApplePolicy): KeyAgreementKeyPair {
+        if (!eligible(ProtectedKeyAlgorithm.EcdhP256)) throw HardwareKeyException.AlgorithmNotEligible()
+        val generated =
+            when (policy) {
+                is ResolvedApplePolicy.Advisory -> enclaveGenerateKaP256()
+                is ResolvedApplePolicy.Session -> enclaveGenerateKaP256AccessControlled(policy.method)
+                is ResolvedApplePolicy.PerUse -> enclaveGenerateKaP256AccessControlled(policy.method)
+            }
+        return buildBoundKeyAgreement(policy, generated.blob, generated.point)
+    }
+
+    /**
+     * Probes the Enclave's ECDH support end to end: generate a throwaway advisory agreement key, then
+     * run one real agreement against a freshly generated software peer through the production
      * [enclaveAgreeP256] path. Generation alone would over-promise — an element that mints the key
      * and then refuses the DH must route to the software floor, not report hardware custody.
      */
@@ -155,9 +249,9 @@ internal class SecureEnclaveHardwareKeyProvider : HardwareKeyProvider {
             try {
                 val peer = generateKeyPairPlatform(KeyAgreementCurve.P256)
                 try {
-                    val secret = enclaveAgreeP256(key.blob, peer.publicKey.encoded)
-                    val ok = secret.remaining() == KeyAgreementCurve.P256.sharedSecretBytes
-                    secret.freeNativeMemory()
+                    val secret = enclaveAgreeP256(key.blob, peer.publicKey.encoded, laHandle = 0L)
+                    val ok = secret != null && secret.remaining() == KeyAgreementCurve.P256.sharedSecretBytes
+                    secret?.freeNativeMemory()
                     ok
                 } finally {
                     peer.close()
@@ -170,6 +264,9 @@ internal class SecureEnclaveHardwareKeyProvider : HardwareKeyProvider {
             // No Enclave, no entitlement, or an element that declines agreement keys.
             false
         }
+
+    private fun requireP256(peer: KeyAgreementPublicKey) =
+        require(peer.curve == KeyAgreementCurve.P256) { "private/public key curve mismatch" }
 
     /** Generates an Enclave P-256 key under [policy] — the shared path for unbound and OS-bound keys. */
     internal suspend fun generateSigningBound(
@@ -360,7 +457,9 @@ internal sealed interface ResolvedApplePolicy {
 internal class AppleUserAuthenticatedKeyProvider(
     private val base: SecureEnclaveHardwareKeyProvider,
     private val authenticator: LocalAuthAuthenticator,
-) : UserAuthenticatedKeyProvider {
+) : PerUseAgreementCapable {
+    // PerUseAgreementCapable: the Enclave binds authentication to the exact derive op (a fresh
+    // LAContext per agreement), so per-use ECDH is real here — unlike Android's window-only binding.
     override fun eligible(alg: ProtectedKeyAlgorithm): Boolean = base.eligible(alg)
 
     override suspend fun generateAesGcm(
@@ -372,6 +471,26 @@ internal class AppleUserAuthenticatedKeyProvider(
         scheme: SignatureScheme,
         policy: UserAuthenticationPolicy,
     ): SigningKey = base.generateSigningBound(policy.resolve(), scheme)
+
+    override suspend fun generateKeyAgreement(
+        curve: KeyAgreementCurve,
+        policy: UserAuthenticationPolicy.Windowed,
+    ): KeyAgreementKeyPair = boundKeyAgreement(curve, policy)
+
+    override suspend fun generateKeyAgreement(
+        curve: KeyAgreementCurve,
+        policy: UserAuthenticationPolicy.PerUse,
+    ): KeyAgreementKeyPair = boundKeyAgreement(curve, policy)
+
+    private fun boundKeyAgreement(
+        curve: KeyAgreementCurve,
+        policy: UserAuthenticationPolicy,
+    ): KeyAgreementKeyPair {
+        if (curve != KeyAgreementCurve.P256 || !base.eligible(ProtectedKeyAlgorithm.EcdhP256)) {
+            throw HardwareKeyException.AlgorithmNotEligible()
+        }
+        return base.generateKeyAgreementBound(policy.resolve())
+    }
 
     private fun UserAuthenticationPolicy.resolve(): ResolvedApplePolicy =
         when (this) {

--- a/buffer-crypto/src/appleTest/kotlin/com/ditchoom/buffer/crypto/EnclaveBoundKeyAgreementTest.kt
+++ b/buffer-crypto/src/appleTest/kotlin/com/ditchoom/buffer/crypto/EnclaveBoundKeyAgreementTest.kt
@@ -15,6 +15,12 @@ import kotlin.time.Duration.Companion.minutes
  * generates and reports hardware custody. Generation does not prompt — only a derive does — so these
  * need no human.
  *
+ * Generation of an access-controlled key still depends on the *enrollment* the policy demands:
+ * `Session`/`userPresence` is satisfied by a device passcode, but `PerUse`/`biometryCurrentSet`
+ * needs an enrolled biometric, and the Enclave declines to mint the key without one
+ * ([HardwareKeyException.SecureElementUnavailable]). A runner without that enrollment (CI, a device
+ * with no fingerprint set) is not a failure — the test skips, exactly as it does without an Enclave.
+ *
  * The **positive** path (authenticate → derive succeeds; per-use prompts every time; session prompts
  * once per window) drives a real Touch ID / Face ID prompt and is therefore attended: it is covered
  * in the manual device session, not here. This test never triggers a prompt.
@@ -27,6 +33,21 @@ class EnclaveBoundKeyAgreementTest {
         val auth = authenticator().takeIf { it.available } ?: return null
         return appleEnclaveProviderOrNull()?.userAuthenticated(auth) as? PerUseAgreementCapable
     }
+
+    /**
+     * Generates a bound agreement key, or `null` when this environment's enrollment cannot mint one
+     * for [policy] (no passcode / no enrolled biometric) — the element's honest refusal, which the
+     * caller treats as a skip rather than a failure.
+     */
+    private suspend fun PerUseAgreementCapable.generateOrSkip(policy: UserAuthenticationPolicy): KeyAgreementKeyPair? =
+        try {
+            when (policy) {
+                is UserAuthenticationPolicy.Windowed -> generateKeyAgreement(KeyAgreementCurve.P256, policy)
+                is UserAuthenticationPolicy.PerUse -> generateKeyAgreement(KeyAgreementCurve.P256, policy)
+            }
+        } catch (_: HardwareKeyException.SecureElementUnavailable) {
+            null
+        }
 
     @Test
     fun enclaveProviderAdvertisesPerDeriveAgreement() {
@@ -48,8 +69,7 @@ class EnclaveBoundKeyAgreementTest {
             if (!provider.eligible(ProtectedKeyAlgorithm.EcdhP256)) return@runTest
             // Generating an access-controlled Enclave agreement key does not prompt (only a derive
             // does), so this exercises enclaveGenerateKaP256AccessControlled on real hardware headless.
-            val policy = UserAuthenticationPolicy.Session(5.minutes)
-            val pair = provider.generateKeyAgreement(KeyAgreementCurve.P256, policy)
+            val pair = provider.generateOrSkip(UserAuthenticationPolicy.Session(5.minutes)) ?: return@runTest
             try {
                 assertEquals(KeyProvenance.Hardware, pair.privateKey.provenance)
                 assertFailsWith<UnsupportedOperationException>("an Enclave scalar is never exportable") {
@@ -65,7 +85,9 @@ class EnclaveBoundKeyAgreementTest {
         runTest {
             val provider = boundProvider() ?: return@runTest
             if (!provider.eligible(ProtectedKeyAlgorithm.EcdhP256)) return@runTest
-            val pair = provider.generateKeyAgreement(KeyAgreementCurve.P256, UserAuthenticationPolicy.PerUse())
+            // PerUse ⇒ biometryCurrentSet, which needs an enrolled biometric; without one the element
+            // declines and generateOrSkip returns null (skip). Verified minting on a Mac with a print.
+            val pair = provider.generateOrSkip(UserAuthenticationPolicy.PerUse()) ?: return@runTest
             try {
                 assertEquals(KeyProvenance.Hardware, pair.privateKey.provenance)
             } finally {

--- a/buffer-crypto/src/appleTest/kotlin/com/ditchoom/buffer/crypto/EnclaveBoundKeyAgreementTest.kt
+++ b/buffer-crypto/src/appleTest/kotlin/com/ditchoom/buffer/crypto/EnclaveBoundKeyAgreementTest.kt
@@ -1,0 +1,84 @@
+package com.ditchoom.buffer.crypto
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.minutes
+
+/**
+ * User-authentication-bound Secure Enclave ECDH — the Apple half of biometric key agreement.
+ *
+ * What runs headless (and does here, on real Enclave hardware): the Enclave *advertises* per-derive
+ * agreement ([PerUseAgreementCapable]), and an OS-bound (`SecAccessControl`) agreement key both
+ * generates and reports hardware custody. Generation does not prompt — only a derive does — so these
+ * need no human.
+ *
+ * The **positive** path (authenticate → derive succeeds; per-use prompts every time; session prompts
+ * once per window) drives a real Touch ID / Face ID prompt and is therefore attended: it is covered
+ * in the manual device session, not here. This test never triggers a prompt.
+ */
+class EnclaveBoundKeyAgreementTest {
+    private fun authenticator() = LocalAuthAuthenticator(reason = "unit test bound agreement")
+
+    /** The Enclave provider narrowed to user-auth capability, or null where it cannot be driven. */
+    private fun boundProvider(): PerUseAgreementCapable? {
+        val auth = authenticator().takeIf { it.available } ?: return null
+        return appleEnclaveProviderOrNull()?.userAuthenticated(auth) as? PerUseAgreementCapable
+    }
+
+    @Test
+    fun enclaveProviderAdvertisesPerDeriveAgreement() {
+        val provider = appleEnclaveProviderOrNull() ?: return
+        val auth = authenticator()
+        if (!auth.available) return
+        // Unlike Android (window-only), the Enclave binds authentication to the exact derive, so the
+        // Apple user-auth provider IS a PerUseAgreementCapable — the narrowing a consumer relies on.
+        assertTrue(
+            provider.userAuthenticated(auth) is PerUseAgreementCapable,
+            "the Enclave user-auth provider must advertise per-derive agreement",
+        )
+    }
+
+    @Test
+    fun sessionBoundAgreementKeyGeneratesWithHardwareCustody() =
+        runTest {
+            val provider = boundProvider() ?: return@runTest
+            if (!provider.eligible(ProtectedKeyAlgorithm.EcdhP256)) return@runTest
+            // Generating an access-controlled Enclave agreement key does not prompt (only a derive
+            // does), so this exercises enclaveGenerateKaP256AccessControlled on real hardware headless.
+            val policy = UserAuthenticationPolicy.Session(5.minutes)
+            val pair = provider.generateKeyAgreement(KeyAgreementCurve.P256, policy)
+            try {
+                assertEquals(KeyProvenance.Hardware, pair.privateKey.provenance)
+                assertFailsWith<UnsupportedOperationException>("an Enclave scalar is never exportable") {
+                    pair.privateKey.exportEncoded()
+                }
+            } finally {
+                pair.close()
+            }
+        }
+
+    @Test
+    fun perUseBoundAgreementKeyGeneratesWithHardwareCustody() =
+        runTest {
+            val provider = boundProvider() ?: return@runTest
+            if (!provider.eligible(ProtectedKeyAlgorithm.EcdhP256)) return@runTest
+            val pair = provider.generateKeyAgreement(KeyAgreementCurve.P256, UserAuthenticationPolicy.PerUse())
+            try {
+                assertEquals(KeyProvenance.Hardware, pair.privateKey.provenance)
+            } finally {
+                pair.close()
+            }
+        }
+
+    @Test
+    fun boundAgreementRejectsIneligibleCurve() =
+        runTest {
+            val provider = boundProvider() ?: return@runTest
+            assertFailsWith<HardwareKeyException.AlgorithmNotEligible> {
+                provider.generateKeyAgreement(KeyAgreementCurve.X25519, UserAuthenticationPolicy.Session(5.minutes))
+            }
+        }
+}

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.kt
@@ -127,6 +127,18 @@ enum class UserAuthenticationMethod {
  */
 sealed interface UserAuthenticationPolicy {
     /**
+     * The policies an element enforces with a **validity-window / timestamp** check rather than by
+     * binding authentication to one exact operation. This is the subset that composes with *every*
+     * key kind on every OS-binding platform — including operations no per-operation auth object can
+     * wrap. Key agreement is the motivating case: Android's `BiometricPrompt.CryptoObject` has no
+     * `KeyAgreement` overload, so a keystore ECDH key can only be gated by the auth window, never
+     * per-derive — [UserAuthenticatedKeyProvider.generateKeyAgreement] therefore accepts only a
+     * [Windowed] policy, and per-derive agreement is offered separately through
+     * [PerUseAgreementCapable] where the element actually binds it (Apple Secure Enclave).
+     */
+    sealed interface Windowed : UserAuthenticationPolicy
+
+    /**
      * One successful user authentication unlocks the key for [validity]; ops inside the window do
      * not re-prompt. The provider prompts lazily — it attempts the op and only prompts when the
      * OS reports the window stale — so an already-authenticated user is never re-prompted.
@@ -138,7 +150,7 @@ sealed interface UserAuthenticationPolicy {
     data class Session(
         val validity: Duration,
         val method: UserAuthenticationMethod = UserAuthenticationMethod.BiometricOrCredential,
-    ) : UserAuthenticationPolicy {
+    ) : Windowed {
         init {
             require(validity >= 1.seconds) { "session validity must be at least 1 second, was $validity" }
         }
@@ -148,6 +160,10 @@ sealed interface UserAuthenticationPolicy {
      * Every operation requires a fresh user authentication bound to that exact operation (Android:
      * auth-per-use key + `BiometricPrompt.CryptoObject` wrapping the exact `Cipher`/`Signature`;
      * Apple: a fresh, un-evaluated `LAContext` per sign, so the Enclave prompts each time).
+     *
+     * Not a [Windowed] policy: per-op binding needs an auth object wrapping the exact operation,
+     * which does not exist for JCA `KeyAgreement`. So a `PerUse` **key agreement** key is reachable
+     * only through [PerUseAgreementCapable]; `PerUse` signing / AES-GCM stay on the base provider.
      */
     data class PerUse(
         val method: UserAuthenticationMethod = UserAuthenticationMethod.BiometricOnly,
@@ -192,6 +208,53 @@ interface UserAuthenticatedKeyProvider {
         scheme: SignatureScheme,
         policy: UserAuthenticationPolicy,
     ): SigningKey
+
+    /**
+     * Generates a fresh key-agreement key pair for [curve] inside the secure element, OS-bound to a
+     * [UserAuthenticationPolicy.Windowed] policy (the element gates each derive by its auth window).
+     *
+     * The parameter is `Windowed`, not the full policy, on purpose: a per-derive-bound agreement key
+     * needs an auth object wrapping the exact `KeyAgreement` op, which Android cannot express — so
+     * `PerUse` agreement is not offered here at all. Where the element *can* bind per-derive (Apple
+     * Secure Enclave), the provider additionally implements [PerUseAgreementCapable]; narrow to it to
+     * request [UserAuthenticationPolicy.PerUse]. An ineligible [curve] throws
+     * [HardwareKeyException.AlgorithmNotEligible].
+     */
+    suspend fun generateKeyAgreement(
+        curve: KeyAgreementCurve,
+        policy: UserAuthenticationPolicy.Windowed,
+    ): KeyAgreementKeyPair
+}
+
+/**
+ * A [UserAuthenticatedKeyProvider] whose secure element binds authentication to the **exact derive
+ * operation** for key agreement — so a fresh user authentication is required for every derive, not
+ * merely a recent one within a window. Only the Apple Secure Enclave qualifies: it drives a fresh
+ * `LAContext` per agreement, whereas Android's keystore has no `CryptoObject` overload for
+ * `KeyAgreement` and can gate ECDH by the auth window only.
+ *
+ * Obtained by narrowing the provider from `userAuthenticated(...)`:
+ * ```kotlin
+ * val kex = when (val p = provider.userAuthenticated(prompt)) {
+ *     is PerUseAgreementCapable -> p.generateKeyAgreement(P256, UserAuthenticationPolicy.PerUse())
+ *     else                      -> p.generateKeyAgreement(P256, UserAuthenticationPolicy.Session(5.minutes))
+ * }
+ * ```
+ * A platform that gains per-derive agreement later implements this interface additively — no ABI
+ * break, no deprecation. It is deliberately **not** sealed: the test fake implements it too, and the
+ * only compile-time guarantee this design needs (no `PerUse` on the base agreement method) already
+ * comes from [UserAuthenticationPolicy.Windowed].
+ */
+interface PerUseAgreementCapable : UserAuthenticatedKeyProvider {
+    /**
+     * Generates a key-agreement key pair for [curve] whose every derive requires a fresh user
+     * authentication bound to that exact operation. An ineligible [curve] throws
+     * [HardwareKeyException.AlgorithmNotEligible].
+     */
+    suspend fun generateKeyAgreement(
+        curve: KeyAgreementCurve,
+        policy: UserAuthenticationPolicy.PerUse,
+    ): KeyAgreementKeyPair
 }
 
 /**

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/FakeHardware.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/FakeHardware.kt
@@ -66,7 +66,10 @@ internal class FakeHardware(
      * a bound key without a prompt host is unrepresentable.
      */
     fun userAuthenticated(gate: HardwareAuthorization): UserAuthenticatedKeyProvider =
-        object : UserAuthenticatedKeyProvider {
+        // Implements PerUseAgreementCapable so the common conformance test exercises BOTH the
+        // Windowed-agreement path and the per-derive path against the same production dispatch — the
+        // fake models a dedicated element (Apple), which is the tier that binds per-derive agreement.
+        object : PerUseAgreementCapable {
             override fun eligible(alg: ProtectedKeyAlgorithm): Boolean = this@FakeHardware.eligible(alg)
 
             override suspend fun generateAesGcm(
@@ -81,7 +84,29 @@ internal class FakeHardware(
                 if (!eligible(scheme.toProtectedKeyAlgorithm())) throw HardwareKeyException.AlgorithmNotEligible()
                 return signingPair(ProtectedKeySpec(gate), policy).hardware
             }
+
+            override suspend fun generateKeyAgreement(
+                curve: KeyAgreementCurve,
+                policy: UserAuthenticationPolicy.Windowed,
+            ): KeyAgreementKeyPair = boundKeyAgreement(curve, gate, policy)
+
+            override suspend fun generateKeyAgreement(
+                curve: KeyAgreementCurve,
+                policy: UserAuthenticationPolicy.PerUse,
+            ): KeyAgreementKeyPair = boundKeyAgreement(curve, gate, policy)
         }
+
+    /** Shared body for both OS-bound agreement overloads: eligibility gate + the fake's gated closure. */
+    private suspend fun boundKeyAgreement(
+        curve: KeyAgreementCurve,
+        gate: HardwareAuthorization,
+        policy: UserAuthenticationPolicy,
+    ): KeyAgreementKeyPair {
+        if (curve != KeyAgreementCurve.P256 || !eligible(curve.toProtectedKeyAlgorithm())) {
+            throw HardwareKeyException.AlgorithmNotEligible()
+        }
+        return keyAgreementPair(ProtectedKeySpec(gate), policy).hardware
+    }
 
     /** A hardware AES-GCM key plus the software twin (same material) the test opens with to cross-check. */
     class AesGcmPair(

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/HardwareKeyConformanceTest.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/HardwareKeyConformanceTest.kt
@@ -274,6 +274,79 @@ class HardwareKeyConformanceTest {
             }
         }
 
+    // ---- User-authentication-bound key agreement (Session on the base, PerUse via capability) ----
+    // The fake models a dedicated element (Apple's tier), so its userAuthenticated() provider IS a
+    // PerUseAgreementCapable — exercising BOTH the Windowed and the per-derive dispatch against the
+    // real ProtectedKeyAgreementPrivateKey machinery, not a stub.
+
+    private suspend fun deriveOnce(
+        kex: KeyAgreementKeyPair,
+        peer: KeyAgreementKeyPair,
+        ops: KeyAgreementAsyncOps,
+    ) = ops.deriveSharedSecret(kex.privateKey, peer.publicKey, Info.Of(ascii("bound-kex")), length = 32)
+
+    @Test
+    fun boundSessionAgreementAuthenticatesOncePerValidityWindow() =
+        runTest {
+            val clock = TestTimeSource()
+            val gate = CountingGate(true)
+            val authed = FakeHardware(timeSource = clock).userAuthenticated(gate)
+            val kex = authed.generateKeyAgreement(KeyAgreementCurve.P256, UserAuthenticationPolicy.Session(5.minutes))
+            val ops = keyAgreementAsyncOrNull(KeyAgreementCurve.P256) ?: return@runTest
+            val peer = ops.generateKeyPair()
+
+            deriveOnce(kex, peer, ops)
+            deriveOnce(kex, peer, ops)
+            assertEquals(1, gate.calls, "derives inside the window must not re-prompt")
+
+            clock += 6.minutes
+            deriveOnce(kex, peer, ops)
+            assertEquals(2, gate.calls, "a stale window must re-prompt exactly once")
+        }
+
+    @Test
+    fun boundPerUseAgreementAuthenticatesEveryDerive() =
+        runTest {
+            val gate = CountingGate(true)
+            val authed = provider.userAuthenticated(gate)
+            // The documented consumer pattern: narrow to the per-derive capability where the element
+            // binds it, else fall back to a Session window.
+            val kex =
+                when (authed) {
+                    is PerUseAgreementCapable ->
+                        authed.generateKeyAgreement(KeyAgreementCurve.P256, UserAuthenticationPolicy.PerUse())
+                    else ->
+                        authed.generateKeyAgreement(KeyAgreementCurve.P256, UserAuthenticationPolicy.Session(5.minutes))
+                }
+            assertTrue(authed is PerUseAgreementCapable, "the fake models a per-derive-capable element")
+            assertEquals(KeyProvenance.Hardware, kex.privateKey.provenance)
+            val ops = keyAgreementAsyncOrNull(KeyAgreementCurve.P256) ?: return@runTest
+            val peer = ops.generateKeyPair()
+
+            deriveOnce(kex, peer, ops)
+            deriveOnce(kex, peer, ops)
+            assertEquals(2, gate.calls, "per-use must authenticate every derive")
+        }
+
+    @Test
+    fun boundAgreementDeniedAuthorizationFails() =
+        runTest {
+            val authed = provider.userAuthenticated(CountingGate(false, true))
+            val kex = authed.generateKeyAgreement(KeyAgreementCurve.P256, UserAuthenticationPolicy.Session(5.minutes))
+            val ops = keyAgreementAsyncOrNull(KeyAgreementCurve.P256) ?: return@runTest
+            val peer = ops.generateKeyPair()
+            assertFailsWith<AuthorizationFailed> { deriveOnce(kex, peer, ops) }
+        }
+
+    @Test
+    fun boundAgreementRejectsIneligibleCurve() =
+        runTest {
+            val authed = provider.userAuthenticated(CountingGate(true))
+            assertFailsWith<HardwareKeyException.AlgorithmNotEligible> {
+                authed.generateKeyAgreement(KeyAgreementCurve.X25519, UserAuthenticationPolicy.Session(5.minutes))
+            }
+        }
+
     @Test
     fun generateAesGcmRejectsUnsupportedKeySizeTyped() =
         runTest {

--- a/buffer-crypto/src/nativeInterop/swift/CryptoKitShim.h
+++ b/buffer-crypto/src/nativeInterop/swift/CryptoKitShim.h
@@ -158,12 +158,22 @@ int32_t bcks_secure_enclave_p256_ka_generate(
     uint8_t *blobOut, size_t blobCap, size_t *blobLenOut,
     uint8_t *pointOut, size_t pointCap, size_t *pointLenOut);
 
-// Computes DH(enclaveKey, peer) inside the Enclave, emitting the raw 32-byte shared secret. `peer`
-// is the uncompressed SEC1 point (04 || X || Y), validated on-curve by CryptoKit. BCKS_ERR_PEER when
-// the peer point is malformed / off-curve / rejected (one uniform code — no oracle), BCKS_ERR_INPUT
-// when the blob is not restorable by this Enclave, BCKS_ERR_AUTH on a denied user authentication.
-int32_t bcks_secure_enclave_p256_ka_agree(
+// Generates a Secure Enclave P-256 key-agreement key bound to user authentication via
+// SecAccessControl (authReq: 1 = userPresence, 2 = biometryCurrentSet); the element then refuses an
+// unauthenticated derive. Outputs match bcks_secure_enclave_p256_ka_generate.
+int32_t bcks_secure_enclave_p256_ka_generate_ac(
+    int32_t authReq,
+    uint8_t *blobOut, size_t blobCap, size_t *blobLenOut,
+    uint8_t *pointOut, size_t pointCap, size_t *pointLenOut);
+
+// Computes DH(enclaveKey, peer) authorizing through the LAContext behind laHandle (0 = no context:
+// the OS drives any prompt itself, or refuses when it cannot). `peer` is the uncompressed SEC1 point
+// (04 || X || Y), validated on-curve by CryptoKit. BCKS_ERR_PEER when the peer point is malformed /
+// off-curve / rejected (one uniform code — no oracle), BCKS_ERR_INPUT when the blob is not
+// restorable by this Enclave, BCKS_ERR_AUTH on a denied user authentication.
+int32_t bcks_secure_enclave_p256_ka_agree_ctx(
     const uint8_t *blobPtr, size_t blobLen,
+    int64_t laHandle,
     const uint8_t *peerPtr, size_t peerLen,
     uint8_t *secretOut, size_t secretCap,
     size_t *secretLenOut);

--- a/buffer-crypto/src/nativeInterop/swift/CryptoKitShim.swift
+++ b/buffer-crypto/src/nativeInterop/swift/CryptoKitShim.swift
@@ -584,27 +584,69 @@ private func classifyAgreeFailure(_ error: Error) -> Int32 {
     return classifySignFailure(error)
 }
 
-// Compute DH(enclaveKey, peer) inside the Secure Enclave, emitting the raw 32-byte shared secret.
-// The peer point is the uncompressed SEC1 encoding (04 ‖ X ‖ Y); CryptoKit validates it is on-curve.
-// BCKS_ERR_PEER: peer point malformed / off-curve / rejected. BCKS_ERR_INPUT: the blob is not
-// restorable by this Enclave. BCKS_ERR_AUTH: user authentication denied.
-@_cdecl("bcks_secure_enclave_p256_ka_agree")
-public func bcks_secure_enclave_p256_ka_agree(
+// Generate a Secure Enclave P-256 *key agreement* key bound to user authentication via
+// SecAccessControl (authReq: 1 = userPresence, 2 = biometryCurrentSet). The Enclave then refuses an
+// unauthenticated derive. Outputs match bcks_secure_enclave_p256_ka_generate.
+@_cdecl("bcks_secure_enclave_p256_ka_generate_ac")
+public func bcks_secure_enclave_p256_ka_generate_ac(
+    _ authReq: Int32,
+    _ blobOut: UnsafeMutablePointer<UInt8>?, _ blobCap: Int,
+    _ blobLenOut: UnsafeMutablePointer<Int>?,
+    _ pointOut: UnsafeMutablePointer<UInt8>?, _ pointCap: Int,
+    _ pointLenOut: UnsafeMutablePointer<Int>?
+) -> Int32 {
+    guard SecureEnclave.isAvailable else { return BCKS_ERR_INTERNAL }
+    var flags: SecAccessControlCreateFlags = [.privateKeyUsage]
+    switch authReq {
+    case 1: flags.insert(.userPresence)
+    case 2: flags.insert(.biometryCurrentSet)
+    default: return BCKS_ERR_INPUT
+    }
+    var acError: Unmanaged<CFError>?
+    guard let ac = SecAccessControlCreateWithFlags(
+        kCFAllocatorDefault, kSecAttrAccessibleWhenUnlockedThisDeviceOnly, flags, &acError
+    ) else { return BCKS_ERR_INTERNAL }
+    guard let key = try? SecureEnclave.P256.KeyAgreement.PrivateKey(accessControl: ac) else {
+        return BCKS_ERR_INTERNAL
+    }
+    let s = emit(key.dataRepresentation, blobOut, blobCap, blobLenOut)
+    if s != BCKS_OK { return s }
+    return emit(key.publicKey.x963Representation, pointOut, pointCap, pointLenOut)
+}
+
+// Compute DH(enclaveKey, peer) authorizing through the LAContext behind laHandle (0 = no context:
+// the OS drives any required prompt itself, or refuses when it cannot). Same status contract as
+// bcks_secure_enclave_p256_ka_agree, plus BCKS_ERR_AUTH when user authentication was denied.
+@_cdecl("bcks_secure_enclave_p256_ka_agree_ctx")
+public func bcks_secure_enclave_p256_ka_agree_ctx(
     _ blobPtr: UnsafePointer<UInt8>?, _ blobLen: Int,
+    _ laHandle: Int64,
     _ peerPtr: UnsafePointer<UInt8>?, _ peerLen: Int,
     _ secretOut: UnsafeMutablePointer<UInt8>?, _ secretCap: Int,
     _ secretLenOut: UnsafeMutablePointer<Int>?
 ) -> Int32 {
-    guard let key = try? SecureEnclave.P256.KeyAgreement.PrivateKey(
-        dataRepresentation: bytes(blobPtr, blobLen)
-    ) else { return BCKS_ERR_INPUT }
     guard let peer = try? P256.KeyAgreement.PublicKey(x963Representation: bytes(peerPtr, peerLen)) else {
         return BCKS_ERR_PEER
     }
+    let blob = bytes(blobPtr, blobLen)
+    #if canImport(LocalAuthentication) && !os(tvOS)
+    let ctx: LAContext? = laHandle == 0 ? nil : LAContextRegistry.shared.get(laHandle)?.0
+    if laHandle != 0 && ctx == nil { return BCKS_ERR_INPUT }
+    // The context-carrying init needs watchOS 9; below that (floor: 7) restore without one — the
+    // access control still holds, the OS just drives any prompt itself.
+    let key: SecureEnclave.P256.KeyAgreement.PrivateKey?
+    if #available(watchOS 9.0, iOS 13.0, macOS 10.15, *) {
+        key = try? SecureEnclave.P256.KeyAgreement.PrivateKey(dataRepresentation: blob, authenticationContext: ctx)
+    } else {
+        key = try? SecureEnclave.P256.KeyAgreement.PrivateKey(dataRepresentation: blob)
+    }
+    #else
+    let key = try? SecureEnclave.P256.KeyAgreement.PrivateKey(dataRepresentation: blob)
+    #endif
+    guard let key = key else { return BCKS_ERR_INPUT }
     do {
         let shared = try key.sharedSecretFromKeyAgreement(with: peer)
-        let raw = shared.withUnsafeBytes { Data($0) }
-        return emit(raw, secretOut, secretCap, secretLenOut)
+        return emit(shared.withUnsafeBytes { Data($0) }, secretOut, secretCap, secretLenOut)
     } catch {
         return classifyAgreeFailure(error)
     }


### PR DESCRIPTION
## Summary

Adds **user-authentication-bound** (biometric / device-credential) key agreement to
`UserAuthenticatedKeyProvider` — the follow-up to the hardware ECDH work (Android #316, Apple #319).
A keystore / Secure Enclave ECDH key can now require a satisfied user authentication before each
derive, the same way signing and AES-GCM keys already can.

### Use case

Biometric gating on ECDH is a **receive-side / decryption** control: a device holds a static
hardware ECDH key, payloads arrive HPKE-sealed to its public key, and gating the derive stops
malware (or a device seized while unlocked) from silently draining what was sealed to it. Also
applies to recovery/escrow KEK derivation, device-enrollment handshakes, and HPKE `Auth`/`AuthPsk`
sender static-key DH. `Session(validity)` is the policy that matters in practice; `PerUse` is niche.

### API — the impossible state is a compile error, not a runtime throw

- New marker `UserAuthenticationPolicy.Windowed` (`Session` implements it; `PerUse` does not).
- Base `UserAuthenticatedKeyProvider.generateKeyAgreement(curve, policy: Windowed)` — `Session` is
  enforced by the element's auth window on every OS-binding platform.
- New `PerUseAgreementCapable` interface adds `generateKeyAgreement(curve, PerUse)`, implemented
  **only** where the element binds authentication to the exact derive op. Callers narrow:
  ```kotlin
  val kex = when (val p = provider.userAuthenticated(prompt)) {
      is PerUseAgreementCapable -> p.generateKeyAgreement(P256, PerUse())
      else                      -> p.generateKeyAgreement(P256, Session(5.minutes))
  }
  ```

**Why Windowed-only on the base:** Android's `BiometricPrompt.CryptoObject` has no `KeyAgreement`
overload, so a keystore ECDH key can be gated by the auth window but never per-derive. Passing
`PerUse` to the base method therefore won't compile, and Android's provider is deliberately **not**
`PerUseAgreementCapable`. Apple's Secure Enclave binds a fresh `LAContext` per derive, so its
provider **is** `PerUseAgreementCapable`. `PerUseAgreementCapable` is intentionally not sealed (the
test fake implements it); the compile-time guarantee lives entirely in the `Windowed` param type. A
platform that gains per-derive agreement later just implements the interface — additive, no break.

### Android

`AndroidUserAuthenticatedKeyProvider.generateKeyAgreement(Windowed)` generates a Session-bound
keystore ECDH key (`agreementSpec` already fed `applyUserAuth`). The derive runs under a new
`gatedAgreementDh` — the agreement analogue of `gatedOp`, minus the `CryptoObject` path: on a stale
keystore auth window it prompts once (no `CryptoObject`) and retries the derive fresh.

### Apple

Two new CryptoKit shim functions — `bcks_secure_enclave_p256_ka_generate_ac` (access-controlled
agreement key) and `bcks_secure_enclave_p256_ka_agree_ctx` (derive under an `LAContext`); the
advisory derive now routes through `_ka_agree_ctx` with `laHandle = 0`, replacing the plain
`_ka_agree`. `gatedAgreementDh` dispatches advisory / session (library window + one re-prompt on an
OS-invalidated context) / per-use (fresh `LAContext` per derive), mirroring the signing path.

### What was verified where

**Real Secure Enclave** — `:buffer-crypto:macosArm64Test`, **343 tests, 0 failures**. New
`EnclaveBoundKeyAgreementTest` ran against the real element: an access-controlled agreement key
(both `Session` and `PerUse`) generates with `KeyProvenance.Hardware` and no exportable scalar, and
the provider advertises `PerUseAgreementCapable`. (Generation does not prompt; only a derive does.)

**Real Android Keystore (RMX3933, API 35)** — full `connectedDebugAndroidTest`, **341 tests, 0
failures, 0 skipped**. New negatives in `UserAuthBindingInstrumentedTest`:
`sessionBoundAgreementIsRefusedByTheKeystoreWithoutAuthentication` proves **KeyMint**, not the
library, enforces the binding on ECDH (a stale-window derive is refused even though the prompt host
grants unconditionally); `androidProviderIsNotPerUseAgreementCapable` confirms the type-level limit
on real silicon.

**Common (every platform, via the fake)** — `HardwareKeyConformanceTest` gained four bound-agreement
tests driving the real `ProtectedKeyAgreementPrivateKey` dispatch: session re-prompts once per
window, per-use authenticates every derive, denied auth surfaces `AuthorizationFailed`, ineligible
curve refused. `FakeHardware` implements `PerUseAgreementCapable` so both dispatch paths are covered.

**iOS simulator** — `:buffer-crypto:iosSimulatorArm64Test`, **343/0** (graceful degradation, no
Enclave). Swift shim + tests compile on tvOS (no LocalAuthentication), watchOS, and iOS arm64.

**Attended (not automatable, out of scope of CI):** the biometric *positive* — real fingerprint /
Face ID → derive succeeds (per-use prompts each derive, session prompts once per window) — needs a
human at the sensor and is verified in a manual device session on both platforms.

`apiCheck` updated (additions are interface-level; existing implementors are `internal`),
`ktlintCheck` green, `detekt` clean (0 findings).

Does not close an issue — this follow-up had none filed.
