### PR TITLE
feat(buffer-crypto): Kotlin/Native Linux tpm2-pkcs11 hardware key provider

### DIFF
--- a/.github/workflows/crypto-tpm-integration.yaml
+++ b/.github/workflows/crypto-tpm-integration.yaml
@@ -72,12 +72,26 @@ jobs:
             -P"buffer.crypto.tpm2.pkcs11.pin=1234" \
             -P"buffer.crypto.require.tpm2=true"
 
+      - name: Run TPM-required Kotlin/Native Linux tests
+        run: |
+          # The native backend reads its configuration from the environment; stop the daemon first
+          # so the test task's env forwarding sees these values (daemon env is frozen at launch).
+          ./gradlew --stop
+          export BUFFER_CRYPTO_TPM2_PKCS11_MODULE=/usr/lib/x86_64-linux-gnu/libtpm2_pkcs11.so.1
+          export BUFFER_CRYPTO_TPM2_PKCS11_PIN=1234
+          export BUFFER_CRYPTO_REQUIRE_TPM2=true
+          ./gradlew :buffer-crypto:linuxX64Test \
+            --tests "com.ditchoom.buffer.crypto.Tpm2Pkcs11NativeProviderTest" \
+            --tests "com.ditchoom.buffer.crypto.ProtectedKeyResolutionTest"
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: tpm2-jvm-test-results
-          path: buffer-crypto/build/reports/tests/jvmTest/
+          path: |
+            buffer-crypto/build/reports/tests/jvmTest/
+            buffer-crypto/build/reports/tests/linuxX64Test/
           if-no-files-found: ignore
 
   # tpm2-pkcs11 1.9 lacks CKM_ECDH1_DERIVE, so the swtpm job can only pin agreement's honest
@@ -118,10 +132,21 @@ jobs:
             -P"buffer.crypto.tpm2.pkcs11.pin=1234" \
             -P"buffer.crypto.require.p11.agreement=true"
 
+      - name: Run agreement-required Kotlin/Native Linux tests
+        run: |
+          ./gradlew --stop
+          export BUFFER_CRYPTO_TPM2_PKCS11_MODULE=/usr/lib/softhsm/libsofthsm2.so
+          export BUFFER_CRYPTO_TPM2_PKCS11_PIN=1234
+          export BUFFER_CRYPTO_REQUIRE_P11_AGREEMENT=true
+          ./gradlew :buffer-crypto:linuxX64Test \
+            --tests "com.ditchoom.buffer.crypto.Tpm2Pkcs11NativeProviderTest"
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: softhsm-jvm-test-results
-          path: buffer-crypto/build/reports/tests/jvmTest/
+          path: |
+            buffer-crypto/build/reports/tests/jvmTest/
+            buffer-crypto/build/reports/tests/linuxX64Test/
           if-no-files-found: ignore

