### PR TITLE
feat(buffer-crypto): persistent cert-wrapped aliases for the TPM-backed JVM key store

### DIFF
--- a/.github/workflows/crypto-tpm-integration.yaml
+++ b/.github/workflows/crypto-tpm-integration.yaml
@@ -66,6 +66,7 @@ jobs:
         run: |
           ./gradlew :buffer-crypto:jvmTest \
             --tests "com.ditchoom.buffer.crypto.Tpm2Pkcs11ProviderTest" \
+            --tests "com.ditchoom.buffer.crypto.Tpm2Pkcs11KeyStoreTest" \
             --tests "com.ditchoom.buffer.crypto.ProtectedKeyResolutionTest" \
             -P"buffer.crypto.tpm2.pkcs11.module=/usr/lib/x86_64-linux-gnu/libtpm2_pkcs11.so.1" \
             -P"buffer.crypto.tpm2.pkcs11.pin=1234" \
@@ -76,5 +77,51 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: tpm2-jvm-test-results
+          path: buffer-crypto/build/reports/tests/jvmTest/
+          if-no-files-found: ignore
+
+  # tpm2-pkcs11 1.9 lacks CKM_ECDH1_DERIVE, so the swtpm job can only pin agreement's honest
+  # refusal. SoftHSM is a derive-capable PKCS#11 module, so this job proves the dormant agreement
+  # path - eligibility probe, ephemeral ECDH, and cert-wrapped persistent agreement aliases - through
+  # the exact same SunPKCS11 bridge a future tpm2-pkcs11 release will light up.
+  softhsm:
+    name: "JVM key store against SoftHSM (agreement contract)"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+          cache: gradle
+
+      - name: Install and initialize SoftHSM
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y softhsm2
+          RIG="$RUNNER_TEMP/softhsm"
+          mkdir -p "$RIG/tokens"
+          printf 'directories.tokendir = %s\nobjectstore.backend = file\n' "$RIG/tokens" \
+            > "$RIG/softhsm2.conf"
+          export SOFTHSM2_CONF="$RIG/softhsm2.conf"
+          softhsm2-util --init-token --slot 0 --label buffer-crypto --pin 1234 --so-pin 5678
+          echo "SOFTHSM2_CONF=$RIG/softhsm2.conf" >> "$GITHUB_ENV"
+
+      - name: Run agreement-required JVM tests
+        run: |
+          ./gradlew :buffer-crypto:jvmTest \
+            --tests "com.ditchoom.buffer.crypto.Tpm2Pkcs11KeyStoreTest" \
+            -P"buffer.crypto.tpm2.pkcs11.module=/usr/lib/softhsm/libsofthsm2.so" \
+            -P"buffer.crypto.tpm2.pkcs11.pin=1234" \
+            -P"buffer.crypto.require.p11.agreement=true"
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: softhsm-jvm-test-results
           path: buffer-crypto/build/reports/tests/jvmTest/
           if-no-files-found: ignore

--- a/buffer-crypto/build.gradle.kts
+++ b/buffer-crypto/build.gradle.kts
@@ -567,10 +567,11 @@ tasks.withType<Test>().configureEach {
         "buffer.crypto.tpm2.pkcs11.pin",
         "buffer.crypto.tpm2.pkcs11.slotIndex",
         "buffer.crypto.require.tpm2",
+        "buffer.crypto.require.p11.agreement",
     ).forEach { key ->
         (project.findProperty(key) as? String)?.let { systemProperty(key, it) }
     }
-    listOf("TPM2_PKCS11_TCTI", "TPM2_PKCS11_STORE", "DBUS_SESSION_BUS_ADDRESS").forEach { key ->
+    listOf("TPM2_PKCS11_TCTI", "TPM2_PKCS11_STORE", "DBUS_SESSION_BUS_ADDRESS", "SOFTHSM2_CONF").forEach { key ->
         System.getenv(key)?.let { environment(key, it) }
     }
 }

--- a/buffer-crypto/config/detekt/baseline.xml
+++ b/buffer-crypto/config/detekt/baseline.xml
@@ -113,6 +113,7 @@
     <ID>TooManyFunctions:EcInterop.kt:com.ditchoom.buffer.crypto.EcInterop.kt</ID>
     <ID>TooManyFunctions:HardwareKeys.android.kt:AndroidKeystoreHardwareKeyProvider : HardwareKeyProvider</ID>
     <ID>TooManyFunctions:HardwareKeys.apple.kt:SecureEnclaveHardwareKeyProvider : HardwareKeyProvider</ID>
+    <ID>TooManyFunctions:HardwareKeys.jvm.kt:Tpm2Pkcs11HardwareKeyProvider : HardwareKeyProvider</ID>
     <ID>TooManyFunctions:HardwareKeys.js.kt:com.ditchoom.buffer.crypto.HardwareKeys.js.kt</ID>
     <ID>TooManyFunctions:HardwareKeys.jsAndWasmJs.kt:WebCryptoKeyStore : KeyStore</ID>
     <ID>TooManyFunctions:HardwareKeys.jsAndWasmJs.kt:com.ditchoom.buffer.crypto.HardwareKeys.jsAndWasmJs.kt</ID>
@@ -125,6 +126,7 @@
     <ID>TooManyFunctions:KeyAgreement.linux.kt:com.ditchoom.buffer.crypto.KeyAgreement.linux.kt</ID>
     <ID>TooManyFunctions:KeyStore.android.kt:AndroidKeystoreKeyStore : KeyStore</ID>
     <ID>TooManyFunctions:KeyStore.apple.kt:AppleKeychainKeyStore : KeyStore</ID>
+    <ID>TooManyFunctions:Tpm2Pkcs11KeyStore.jvm.kt:Tpm2Pkcs11KeyStore : KeyStore</ID>
     <ID>TooManyFunctions:KeyStore.kt:SoftwareKeyStore : KeyStore</ID>
     <ID>TooManyFunctions:KeyStore.kt:com.ditchoom.buffer.crypto.KeyStore.kt</ID>
     <ID>TooManyFunctions:Signatures.apple.kt:com.ditchoom.buffer.crypto.Signatures.apple.kt</ID>

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/KeyStore.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/KeyStore.kt
@@ -14,9 +14,9 @@ import com.ditchoom.buffer.ReadBuffer
  * `KeyStore` **is a** [KeyProvider], so the whole custody-tier machinery applies unchanged: query the
  * custody you actually get with [KeyProvider.custodyFor], assert a minimum with
  * [KeyProvider.requireTier]. Custody is per platform — on-disk DER is [KeyCustody.ExportableSoftware]
- * (JVM / Linux), a non-extractable WebCrypto CryptoKey in IndexedDB is
- * [KeyCustody.NonExportable.Software] (JS / WASM), a keystore alias / Keychain tag is
- * [KeyCustody.NonExportable.Hardware] (Android / Apple).
+ * (Linux, and a JVM without a usable TPM token), a non-extractable WebCrypto CryptoKey in IndexedDB
+ * is [KeyCustody.NonExportable.Software] (JS / WASM), a keystore alias / Keychain tag / TPM-backed
+ * PKCS#11 entry is [KeyCustody.NonExportable.Hardware] (Android / Apple / JVM with tpm2-pkcs11).
  *
  * **Regenerate** is [delete] followed by a `getOrGenerate*` call — an honest two-step, since no
  * platform offers an atomic replace.

--- a/buffer-crypto/src/jvmMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.jvm.kt
+++ b/buffer-crypto/src/jvmMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.jvm.kt
@@ -7,12 +7,15 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import java.io.IOException
 import java.security.GeneralSecurityException
 import java.security.KeyFactory
+import java.security.PrivateKey
 import java.security.Provider
 import java.security.ProviderException
 import java.security.Security
 import java.security.Signature
+import java.security.cert.X509Certificate
 import java.security.interfaces.ECPublicKey
 import java.security.spec.X509EncodedKeySpec
 
@@ -41,10 +44,25 @@ import java.security.spec.X509EncodedKeySpec
  *    `slotListIndex` handed to SunPKCS11 (default 0, the first initialized token).
  *
  * **Eligibility mirrors what the stack actually backs.** ECDSA P-256 is the proven baseline (it is
- * the resolution probe). ECDH P-256 is probed lazily end-to-end - as of tpm2-pkcs11 1.9 the module
- * does not advertise `CKM_ECDH1_DERIVE`, so the probe honestly fails and agreement routes to the
- * software floor; when the module gains the mechanism, eligibility lights up with no library change.
- * AES-GCM is not offered (the SunPKCS11 + tpm2-pkcs11 combination does not usably back it).
+ * the resolution probe). ECDH P-256 is probed lazily end-to-end on a second, derive-capable provider
+ * configuration (see the agreement-side note below) - as of tpm2-pkcs11 1.9 the module does not
+ * advertise `CKM_ECDH1_DERIVE`, so the probe honestly fails and agreement routes to the software
+ * floor; a module that backs the mechanism (verified against SoftHSM) lights eligibility up with no
+ * library change. AES-GCM is not offered (the SunPKCS11 + tpm2-pkcs11 combination does not usably
+ * back it).
+ *
+ * **Agreement runs on a second provider instance** over the same module/slot. SunPKCS11's default EC
+ * keygen template omits `CKA_DERIVE` (a derive attempt fails `CKR_KEY_FUNCTION_NOT_PERMITTED` even on
+ * a mechanism-capable module) and its derived-secret template must be readable, so the agreement side
+ * configures both via `attributes` blocks. Keeping that template off the signing provider is
+ * deliberate key separation at the PKCS#11 object layer: an identity signing key can never be driven
+ * as an ECDH oracle, and an agreement key never signs (its wrapper certificate is software-signed).
+ *
+ * **Persistence** (see [Tpm2Pkcs11KeyStore]): the SunPKCS11 `KeyStore` only addresses private keys
+ * paired with a certificate object, so persistent entries are wrapped in a minimal kind-tagged
+ * certificate (built in Tpm2Pkcs11Persistence.jvm.kt) and stored via `setKeyEntry`, which copies the
+ * session key into a token object (`C_CopyObject` - verified against tpm2-pkcs11 1.9 and SoftHSM).
+ * Ephemeral keys from the plain generate methods stay session objects and die with the process.
  *
  * **Custody honesty:** the provider reports `dedicatedSecureElement = false`. PKCS#11 exposes no
  * reliable way to distinguish a discrete TPM from a firmware TPM, so the claim stays at