--- a/buffer-crypto/build.gradle.kts
+++ b/buffer-crypto/build.gradle.kts
@@ -276,6 +276,14 @@ kotlin {
     // (com.ditchoom.buffer.crypto.cinterop.boringssl.*, carried by the .def's `package=` line); the
     // default name would rename the cinterop/klib and break those imports. cryptoOnly=true links
     // libcrypto.a alone; the .def declares no linkerOpts so the plugin's `-lpthread -ldl` floor fires.
+    // Linux native: the runtime-dlopen'd PKCS#11 binding for the tpm2-pkcs11 hardware key backend.
+    // Types only - no library is linked (see the .def header).
+    targets.matching { it.name == "linuxX64" || it.name == "linuxArm64" }.configureEach {
+        (this as KotlinNativeTarget).compilations.getByName("main").cinterops.create("tpm2pkcs11") {
+            defFile(project.file("src/nativeInterop/cinterop/tpm2pkcs11.def"))
+        }
+    }
+
     targets.matching { it.name == "linuxX64" || it.name == "linuxArm64" }.configureEach {
         boringssl.cinterop(
             target = this as KotlinNativeTarget,
@@ -572,6 +580,25 @@ tasks.withType<Test>().configureEach {
         (project.findProperty(key) as? String)?.let { systemProperty(key, it) }
     }
     listOf("TPM2_PKCS11_TCTI", "TPM2_PKCS11_STORE", "DBUS_SESSION_BUS_ADDRESS", "SOFTHSM2_CONF").forEach { key ->
+        System.getenv(key)?.let { environment(key, it) }
+    }
+}
+
+// Same forwarding for the Kotlin/Native Linux test binary, which reads BOTH halves from the
+// environment (Kotlin/Native has no system properties): the BUFFER_CRYPTO_* configuration the
+// backend itself resolves, and the rig plumbing the module reads.
+tasks.withType<org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeTest>().configureEach {
+    listOf(
+        "BUFFER_CRYPTO_TPM2_PKCS11_MODULE",
+        "BUFFER_CRYPTO_TPM2_PKCS11_PIN",
+        "BUFFER_CRYPTO_TPM2_PKCS11_SLOT_INDEX",
+        "BUFFER_CRYPTO_REQUIRE_TPM2",
+        "BUFFER_CRYPTO_REQUIRE_P11_AGREEMENT",
+        "TPM2_PKCS11_TCTI",
+        "TPM2_PKCS11_STORE",
+        "DBUS_SESSION_BUS_ADDRESS",
+        "SOFTHSM2_CONF",
+    ).forEach { key ->
         System.getenv(key)?.let { environment(key, it) }
     }
 }

--- a/buffer-crypto/config/detekt/baseline.xml
+++ b/buffer-crypto/config/detekt/baseline.xml
@@ -27,6 +27,7 @@
     <ID>MatchingDeclarationName:NativeCryptoException.jsAndWasmJs.kt:NativeCryptoException : Exception</ID>
     <ID>MatchingDeclarationName:NativeCryptoException.linux.kt:NativeCryptoException : Exception</ID>
     <ID>MatchingDeclarationName:PosixFileKeyStoreTest.linux.kt:PosixFileKeyStoreTest</ID>
+    <ID>MatchingDeclarationName:Tpm2Pkcs11NativeProviderTest.linux.kt:Tpm2Pkcs11NativeProviderTest</ID>
     <ID>MaxLineLength:AeadTamperTest.kt:AeadTamperTest$assertFailsWith&lt;VerificationFailed> { ops.open(sealed, wrongKey, Aad.Of(ascii(aad)), BufferFactory.Default) }</ID>
     <ID>MaxLineLength:EcInteropTest.kt:EcInteropTest$assertEquals(1 + curve.privateKeyBytes, compressed.remaining(), "${curve.curveName} compressed width")</ID>
     <ID>MaxLineLength:EcInteropTest.kt:EcInteropTest$private fun ByteArray.toHexString: String</ID>

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.linux.kt
@@ -1,10 +1,444 @@
+@file:OptIn(ExperimentalForeignApi::class)
+@file:Suppress("MatchingDeclarationName") // MPP platform-suffixed actual file
+
 package com.ditchoom.buffer.crypto
 
-/**
- * Kotlin/Native Linux (BoringSSL-backed) wires no non-exportable key backend in this version, so the
- * resolution is honestly [ProtectedKeyResolution.None] — a fact about this library build, distinct
- * (by type, not by `null`) from a wired-but-refused backend. A TPM 2.0 reached through PKCS#11
- * cinterop is the natural future backend here; the **JVM-on-Linux** target already provides one via
- * `tpm2-pkcs11` (see `HardwareKeys.jvm.kt`).
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.crypto.cinterop.boringssl.BCL_OK
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_ec_generate
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_ecdh
+import com.ditchoom.buffer.crypto.cinterop.boringssl.bcl_ecdsa_verify
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.get
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.set
+import kotlinx.cinterop.toKString
+import kotlinx.cinterop.value
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import platform.posix.R_OK
+import platform.posix.access
+import platform.posix.getenv
+import platform.posix.size_tVar
+
+/*
+ * Kotlin/Native Linux non-exportable key backend: a TPM 2.0 reached through the standard
+ * `tpm2-pkcs11` module, dlopen'd at runtime and driven directly over the PKCS#11 C API
+ * (see Pkcs11Token.linux.kt) - the native sibling of the JVM SunPKCS11 backend, sharing its typed
+ * findings, its probe-not-infer resolution discipline, and its custody posture.
+ *
+ * **Resolution is probed end-to-end, never inferred**: the module must dlopen, the token must accept
+ * a login, and a full generate -> sign-on-token -> BoringSSL-software-verify round-trip must succeed
+ * before [ProtectedKeyResolution.Available] is reported. Every refusal is a typed
+ * [CapabilityFinding.Tpm2]; the native bridge sees each `CKR_*` code numerically, so classification
+ * needs no message parsing.
+ *
+ * **Configuration** (environment only - Kotlin/Native has no system properties):
+ *  - `BUFFER_CRYPTO_TPM2_PKCS11_MODULE` - module path; otherwise well-known distro locations.
+ *  - `BUFFER_CRYPTO_TPM2_PKCS11_PIN` - token user PIN (required; absent is a typed refusal).
+ *  - `BUFFER_CRYPTO_TPM2_PKCS11_SLOT_INDEX` - index into the present-token slot list (default 0).
+ *
+ * **Eligibility mirrors what the stack actually backs.** ECDSA P-256 is the proven baseline (the
+ * resolution probe). ECDH P-256 is probed lazily end-to-end against a BoringSSL software peer - as
+ * of tpm2-pkcs11 1.9 `CKM_ECDH1_DERIVE` is absent and the probe honestly fails; a derive-capable
+ * module (verified against SoftHSM) lights it up with no library change. AES-GCM is not offered.
+ * Unlike the SunPKCS11 bridge, key templates are per-call here, so signing keys carry `CKA_SIGN`
+ * only and agreement keys `CKA_DERIVE` only - object-level key separation without a second
+ * provider configuration.
+ *
+ * **Custody honesty / trust boundary:** identical to the JVM backend - `dedicatedSecureElement` is
+ * `false` (PKCS#11 cannot distinguish discrete from firmware TPMs), and the hardware-custody claim
+ * is exactly as trustworthy as the configured module path/PIN, which deployments MUST treat as
+ * same-integrity-domain state.
  */
-internal actual fun platformProtectedKeyResolution(): ProtectedKeyResolution = ProtectedKeyResolution.None
+internal class Tpm2Pkcs11NativeKeyProvider(
+    private val token: Pkcs11Token,
+) : HardwareKeyProvider {
+    /** PKCS#11 cannot confirm a discrete element, so this never over-claims. See the file KDoc. */
+    override val dedicatedSecureElement: Boolean get() = false
+
+    /**
+     * Serializes suspend token ops off the calling thread. The lazy [agreementSupported] probe is
+     * the one exception ([eligible] is non-suspend); safe because `C_Initialize` requested
+     * `CKF_OS_LOCKING_OK`, so the module itself locks at the PKCS#11 boundary.
+     */
+    private val tokenLock = Mutex()
+
+    /**
+     * `true` once a full token ECDH against a BoringSSL software peer matches the software-side
+     * derivation in both directions. tpm2-pkcs11 1.9 lacks `CKM_ECDH1_DERIVE`, so this honestly
+     * fails there; a derive-capable module (verified against SoftHSM) passes with no library change.
+     */
+    private val agreementSupported: Boolean by lazy { probeNativeAgreement(token) }
+
+    override fun eligible(alg: ProtectedKeyAlgorithm): Boolean =
+        when (alg) {
+            ProtectedKeyAlgorithm.EcdsaP256 -> true
+            ProtectedKeyAlgorithm.EcdhP256 -> agreementSupported
+            else -> false
+        }
+
+    override suspend fun generateSigning(
+        scheme: SignatureScheme,
+        spec: ProtectedKeySpec,
+    ): SigningKey {
+        if (!eligible(scheme.toProtectedKeyAlgorithm())) throw HardwareKeyException.AlgorithmNotEligible()
+        val (pair, point) =
+            tokenOp {
+                val kp = token.generateP256KeyPair(signing = true)
+                kp to token.ecPoint(kp.publicHandle)
+            }
+        val verifyKey = VerifyKey.ecdsaP256(point)
+        val gate = spec.authorization
+        return ProtectedSigningKey(
+            scheme = SignatureScheme.EcdsaP256,
+            custody = custody,
+            gatedSign = { message, factory ->
+                if (!gate.authorize()) throw AuthorizationFailed()
+                tokenOp {
+                    // CKM_ECDSA signs a caller-supplied digest; hash here, then DER-wrap the raw r||s.
+                    val digest = sha256(message.slice())
+                    rawEcdsaToDer(token.signDigest(pair.privateHandle, digest), factory)
+                }
+            },
+            verifyKey = verifyKey,
+            // Session objects die with the process anyway; destroying early frees token memory.
+            onClose = {
+                token.destroy(pair.privateHandle)
+                token.destroy(pair.publicHandle)
+            },
+        )
+    }
+
+    override suspend fun generateAesGcm(spec: ProtectedKeySpec): AesGcmKey =
+        // The tpm2-pkcs11 stack does not usably back AES-GCM; see eligible().
+        throw HardwareKeyException.AlgorithmNotEligible()
+
+    // A denied gate / curve clash / peer rejection are distinct typed outcomes; the swallowed
+    // UnsupportedHardwareKey is deliberately replaced by the uniform InvalidPublicKey (no oracle).
+    @Suppress("ThrowsCount", "SwallowedException")
+    override suspend fun generateKeyAgreement(
+        curve: KeyAgreementCurve,
+        spec: ProtectedKeySpec,
+    ): KeyAgreementKeyPair {
+        // Only ECDH P-256, and only where the end-to-end probe holds (see agreementSupported).
+        if (curve != KeyAgreementCurve.P256 || !eligible(ProtectedKeyAlgorithm.EcdhP256)) {
+            throw HardwareKeyException.AlgorithmNotEligible()
+        }
+        val (pair, point) =
+            tokenOp {
+                val kp = token.generateP256KeyPair(signing = false)
+                kp to token.ecPoint(kp.publicHandle)
+            }
+        val publicKey = KeyAgreementPublicKey.of(curve, point)
+        val gate = spec.authorization
+        val privateKey =
+            ProtectedKeyAgreementPrivateKey(
+                curve = curve,
+                custody = custody,
+                gatedDh = { peer ->
+                    if (!gate.authorize()) throw AuthorizationFailed()
+                    require(peer.curve == curve) { "private/public key curve mismatch" }
+                    val peerPoint = structurallyValidPoint(peer.encoded)
+                    try {
+                        tokenOp { token.deriveEcdh(pair.privateHandle, peerPoint) }
+                    } catch (e: HardwareKeyException.UnsupportedHardwareKey) {
+                        // Uniform peer-attributable rejection - no oracle, matching the JVM backend.
+                        throw InvalidPublicKey(curve)
+                    }
+                },
+                onClose = {
+                    token.destroy(pair.privateHandle)
+                    token.destroy(pair.publicHandle)
+                },
+            )
+        return keyAgreementKeyPairOf(curve, privateKey, publicKey)
+    }
+
+    /**
+     * Runs a token [block] serialized and off the calling thread, normalizing [Pkcs11Failure] to a
+     * [HardwareKeyException]. A [CryptoException] thrown inside passes through untouched.
+     */
+    @Suppress("SwallowedException")
+    private suspend fun <T> tokenOp(block: () -> T): T =
+        tokenLock.withLock {
+            withContext(Dispatchers.Default) {
+                try {
+                    block()
+                } catch (e: CryptoException) {
+                    throw e
+                } catch (e: Pkcs11Failure) {
+                    throw HardwareKeyException.UnsupportedHardwareKey()
+                }
+            }
+        }
+}
+
+// =============================================================================
+// Resolution - every step's refusal is a distinct typed finding, never a bare null
+// =============================================================================
+
+private val linuxResolution: ProtectedKeyResolution by lazy { resolveNativeTpm2Pkcs11() }
+
+internal actual fun platformProtectedKeyResolution(): ProtectedKeyResolution = linuxResolution
+
+@Suppress("ReturnCount", "SwallowedException", "TooGenericExceptionCaught") // typed refusals; probe fails closed
+private fun resolveNativeTpm2Pkcs11(): ProtectedKeyResolution {
+    val modulePath =
+        env(MODULE_ENV) ?: WELL_KNOWN_MODULE_PATHS.firstOrNull { access(it, R_OK) == 0 }
+            ?: return refused(CapabilityFinding.Tpm2.ModuleNotFound)
+    val pin = env(PIN_ENV) ?: return refused(CapabilityFinding.Tpm2.AuthNotConfigured)
+    val slotIndex = env(SLOT_ENV)?.toIntOrNull() ?: 0
+
+    val token =
+        when (val opened = Pkcs11Token.open(modulePath, pin, slotIndex)) {
+            is Pkcs11OpenResult.Opened -> opened.token
+            is Pkcs11OpenResult.ModuleUnloadable -> return refused(CapabilityFinding.Tpm2.TokenRejectedOpaque)
+            is Pkcs11OpenResult.Rejected ->
+                return refused(CapabilityFinding.Tpm2.TokenRejected(opened.ckr.classify()))
+        }
+
+    // End-to-end probe: generate -> sign on token -> verify in software (BoringSSL). Only a full
+    // round-trip upgrades the resolution to Available; anything less would over-promise.
+    return try {
+        val pair = token.generateP256KeyPair(signing = true)
+        try {
+            val point = token.ecPoint(pair.publicHandle)
+            val message = BufferFactory.Default.wrap(PROBE_MESSAGE.encodeToByteArray())
+            val digest = sha256(message.slice())
+            val der = rawEcdsaToDer(token.signDigest(pair.privateHandle, digest), BufferFactory.Default)
+            if (softwareVerifiesP256(point, message, der)) {
+                ProtectedKeyResolution.Available(
+                    ProtectedKeyBackend.Tpm2Pkcs11,
+                    Tpm2Pkcs11NativeKeyProvider(token),
+                )
+            } else {
+                refused(CapabilityFinding.Tpm2.ProbeOpFailedOpaque(ProtectedKeyAlgorithm.EcdsaP256))
+            }
+        } finally {
+            token.destroy(pair.privateHandle)
+            token.destroy(pair.publicHandle)
+        }
+    } catch (e: Pkcs11Failure) {
+        refused(CapabilityFinding.Tpm2.ProbeOpFailed(ProtectedKeyAlgorithm.EcdsaP256, e.ckr.classify()))
+    } catch (e: Throwable) {
+        refused(CapabilityFinding.Tpm2.ProbeOpFailedOpaque(ProtectedKeyAlgorithm.EcdsaP256))
+    }
+}
+
+private fun refused(finding: CapabilityFinding.Tpm2): ProtectedKeyResolution =
+    ProtectedKeyResolution.Refused(ProtectedKeyBackend.Tpm2Pkcs11, finding)
+
+/**
+ * Full agreement probe against a BoringSSL software peer, both directions matching - the same
+ * evidence bar as the JVM backend's probe. Any failure (mechanism absent, template refused, secret
+ * mismatch) answers `false`: agreement routes to the software floor instead of over-promising.
+ */
+@Suppress("SwallowedException", "TooGenericExceptionCaught")
+private fun probeNativeAgreement(token: Pkcs11Token): Boolean =
+    try {
+        val pair = token.generateP256KeyPair(signing = false)
+        try {
+            val tokenPoint = token.ecPoint(pair.publicHandle)
+            probeAgainstSoftwarePeer(token, pair, tokenPoint)
+        } finally {
+            token.destroy(pair.privateHandle)
+            token.destroy(pair.publicHandle)
+        }
+    } catch (e: Throwable) {
+        false
+    }
+
+private fun probeAgainstSoftwarePeer(
+    token: Pkcs11Token,
+    pair: Pkcs11KeyPair,
+    tokenPoint: ReadBuffer,
+): Boolean =
+    memScoped {
+        // Software peer via BoringSSL: raw scalar + uncompressed point.
+        val priv = allocArray<ByteVar>(P256_SCALAR_CAP)
+        val privLen = alloc<size_tVar>()
+        val pub = allocArray<ByteVar>(P256_POINT_CAP)
+        val pubLen = alloc<size_tVar>()
+        val generated =
+            bcl_ec_generate(
+                P256_CURVE_CODE,
+                priv.reinterpret(),
+                P256_SCALAR_CAP.convert(),
+                privLen.ptr,
+                pub.reinterpret(),
+                P256_POINT_CAP.convert(),
+                pubLen.ptr,
+            )
+        if (generated != BCL_OK) return@memScoped false
+
+        val peerPoint = BufferFactory.Default.allocate(pubLen.value.toInt())
+        for (i in 0 until pubLen.value.toInt()) peerPoint.writeByte(pub[i])
+        peerPoint.resetForRead()
+
+        // Token side: DH(tokenPriv, softwarePub).
+        val tokenSecret = token.deriveEcdh(pair.privateHandle, peerPoint)
+
+        // Software side: DH(softwarePriv, tokenPub) via BoringSSL.
+        val softwareSecret = allocArray<ByteVar>(P256_SCALAR_CAP)
+        val softwareSecretLen = alloc<size_tVar>()
+        val tokenPointLen = tokenPoint.remaining()
+        var agreed = -1
+        tokenPoint.withRemainingBytes2(tokenPointLen) { pointPtr ->
+            agreed =
+                bcl_ecdh(
+                    P256_CURVE_CODE,
+                    priv.reinterpret(),
+                    privLen.value,
+                    pointPtr.reinterpret(),
+                    tokenPointLen.convert(),
+                    softwareSecret.reinterpret(),
+                    P256_SCALAR_CAP.convert(),
+                    softwareSecretLen.ptr,
+                )
+        }
+        for (i in 0 until P256_SCALAR_CAP) priv[i] = 0.toByte()
+
+        val match =
+            agreed == BCL_OK &&
+                softwareSecretLen.value.toInt() == tokenSecret.remaining() &&
+                (0 until tokenSecret.remaining()).all {
+                    tokenSecret.get(tokenSecret.position() + it) == softwareSecret[it]
+                }
+        for (i in 0 until P256_SCALAR_CAP) softwareSecret[i] = 0.toByte()
+        tokenSecret.freeNativeMemory()
+        match
+    }
+
+/** Verifies a DER [signature] over [message] under the uncompressed [point] via BoringSSL. */
+private fun softwareVerifiesP256(
+    point: ReadBuffer,
+    message: ReadBuffer,
+    signature: ReadBuffer,
+): Boolean {
+    val pointLen = point.remaining()
+    val messageLen = message.remaining()
+    val signatureLen = signature.remaining()
+    var status = -1
+    point.withRemainingBytes2(pointLen) { pointPtr ->
+        message.withRemainingBytes2(messageLen) { msgPtr ->
+            signature.withRemainingBytes2(signatureLen) { sigPtr ->
+                status =
+                    bcl_ecdsa_verify(
+                        P256_CURVE_CODE,
+                        pointPtr.reinterpret(),
+                        pointLen.convert(),
+                        msgPtr.reinterpret(),
+                        messageLen.convert(),
+                        sigPtr.reinterpret(),
+                        signatureLen.convert(),
+                    )
+            }
+        }
+    }
+    return status == BCL_OK
+}
+
+/**
+ * Wraps a raw `r || s` token signature (64 bytes) as a canonical DER `ECDSA-Sig-Value` - the
+ * cross-platform wire format every backend emits. Leading zeros are stripped to the minimal
+ * magnitude; a sign-padding octet is added when the leading bit is set.
+ */
+internal fun rawEcdsaToDer(
+    raw: ReadBuffer,
+    factory: BufferFactory,
+): PlatformBuffer {
+    if (raw.remaining() != 2 * P256_FIELD_BYTES) throw HardwareKeyException.UnsupportedHardwareKey()
+    val base = raw.position()
+
+    fun magnitudeStart(offset: Int): Int {
+        var i = 0
+        while (i < P256_FIELD_BYTES - 1 && raw.get(base + offset + i).toInt() == 0) i++
+        return i
+    }
+
+    fun encodedLength(offset: Int): Int {
+        val start = magnitudeStart(offset)
+        val pad = if (raw.get(base + offset + start).toInt() and BYTE_MASK >= SIGN_BIT) 1 else 0
+        return P256_FIELD_BYTES - start + pad
+    }
+
+    val rLen = encodedLength(0)
+    val sLen = encodedLength(P256_FIELD_BYTES)
+    val contentLength = 2 + rLen + 2 + sLen
+    val out = factory.allocate(2 + contentLength)
+    out.writeByte(DER_SEQUENCE_TAG.toByte())
+    out.writeByte(contentLength.toByte())
+
+    fun writeInteger(
+        offset: Int,
+        encoded: Int,
+    ) {
+        out.writeByte(DER_INTEGER_TAG.toByte())
+        out.writeByte(encoded.toByte())
+        var remaining = encoded
+        if (encoded > P256_FIELD_BYTES - magnitudeStart(offset)) {
+            out.writeByte(0)
+            remaining--
+        }
+        for (i in P256_FIELD_BYTES - remaining until P256_FIELD_BYTES) {
+            out.writeByte(raw.get(base + offset + i))
+        }
+    }
+    writeInteger(0, rLen)
+    writeInteger(P256_FIELD_BYTES, sLen)
+    out.resetForRead()
+    return out
+}
+
+/** Structural SEC1 check (65 bytes, `04` lead) before the token sees the point; on-curve validation
+ *  happens inside the module/TPM (mandated by TPM 2.0 `ECDH_ZGen`), and any refusal maps uniformly
+ *  to [InvalidPublicKey]. */
+private fun structurallyValidPoint(encoded: ReadBuffer): ReadBuffer {
+    val view = encoded.slice()
+    if (view.remaining() != P256_POINT_BYTES ||
+        (view.get(view.position()).toInt() and BYTE_MASK) != SEC1_UNCOMPRESSED
+    ) {
+        throw InvalidPublicKey(KeyAgreementCurve.P256)
+    }
+    return view
+}
+
+private fun env(name: String): String? = getenv(name)?.toKString()?.takeIf { it.isNotBlank() }
+
+private const val MODULE_ENV = "BUFFER_CRYPTO_TPM2_PKCS11_MODULE"
+private const val PIN_ENV = "BUFFER_CRYPTO_TPM2_PKCS11_PIN"
+private const val SLOT_ENV = "BUFFER_CRYPTO_TPM2_PKCS11_SLOT_INDEX"
+
+private val WELL_KNOWN_MODULE_PATHS =
+    listOf(
+        "/usr/lib/x86_64-linux-gnu/libtpm2_pkcs11.so.1",
+        "/usr/lib/x86_64-linux-gnu/libtpm2_pkcs11.so",
+        "/usr/lib/aarch64-linux-gnu/libtpm2_pkcs11.so.1",
+        "/usr/lib64/libtpm2_pkcs11.so.1",
+        "/usr/lib/libtpm2_pkcs11.so.1",
+        "/usr/local/lib/libtpm2_pkcs11.so.1",
+    )
+
+private const val PROBE_MESSAGE = "buffer-crypto tpm2-pkcs11 native resolution probe"
+private const val P256_CURVE_CODE = 256
+private const val P256_FIELD_BYTES = 32
+private const val P256_POINT_BYTES = 65
+private const val P256_SCALAR_CAP = 72
+private const val P256_POINT_CAP = 133
+private const val SEC1_UNCOMPRESSED = 0x04
+private const val BYTE_MASK = 0xFF
+private const val SIGN_BIT = 0x80
+private const val DER_SEQUENCE_TAG = 0x30
+private const val DER_INTEGER_TAG = 0x02

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Pkcs11Token.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/Pkcs11Token.linux.kt
@@ -1,0 +1,461 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.crypto.cinterop.pkcs11.BCP11_C_CloseSession
+import com.ditchoom.buffer.crypto.cinterop.pkcs11.BCP11_C_DeriveKey
+import com.ditchoom.buffer.crypto.cinterop.pkcs11.BCP11_C_DestroyObject
+import com.ditchoom.buffer.crypto.cinterop.pkcs11.BCP11_C_GenerateKeyPair
+import com.ditchoom.buffer.crypto.cinterop.pkcs11.BCP11_C_GetAttributeValue
+import com.ditchoom.buffer.crypto.cinterop.pkcs11.BCP11_C_GetSlotList
+import com.ditchoom.buffer.crypto.cinterop.pkcs11.BCP11_C_Initialize
+import com.ditchoom.buffer.crypto.cinterop.pkcs11.BCP11_C_Login
+import com.ditchoom.buffer.crypto.cinterop.pkcs11.BCP11_C_OpenSession
+import com.ditchoom.buffer.crypto.cinterop.pkcs11.BCP11_C_Sign
+import com.ditchoom.buffer.crypto.cinterop.pkcs11.BCP11_C_SignInit
+import com.ditchoom.buffer.crypto.cinterop.pkcs11.CK_ATTRIBUTE
+import com.ditchoom.buffer.crypto.cinterop.pkcs11.CK_C_INITIALIZE_ARGS
+import com.ditchoom.buffer.crypto.cinterop.pkcs11.CK_ECDH1_DERIVE_PARAMS
+import com.ditchoom.buffer.crypto.cinterop.pkcs11.CK_MECHANISM
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.COpaquePointer
+import kotlinx.cinterop.CPointer
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.MemScope
+import kotlinx.cinterop.UByteVar
+import kotlinx.cinterop.ULongVar
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.allocArrayOf
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.get
+import kotlinx.cinterop.invoke
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.set
+import kotlinx.cinterop.sizeOf
+import kotlinx.cinterop.value
+import platform.posix.RTLD_NOW
+import platform.posix.dlopen
+import platform.posix.dlsym
+
+/*
+ * Low-level PKCS#11 session over a runtime-dlopen'd module (see tpm2pkcs11.def for the binding
+ * approach). One process-lifetime session, opened and logged-in by [Pkcs11Token.open]; every op is
+ * synchronous and the provider above serializes them. Failures carry the raw `CKR_*` code as a typed
+ * [Ckr] inside [Pkcs11Failure] - the native bridge sees the numeric code directly, so unlike the JVM
+ * side there is no exception-message parsing at this seam.
+ */
+
+/** A token call failed with [ckr]; classified into typed findings/exceptions at the seams above. */
+internal class Pkcs11Failure(
+    val ckr: Ckr,
+) : Exception("PKCS#11 operation failed (CKR 0x${ckr.raw.toString(HEX_RADIX)})")
+
+/** How [Pkcs11Token.open] failed, when it did - each is a distinct typed refusal, never a null. */
+internal sealed interface Pkcs11OpenResult {
+    /** The session is up and logged in. */
+    data class Opened(
+        val token: Pkcs11Token,
+    ) : Pkcs11OpenResult
+
+    /** dlopen failed or a `C_*` entry point is not exported - the module is unusable as built. */
+    data object ModuleUnloadable : Pkcs11OpenResult
+
+    /** The module loaded but a bootstrap call refused with [ckr]. */
+    data class Rejected(
+        val ckr: Ckr,
+    ) : Pkcs11OpenResult
+}
+
+@Suppress("TooManyFunctions") // one member per PKCS#11 operation the backend performs
+internal class Pkcs11Token private constructor(
+    private val fGenerateKeyPair: BCP11_C_GenerateKeyPair,
+    private val fGetAttributeValue: BCP11_C_GetAttributeValue,
+    private val fSignInit: BCP11_C_SignInit,
+    private val fSign: BCP11_C_Sign,
+    private val fDeriveKey: BCP11_C_DeriveKey,
+    private val fDestroyObject: BCP11_C_DestroyObject,
+    private val session: ULong,
+) {
+    /**
+     * Generates a session-object P-256 keypair whose private key is single-purpose by template:
+     * `CKA_SIGN` for [signing]`= true`, `CKA_DERIVE` otherwise - never both (unlike the SunPKCS11
+     * bridge, this binding controls the template per call). Sensitive and non-extractable always.
+     */
+    fun generateP256KeyPair(signing: Boolean): Pkcs11KeyPair =
+        memScoped {
+            val mech = mechanism(CKM_EC_KEY_PAIR_GEN)
+            val ecParams = allocArrayOf(P256_OID_DER)
+            val yes = alloc<UByteVar> { value = CK_TRUE }
+            val no = alloc<UByteVar> { value = CK_FALSE }
+
+            val pubTemplate = allocArray<CK_ATTRIBUTE>(PUB_TEMPLATE_ATTRS.toInt())
+            pubTemplate.setAttr(0, CKA_EC_PARAMS, ecParams, P256_OID_DER.size)
+            pubTemplate.setAttr(1, CKA_VERIFY, if (signing) yes.ptr else no.ptr, 1)
+
+            val privTemplate = allocArray<CK_ATTRIBUTE>(PRIV_TEMPLATE_ATTRS.toInt())
+            privTemplate.setAttr(0, CKA_SENSITIVE, yes.ptr, 1)
+            privTemplate.setAttr(1, CKA_EXTRACTABLE, no.ptr, 1)
+            privTemplate.setAttr(2, if (signing) CKA_SIGN else CKA_DERIVE, yes.ptr, 1)
+
+            val hPub = alloc<ULongVar>()
+            val hPriv = alloc<ULongVar>()
+            checkRv(
+                fGenerateKeyPair(
+                    session,
+                    mech.ptr,
+                    pubTemplate,
+                    PUB_TEMPLATE_ATTRS,
+                    privTemplate,
+                    PRIV_TEMPLATE_ATTRS,
+                    hPub.ptr,
+                    hPriv.ptr,
+                ),
+            )
+            Pkcs11KeyPair(publicHandle = hPub.value, privateHandle = hPriv.value)
+        }
+
+    /**
+     * The public key of [handle] as an uncompressed SEC1 point (`04 || X || Y`, 65 bytes,
+     * read-ready). `CKA_EC_POINT` is spec'd as a DER OCTET STRING around the point; some modules
+     * return the bare point, so both encodings are accepted.
+     */
+    fun ecPoint(handle: ULong): ReadBuffer =
+        memScoped {
+            val raw = readAttribute(this, handle, CKA_EC_POINT)
+            val n = raw.remaining()
+            when {
+                n == P256_POINT_BYTES + 2 &&
+                    raw.get(raw.position()).toInt() == DER_OCTET_STRING &&
+                    (raw.get(raw.position() + 1).toInt() and BYTE_MASK) == P256_POINT_BYTES -> {
+                    raw.position(raw.position() + 2)
+                    raw
+                }
+                n == P256_POINT_BYTES -> raw
+                else -> throw Pkcs11Failure(Ckr(CKR_GENERAL_ERROR_CODE))
+            }
+        }
+
+    /** `ECDSA(digest)` on the token: raw `r || s` (64 bytes for P-256), read-ready. */
+    fun signDigest(
+        privateHandle: ULong,
+        digest: ReadBuffer,
+    ): ReadBuffer =
+        memScoped {
+            val mech = mechanism(CKM_ECDSA)
+            checkRv(fSignInit(session, mech.ptr, privateHandle))
+            val digestLen = digest.remaining()
+            val out = allocArray<UByteVar>(SIGNATURE_CAP)
+            val outLen = alloc<ULongVar> { value = SIGNATURE_CAP.convert() }
+            digest.withRemainingBytes2(digestLen) { digestPtr ->
+                checkRv(fSign(session, digestPtr.reinterpret(), digestLen.convert(), out, outLen.ptr))
+            }
+            val n = outLen.value.toInt()
+            val result = BufferFactory.Default.allocate(n)
+            for (i in 0 until n) result.writeByte(out[i].toByte())
+            result.resetForRead()
+            result
+        }
+
+    /**
+     * `DH(privateHandle, peerPoint)` inside the token via `CKM_ECDH1_DERIVE` / `CKD_NULL`: derives a
+     * readable generic-secret session object, copies its 32-byte X-coordinate value into a wiped
+     * secure buffer, and destroys the derived object before returning.
+     */
+    fun deriveEcdh(
+        privateHandle: ULong,
+        peerPoint: ReadBuffer,
+    ): PlatformBuffer =
+        memScoped {
+            val peerLen = peerPoint.remaining()
+            val derived = alloc<ULongVar>()
+            peerPoint.withRemainingBytes2(peerLen) { peerPtr ->
+                val params =
+                    alloc<CK_ECDH1_DERIVE_PARAMS> {
+                        kdf = CKD_NULL
+                        ulSharedDataLen = 0u
+                        pSharedData = null
+                        ulPublicDataLen = peerLen.convert()
+                        pPublicData = peerPtr.reinterpret()
+                    }
+                val mech = alloc<CK_MECHANISM>()
+                mech.mechanism = CKM_ECDH1_DERIVE
+                mech.pParameter = params.ptr
+                mech.ulParameterLen = sizeOf<CK_ECDH1_DERIVE_PARAMS>().convert()
+
+                val classVal = alloc<ULongVar> { value = CKO_SECRET_KEY }
+                val keyType = alloc<ULongVar> { value = CKK_GENERIC_SECRET }
+                val valueLen = alloc<ULongVar> { value = P256_FIELD_BYTES.convert() }
+                val yes = alloc<UByteVar> { value = CK_TRUE }
+                val no = alloc<UByteVar> { value = CK_FALSE }
+                val template = allocArray<CK_ATTRIBUTE>(DERIVE_TEMPLATE_ATTRS.toInt())
+                template.setAttr(0, CKA_CLASS, classVal.ptr, ULONG_BYTES)
+                template.setAttr(1, CKA_KEY_TYPE, keyType.ptr, ULONG_BYTES)
+                template.setAttr(2, CKA_VALUE_LEN, valueLen.ptr, ULONG_BYTES)
+                template.setAttr(SENSITIVE_ATTR_INDEX, CKA_SENSITIVE, no.ptr, 1)
+                template.setAttr(EXTRACTABLE_ATTR_INDEX, CKA_EXTRACTABLE, yes.ptr, 1)
+
+                checkRv(fDeriveKey(session, mech.ptr, privateHandle, template, DERIVE_TEMPLATE_ATTRS, derived.ptr))
+            }
+            try {
+                val value = readAttribute(this, derived.value, CKA_VALUE)
+                if (value.remaining() != P256_FIELD_BYTES) throw Pkcs11Failure(Ckr(CKR_GENERAL_ERROR_CODE))
+                val secret = secureScratch.allocate(P256_FIELD_BYTES)
+                secret.write(value)
+                secret.resetForRead()
+                secret
+            } finally {
+                destroy(derived.value)
+            }
+        }
+
+    /** Destroys a session object; best-effort (a failed destroy cannot un-happen the op above it). */
+    fun destroy(handle: ULong) {
+        fDestroyObject(session, handle)
+    }
+
+    /** Two-phase `C_GetAttributeValue`: length query, then fetch into a fresh read-ready buffer. */
+    private fun readAttribute(
+        scope: MemScope,
+        handle: ULong,
+        attribute: ULong,
+    ): PlatformBuffer =
+        with(scope) {
+            val probe = allocArray<CK_ATTRIBUTE>(1)
+            probe.setAttr(0, attribute, null, 0)
+            checkRv(fGetAttributeValue(session, handle, probe, 1u))
+            val n = probe[0].ulValueLen.toInt()
+            if (n <= 0) throw Pkcs11Failure(Ckr(CKR_GENERAL_ERROR_CODE))
+            val storage = allocArray<ByteVar>(n)
+            probe.setAttr(0, attribute, storage, n)
+            checkRv(fGetAttributeValue(session, handle, probe, 1u))
+            val out = BufferFactory.Default.allocate(n)
+            for (i in 0 until n) out.writeByte(storage[i])
+            out.resetForRead()
+            out
+        }
+
+    private fun MemScope.mechanism(type: ULong): CK_MECHANISM =
+        alloc<CK_MECHANISM> {
+            mechanism = type
+            pParameter = null
+            ulParameterLen = 0u
+        }
+
+    private fun checkRv(rv: ULong) {
+        if (rv != CKR_OK) throw Pkcs11Failure(Ckr(rv))
+    }
+
+    companion object {
+        /**
+         * dlopens [modulePath], resolves the entry points, and bootstraps `C_Initialize` ->
+         * `C_GetSlotList` -> `C_OpenSession` -> `C_Login(CKU_USER)`. Already-initialized and
+         * already-logged-in answers are tolerated (another library in-process may own the module).
+         */
+        @Suppress("ReturnCount") // each typed refusal exits as soon as it is known
+        fun open(
+            modulePath: String,
+            pin: String,
+            slotIndex: Int,
+        ): Pkcs11OpenResult {
+            val handle = dlopen(modulePath, RTLD_NOW) ?: return Pkcs11OpenResult.ModuleUnloadable
+            val entry = resolveEntryPoints(handle) ?: return Pkcs11OpenResult.ModuleUnloadable
+            return memScoped {
+                // CKF_OS_LOCKING_OK: the module locks internally with OS primitives, so the one
+                // non-serialized caller (the lazy eligibility probe) is safe alongside token ops.
+                val initArgs =
+                    alloc<CK_C_INITIALIZE_ARGS> {
+                        CreateMutex = null
+                        DestroyMutex = null
+                        LockMutex = null
+                        UnlockMutex = null
+                        flags = CKF_OS_LOCKING_OK
+                        pReserved = null
+                    }
+                val initRv = entry.initialize(initArgs.ptr)
+                if (initRv != CKR_OK && initRv != CKR_ALREADY_INITIALIZED) {
+                    return@memScoped Pkcs11OpenResult.Rejected(Ckr(initRv))
+                }
+                val session =
+                    when (val bootstrap = openAndLogin(entry, pin, slotIndex)) {
+                        is SessionResult.Live -> bootstrap.session
+                        is SessionResult.Refused -> return@memScoped Pkcs11OpenResult.Rejected(bootstrap.ckr)
+                    }
+                Pkcs11OpenResult.Opened(
+                    Pkcs11Token(
+                        fGenerateKeyPair = entry.generateKeyPair,
+                        fGetAttributeValue = entry.getAttributeValue,
+                        fSignInit = entry.signInit,
+                        fSign = entry.sign,
+                        fDeriveKey = entry.deriveKey,
+                        fDestroyObject = entry.destroyObject,
+                        session = session,
+                    ),
+                )
+            }
+        }
+
+        /** Every `C_*` entry point this backend uses, dlsym-resolved; `null` when any is missing. */
+        @Suppress("ReturnCount") // one exit per missing symbol keeps the resolution flat
+        private fun resolveEntryPoints(handle: COpaquePointer): EntryPoints? {
+            fun sym(name: String): COpaquePointer? = dlsym(handle, name)
+            return EntryPoints(
+                initialize = sym("C_Initialize")?.reinterpret() ?: return null,
+                getSlotList = sym("C_GetSlotList")?.reinterpret() ?: return null,
+                openSession = sym("C_OpenSession")?.reinterpret() ?: return null,
+                closeSession = sym("C_CloseSession")?.reinterpret() ?: return null,
+                login = sym("C_Login")?.reinterpret() ?: return null,
+                generateKeyPair = sym("C_GenerateKeyPair")?.reinterpret() ?: return null,
+                getAttributeValue = sym("C_GetAttributeValue")?.reinterpret() ?: return null,
+                signInit = sym("C_SignInit")?.reinterpret() ?: return null,
+                sign = sym("C_Sign")?.reinterpret() ?: return null,
+                deriveKey = sym("C_DeriveKey")?.reinterpret() ?: return null,
+                destroyObject = sym("C_DestroyObject")?.reinterpret() ?: return null,
+            )
+        }
+
+        /** Slot lookup, session open, and login - the CKR-refusable half of the bootstrap. */
+        @Suppress("ReturnCount") // each typed refusal exits as soon as it is known
+        private fun openAndLogin(
+            entry: EntryPoints,
+            pin: String,
+            slotIndex: Int,
+        ): SessionResult =
+            memScoped {
+                val count = alloc<ULongVar>()
+                val listRv = entry.getSlotList(CK_TRUE, null, count.ptr)
+                if (listRv != CKR_OK) return@memScoped SessionResult.Refused(Ckr(listRv))
+                val n = count.value.toInt()
+                if (slotIndex >= n) return@memScoped SessionResult.Refused(Ckr(CKR_SLOT_ID_INVALID_CODE))
+                val slots = allocArray<ULongVar>(n)
+                val fillRv = entry.getSlotList(CK_TRUE, slots, count.ptr)
+                if (fillRv != CKR_OK) return@memScoped SessionResult.Refused(Ckr(fillRv))
+
+                val session = alloc<ULongVar>()
+                val openRv =
+                    entry.openSession(slots[slotIndex], CKF_SERIAL_SESSION or CKF_RW_SESSION, null, null, session.ptr)
+                if (openRv != CKR_OK) return@memScoped SessionResult.Refused(Ckr(openRv))
+
+                val pinBytes = pin.encodeToByteArray()
+                val pinNative = allocArray<ByteVar>(pinBytes.size)
+                for (i in pinBytes.indices) pinNative[i] = pinBytes[i]
+                val loginRv = entry.login(session.value, CKU_USER, pinNative.reinterpret(), pinBytes.size.convert())
+                for (i in pinBytes.indices) {
+                    pinBytes[i] = 0
+                    pinNative[i] = 0
+                }
+                if (loginRv != CKR_OK && loginRv != CKR_USER_ALREADY_LOGGED_IN) {
+                    entry.closeSession(session.value)
+                    return@memScoped SessionResult.Refused(Ckr(loginRv))
+                }
+                SessionResult.Live(session.value)
+            }
+    }
+}
+
+/** The dlsym-resolved `C_*` entry points, typed via the .def's function-pointer typedefs. */
+private class EntryPoints(
+    val initialize: BCP11_C_Initialize,
+    val getSlotList: BCP11_C_GetSlotList,
+    val openSession: BCP11_C_OpenSession,
+    val closeSession: BCP11_C_CloseSession,
+    val login: BCP11_C_Login,
+    val generateKeyPair: BCP11_C_GenerateKeyPair,
+    val getAttributeValue: BCP11_C_GetAttributeValue,
+    val signInit: BCP11_C_SignInit,
+    val sign: BCP11_C_Sign,
+    val deriveKey: BCP11_C_DeriveKey,
+    val destroyObject: BCP11_C_DestroyObject,
+)
+
+/** A live logged-in session handle, or the CKR that refused the bootstrap. */
+private sealed interface SessionResult {
+    data class Live(
+        val session: ULong,
+    ) : SessionResult
+
+    data class Refused(
+        val ckr: Ckr,
+    ) : SessionResult
+}
+
+/** A generated keypair's object handles. */
+internal class Pkcs11KeyPair(
+    val publicHandle: ULong,
+    val privateHandle: ULong,
+)
+
+private fun CPointer<CK_ATTRIBUTE>.setAttr(
+    index: Int,
+    type: ULong,
+    value: COpaquePointer?,
+    length: Int,
+) {
+    this[index].type = type
+    this[index].pValue = value
+    this[index].ulValueLen = length.convert()
+}
+
+// Cryptoki constants (PKCS#11 v2.40) - only what this backend uses.
+private const val CKR_OK = 0uL
+private const val CKR_ALREADY_INITIALIZED = 0x191uL
+private const val CKR_USER_ALREADY_LOGGED_IN = 0x100uL
+private const val CKR_SLOT_ID_INVALID_CODE = 0x3uL
+private const val CKR_GENERAL_ERROR_CODE = 0x5uL
+private const val CKM_EC_KEY_PAIR_GEN = 0x1040uL
+private const val CKM_ECDSA = 0x1041uL
+private const val CKM_ECDH1_DERIVE = 0x1050uL
+private const val CKA_CLASS = 0x0uL
+private const val CKA_VALUE = 0x11uL
+private const val CKA_KEY_TYPE = 0x100uL
+private const val CKA_SENSITIVE = 0x103uL
+private const val CKA_SIGN = 0x108uL
+private const val CKA_VERIFY = 0x10AuL
+private const val CKA_DERIVE = 0x10CuL
+private const val CKA_VALUE_LEN = 0x161uL
+private const val CKA_EXTRACTABLE = 0x162uL
+private const val CKA_EC_PARAMS = 0x180uL
+private const val CKA_EC_POINT = 0x181uL
+private const val CKO_SECRET_KEY = 0x4uL
+private const val CKK_GENERIC_SECRET = 0x10uL
+private const val CKD_NULL = 0x1uL
+private const val CKU_USER = 1uL
+private const val CKF_SERIAL_SESSION = 0x4uL
+private const val CKF_RW_SESSION = 0x2uL
+private const val CKF_OS_LOCKING_OK = 0x2uL
+private const val CK_TRUE: UByte = 1u
+private const val CK_FALSE: UByte = 0u
+
+private const val ULONG_BYTES = 8
+private const val PUB_TEMPLATE_ATTRS = 2uL
+private const val PRIV_TEMPLATE_ATTRS = 3uL
+private const val DERIVE_TEMPLATE_ATTRS = 5uL
+private const val SENSITIVE_ATTR_INDEX = 3
+private const val EXTRACTABLE_ATTR_INDEX = 4
+private const val P256_POINT_BYTES = 65
+private const val P256_FIELD_BYTES = 32
+private const val SIGNATURE_CAP = 144
+private const val DER_OCTET_STRING = 0x04
+private const val BYTE_MASK = 0xFF
+private const val HEX_RADIX = 16
+
+/** DER OID for prime256v1 / secp256r1 (1.2.840.10045.3.1.7) - the `CKA_EC_PARAMS` value. */
+private val P256_OID_DER =
+    byteArrayOf(
+        0x06,
+        0x08,
+        0x2A,
+        0x86.toByte(),
+        0x48,
+        0xCE.toByte(),
+        0x3D,
+        0x03,
+        0x01,
+        0x07,
+    )

--- a/buffer-crypto/src/linuxTest/kotlin/com/ditchoom/buffer/crypto/Tpm2Pkcs11NativeProviderTest.linux.kt
+++ b/buffer-crypto/src/linuxTest/kotlin/com/ditchoom/buffer/crypto/Tpm2Pkcs11NativeProviderTest.linux.kt
@@ -1,0 +1,144 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.crypto.CryptoTestVectors.ascii
+import com.ditchoom.buffer.crypto.CryptoTestVectors.hexBuffer
+import com.ditchoom.buffer.crypto.CryptoTestVectors.toHex
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.toKString
+import kotlinx.coroutines.test.runTest
+import platform.posix.getenv
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * On-token conformance for the Kotlin/Native tpm2-pkcs11-backed [HardwareKeyProvider] — the Linux
+ * hardware tier that only runs against a real TPM or a software PKCS#11 rig. Two required modes,
+ * selected by environment (Kotlin/Native has no system properties), mirroring the JVM twin:
+ *
+ *  - `BUFFER_CRYPTO_REQUIRE_TPM2=true` (the swtpm CI job): the resolution MUST be Available and the
+ *    full signing contract is pinned — plus agreement's honest refusal (tpm2-pkcs11 1.9 advertises
+ *    no `CKM_ECDH1_DERIVE`).
+ *  - `BUFFER_CRYPTO_REQUIRE_P11_AGREEMENT=true` (the SoftHSM CI job): the signing contract plus the
+ *    agreement contract that tpm2-pkcs11 cannot yet exercise, through the same dlopen bridge.
+ *
+ * Unconfigured machines skip; the typed resolution shape is covered by ProtectedKeyResolutionTest.
+ */
+class Tpm2Pkcs11NativeProviderTest {
+    private val requiredTpm = envFlag("BUFFER_CRYPTO_REQUIRE_TPM2")
+    private val requiredAgreement = envFlag("BUFFER_CRYPTO_REQUIRE_P11_AGREEMENT")
+    private val anyRequired get() = requiredTpm || requiredAgreement
+
+    @Test
+    fun tokenBackendResolvesAndSignsWhenRequired() =
+        runTest {
+            if (!anyRequired) return@runTest
+            val resolution =
+                assertIs<ProtectedKeyResolution.Available>(
+                    CryptoCapabilities.protectedKeyResolution,
+                    "the PKCS#11 rig is configured, so resolution must be Available",
+                )
+            assertEquals(ProtectedKeyBackend.Tpm2Pkcs11, resolution.backend)
+            val provider = assertIs<HardwareKeyProvider>(resolution.provider)
+
+            // The secure-element witness surfaces the token (issue: hardware never Available on Linux).
+            val hw = assertIs<HardwareSupport.Available>(CryptoCapabilities.hardware)
+            assertEquals(provider, hw.provider)
+
+            assertTrue(provider.eligible(ProtectedKeyAlgorithm.EcdsaP256))
+            val signing = provider.generateSigning(SignatureScheme.EcdsaP256, ProtectedKeySpec())
+            try {
+                assertEquals(KeyProvenance.Hardware, signing.provenance)
+                val custody = signing.custody
+                assertIs<KeyCustody.NonExportable.Hardware>(custody)
+                // PKCS#11 cannot confirm a discrete vs. firmware TPM; the claim stays conservative.
+                assertFalse(custody.dedicatedSecureElement)
+                val message = ascii("tpm2-pkcs11 native identity signature")
+                val signature = signAsync(signing, message)
+                assertTrue(
+                    verifyAsync(signing.verifyKey, message, signature),
+                    "token-sign must verify under its public key via the software witness",
+                )
+            } finally {
+                signing.close()
+            }
+
+            // A denying advisory gate surfaces as AuthorizationFailed, exactly like the other backends.
+            val denied =
+                provider.generateSigning(
+                    SignatureScheme.EcdsaP256,
+                    ProtectedKeySpec(authorization = HardwareAuthorization { false }),
+                )
+            try {
+                assertFailsWith<AuthorizationFailed> { signAsync(denied, ascii("denied")) }
+            } finally {
+                denied.close()
+            }
+        }
+
+    @Test
+    fun agreementIsHonestlyRefusedWhereTheModuleLacksTheMechanism() =
+        runTest {
+            if (!requiredTpm) return@runTest
+            val resolution = assertIs<ProtectedKeyResolution.Available>(CryptoCapabilities.protectedKeyResolution)
+            val provider = resolution.provider
+
+            // tpm2-pkcs11 1.9 advertises no CKM_ECDH1_DERIVE: the end-to-end probe must fail closed.
+            assertFalse(provider.eligible(ProtectedKeyAlgorithm.EcdhP256))
+            assertFailsWith<HardwareKeyException.AlgorithmNotEligible> {
+                provider.generateKeyAgreement(KeyAgreementCurve.P256, ProtectedKeySpec())
+            }
+
+            // The total resolver still serves agreement — from the software floor, with honest custody.
+            val resolver = CryptoCapabilities.keyProvider()
+            assertEquals(KeyCustody.ExportableSoftware, resolver.custodyFor(ProtectedKeyAlgorithm.EcdhP256))
+            resolver.requireTier(ProtectedKeyAlgorithm.EcdsaP256, CustodyTier.Hardware)
+            assertFailsWith<InsufficientKeyCustody> {
+                resolver.requireTier(ProtectedKeyAlgorithm.EcdhP256, CustodyTier.Hardware)
+            }
+        }
+
+    @Test
+    fun agreementLightsUpOnADeriveCapableModule() =
+        runTest {
+            if (!requiredAgreement) return@runTest
+            val resolution = assertIs<ProtectedKeyResolution.Available>(CryptoCapabilities.protectedKeyResolution)
+            val provider = resolution.provider
+            assertTrue(
+                provider.eligible(ProtectedKeyAlgorithm.EcdhP256),
+                "a derive-capable module must light agreement eligibility up",
+            )
+
+            val pair = provider.generateKeyAgreement(KeyAgreementCurve.P256, ProtectedKeySpec())
+            try {
+                assertEquals(KeyProvenance.Hardware, pair.privateKey.provenance)
+                val peer = generateKeyPairAsync(KeyAgreementCurve.P256)
+                val info = hexBuffer("6b6578")
+                val viaToken = deriveSharedSecretAsync(pair.privateKey, peer.publicKey, info, SECRET_BYTES).toHex()
+                val viaPeer = deriveSharedSecretAsync(peer.privateKey, pair.publicKey, info, SECRET_BYTES).toHex()
+                assertEquals(viaPeer, viaToken, "token ECDH must match the software peer's derivation")
+
+                // A well-formed but off-curve peer point is the uniform typed rejection — the module
+                // (or TPM, which must validate per TPM2_ECDH_ZGen) refuses, never a raw CKR leak.
+                val offCurve = KeyAgreementPublicKey.of(KeyAgreementCurve.P256, hexBuffer("04" + "ee".repeat(64)))
+                assertNotNull(
+                    assertFailsWith<InvalidPublicKey> {
+                        deriveSharedSecretAsync(pair.privateKey, offCurve, info, SECRET_BYTES)
+                    },
+                )
+            } finally {
+                pair.close()
+            }
+        }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun envFlag(name: String): Boolean = getenv(name)?.toKString() == "true"
+
+private const val SECRET_BYTES = 32

--- a/buffer-crypto/src/nativeInterop/cinterop/tpm2pkcs11.def
+++ b/buffer-crypto/src/nativeInterop/cinterop/tpm2pkcs11.def
@@ -1,0 +1,86 @@
+# Minimal PKCS#11 (Cryptoki v2.40) subset for the Linux-native tpm2-pkcs11 backend.
+#
+# The module (.so) is loaded at RUNTIME via dlopen and each C_* entry point resolved with dlsym -
+# nothing links against a PKCS#11 library at build time, so the binding needs only the types the
+# calls exchange, declared inline here from the OASIS specification. The full vendored cryptoki
+# headers are deliberately avoided: they exist to define CK_FUNCTION_LIST (~70 ordered function
+# pointers whose layout must match the module exactly), which the dlsym-per-symbol approach never
+# touches. Both tpm2-pkcs11 and SoftHSM export every C_* symbol directly, per longstanding
+# convention; a module that hides them behind C_GetFunctionList resolves honestly to a typed refusal.
+#
+# Layout notes: on LP64 Linux the spec's types are plain unsigned longs / pointers with default
+# alignment (the pack(1) pragmas in the official headers apply to Windows only), so these struct
+# declarations are ABI-identical to the module's.
+package = com.ditchoom.buffer.crypto.cinterop.pkcs11
+---
+#include <stddef.h>
+
+typedef unsigned char CK_BYTE;
+typedef unsigned char CK_BBOOL;
+typedef unsigned long CK_ULONG;
+typedef CK_ULONG CK_RV;
+typedef CK_ULONG CK_SLOT_ID;
+typedef CK_ULONG CK_SESSION_HANDLE;
+typedef CK_ULONG CK_OBJECT_HANDLE;
+typedef CK_ULONG CK_FLAGS;
+typedef CK_ULONG CK_USER_TYPE;
+typedef CK_ULONG CK_ATTRIBUTE_TYPE;
+typedef CK_ULONG CK_MECHANISM_TYPE;
+
+typedef struct CK_ATTRIBUTE {
+    CK_ATTRIBUTE_TYPE type;
+    void *pValue;
+    CK_ULONG ulValueLen;
+} CK_ATTRIBUTE;
+
+typedef struct CK_MECHANISM {
+    CK_MECHANISM_TYPE mechanism;
+    void *pParameter;
+    CK_ULONG ulParameterLen;
+} CK_MECHANISM;
+
+/* C_Initialize argument block - used only to request CKF_OS_LOCKING_OK. */
+typedef struct CK_C_INITIALIZE_ARGS {
+    void *CreateMutex;
+    void *DestroyMutex;
+    void *LockMutex;
+    void *UnlockMutex;
+    CK_FLAGS flags;
+    void *pReserved;
+} CK_C_INITIALIZE_ARGS;
+
+/* CKM_ECDH1_DERIVE parameter block (CK_ECDH1_DERIVE_PARAMS). */
+typedef struct CK_ECDH1_DERIVE_PARAMS {
+    CK_ULONG kdf;
+    CK_ULONG ulSharedDataLen;
+    CK_BYTE *pSharedData;
+    CK_ULONG ulPublicDataLen;
+    CK_BYTE *pPublicData;
+} CK_ECDH1_DERIVE_PARAMS;
+
+/* The entry points this backend resolves with dlsym, as named function-pointer types so the
+ * Kotlin side reinterprets each dlsym result into a typed, directly invocable CFunction. */
+typedef CK_RV (*BCP11_C_Initialize)(void *pInitArgs);
+typedef CK_RV (*BCP11_C_Finalize)(void *pReserved);
+typedef CK_RV (*BCP11_C_GetSlotList)(CK_BBOOL tokenPresent, CK_SLOT_ID *pSlotList, CK_ULONG *pulCount);
+typedef CK_RV (*BCP11_C_OpenSession)(
+    CK_SLOT_ID slotID, CK_FLAGS flags, void *pApplication, void *Notify, CK_SESSION_HANDLE *phSession);
+typedef CK_RV (*BCP11_C_CloseSession)(CK_SESSION_HANDLE hSession);
+typedef CK_RV (*BCP11_C_Login)(
+    CK_SESSION_HANDLE hSession, CK_USER_TYPE userType, CK_BYTE *pPin, CK_ULONG ulPinLen);
+typedef CK_RV (*BCP11_C_GenerateKeyPair)(
+    CK_SESSION_HANDLE hSession, CK_MECHANISM *pMechanism,
+    CK_ATTRIBUTE *pPublicKeyTemplate, CK_ULONG ulPublicKeyAttributeCount,
+    CK_ATTRIBUTE *pPrivateKeyTemplate, CK_ULONG ulPrivateKeyAttributeCount,
+    CK_OBJECT_HANDLE *phPublicKey, CK_OBJECT_HANDLE *phPrivateKey);
+typedef CK_RV (*BCP11_C_GetAttributeValue)(
+    CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hObject, CK_ATTRIBUTE *pTemplate, CK_ULONG ulCount);
+typedef CK_RV (*BCP11_C_SignInit)(
+    CK_SESSION_HANDLE hSession, CK_MECHANISM *pMechanism, CK_OBJECT_HANDLE hKey);
+typedef CK_RV (*BCP11_C_Sign)(
+    CK_SESSION_HANDLE hSession, CK_BYTE *pData, CK_ULONG ulDataLen,
+    CK_BYTE *pSignature, CK_ULONG *pulSignatureLen);
+typedef CK_RV (*BCP11_C_DeriveKey)(
+    CK_SESSION_HANDLE hSession, CK_MECHANISM *pMechanism, CK_OBJECT_HANDLE hBaseKey,
+    CK_ATTRIBUTE *pTemplate, CK_ULONG ulAttributeCount, CK_OBJECT_HANDLE *phKey);
+typedef CK_RV (*BCP11_C_DestroyObject)(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hObject);


### PR DESCRIPTION
The Kotlin/Native Linux half of #313: `platformProtectedKeyResolution` on linuxMain stops answering a permanent `None`. The tpm2-pkcs11 module is dlopen'd at runtime and driven directly over the PKCS#11 C API, giving native Linux the same probed, typed hardware tier the desktop JVM gained in #317.

> **Stacked on #321** (both extend the same CI workflow file); retarget to `main` after it merges. The diff shown here is this change alone.

### What changed

**`tpm2pkcs11.def`** (new cinterop): a minimal spec-declared Cryptoki v2.40 subset. The binding deliberately avoids `CK_FUNCTION_LIST` — ~70 ordered function pointers whose memory layout must match the module exactly — by `dlsym`-resolving each `C_*` entry point individually (both tpm2-pkcs11 and SoftHSM export them, per longstanding convention; a module that hides them resolves honestly to a typed refusal). Nothing links at build time.

**`Pkcs11Token`** (new): one process-lifetime logged-in session (`C_Initialize` with `CKF_OS_LOCKING_OK` → slots → session → login, tolerating already-initialized/already-logged-in). Ops: keypair generation, `CKA_EC_POINT` read (both OCTET-STRING-wrapped and bare encodings), `CKM_ECDSA` digest signing, `CKM_ECDH1_DERIVE`/`CKD_NULL` with the derived secret copied into a wiped secure buffer and the derived object destroyed. Failures carry the raw `CKR_*` numerically as a typed `Ckr` — no exception-message parsing at this seam, unlike the JVM bridge.

**`Tpm2Pkcs11NativeKeyProvider`**: mirrors the JVM provider's contract — resolution probed end-to-end (generate → sign on token → BoringSSL software verify) before `Available` is ever reported; agreement probe-gated against a BoringSSL software peer, both directions matching; advisory gates, serialized ops, uniform `InvalidPublicKey` on peer rejection (structural SEC1 precheck, on-curve validation in the module/TPM as TPM 2.0 `ECDH_ZGen` mandates). Configuration is environment-only (`BUFFER_CRYPTO_TPM2_PKCS11_MODULE` / `_PIN` / `_SLOT_INDEX`) — Kotlin/Native has no system properties.

Two places this backend is *better* than its JVM twin, thanks to controlling the C API directly: key templates are per-call, so signing keys carry `CKA_SIGN` only and agreement keys `CKA_DERIVE` only (the object-level key separation SunPKCS11 needed a second provider configuration to achieve), and `CKM_ECDSA`'s raw `r||s` is DER-wrapped in-library to the cross-platform signature format.

### What was verified where

**swtpm + tpm2-abrmd (local rig; CI job gains a `linuxX64Test` leg)** — resolution `Available`, hardware witness surfaces the provider, token-sign verifies under its public key via the software witness, hardware custody without the dedicated-element over-claim, denied advisory gate → `AuthorizationFailed`, and agreement honestly refused (1.9 lacks the mechanism) with software-floor routing plus `requireTier` refusing hardware agreement. Negative control verified: wrong PIN makes the required-mode tests fail loudly, so the green runs are not skips.

**SoftHSM (local; CI SoftHSM job gains the same leg)** — agreement eligibility lights up, token ECDH matches the software peer's derivation in both directions through the public API, and a well-formed off-curve peer point raises the uniform `InvalidPublicKey`.

**Unconfigured** — full `:buffer-crypto:linuxX64Test` suite green (typed-refusal shape only); `linuxArm64` compiles; `ktlintCheck` green, detekt zero findings (one `MatchingDeclarationName` baseline entry for the platform-suffixed test file, sibling precedent), `apiCheck` green (all additions internal).

Remaining on #313 after this: the JVM-on-macOS Keychain bridge (on hold). Native-side persistent aliases (the linuxMain counterpart of #321's cert-wrapped entries) are a natural follow-up once both land.