@@ -64,6 +82,9 @@ import java.security.spec.X509EncodedKeySpec
  */
 internal class Tpm2Pkcs11HardwareKeyProvider(
     private val p11: Provider,
+    private val tokenKeyStore: java.security.KeyStore,
+    private val modulePath: String,
+    private val slotIndex: Int,
 ) : HardwareKeyProvider {
     /** PKCS#11 cannot confirm a discrete element, so this never over-claims. See the file KDoc. */
     override val dedicatedSecureElement: Boolean get() = false
@@ -77,12 +98,45 @@ internal class Tpm2Pkcs11HardwareKeyProvider(
     private val tokenLock = Mutex()
 
     /**
-     * `true` once a full token ECDH against a software peer matches the software-side derivation.
-     * Lazily probed: tpm2-pkcs11 1.9 lacks `CKM_ECDH1_DERIVE` (SunPKCS11 then registers no `ECDH`
-     * service, and the probe fails on `NoSuchAlgorithmException`), but a module that gains the
-     * mechanism passes with no library change.
+     * The derive-capable provider configuration over the same module/slot, plus its logged-in
+     * keystore view - every agreement op (ephemeral, persistent, and the eligibility probe) runs
+     * here, never on [p11] (see the file KDoc's key-separation note). `null` when the second
+     * configure/login fails, which keeps agreement honestly ineligible.
      */
-    private val agreementSupported: Boolean by lazy { probeAgreement(p11) }
+    private val agreementSide: AgreementSide? by lazy { configureAgreementSide() }
+
+    /**
+     * `true` once a full token ECDH against a software peer matches the software-side derivation.
+     * Lazily probed on the agreement side: tpm2-pkcs11 1.9 lacks `CKM_ECDH1_DERIVE` (SunPKCS11 then
+     * registers no `ECDH` service, and the probe fails on `NoSuchAlgorithmException`), but a module
+     * that backs the mechanism passes with no library change (verified against SoftHSM).
+     */
+    private val agreementSupported: Boolean by lazy { agreementSide?.let { probeAgreement(it.provider) } ?: false }
+
+    @Suppress("SwallowedException", "TooGenericExceptionCaught")
+    private fun configureAgreementSide(): AgreementSide? =
+        try {
+            val base = Security.getProvider(SUN_PKCS11)
+            val pin = configured(PIN_PROP, PIN_ENV)
+            if (base == null || pin == null) {
+                null
+            } else {
+                val conf =
+                    "--name=$AGREEMENT_PROVIDER_NAME\nlibrary=$modulePath\nslotListIndex=$slotIndex\n" +
+                        AGREEMENT_ATTRIBUTES
+                val provider = base.configure(conf)
+                val keyStore = java.security.KeyStore.getInstance(PKCS11_KEYSTORE, provider)
+                val pinChars = pin.toCharArray()
+                try {
+                    keyStore.load(null, pinChars)
+                } finally {
+                    pinChars.fill(' ')
+                }
+                AgreementSide(provider, keyStore)
+            }
+        } catch (e: Throwable) {
+            null
+        }
 
     override fun eligible(alg: ProtectedKeyAlgorithm): Boolean =
         when (alg) {
@@ -96,16 +150,25 @@ internal class Tpm2Pkcs11HardwareKeyProvider(
         spec: ProtectedKeySpec,
     ): SigningKey {
         if (!eligible(scheme.toProtectedKeyAlgorithm())) throw HardwareKeyException.AlgorithmNotEligible()
+        // Session objects: the token drops the key with the process; nothing to delete on close.
         val keyPair = tokenOp { generateP256KeyPair(p11) }
         val verifyKey = VerifyKey.ecdsaP256(uncompressedP256Point(keyPair.public as ECPublicKey))
-        val gate = spec.authorization
-        return ProtectedSigningKey(
+        return tokenSigningKey(keyPair.private, verifyKey, spec.authorization)
+    }
+
+    /** A [SigningKey] whose gated sign drives [privateKey] on the token - shared by generate and reload. */
+    private fun tokenSigningKey(
+        privateKey: PrivateKey,
+        verifyKey: VerifyKey,
+        gate: HardwareAuthorization,
+    ): SigningKey =
+        ProtectedSigningKey(
             scheme = SignatureScheme.EcdsaP256,
             custody = custody,
             gatedSign = { message, factory ->
                 if (!gate.authorize()) throw AuthorizationFailed()
                 tokenOp {
-                    val signer = Signature.getInstance(ECDSA_SHA256, p11).apply { initSign(keyPair.private) }
+                    val signer = Signature.getInstance(ECDSA_SHA256, p11).apply { initSign(privateKey) }
                     signer.update(message.slice().remainingBytes())
                     val der = signer.sign()
                     val out: PlatformBuffer = factory.allocate(der.size)
@@ -115,10 +178,9 @@ internal class Tpm2Pkcs11HardwareKeyProvider(
                 }
             },
             verifyKey = verifyKey,
-            // Session objects: the token drops the key with the process; nothing to delete here.
+            // Persistent entries outlive close(); session objects die with the process either way.
             onClose = {},
         )
-    }
 
     override suspend fun generateAesGcm(spec: ProtectedKeySpec): AesGcmKey =
         // The SunPKCS11 + tpm2-pkcs11 combination does not usably back AES-GCM; see eligible().
@@ -132,25 +194,218 @@ internal class Tpm2Pkcs11HardwareKeyProvider(
         if (curve != KeyAgreementCurve.P256 || !eligible(ProtectedKeyAlgorithm.EcdhP256)) {
             throw HardwareKeyException.AlgorithmNotEligible()
         }
-        val keyPair = tokenOp { generateP256KeyPair(p11) }
+        // eligible() implies the side resolved; the fallback keeps this total rather than trusting it.
+        val side = agreementSide ?: throw HardwareKeyException.AlgorithmNotEligible()
+        val keyPair = tokenOp { generateP256KeyPair(side.provider) }
         val publicKey = KeyAgreementPublicKey.of(curve, uncompressedP256Point(keyPair.public as ECPublicKey))
-        val gate = spec.authorization
-        val privateKey =
+        return tokenAgreementPair(side, keyPair.private, publicKey, spec.authorization)
+    }
+
+    /** A [KeyAgreementKeyPair] whose gated DH drives [privateKey] on the agreement side - generate and reload. */
+    private fun tokenAgreementPair(
+        side: AgreementSide,
+        privateKey: PrivateKey,
+        publicKey: KeyAgreementPublicKey,
+        gate: HardwareAuthorization,
+    ): KeyAgreementKeyPair {
+        val privateHandle =
             ProtectedKeyAgreementPrivateKey(
-                curve = curve,
+                curve = KeyAgreementCurve.P256,
                 custody = custody,
                 gatedDh = { peer ->
                     if (!gate.authorize()) throw AuthorizationFailed()
-                    require(peer.curve == curve) { "private/public key curve mismatch" }
+                    require(peer.curve == KeyAgreementCurve.P256) { "private/public key curve mismatch" }
                     // Peer-point conversion happens outside the token lock; a malformed or
                     // off-curve point is rejected before the TPM is ever touched.
                     val jcaPeer = p256PublicKeyFromSec1(peer.encoded)
-                    tokenOp { agreeP256OnToken(p11, keyPair.private, jcaPeer) }
+                    tokenOp { agreeP256OnToken(side.provider, privateKey, jcaPeer) }
                 },
                 onClose = {},
             )
-        return keyAgreementKeyPairOf(curve, privateKey, publicKey)
+        return keyAgreementKeyPairOf(KeyAgreementCurve.P256, privateHandle, publicKey)
     }
+
+    // --- Persistent cert-wrapped entries (the [Tpm2Pkcs11KeyStore] seam) --------------------------
+    //
+    // Labels arrive fully namespaced from the store ("<name>:<alias>"). Reads go through
+    // [tokenKeyStore]; agreement entries are written and reloaded through the agreement side so the
+    // reloaded key handle is bound to the derive-capable provider. Both views enumerate the same
+    // token objects. Concurrent get-or-generate races on one label are benign: the last setKeyEntry
+    // wins and the loser's session key dies with the process.
+
+    /**
+     * The (kind, tag) wrapper-certificate record under [p11Label], `null` when the label is absent,
+     * or [KeyStoreException.CorruptEntry] when a certificate exists but carries no kind tag (a
+     * foreign token object squatting in our namespace is surfaced, never silently overwritten).
+     */
+    internal suspend fun storedEntryKind(p11Label: String): Pair<Int, Int>? =
+        storeOp {
+            when (val cert = refreshed(tokenKeyStore).getCertificate(p11Label) as? X509Certificate) {
+                null -> null
+                else -> storedKindOf(cert) ?: throw KeyStoreException.CorruptEntry()
+            }
+        }
+
+    /**
+     * Re-loads [ks]'s cached token-object view before a read. SunPKCS11's `KeyStore` maps the
+     * token's objects at `load()` and only tracks its *own* writes afterwards, so entries written
+     * through the other side's view (signing vs. agreement provider) stay invisible until a re-load
+     * - verified empirically against SoftHSM.
+     *
+     * `engineLoad` wraps every internal failure (login, `PKCS11Exception`) in a bare [IOException] -
+     * there is no more specific public type - so the mapping to the typed storage failure is caught
+     * exactly here, never as a blanket handler over a whole store op.
+     */
+    @Suppress("SwallowedException")
+    private fun refreshed(ks: java.security.KeyStore): java.security.KeyStore {
+        try {
+            ks.load(null, null)
+        } catch (e: IOException) {
+            throw KeyStoreException.StorageFailure(retryable = false)
+        }
+        return ks
+    }
+
+    /** Generates a signing key and persists it under [p11Label] - cert self-signed on the token. */
+    internal suspend fun persistSigning(
+        p11Label: String,
+        spec: ProtectedKeySpec,
+    ): SigningKey {
+        val keyPair =
+            storeOp {
+                val kp = generateP256KeyPair(p11)
+                val cert =
+                    buildWrapperCertificate(
+                        KIND_SIGNING,
+                        signingTag(SignatureScheme.EcdsaP256),
+                        p11Label,
+                        kp.public,
+                    ) { tbs ->
+                        val signer = Signature.getInstance(ECDSA_SHA256, p11).apply { initSign(kp.private) }
+                        signer.update(tbs)
+                        signer.sign()
+                    }
+                tokenKeyStore.setKeyEntry(p11Label, kp.private, null, arrayOf(cert))
+                kp
+            }
+        val verifyKey = VerifyKey.ecdsaP256(uncompressedP256Point(keyPair.public as ECPublicKey))
+        return tokenSigningKey(keyPair.private, verifyKey, spec.authorization)
+    }
+
+    /** Re-attaches the signing entry under [p11Label], or `null` when the key or certificate is gone. */
+    internal suspend fun signingFromEntry(
+        p11Label: String,
+        spec: ProtectedKeySpec,
+    ): SigningKey? {
+        val loaded =
+            storeOp {
+                val view = refreshed(tokenKeyStore)
+                val key = view.getKey(p11Label, null) as? PrivateKey
+                val cert = view.getCertificate(p11Label) as? X509Certificate
+                if (key == null || cert == null) null else key to cert
+            } ?: return null
+        val verifyKey = VerifyKey.ecdsaP256(uncompressedP256Point(loaded.second.publicKey as ECPublicKey))
+        return tokenSigningKey(loaded.first, verifyKey, spec.authorization)
+    }
+
+    /**
+     * Generates an agreement key on the agreement side and persists it under [p11Label]. The wrapper
+     * certificate is software-signed: the token object is derive-capable by design, and the wrapper
+     * is packaging, not a trust assertion (see Tpm2Pkcs11Persistence.jvm.kt).
+     */
+    internal suspend fun persistAgreement(
+        p11Label: String,
+        spec: ProtectedKeySpec,
+    ): KeyAgreementKeyPair {
+        val side = agreementSide ?: throw HardwareKeyException.AlgorithmNotEligible()
+        val keyPair =
+            storeOp {
+                val kp = generateP256KeyPair(side.provider)
+                val cert =
+                    buildWrapperCertificate(
+                        KIND_AGREEMENT,
+                        agreementTag(KeyAgreementCurve.P256),
+                        p11Label,
+                        kp.public,
+                        ::softwareWrapperSignature,
+                    )
+                side.keyStore.setKeyEntry(p11Label, kp.private, null, arrayOf(cert))
+                kp
+            }
+        val publicKey =
+            KeyAgreementPublicKey.of(KeyAgreementCurve.P256, uncompressedP256Point(keyPair.public as ECPublicKey))
+        return tokenAgreementPair(side, keyPair.private, publicKey, spec.authorization)
+    }
+
+    /** Re-attaches the agreement entry under [p11Label], `null` when gone or agreement is unavailable. */
+    internal suspend fun agreementFromEntry(
+        p11Label: String,
+        spec: ProtectedKeySpec,
+    ): KeyAgreementKeyPair? {
+        val side = agreementSide ?: return null
+        val loaded =
+            storeOp {
+                val view = refreshed(side.keyStore)
+                val key = view.getKey(p11Label, null) as? PrivateKey
+                val cert = view.getCertificate(p11Label) as? X509Certificate
+                if (key == null || cert == null) null else key to cert
+            }
+        return loaded?.let { (key, cert) ->
+            val publicKey =
+                KeyAgreementPublicKey.of(
+                    KeyAgreementCurve.P256,
+                    uncompressedP256Point(cert.publicKey as ECPublicKey),
+                )
+            tokenAgreementPair(side, key, publicKey, spec.authorization)
+        }
+    }
+
+    /** Every certificate-paired label on the token (all namespaces; the store filters its own). */
+    internal suspend fun entryAliases(): Set<String> =
+        storeOp {
+            buildSet {
+                val aliases = refreshed(tokenKeyStore).aliases()
+                while (aliases.hasMoreElements()) add(aliases.nextElement())
+            }
+        }
+
+    internal suspend fun containsEntry(p11Label: String): Boolean =
+        storeOp {
+            refreshed(tokenKeyStore).containsAlias(p11Label)
+        }
+
+    /** Destroys the token objects under [p11Label]; `false` when nothing was stored there. */
+    internal suspend fun deleteEntry(p11Label: String): Boolean =
+        storeOp {
+            val view = refreshed(tokenKeyStore)
+            if (!view.containsAlias(p11Label)) {
+                false
+            } else {
+                view.deleteEntry(p11Label)
+                true
+            }
+        }
+
+    /**
+     * Like [tokenOp], but normalizes provider failures to [KeyStoreException.StorageFailure] - these
+     * are durable-entry operations, so the store-shaped error is the honest one. A [CryptoException]
+     * (e.g. [KeyStoreException.CorruptEntry]) passes through untouched.
+     */
+    @Suppress("SwallowedException")
+    private suspend fun <T> storeOp(block: () -> T): T =
+        tokenLock.withLock {
+            withContext(Dispatchers.IO) {
+                try {
+                    block()
+                } catch (e: CryptoException) {
+                    throw e
+                } catch (e: GeneralSecurityException) {
+                    throw KeyStoreException.StorageFailure(retryable = false)
+                } catch (e: ProviderException) {
+                    throw KeyStoreException.StorageFailure(retryable = false)
+                }
+            }
+        }
 
     /**
      * Runs a token [block] serialized and on [Dispatchers.IO] (PKCS#11 calls block), normalizing any
@@ -174,6 +429,12 @@ internal class Tpm2Pkcs11HardwareKeyProvider(
         }
 }
 
+/** A provider configuration paired with its logged-in keystore view of the same token. */
+private class AgreementSide(
+    val provider: Provider,
+    val keyStore: java.security.KeyStore,
+)
+
 // =============================================================================
 // Resolution - every step's refusal is a distinct typed finding, never a bare null
 // =============================================================================
@@ -181,6 +442,10 @@ internal class Tpm2Pkcs11HardwareKeyProvider(
 private val jvmResolution: ProtectedKeyResolution by lazy { resolveTpm2Pkcs11() }
 
 internal actual fun platformProtectedKeyResolution(): ProtectedKeyResolution = jvmResolution
+
+/** The resolved TPM-backed provider for the platform key store, or `null` short of Available. */
+internal fun tpm2Pkcs11ProviderOrNull(): Tpm2Pkcs11HardwareKeyProvider? =
+    (jvmResolution as? ProtectedKeyResolution.Available)?.provider as? Tpm2Pkcs11HardwareKeyProvider
 
 @Suppress("SwallowedException", "TooGenericExceptionCaught", "ReturnCount", "CyclomaticComplexMethod")
 private fun resolveTpm2Pkcs11(): ProtectedKeyResolution {
@@ -199,7 +464,8 @@ private fun resolveTpm2Pkcs11(): ProtectedKeyResolution {
     val slotIndex = configured(SLOT_PROP, SLOT_ENV)?.toIntOrNull() ?: 0
 
     // Configure SunPKCS11 + login. Provider.configure is JVM 9+; a JVM 8 runtime is a typed refusal.
-    val p11 =
+    // The logged-in keystore is retained: it is the persistence surface for Tpm2Pkcs11KeyStore.
+    val (p11, tokenKeyStore) =
         try {
             val base =
                 Security.getProvider(SUN_PKCS11)
@@ -213,7 +479,7 @@ private fun resolveTpm2Pkcs11(): ProtectedKeyResolution {
             } finally {
                 pinChars.fill(' ')
             }
-            configured
+            configured to keyStore
         } catch (e: NoSuchMethodError) {
             return refused(CapabilityFinding.Tpm2.RuntimeUnsupported)
         } catch (e: Throwable) {
@@ -233,7 +499,10 @@ private fun resolveTpm2Pkcs11(): ProtectedKeyResolution {
         val verifier = Signature.getInstance(ECDSA_SHA256).apply { initVerify(softPub) }
         verifier.update(message)
         if (verifier.verify(der)) {
-            ProtectedKeyResolution.Available(ProtectedKeyBackend.Tpm2Pkcs11, Tpm2Pkcs11HardwareKeyProvider(p11))
+            ProtectedKeyResolution.Available(
+                ProtectedKeyBackend.Tpm2Pkcs11,
+                Tpm2Pkcs11HardwareKeyProvider(p11, tokenKeyStore, modulePath, slotIndex),
+            )
         } else {
             refused(probeFailure(ProtectedKeyAlgorithm.EcdsaP256, cause = null))
         }
@@ -309,6 +578,24 @@ private val WELL_KNOWN_MODULE_PATHS =
 private const val SUN_PKCS11 = "SunPKCS11"
 private const val PKCS11_KEYSTORE = "PKCS11"
 private const val PROVIDER_NAME = "buffer-crypto-tpm2"
+private const val AGREEMENT_PROVIDER_NAME = "buffer-crypto-tpm2-agree"
+
+/**
+ * The agreement side's template overrides: SunPKCS11's default EC keygen omits `CKA_DERIVE`, and the
+ * ECDH-derived secret must be readable for `generateSecret` to return it (`CKR_ATTRIBUTE_SENSITIVE`
+ * otherwise) - both verified empirically against SoftHSM. Scoped to this second provider so signing
+ * keys never gain derive capability.
+ */
+private val AGREEMENT_ATTRIBUTES =
+    """
+    attributes(generate,CKO_PRIVATE_KEY,*) = {
+      CKA_DERIVE = true
+    }
+    attributes(*,CKO_SECRET_KEY,*) = {
+      CKA_SENSITIVE = false
+      CKA_EXTRACTABLE = true
+    }
+    """.trimIndent() + "\n"
 private const val PKCS11_EXCEPTION_CLASS = "sun.security.pkcs11.wrapper.PKCS11Exception"
 private const val ECDSA_SHA256 = "SHA256withECDSA"
 private const val EC = "EC"

--- a/buffer-crypto/src/jvmMain/kotlin/com/ditchoom/buffer/crypto/KeyStore.jvm.kt
+++ b/buffer-crypto/src/jvmMain/kotlin/com/ditchoom/buffer/crypto/KeyStore.jvm.kt
@@ -1,9 +1,18 @@
 package com.ditchoom.buffer.crypto
 
 /**
- * JVM: a durable on-disk software key store ([KeyCustody.ExportableSoftware]). The medium is
- * pluggable via [KeyStoreConfig.storage]; the default is one DER file per alias under
- * `<user.home>/.buffer-crypto/<name>` (or [KeyStoreConfig.location]).
+ * JVM: a durable [Tpm2Pkcs11KeyStore] where a TPM-backed PKCS#11 token is configured and usable -
+ * each persistent key lives inside the token ([KeyCustody.NonExportable.Hardware]) and survives
+ * process restart as a cert-wrapped token object. Elsewhere, the durable on-disk software store
+ * ([KeyCustody.ExportableSoftware]): one DER file per alias under `<user.home>/.buffer-crypto/<name>`
+ * (or [KeyStoreConfig.location]). Supplying [KeyStoreConfig.storage] always selects the software
+ * store over that medium - the escape hatch for persisting what the token cannot hold (AES-GCM,
+ * non-P256 schemes) on a TPM-configured host.
  */
 internal actual fun platformKeyStore(config: KeyStoreConfig): KeyStore =
-    SoftwareKeyStore(config.storage ?: FileKeyStorage(config.name, config.location))
+    when {
+        config.storage != null -> SoftwareKeyStore(config.storage)
+        else ->
+            tpm2Pkcs11ProviderOrNull()?.let { Tpm2Pkcs11KeyStore(it, config.name) }
+                ?: SoftwareKeyStore(FileKeyStorage(config.name, config.location))
+    }

--- a/buffer-crypto/src/jvmMain/kotlin/com/ditchoom/buffer/crypto/Tpm2Pkcs11KeyStore.jvm.kt
+++ b/buffer-crypto/src/jvmMain/kotlin/com/ditchoom/buffer/crypto/Tpm2Pkcs11KeyStore.jvm.kt
@@ -1,0 +1,163 @@
+package com.ditchoom.buffer.crypto
+
+/**
+ * A persistent, alias-addressable [KeyStore] whose keys live inside the TPM-backed PKCS#11 token
+ * ([KeyCustody.NonExportable.Hardware]) - the desktop-JVM counterpart of the Android Keystore and
+ * Apple Keychain stores. Each store alias maps to the token label `"$name:$alias"`, so independent
+ * stores (distinct [KeyStoreConfig.name]) never collide and never see each other's aliases.
+ *
+ * The ephemeral [KeyProvider] methods delegate to [provider] (session objects, dropped with the
+ * process); the alias methods persist - a key from [getOrGenerateSigning] / [loadSigning] survives
+ * `close()` and process restart until [delete]d. Entries are cert-wrapped token objects (the
+ * SunPKCS11 `KeyStore` packaging requirement; see Tpm2Pkcs11Persistence.jvm.kt), and the wrapper's
+ * kind tag is what keeps signing and agreement entries apart: a kind-mismatched load answers `null`
+ * and a kind-mismatched get-or-generate raises [KeyStoreException.AliasMismatch], never a mistyped
+ * handle.
+ *
+ * Serves what the token backs non-exportably: ECDSA P-256 signing, and - where the end-to-end probe
+ * holds (not tpm2-pkcs11 1.9, which lacks `CKM_ECDH1_DERIVE`) - ECDH P-256 key agreement. A
+ * get-or-generate for anything else (other schemes, AES-GCM, X25519) throws
+ * [HardwareKeyException.AlgorithmNotEligible] - consult [custodyFor] / [eligible] first, or supply a
+ * software [KeyStoreConfig.storage] for a persistent key the token cannot hold.
+ *
+ * **Custody trust boundary:** identical to the provider's (see HardwareKeys.jvm.kt) - the
+ * hardware-custody claim is exactly as trustworthy as the configured module path/PIN.
+ */
+internal class Tpm2Pkcs11KeyStore(
+    private val provider: Tpm2Pkcs11HardwareKeyProvider,
+    private val name: String,
+) : KeyStore {
+    override fun custodyFor(alg: ProtectedKeyAlgorithm): KeyCustody = provider.custody
+
+    override fun eligible(alg: ProtectedKeyAlgorithm): Boolean = provider.eligible(alg)
+
+    // --- KeyProvider (ephemeral) - delegate to the token provider ---------------------------------
+
+    override suspend fun generateSigning(
+        scheme: SignatureScheme,
+        spec: ProtectedKeySpec,
+    ): SigningKey = provider.generateSigning(scheme, spec)
+
+    override suspend fun generateAesGcm(spec: ProtectedKeySpec): AesGcmKey = provider.generateAesGcm(spec)
+
+    override suspend fun generateKeyAgreement(
+        curve: KeyAgreementCurve,
+        spec: ProtectedKeySpec,
+    ): KeyAgreementKeyPair = provider.generateKeyAgreement(curve, spec)
+
+    // --- Persistent alias lifecycle ----------------------------------------------------------------
+
+    @Suppress("ThrowsCount") // not-eligible / alias-mismatch / corrupt are distinct typed outcomes
+    override suspend fun getOrGenerateSigning(
+        alias: String,
+        scheme: SignatureScheme,
+        spec: ProtectedKeySpec,
+    ): SigningKey {
+        requireValidAlias(alias)
+        if (!provider.eligible(scheme.toProtectedKeyAlgorithm())) throw HardwareKeyException.AlgorithmNotEligible()
+        val label = p11Label(alias)
+        provider.storedEntryKind(label)?.let { (kind, tag) ->
+            if (kind != KIND_SIGNING || signingScheme(tag) != scheme) {
+                throw KeyStoreException
+                    .AliasMismatch(alias, storedAlgorithm(kind, tag), scheme.toProtectedKeyAlgorithm())
+            }
+            // The kind record exists but the key or certificate vanished underneath it: corrupt.
+            return provider.signingFromEntry(label, spec) ?: throw KeyStoreException.CorruptEntry()
+        }
+        return provider.persistSigning(label, spec)
+    }
+
+    override suspend fun getOrGenerateAesGcm(
+        alias: String,
+        spec: ProtectedKeySpec,
+    ): AesGcmKey {
+        requireValidAlias(alias)
+        // The SunPKCS11 + tpm2-pkcs11 combination does not usably back AES-GCM; see the provider.
+        throw HardwareKeyException.AlgorithmNotEligible()
+    }
+
+    @Suppress("ThrowsCount") // not-eligible / alias-mismatch / corrupt are distinct typed outcomes
+    override suspend fun getOrGenerateKeyAgreement(
+        alias: String,
+        curve: KeyAgreementCurve,
+        spec: ProtectedKeySpec,
+    ): KeyAgreementKeyPair {
+        requireValidAlias(alias)
+        // Only ECDH P-256, and only where the probed module support holds (see the provider).
+        if (curve != KeyAgreementCurve.P256 || !provider.eligible(ProtectedKeyAlgorithm.EcdhP256)) {
+            throw HardwareKeyException.AlgorithmNotEligible()
+        }
+        val label = p11Label(alias)
+        provider.storedEntryKind(label)?.let { (kind, tag) ->
+            if (kind != KIND_AGREEMENT || agreementCurve(tag) != curve) {
+                throw KeyStoreException
+                    .AliasMismatch(alias, storedAlgorithm(kind, tag), curve.toProtectedKeyAlgorithm())
+            }
+            return provider.agreementFromEntry(label, spec) ?: throw KeyStoreException.CorruptEntry()
+        }
+        return provider.persistAgreement(label, spec)
+    }
+
+    override suspend fun loadSigning(alias: String): SigningKey? {
+        requireValidAlias(alias)
+        val label = p11Label(alias)
+        val stored = provider.storedEntryKind(label)
+        return when {
+            stored == null -> null
+            stored.first != KIND_SIGNING || signingScheme(stored.second) != SignatureScheme.EcdsaP256 -> null
+            else -> provider.signingFromEntry(label, ProtectedKeySpec())
+        }
+    }
+
+    override suspend fun loadAesGcm(alias: String): AesGcmKey? {
+        requireValidAlias(alias)
+        // No AES key is ever persisted here (see getOrGenerateAesGcm).
+        return null
+    }
+
+    /**
+     * Re-attaches a persisted agreement key, or `null` when the alias is absent, holds a different
+     * kind, **or the backend no longer serves agreement** (a store created against a derive-capable
+     * module, reopened against one without the mechanism, degrades to `null` rather than a handle
+     * whose every operation would fail).
+     */
+    override suspend fun loadKeyAgreement(alias: String): KeyAgreementKeyPair? {
+        requireValidAlias(alias)
+        if (!provider.eligible(ProtectedKeyAlgorithm.EcdhP256)) return null
+        val label = p11Label(alias)
+        val stored = provider.storedEntryKind(label)
+        return when {
+            stored == null -> null
+            stored.first != KIND_AGREEMENT || agreementCurve(stored.second) != KeyAgreementCurve.P256 -> null
+            else -> provider.agreementFromEntry(label, ProtectedKeySpec())
+        }
+    }
+
+    override suspend fun contains(alias: String): Boolean {
+        requireValidAlias(alias)
+        return provider.containsEntry(p11Label(alias))
+    }
+
+    override suspend fun aliases(): Set<String> =
+        provider
+            .entryAliases()
+            .filter { it.startsWith(labelPrefix) }
+            .map { it.removePrefix(labelPrefix) }
+            .toSet()
+
+    override suspend fun delete(alias: String): Boolean {
+        requireValidAlias(alias)
+        return provider.deleteEntry(p11Label(alias))
+    }
+
+    override fun close() = Unit
+
+    private val labelPrefix = "$name$LABEL_SEPARATOR"
+
+    private fun p11Label(alias: String): String = "$labelPrefix$alias"
+
+    private companion object {
+        /** Outside the portable alias/name charset, so namespaced labels can never collide. */
+        const val LABEL_SEPARATOR = ':'
+    }
+}

--- a/buffer-crypto/src/jvmMain/kotlin/com/ditchoom/buffer/crypto/Tpm2Pkcs11Persistence.jvm.kt
+++ b/buffer-crypto/src/jvmMain/kotlin/com/ditchoom/buffer/crypto/Tpm2Pkcs11Persistence.jvm.kt
@@ -1,0 +1,208 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.toByteArray
+import java.io.ByteArrayInputStream
+import java.security.PublicKey
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+
+/*
+ * Cert-wrapped persistence support for [Tpm2Pkcs11KeyStore].
+ *
+ * The SunPKCS11 `KeyStore` refuses to list or address a private key that has no matching X.509
+ * certificate object on the token, so every persisted key is wrapped in a minimal self-issued
+ * certificate built here. The certificate is a **packaging requirement, not a trust assertion**:
+ * nothing ever verifies it. Signing keys sign their own wrapper on the token; agreement keys cannot
+ * sign (their PKCS#11 object is derive-capable, and key separation is deliberate), so their wrapper
+ * carries a throwaway software signature over the real token public key.
+ *
+ * The wrapper doubles as the entry's kind record: the issuer CN is `bck.<kind>.<tag>` using the
+ * shared persisted-key kind/tag constants from KeyStore.kt (KIND_SIGNING / KIND_AGREEMENT +
+ * signingTag / agreementTag), so a reload can distinguish a signing entry from an agreement entry
+ * without touching the private key — the same role the record kind byte plays in the Apple Keychain
+ * store. The subject CN is the PKCS#11 label, which keeps entries legible to external tooling.
+ *
+ * `ByteArray` appears only at the unavoidable JCA seams (`PublicKey.getEncoded`, `Signature.sign`,
+ * `CertificateFactory.generateCertificate`); the DER assembly itself stages through buffers.
+ */
+
+/** Builds the kind-tagged wrapper certificate over [publicKey], signed by [signTbs] (DER ECDSA out). */
+internal fun buildWrapperCertificate(
+    kind: Int,
+    tag: Int,
+    subjectCn: String,
+    publicKey: PublicKey,
+    signTbs: (ByteArray) -> ByteArray,
+): X509Certificate {
+    val issuer = rdnSequence(kindTagCn(kind, tag))
+    val subject = rdnSequence(subjectCn)
+    val tbs =
+        der(
+            DER_SEQUENCE,
+            der(DER_CONTEXT_0, wrap(VERSION_V3_INTEGER)),
+            positiveSerial(),
+            wrap(ECDSA_SHA256_ALG_ID),
+            issuer,
+            wrap(VALIDITY),
+            subject,
+            wrap(publicKey.encoded),
+        )
+    val tbsBytes = tbs.toByteArray()
+    val signature = signTbs(tbsBytes)
+    val certificate =
+        der(
+            DER_SEQUENCE,
+            wrap(tbsBytes),
+            wrap(ECDSA_SHA256_ALG_ID),
+            der(DER_BIT_STRING, wrap(ZERO_UNUSED_BITS), wrap(signature)),
+        )
+    return CertificateFactory
+        .getInstance(X509_TYPE)
+        .generateCertificate(ByteArrayInputStream(certificate.toByteArray())) as X509Certificate
+}
+
+/**
+ * A wrapper signature from a throwaway software P-256 key, for keys that cannot sign their own
+ * wrapper (agreement keys are derive-capable by design). The signer is discarded immediately;
+ * nothing ever verifies the wrapper, so an unverifiable signature is exactly as good as any other.
+ */
+internal fun softwareWrapperSignature(tbs: ByteArray): ByteArray {
+    val signer =
+        java.security.KeyPairGenerator
+            .getInstance(EC_ALGORITHM)
+            .apply { initialize(java.security.spec.ECGenParameterSpec(SECP256R1_CURVE)) }
+            .generateKeyPair()
+    return java.security.Signature
+        .getInstance(SHA256_ECDSA)
+        .apply { initSign(signer.private) }
+        .run {
+            update(tbs)
+            sign()
+        }
+}
+
+/**
+ * The (kind, tag) recorded in a wrapper certificate's issuer CN, or `null` when the certificate was
+ * not written by this store (a foreign or pre-existing token object under our label namespace).
+ */
+internal fun storedKindOf(certificate: X509Certificate): Pair<Int, Int>? {
+    val match = KIND_CN_REGEX.find(certificate.issuerX500Principal.getName(X500_RFC2253))
+    val kind = match?.groupValues?.get(1)?.toIntOrNull()
+    val tag = match?.groupValues?.get(2)?.toIntOrNull()
+    return if (kind != null && tag != null) kind to tag else null
+}
+
+private fun kindTagCn(
+    kind: Int,
+    tag: Int,
+): String = "$KIND_CN_PREFIX.$kind.$tag"
+
+/** `Name` as a single-RDN `CN=<cn>` (UTF8String). */
+private fun rdnSequence(cn: String): ReadBuffer =
+    der(
+        DER_SEQUENCE,
+        der(
+            DER_SET,
+            der(DER_SEQUENCE, wrap(CN_OID), der(DER_UTF8_STRING, wrap(cn.encodeToByteArray()))),
+        ),
+    )
+
+/**
+ * A DER-minimal positive INTEGER serial from 8 CSPRNG bytes. The leading byte is forced into
+ * `0x40..0x7F`, so the encoding is positive and minimal without a sign-padding octet.
+ */
+private fun positiveSerial(): ReadBuffer {
+    val bytes = cryptoRandom(SERIAL_BYTES, BufferFactory.Default)
+    val lead = bytes.readByte().toInt() and LEAD_CLAMP_MASK or LEAD_SET_BIT
+    val out = BufferFactory.Default.allocate(SERIAL_BYTES)
+    out.writeByte(lead.toByte())
+    out.write(bytes)
+    out.resetForRead()
+    return der(DER_INTEGER, out)
+}
+
+/** One DER TLV: [tag], definite length, then every [parts] buffer's remaining bytes (consumed). */
+private fun der(
+    tag: Int,
+    vararg parts: ReadBuffer,
+): PlatformBuffer {
+    val contentLength = parts.sumOf { it.remaining() }
+    val lengthBytes =
+        when {
+            contentLength < LONG_FORM_THRESHOLD -> 1
+            contentLength < ONE_BYTE_LENGTH_MAX -> 2
+            else -> 3
+        }
+    val out = BufferFactory.Default.allocate(1 + lengthBytes + contentLength)
+    out.writeByte(tag.toByte())
+    when (lengthBytes) {
+        1 -> out.writeByte(contentLength.toByte())
+        2 -> {
+            out.writeByte(LONG_FORM_ONE_BYTE.toByte())
+            out.writeByte(contentLength.toByte())
+        }
+        else -> {
+            out.writeByte(LONG_FORM_TWO_BYTES.toByte())
+            out.writeShort(contentLength.toShort())
+        }
+    }
+    parts.forEach { out.write(it) }
+    out.resetForRead()
+    return out
+}
+
+private fun wrap(bytes: ByteArray): ReadBuffer = BufferFactory.Default.wrap(bytes)
+
+// TLV pieces small enough that the byte-level encodings are clearer than an arc/time encoder.
+private const val DER_SEQUENCE = 0x30
+private const val DER_SET = 0x31
+private const val DER_INTEGER = 0x02
+private const val DER_BIT_STRING = 0x03
+private const val DER_UTF8_STRING = 0x0C
+private const val DER_CONTEXT_0 = 0xA0
+private const val LONG_FORM_THRESHOLD = 0x80
+private const val ONE_BYTE_LENGTH_MAX = 0x100
+private const val LONG_FORM_ONE_BYTE = 0x81
+private const val LONG_FORM_TWO_BYTES = 0x82
+private const val SERIAL_BYTES = 8
+private const val LEAD_CLAMP_MASK = 0x3F
+private const val LEAD_SET_BIT = 0x40
+private const val X509_TYPE = "X.509"
+private const val SHA256_ECDSA = "SHA256withECDSA"
+private const val X500_RFC2253 = "RFC2253"
+private const val KIND_CN_PREFIX = "bck"
+private val KIND_CN_REGEX = Regex("""CN=bck\.(\d+)\.(\d+)""")
+
+/** `INTEGER 2` — X.509 v3. */
+private val VERSION_V3_INTEGER = byteArrayOf(0x02, 0x01, 0x02)
+
+/** OID 2.5.4.3 (`commonName`), pre-encoded. */
+private val CN_OID = byteArrayOf(0x06, 0x03, 0x55, 0x04, 0x03)
+
+/** `AlgorithmIdentifier` for ecdsa-with-SHA256 (1.2.840.10045.4.3.2, no parameters). */
+private val ECDSA_SHA256_ALG_ID =
+    byteArrayOf(
+        0x30,
+        0x0A,
+        0x06,
+        0x08,
+        0x2A,
+        0x86.toByte(),
+        0x48,
+        0xCE.toByte(),
+        0x3D,
+        0x04,
+        0x03,
+        0x02,
+    )
+
+/** `Validity`: notBefore 2025-01-01 UTCTime, notAfter 9999-12-31 GeneralizedTime (RFC 5280 no-expiry). */
+private val VALIDITY =
+    byteArrayOf(0x30, 0x20, 0x17) + byteArrayOf(0x0D) + "250101000000Z".encodeToByteArray() +
+        byteArrayOf(0x18, 0x0F) + "99991231235959Z".encodeToByteArray()
+
+private val ZERO_UNUSED_BITS = byteArrayOf(0x00)

--- a/buffer-crypto/src/jvmTest/kotlin/com/ditchoom/buffer/crypto/Tpm2Pkcs11KeyStoreTest.kt
+++ b/buffer-crypto/src/jvmTest/kotlin/com/ditchoom/buffer/crypto/Tpm2Pkcs11KeyStoreTest.kt
@@ -1,0 +1,223 @@
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.crypto.CryptoTestVectors.hexBuffer
+import com.ditchoom.buffer.crypto.CryptoTestVectors.toHex
+import kotlinx.coroutines.test.runTest
+import java.security.Security
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Persistent-alias conformance for [Tpm2Pkcs11KeyStore] — cert-wrapped entries on a PKCS#11 token,
+ * runnable only against a configured module. Two required modes, matching Tpm2Pkcs11ProviderTest:
+ *
+ *  - `buffer.crypto.require.tpm2` (the swtpm CI job): the full signing persistence contract, plus
+ *    the honest agreement refusal (tpm2-pkcs11 1.9 lacks `CKM_ECDH1_DERIVE`).
+ *  - `buffer.crypto.require.p11.agreement` (the SoftHSM CI job): the same signing contract, plus the
+ *    agreement persistence contract that tpm2-pkcs11 cannot yet exercise — proving the dormant path
+ *    lights up correctly on a derive-capable module.
+ *
+ * Unconfigured machines skip (resolution-shape coverage lives in ProtectedKeyResolutionTest).
+ *
+ * "Process restart" is simulated with [freshProviderStore]: a brand-new SunPKCS11 provider instance
+ * over the same module carries no session state, so an alias it can see and drive is a durable token
+ * object, not an artifact of the resolved singleton's session.
+ */
+class Tpm2Pkcs11KeyStoreTest {
+    private val requiredTpm = System.getProperty("buffer.crypto.require.tpm2") == "true"
+    private val requiredAgreement = System.getProperty("buffer.crypto.require.p11.agreement") == "true"
+    private val anyRequired get() = requiredTpm || requiredAgreement
+
+    @Test
+    fun signingAliasPersistsAcrossStoreAndProviderInstances() =
+        runTest {
+            if (!anyRequired) return@runTest
+            val store = CryptoCapabilities.keyStore(KeyStoreConfig(name = "bckstest-signing"))
+            try {
+                val first = store.getOrGenerateSigning(ALIAS, SignatureScheme.EcdsaP256)
+                assertIs<KeyCustody.NonExportable.Hardware>(first.custody)
+                assertEquals(KeyProvenance.Hardware, first.provenance)
+                val msg = hexBuffer("00112233445566778899aabbccddeeff")
+                assertTrue(verifyAsync(first.verifyKey, msg, signAsync(first, msg)))
+
+                assertTrue(store.contains(ALIAS))
+                assertTrue(ALIAS in store.aliases())
+
+                // Re-attach paths must drive the SAME token key: every signature verifies under the
+                // first public key.
+                val again = store.getOrGenerateSigning(ALIAS, SignatureScheme.EcdsaP256)
+                assertTrue(verifyAsync(first.verifyKey, msg, signAsync(again, msg)))
+                val reloaded = assertNotNull(store.loadSigning(ALIAS))
+                assertTrue(verifyAsync(first.verifyKey, msg, signAsync(reloaded, msg)))
+
+                val restarted = freshProviderStore("bckstest-signing")
+                val survivor = assertNotNull(restarted.loadSigning(ALIAS))
+                assertTrue(
+                    verifyAsync(first.verifyKey, msg, signAsync(survivor, msg)),
+                    "a fresh provider instance must reload the same token key",
+                )
+
+                assertTrue(store.delete(ALIAS))
+                assertFalse(store.contains(ALIAS))
+                assertNull(store.loadSigning(ALIAS))
+                assertFalse(store.delete(ALIAS), "double delete answers false, never throws")
+            } finally {
+                store.delete(ALIAS)
+            }
+        }
+
+    @Test
+    fun kindRulesAndIneligibleAlgorithmsAreTyped() =
+        runTest {
+            if (!anyRequired) return@runTest
+            val store = CryptoCapabilities.keyStore(KeyStoreConfig(name = "bckstest-kinds"))
+            try {
+                store.getOrGenerateSigning(ALIAS, SignatureScheme.EcdsaP256)
+                // Wrong-kind loads answer null, never a mistyped handle.
+                assertNull(store.loadKeyAgreement(ALIAS))
+                assertNull(store.loadAesGcm(ALIAS))
+
+                // What the token cannot hold is a typed refusal before any alias is touched.
+                assertFailsWith<HardwareKeyException.AlgorithmNotEligible> { store.getOrGenerateAesGcm("untouched") }
+                assertFailsWith<HardwareKeyException.AlgorithmNotEligible> {
+                    store.getOrGenerateSigning("untouched", SignatureScheme.Ed25519)
+                }
+                assertFailsWith<HardwareKeyException.AlgorithmNotEligible> {
+                    store.getOrGenerateKeyAgreement("untouched", KeyAgreementCurve.X25519)
+                }
+                assertFalse(store.contains("untouched"), "a refused get-or-generate must not create an entry")
+            } finally {
+                store.delete(ALIAS)
+            }
+        }
+
+    @Test
+    fun distinctStoreNamesNeverSeeEachOthersAliases() =
+        runTest {
+            if (!anyRequired) return@runTest
+            val storeA = CryptoCapabilities.keyStore(KeyStoreConfig(name = "bckstest-ns-a"))
+            val storeB = CryptoCapabilities.keyStore(KeyStoreConfig(name = "bckstest-ns-b"))
+            try {
+                val keyA = storeA.getOrGenerateSigning(ALIAS, SignatureScheme.EcdsaP256)
+                val keyB = storeB.getOrGenerateSigning(ALIAS, SignatureScheme.EcdsaP256)
+                val msg = hexBuffer("aa55aa55")
+                // Same alias, different namespaces: two independent keys.
+                assertFalse(verifyAsync(keyA.verifyKey, msg, signAsync(keyB, msg)))
+                assertEquals(setOf(ALIAS), storeA.aliases())
+                assertEquals(setOf(ALIAS), storeB.aliases())
+
+                assertTrue(storeA.delete(ALIAS))
+                assertFalse(storeA.contains(ALIAS))
+                assertTrue(storeB.contains(ALIAS), "deleting in one namespace must not touch the other")
+            } finally {
+                storeA.delete(ALIAS)
+                storeB.delete(ALIAS)
+            }
+        }
+
+    @Test
+    fun softwareStorageOverrideKeepsTheSoftwareTier() =
+        runTest {
+            if (!anyRequired) return@runTest
+            // The escape hatch for what the token cannot hold: an explicit software medium wins over
+            // the hardware store, with the honestly weaker custody.
+            val store =
+                CryptoCapabilities.keyStore(KeyStoreConfig(name = "bckstest-sw", storage = InMemoryKeyStorage()))
+            assertEquals(KeyCustody.ExportableSoftware, store.custodyFor(ProtectedKeyAlgorithm.EcdsaP256))
+            val aes = store.getOrGenerateAesGcm(ALIAS)
+            assertEquals(KeyProvenance.Software, aes.provenance)
+        }
+
+    @Test
+    fun agreementRemainsHonestlyRefusedWhereTheModuleLacksTheMechanism() =
+        runTest {
+            if (!requiredTpm) return@runTest
+            val store = CryptoCapabilities.keyStore(KeyStoreConfig(name = "bckstest-refusal"))
+            assertFalse(store.eligible(ProtectedKeyAlgorithm.EcdhP256))
+            assertFailsWith<HardwareKeyException.AlgorithmNotEligible> {
+                store.getOrGenerateKeyAgreement(KEX, KeyAgreementCurve.P256)
+            }
+            assertNull(store.loadKeyAgreement(KEX))
+            assertFalse(store.contains(KEX))
+        }
+
+    @Test
+    fun agreementLightsUpAndPersistsOnADeriveCapableModule() =
+        runTest {
+            if (!requiredAgreement) return@runTest
+            val resolution = assertIs<ProtectedKeyResolution.Available>(CryptoCapabilities.protectedKeyResolution)
+            assertTrue(
+                resolution.provider.eligible(ProtectedKeyAlgorithm.EcdhP256),
+                "a derive-capable module must light agreement eligibility up",
+            )
+
+            val store = CryptoCapabilities.keyStore(KeyStoreConfig(name = "bckstest-agree"))
+            try {
+                val ours = store.getOrGenerateKeyAgreement(KEX, KeyAgreementCurve.P256)
+                assertEquals(KeyProvenance.Hardware, ours.privateKey.provenance)
+                val peer = generateKeyPairAsync(KeyAgreementCurve.P256)
+                val info = hexBuffer("6b6578")
+                val fromPeer = deriveSharedSecretAsync(peer.privateKey, ours.publicKey, info, 32).toHex()
+                assertEquals(fromPeer, deriveSharedSecretAsync(ours.privateKey, peer.publicKey, info, 32).toHex())
+
+                // Reload and simulated restart both reconstruct the same token scalar: the derived
+                // secret against the same peer cannot change.
+                val reloaded = assertNotNull(store.loadKeyAgreement(KEX))
+                assertEquals(fromPeer, deriveSharedSecretAsync(reloaded.privateKey, peer.publicKey, info, 32).toHex())
+                val restarted = freshProviderStore("bckstest-agree")
+                val survivor = assertNotNull(restarted.loadKeyAgreement(KEX))
+                assertEquals(fromPeer, deriveSharedSecretAsync(survivor.privateKey, peer.publicKey, info, 32).toHex())
+
+                // Kind mismatches, both directions.
+                assertNull(store.loadSigning(KEX))
+                val overAgreement =
+                    assertFailsWith<KeyStoreException.AliasMismatch> {
+                        store.getOrGenerateSigning(KEX, SignatureScheme.EcdsaP256)
+                    }
+                assertEquals(ProtectedKeyAlgorithm.EcdhP256, overAgreement.stored)
+                store.getOrGenerateSigning(ALIAS, SignatureScheme.EcdsaP256)
+                val overSigning =
+                    assertFailsWith<KeyStoreException.AliasMismatch> {
+                        store.getOrGenerateKeyAgreement(ALIAS, KeyAgreementCurve.P256)
+                    }
+                assertEquals(ProtectedKeyAlgorithm.EcdsaP256, overSigning.stored)
+            } finally {
+                store.delete(KEX)
+                store.delete(ALIAS)
+            }
+        }
+
+    /**
+     * A [Tpm2Pkcs11KeyStore] over a brand-new provider instance and login — the closest a single
+     * process can come to a restart: no session objects, no cached handles, only durable token state.
+     */
+    private fun freshProviderStore(name: String): KeyStore {
+        val module = assertNotNull(System.getProperty("buffer.crypto.tpm2.pkcs11.module"))
+        val pin = assertNotNull(System.getProperty("buffer.crypto.tpm2.pkcs11.pin"))
+        val slot = System.getProperty("buffer.crypto.tpm2.pkcs11.slotIndex")?.toIntOrNull() ?: 0
+        val p11 =
+            Security
+                .getProvider("SunPKCS11")
+                .configure("--name=bckstest-fresh-${freshCount++}\nlibrary=$module\nslotListIndex=$slot\n")
+        val keyStore = java.security.KeyStore.getInstance("PKCS11", p11)
+        val pinChars = pin.toCharArray()
+        try {
+            keyStore.load(null, pinChars)
+        } finally {
+            pinChars.fill(' ')
+        }
+        return Tpm2Pkcs11KeyStore(Tpm2Pkcs11HardwareKeyProvider(p11, keyStore, module, slot), name)
+    }
+
+    private companion object {
+        const val ALIAS = "device-identity"
+        const val KEX = "device-kex"
+        var freshCount = 0
+    }
+}


### PR DESCRIPTION
Closes the persistent-aliases follow-up from #317: the desktop-JVM hardware tier now has a durable, alias-addressable `KeyStore`, completing the story issue #313 asked for on the JVM half — hardware-backed **identity keys that survive process restart**, on the same `KeyStore` surface as the Android Keystore and Apple Keychain stores.

### What changed

**`Tpm2Pkcs11KeyStore`** (new, internal): `platformKeyStore()` on the JVM now returns it when the tpm2-pkcs11 resolution is `Available` — `KeyStoreConfig.storage` still always selects the software store, and an unconfigured host falls back to the on-disk file store, mirroring the Android/Apple selection chain exactly. Aliases map to token labels `"<name>:<alias>"` (the Android precedent), so independent stores never collide.

**Cert-wrapped entries.** SunPKCS11's `KeyStore` refuses to list or address a private key with no matching X.509 certificate object, so each persisted key is wrapped in a minimal self-issued certificate (hand-assembled DER, no new dependency) and stored via `setKeyEntry` — which converts the session key into a durable token object via `C_CopyObject` (verified against both tpm2-pkcs11 1.9 and SoftHSM). The wrapper is **packaging, not a trust assertion**: nothing verifies it. Its issuer CN carries the shared kind/tag record (the same constants the software blob header and WebCrypto records use), so a kind-mismatched load answers `null` and a kind-mismatched get-or-generate raises the typed `AliasMismatch` — and a foreign token object squatting in our label namespace surfaces as `CorruptEntry`, never silently overwritten.

**Agreement moves to a second provider configuration** over the same module/slot. Two empirical findings drove this:
- SunPKCS11's default EC keygen template omits `CKA_DERIVE` — a derive attempt fails `CKR_KEY_FUNCTION_NOT_PERMITTED` **even on a mechanism-capable module**, so #317's "eligibility lights up with no library change" claim could never actually come true.
- Its derived-secret template must be readable (`CKA_SENSITIVE=false`), or `generateSecret` dies with `CKR_ATTRIBUTE_SENSITIVE`.

Both fixes are `attributes` blocks scoped to the agreement-side provider only, which buys object-level key separation: a signing key's PKCS#11 object never gains derive capability (no ECDH-oracle misuse out-of-band), and an agreement key never signs — its wrapper certificate is signed by a throwaway software key. Keystore views are re-`load()`ed before reads because SunPKCS11 maps token objects once at `load()` and never sees the other view's writes (verified; caught by the new tests).

### What was verified where

**swtpm + tpm2-abrmd (existing CI job, run locally against the rig)** — signing persistence end-to-end: get-or-generate → sign → verify; re-attach via `loadSigning` and a second get-or-generate, both cross-verifying under the original public key; **simulated restart** (a brand-new SunPKCS11 provider instance + fresh login — no session state — reloads the alias and drives the same token key); namespace isolation; typed refusals (AES-GCM, Ed25519, X25519) creating no entry; double-delete answering `false`; agreement still honestly refused (1.9 lacks `CKM_ECDH1_DERIVE`).

**SoftHSM (new CI job)** — the dormant agreement path through the exact same SunPKCS11 bridge: eligibility probe lights up, ephemeral ECDH matches a software peer, persistent agreement aliases round-trip (same derived secret after reload **and** after the simulated restart), and alias-kind mismatch raises `AliasMismatch` in both directions. This is what a future derive-capable tpm2-pkcs11 release will exercise.

**Unconfigured** — full `:buffer-crypto:jvmTest` suite green (typed-refusal shape only, nothing silently faked).

`apiCheck` green (all additions internal; `platformKeyStore` is behind the internal seam), `ktlintCheck` green, detekt zero findings (two `TooManyFunctions` baseline entries for the interface-forced class shapes, exact sibling precedent: `AppleKeychainKeyStore`, both hardware providers).

Remaining on #313: the JVM-on-macOS Keychain bridge and the Kotlin/Native linuxMain PKCS#11 backend (next up).