### PR TITLE
feat(buffer): hex ⇄ String conversions

### DIFF
--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/CryptoTestVectors.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/CryptoTestVectors.kt
@@ -3,18 +3,14 @@ package com.ditchoom.buffer.crypto
 import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.Default
 import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.fromHexString
+import com.ditchoom.buffer.toHexString
 import com.ditchoom.buffer.toReadBuffer
 
 /** Test helpers that build inputs and render outputs through the buffer API only (no ByteArray). */
 object CryptoTestVectors {
-    /** Materializes a hex string into a read-ready buffer via byte writes. */
-    fun hexBuffer(hex: String): ReadBuffer {
-        val n = hex.length / 2
-        val b = BufferFactory.Default.allocate(n)
-        for (i in 0 until n) b.writeByte(hex.substring(i * 2, i * 2 + 2).toInt(16).toByte())
-        b.resetForRead()
-        return b
-    }
+    /** Materializes a hex string into a read-ready buffer. */
+    fun hexBuffer(hex: String): ReadBuffer = BufferFactory.Default.fromHexString(hex)
 
     /** A read-ready buffer of [count] bytes each equal to [value]. */
     fun repeatedByte(
@@ -30,17 +26,6 @@ object CryptoTestVectors {
     /** A read-ready buffer of [text]'s UTF-8 bytes. */
     fun ascii(text: String): ReadBuffer = text.toReadBuffer()
 
-    /** Lowercase hex of this buffer's remaining bytes (non-destructive). */
-    fun ReadBuffer.toHex(): String {
-        val hex = "0123456789abcdef"
-        val start = position()
-        val n = remaining()
-        val sb = StringBuilder(n * 2)
-        for (i in 0 until n) {
-            val v = get(start + i).toInt() and 0xFF
-            sb.append(hex[v ushr 4])
-            sb.append(hex[v and 0xF])
-        }
-        return sb.toString()
-    }
+    /** Lowercase hex of this buffer's remaining bytes (non-destructive). The suite's short alias. */
+    fun ReadBuffer.toHex(): String = toHexString()
 }

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Aead.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Aead.jsAndWasmJs.kt
@@ -4,6 +4,7 @@ import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.toHexString
 
 /*
  * js/wasmJs AEAD.
@@ -84,10 +85,10 @@ internal actual suspend fun aesGcmSealWithNonceAsync(
     }
     val ctTagHex =
         webCryptoAesGcmEncrypt(
-            keyHex = key.requireInMemoryMaterial().toHexRemaining(),
-            ivHex = nonce.toHexRemaining(),
-            aadHex = aad?.toHexRemaining() ?: "",
-            plaintextHex = plaintext.toHexRemaining(),
+            keyHex = key.requireInMemoryMaterial().toHexString(),
+            ivHex = nonce.toHexString(),
+            aadHex = aad?.toHexString() ?: "",
+            plaintextHex = plaintext.toHexString(),
         )
     val out = factory.allocate(plaintext.remaining() + AEAD_TAG_BYTES)
     out.writeHex(ctTagHex)
@@ -107,10 +108,10 @@ internal actual suspend fun aesGcmOpenWithNonceAsync(
     }
     val ptHex =
         webCryptoAesGcmDecrypt(
-            keyHex = key.requireInMemoryMaterial().toHexRemaining(),
-            ivHex = nonce.toHexRemaining(),
-            aadHex = aad?.toHexRemaining() ?: "",
-            ciphertextAndTagHex = ciphertextAndTag.toHexRemaining(),
+            keyHex = key.requireInMemoryMaterial().toHexString(),
+            ivHex = nonce.toHexString(),
+            aadHex = aad?.toHexString() ?: "",
+            ciphertextAndTagHex = ciphertextAndTag.toHexString(),
         ) ?: throw VerificationFailed()
     val out = factory.allocate(maxOf(0, ciphertextAndTag.remaining() - AEAD_TAG_BYTES))
     out.writeHex(ptHex)
@@ -122,22 +123,8 @@ internal actual suspend fun aesGcmOpenWithNonceAsync(
 // hex marshalling (shared js/wasmJs)
 // =============================================================================
 
-private const val HEX = "0123456789abcdef"
 private const val HEX_RADIX = 16
 private const val NIBBLE_BITS = 4
-
-/** Lowercase hex of this buffer's remaining bytes (non-destructive). */
-internal fun ReadBuffer.toHexRemaining(): String {
-    val start = position()
-    val n = remaining()
-    val sb = StringBuilder(n * 2)
-    for (i in 0 until n) {
-        val v = get(start + i).toInt() and 0xFF
-        sb.append(HEX[v ushr NIBBLE_BITS])
-        sb.append(HEX[v and 0xF])
-    }
-    return sb.toString()
-}
 
 /** Writes the bytes decoded from a lowercase/uppercase hex string at the buffer's position. */
 internal fun WriteBuffer.writeHex(hex: String) {

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/EcInterop.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/EcInterop.jsAndWasmJs.kt
@@ -2,6 +2,8 @@ package com.ditchoom.buffer.crypto
 
 import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.fromHexString
+import com.ditchoom.buffer.toHexString
 
 /*
  * js / wasmJs EC point decompression marshals through hex, the same convention the WebCrypto glue uses
@@ -11,32 +13,15 @@ import com.ditchoom.buffer.ReadBuffer
  * it runs only on the public X coordinate, so its variable-time math leaks nothing.
  */
 
-private const val HEX_DIGITS = "0123456789abcdef"
-private const val HEX_RADIX = 16
-
 /** Lowercase hex of [len] bytes of [buf] starting at absolute [start]. */
 internal fun readFieldHex(
     buf: ReadBuffer,
     start: Int,
     len: Int,
-): String {
-    val sb = StringBuilder(len * 2)
-    for (i in 0 until len) {
-        val v = buf.get(start + i).toInt() and 0xFF
-        sb.append(HEX_DIGITS[v ushr 4])
-        sb.append(HEX_DIGITS[v and 0xF])
-    }
-    return sb.toString()
-}
+): String = buf.toHexString(start, len)
 
 /** Writes a hex string's bytes into a fresh read-ready buffer from [factory]. */
 internal fun hexToReadBuffer(
     hex: String,
     factory: BufferFactory,
-): ReadBuffer {
-    val n = hex.length / 2
-    val out = factory.allocate(n)
-    for (i in 0 until n) out.writeByte(hex.substring(i * 2, i * 2 + 2).toInt(HEX_RADIX).toByte())
-    out.resetForRead()
-    return out
-}
+): ReadBuffer = factory.fromHexString(hex)

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.jsAndWasmJs.kt
@@ -2,7 +2,8 @@ package com.ditchoom.buffer.crypto
 
 import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.Default
-import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.fromHexString
+import com.ditchoom.buffer.toHexString
 import com.ditchoom.buffer.use
 
 /*
@@ -96,7 +97,7 @@ internal fun buildWebCryptoSigningKey(
     spec: ProtectedKeySpec,
 ): SigningKey {
     val hashName = ecdsaHashName(scheme)
-    val verifyKey = verifyKeyOf(scheme, hexBuffer(publicHex, BufferFactory.Default))
+    val verifyKey = verifyKeyOf(scheme, BufferFactory.Default.fromHexString(publicHex))
     return ProtectedSigningKey(
         scheme = scheme,
         custody = KeyCustody.NonExportable.Software,
@@ -104,7 +105,7 @@ internal fun buildWebCryptoSigningKey(
             if (!spec.authorization.authorize()) throw AuthorizationFailed()
             // WebCrypto ECDSA sign is raw P1363 (r ‖ s) — the pinned web wire form; DER conversion
             // is a consumer's concern via the existing helpers.
-            hexBuffer(webCryptoEcdsaSign(token, hashName, message.toHexRemaining()), factory)
+            factory.fromHexString(webCryptoEcdsaSign(token, hashName, message.toHexString()))
         },
         verifyKey = verifyKey,
         onClose = { webCryptoReleaseHandle(token) },
@@ -130,9 +131,9 @@ internal fun buildWebCryptoAesGcmKey(
                 val ctTagHex =
                     webCryptoAesGcmSealHandle(
                         token = token,
-                        ivHex = nonce.toHexRemaining(),
-                        aadHex = aad?.toHexRemaining() ?: "",
-                        plaintextHex = plaintext.toHexRemaining(),
+                        ivHex = nonce.toHexString(),
+                        aadHex = aad?.toHexString() ?: "",
+                        plaintextHex = plaintext.toHexString(),
                     )
                 val out = allocateFramed(plaintext.remaining(), factory)
                 out.write(nonce)
@@ -146,11 +147,11 @@ internal fun buildWebCryptoAesGcmKey(
             val ptHex =
                 webCryptoAesGcmOpenHandle(
                     token = token,
-                    ivHex = nonce.toHexRemaining(),
-                    aadHex = aad?.toHexRemaining() ?: "",
-                    ciphertextAndTagHex = ciphertextAndTag.toHexRemaining(),
+                    ivHex = nonce.toHexString(),
+                    aadHex = aad?.toHexString() ?: "",
+                    ciphertextAndTagHex = ciphertextAndTag.toHexString(),
                 ) ?: throw VerificationFailed()
-            hexBuffer(ptHex, factory)
+            factory.fromHexString(ptHex)
         },
         onClose = { webCryptoReleaseHandle(token) },
     )
@@ -162,7 +163,7 @@ internal fun buildWebCryptoKeyAgreementPair(
     publicHex: String,
     spec: ProtectedKeySpec,
 ): KeyAgreementKeyPair {
-    val publicKey = KeyAgreementPublicKey.of(curve, hexBuffer(publicHex, BufferFactory.Default))
+    val publicKey = KeyAgreementPublicKey.of(curve, BufferFactory.Default.fromHexString(publicHex))
     val bits = deriveBitsFor(curve)
     val privateKey =
         ProtectedKeyAgreementPrivateKey(
@@ -177,14 +178,14 @@ internal fun buildWebCryptoKeyAgreementPair(
                 require(peer.curve == curve) { "private/public key curve mismatch" }
                 val sharedHex =
                     try {
-                        webCryptoEcdhDeriveBits(token, curve.curveName, peer.encoded.toHexRemaining(), bits)
+                        webCryptoEcdhDeriveBits(token, curve.curveName, peer.encoded.toHexString(), bits)
                     } catch (_: Throwable) {
                         // A rejected import / deriveBits means an off-curve / low-order / malformed
                         // peer point — surfaced uniformly, cause dropped (oracle avoidance).
                         @Suppress("SwallowedException", "TooGenericExceptionCaught")
                         throw InvalidPublicKey(curve)
                     }
-                hexBuffer(sharedHex, secureScratch)
+                secureScratch.fromHexString(sharedHex)
             },
             onClose = { webCryptoReleaseHandle(token) },
         )
@@ -239,17 +240,6 @@ private fun splitTokenAndHex(marshalled: String): Pair<Int, String> {
     val sep = marshalled.indexOf(':')
     require(sep > 0) { "malformed non-exportable key marshalling" }
     return marshalled.substring(0, sep).toInt() to marshalled.substring(sep + 1)
-}
-
-/** Builds a fresh read-ready buffer from a lowercase-hex string via [factory]. */
-private fun hexBuffer(
-    hex: String,
-    factory: BufferFactory,
-): PlatformBuffer {
-    val out = factory.allocate(hex.length / 2)
-    out.writeHex(hex)
-    out.resetForRead()
-    return out
 }
 
 // =============================================================================

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/KeyAgreement.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/KeyAgreement.jsAndWasmJs.kt
@@ -4,6 +4,8 @@ import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.Default
 import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.fromHexString
+import com.ditchoom.buffer.toHexString
 
 /**
  * js/wasmJs key agreement over **WebCrypto** (`crypto.subtle`). WebCrypto's key-agreement API is
@@ -32,7 +34,6 @@ import com.ditchoom.buffer.ReadBuffer
  * targets is best-effort; SecureBuffer wiping covers only the Kotlin-side buffers.
  */
 
-private const val HEX_RADIX = 16
 private const val NIBBLE_BITS = 4
 
 // --- raw scalar -> PKCS#8 (WebCrypto importKey('pkcs8') input) ----------------
@@ -78,7 +79,7 @@ private fun scalarToPkcs8Hex(
     curve: KeyAgreementCurve,
     scalar: ReadBuffer,
 ): String {
-    val dHex = scalar.toHex()
+    val dHex = scalar.toHexString()
     if (curve == KeyAgreementCurve.X25519) return X25519_PKCS8_PREFIX + dHex
     // ECPrivateKey ::= SEQUENCE { version INTEGER(1), privateKey OCTET STRING(scalar) }
     val ecPrivateKey = tlv("30", tlv("02", "01") + tlv("04", dHex))
@@ -117,32 +118,6 @@ private fun ensureSupported(curve: KeyAgreementCurve) {
     }
 }
 
-/** Lowercase hex of a buffer's remaining bytes (non-destructive); for WebCrypto string marshalling. */
-private fun ReadBuffer.toHex(): String {
-    val digits = "0123456789abcdef"
-    val start = position()
-    val n = remaining()
-    val sb = StringBuilder(n * 2)
-    for (i in 0 until n) {
-        val v = get(start + i).toInt() and 0xFF
-        sb.append(digits[v ushr NIBBLE_BITS])
-        sb.append(digits[v and 0xF])
-    }
-    return sb.toString()
-}
-
-/** Writes a hex string's bytes into a fresh read-ready buffer from [factory]. */
-private fun hexToBuffer(
-    hex: String,
-    factory: BufferFactory,
-): PlatformBuffer {
-    val n = hex.length / 2
-    val b = factory.allocate(n)
-    for (i in 0 until n) b.writeByte(hex.substring(i * 2, i * 2 + 2).toInt(HEX_RADIX).toByte())
-    b.resetForRead()
-    return b
-}
-
 internal actual suspend fun generateKeyPairAsyncPlatform(curve: KeyAgreementCurve): KeyAgreementKeyPair {
     ensureSupported(curve)
     // WebCrypto returns "publicHex|privateHex" (raw public export, raw private scalar from JWK `d`), or
@@ -151,8 +126,8 @@ internal actual suspend fun generateKeyPairAsyncPlatform(curve: KeyAgreementCurv
     if (result.publicHex == UNSUPPORTED_SENTINEL) {
         throw UnsupportedOperationException("${curve.curveName} is not available in this WebCrypto engine")
     }
-    val pubBuf = hexToBuffer(result.publicHex, BufferFactory.Default)
-    val privBuf = hexToBuffer(result.privateHex, secureScratch)
+    val pubBuf = BufferFactory.Default.fromHexString(result.publicHex)
+    val privBuf = secureScratch.fromHexString(result.privateHex)
     val publicKey = KeyAgreementPublicKey.of(curve, pubBuf)
     return keyAgreementKeyPairOf(curve, keyAgreementPrivateKeyOf(curve, privBuf), publicKey)
 }
@@ -178,7 +153,7 @@ internal actual suspend fun deriveSharedSecretAsyncPlatform(
             webCryptoDeriveSharedSecret(
                 curve.curveName,
                 scalarToPkcs8Hex(curve, privateKey.requireInMemoryMaterial()),
-                peerPublicKey.encoded.toHex(),
+                peerPublicKey.encoded.toHexString(),
             )
         } catch (e: Throwable) {
             // A failed import / deriveBits means an off-curve / low-order / malformed peer point.
@@ -187,7 +162,7 @@ internal actual suspend fun deriveSharedSecretAsyncPlatform(
     if (sharedHex == UNSUPPORTED_SENTINEL) {
         throw UnsupportedOperationException("${curve.curveName} is not available in this WebCrypto engine")
     }
-    val raw = hexToBuffer(sharedHex, secureScratch)
+    val raw = secureScratch.fromHexString(sharedHex)
     return deriveFromRawSecret(curve, raw, info, length, salt, factory)
 }
 
@@ -209,7 +184,7 @@ internal actual suspend fun dhRawSecretInMemory(
             webCryptoDeriveSharedSecret(
                 curve.curveName,
                 scalarToPkcs8Hex(curve, privateKey.requireInMemoryMaterial()),
-                peerPublicKey.encoded.toHex(),
+                peerPublicKey.encoded.toHexString(),
             )
         } catch (e: Throwable) {
             throw InvalidPublicKey(curve)
@@ -217,7 +192,7 @@ internal actual suspend fun dhRawSecretInMemory(
     if (sharedHex == UNSUPPORTED_SENTINEL) {
         throw UnsupportedOperationException("${curve.curveName} is not available in this WebCrypto engine")
     }
-    val raw = hexToBuffer(sharedHex, secureScratch)
+    val raw = secureScratch.fromHexString(sharedHex)
     return validateRawSecret(curve, raw)
 }
 

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Sha512Core.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Sha512Core.kt
@@ -4,6 +4,7 @@ import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.ByteOrder
 import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.fromHexString
 import com.ditchoom.buffer.managed
 
 /**
@@ -179,12 +180,9 @@ internal class Sha512Core(
         private const val HIGH_BYTE_SHIFT = 56 // shift to the most-significant byte of a 64-bit word
         private const val BITS_PER_BYTE = 8
         private const val BYTE_INDEX_MASK = 7 // i mod 8 → byte within the word
-        private const val HEX_RADIX = 16
 
-        private fun hexBufferOf(hex: String): ReadBuffer =
-            BufferFactory.managed().allocate(hex.length / 2, ByteOrder.BIG_ENDIAN).apply {
-                for (i in 0 until hex.length / 2) set(i, hex.substring(i * 2, i * 2 + 2).toInt(HEX_RADIX).toByte())
-            }
+        // fromHexString defaults to BIG_ENDIAN, which is what the round-constant table is read as.
+        private fun hexBufferOf(hex: String): ReadBuffer = BufferFactory.managed().fromHexString(hex)
 
         // First 64 bits of the fractional parts of the cube roots of the first 80 primes.
         private const val K_HEX =

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Signatures.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/Signatures.jsAndWasmJs.kt
@@ -2,9 +2,10 @@ package com.ditchoom.buffer.crypto
 
 import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.Default
-import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.fromHexString
+import com.ditchoom.buffer.toHexString
 
 /**
  * js/wasmJs signature support.
@@ -89,7 +90,8 @@ internal expect suspend fun webCryptoVerify(
 internal expect suspend fun webCryptoGenerateKeyPair(scheme: SignatureScheme): String
 
 // ---------------------------------------------------------------------------
-// Hex <-> buffer helpers (no ByteArray staging beyond the WebCrypto string boundary).
+// Hex marshalling uses the buffer primitives (ReadBuffer.toHexString /
+// BufferFactory.fromHexString) — no ByteArray staging beyond the WebCrypto string boundary.
 // ---------------------------------------------------------------------------
 
 private const val HEX = "0123456789abcdef"
@@ -107,33 +109,6 @@ private const val ED25519_SEED_BYTES = 32
 // DER definite-length encoding thresholds.
 private const val DER_SHORT_LEN_LIMIT = 0x80 // lengths below use the single-byte short form
 private const val DER_ONE_BYTE_LIMIT = 0x100 // lengths below fit in one long-form byte (0x81 LL)
-
-private fun ReadBuffer.toHexString(): String {
-    val start = position()
-    val n = remaining()
-    val sb = StringBuilder(n * 2)
-    for (i in 0 until n) {
-        val v = get(start + i).toInt() and 0xFF
-        sb.append(HEX[v ushr NIBBLE_BITS])
-        sb.append(HEX[v and NIBBLE_MASK])
-    }
-    return sb.toString()
-}
-
-private fun hexToBuffer(
-    hex: String,
-    factory: BufferFactory,
-): PlatformBuffer {
-    val n = hex.length / 2
-    val b = factory.allocate(n)
-    for (i in 0 until n) {
-        val hi = HEX.indexOf(hex[i * 2].lowercaseChar())
-        val lo = HEX.indexOf(hex[i * 2 + 1].lowercaseChar())
-        b.writeByte(((hi shl NIBBLE_BITS) or lo).toByte())
-    }
-    b.resetForRead()
-    return b
-}
 
 // ---------------------------------------------------------------------------
 // PKCS#8 assembly for WebCrypto private-key import, built through the buffer API.
@@ -228,7 +203,7 @@ internal actual suspend fun signAsyncPlatform(
         throw UnsupportedOperationException("Ed25519 is not available on this WebCrypto engine")
     }
     val sigHex = webCryptoSign(key.scheme, privateMaterialHex(key), message.toHexString())
-    return hexToBuffer(sigHex, factory)
+    return factory.fromHexString(sigHex)
 }
 
 internal actual suspend fun verifyAsyncPlatform(
@@ -259,9 +234,9 @@ internal actual suspend fun generateSigningKeyAsyncPlatform(
         throw UnsupportedOperationException("Ed25519 is not available on this WebCrypto engine")
     }
     val parts = webCryptoGenerateKeyPair(scheme).split(":")
-    val verifyKey = verifyKeyOf(scheme, hexToBuffer(parts[1], BufferFactory.Default))
+    val verifyKey = verifyKeyOf(scheme, BufferFactory.Default.fromHexString(parts[1]))
     // Stage the secret private material in a wiped buffer; the import factory copies it into `factory`.
-    val privBuf = hexToBuffer(parts[0], secureScratch)
+    val privBuf = secureScratch.fromHexString(parts[0])
     return try {
         signingKeyOf(scheme, privBuf, verifyKey, factory)
     } finally {

--- a/buffer-crypto/src/jsMain/kotlin/com/ditchoom/buffer/crypto/CryptoAsymDemo.kt
+++ b/buffer-crypto/src/jsMain/kotlin/com/ditchoom/buffer/crypto/CryptoAsymDemo.kt
@@ -2,6 +2,7 @@
 
 package com.ditchoom.buffer.crypto
 
+import com.ditchoom.buffer.toHexString
 import com.ditchoom.buffer.toReadBuffer
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
@@ -54,11 +55,11 @@ object CryptoAsymDemo {
             val alice = ops.generateKeyPair()
             val bob = ops.generateKeyPair()
             try {
-                val pkAlice = alice.publicKey.encoded.toHexRemaining()
-                val pkBob = bob.publicKey.encoded.toHexRemaining()
+                val pkAlice = alice.publicKey.encoded.toHexString()
+                val pkBob = bob.publicKey.encoded.toHexString()
                 val sharedA = ops.deriveSharedSecret(alice.privateKey, bob.publicKey, demoInfo(), X25519_SHARED_BYTES)
                 val sharedB = ops.deriveSharedSecret(bob.privateKey, alice.publicKey, demoInfo(), X25519_SHARED_BYTES)
-                listOf(pkAlice, pkBob, sharedA.toHexRemaining(), sharedB.toHexRemaining()).joinToString(":")
+                listOf(pkAlice, pkBob, sharedA.toHexString(), sharedB.toHexString()).joinToString(":")
             } finally {
                 alice.close()
                 bob.close()
@@ -87,13 +88,13 @@ object CryptoAsymDemo {
             val bob = hpkeGenerateKeyPair(suite.kem)
             val eve = hpkeGenerateKeyPair(suite.kem)
             try {
-                val pkBob = bob.publicKeyBytes.toHexRemaining()
+                val pkBob = bob.publicKeyBytes.toHexString()
                 val sealed = ops.sealBase(bob.publicKey, demoInfo(), plaintext.toReadBuffer())
-                val encHex = sealed.enc.toHexRemaining()
-                val ctHex = sealed.ciphertext.toHexRemaining()
+                val encHex = sealed.enc.toHexString()
+                val ctHex = sealed.ciphertext.toHexString()
                 // Fresh buffers per open so positions never collide across the two decrypt attempts.
                 val opened = ops.openBase(bob.privateKey, encHex.hexToReadBuffer(), demoInfo(), ctHex.hexToReadBuffer())
-                val recovered = opened.readString(opened.remaining()).toReadBuffer().toHexRemaining()
+                val recovered = opened.readString(opened.remaining()).toReadBuffer().toHexString()
                 val wrongKeyRejected =
                     try {
                         ops.openBase(eve.privateKey, encHex.hexToReadBuffer(), demoInfo(), ctHex.hexToReadBuffer())
@@ -126,8 +127,8 @@ object CryptoAsymDemo {
         GlobalScope.promise {
             val sk = ed25519Ops().generateSigningKey()
             try {
-                val seed = sk.requireInMemoryMaterial().toHexRemaining()
-                val pub = sk.verifyKey.requireInMemoryMaterial().toHexRemaining()
+                val seed = sk.requireInMemoryMaterial().toHexString()
+                val pub = sk.verifyKey.requireInMemoryMaterial().toHexString()
                 "$seed:$pub"
             } finally {
                 sk.close()
@@ -147,7 +148,7 @@ object CryptoAsymDemo {
         GlobalScope.promise {
             val verifyKey = VerifyKey.ed25519(publicKeyHex.hexToReadBuffer())
             SigningKey.ed25519(seedHex.hexToReadBuffer(), verifyKey).use { sk ->
-                ed25519Ops().sign(sk, message.toReadBuffer()).toHexRemaining()
+                ed25519Ops().sign(sk, message.toReadBuffer()).toHexString()
             }
         }
 

--- a/buffer-crypto/src/jsMain/kotlin/com/ditchoom/buffer/crypto/CryptoDemo.kt
+++ b/buffer-crypto/src/jsMain/kotlin/com/ditchoom/buffer/crypto/CryptoDemo.kt
@@ -5,6 +5,8 @@ package com.ditchoom.buffer.crypto
 import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.Default
 import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.fromHexString
+import com.ditchoom.buffer.toHexString
 import com.ditchoom.buffer.toReadBuffer
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
@@ -39,10 +41,10 @@ fun main() = Unit
 @JsName("CryptoDemo")
 object CryptoDemo {
     /** A fresh AES-256 key as 64 lowercase hex chars, drawn from the platform CSPRNG. */
-    fun generateKeyHex(): String = cryptoRandom(AES_256_KEY_BYTES).toHexRemaining()
+    fun generateKeyHex(): String = cryptoRandom(AES_256_KEY_BYTES).toHexString()
 
     /** A fresh 12-byte AES-GCM nonce as 24 lowercase hex chars. */
-    fun generateNonceHex(): String = cryptoRandom(AEAD_NONCE_BYTES).toHexRemaining()
+    fun generateNonceHex(): String = cryptoRandom(AEAD_NONCE_BYTES).toHexString()
 
     /**
      * **Demo-only.** Seals with a *caller-supplied* nonce so the playground can pin the nonce while
@@ -69,7 +71,7 @@ object CryptoDemo {
                 )
             // sealWithNonce returns ciphertext ‖ tag (no nonce prefix); prepend the nonce so the
             // output matches the self-framing layout the rest of the demo inspects.
-            nonceHex + sealed.toHexRemaining()
+            nonceHex + sealed.toHexString()
         }
 
     /**
@@ -85,7 +87,7 @@ object CryptoDemo {
         GlobalScope.promise {
             val key = AesGcmKey.of(keyHex.hexToReadBuffer())
             val sealed = aesGcmOps().seal(key, plaintext.toReadBuffer(), aad.toAad())
-            sealed.toHexRemaining()
+            sealed.toHexString()
         }
 
     /**
@@ -139,9 +141,4 @@ object CryptoDemo {
  * [CryptoAsymDemo] as a top-level (non-member) helper so it doesn't count against either
  * `@JsExport` object's function budget.
  */
-internal fun String.hexToReadBuffer(): ReadBuffer {
-    val out = BufferFactory.Default.allocate(length / 2)
-    out.writeHex(this)
-    out.resetForRead()
-    return out
-}
+internal fun String.hexToReadBuffer(): ReadBuffer = BufferFactory.Default.fromHexString(this)

--- a/buffer/build.gradle.kts
+++ b/buffer/build.gradle.kts
@@ -172,7 +172,11 @@ kotlin {
                 }
             }
         } else if (HostManager.hostIsLinux) {
-            linuxX64()
+            linuxX64 {
+                compilations.create("benchmark") {
+                    associateWith(this@linuxX64.compilations.getByName("main"))
+                }
+            }
             // Register linuxArm64 on local Linux dev too (was previously CI-only). K/N
             // ships an aarch64 cross-compiler; required for downstream consumers
             // (socket, mqtt) that target linuxArm64 to resolve buffer's umbrella metadata.
@@ -340,6 +344,14 @@ kotlin {
                 }
             }
         }
+        if (HostManager.hostIsLinux && !isRunningOnGithub) {
+            val linuxX64Benchmark by getting {
+                kotlin.srcDir("src/commonBenchmark/kotlin")
+                dependencies {
+                    implementation(libs.kotlinx.benchmark.runtime)
+                }
+            }
+        }
     }
 }
 
@@ -484,6 +496,9 @@ benchmark {
         register("jvmBenchmark")
         register("jsBenchmark")
         register("wasmJsBenchmark")
+        if (HostManager.hostIsLinux && !isRunningOnGithub) {
+            register("linuxX64Benchmark")
+        }
         if (isArm64) {
             register("macosArm64Benchmark")
         }
@@ -537,11 +552,11 @@ benchmark {
             include("(WriteString|ReadString|Utf8Length)")
         }
         register("codec") {
-            warmups = 3
-            iterations = 5
-            iterationTime = 500
+            warmups = 5
+            iterations = 10
+            iterationTime = 1000
             iterationTimeUnit = "ms"
-            include("(Hex|Base64).*")
+            include("HexBenchmark\\.(to|from)HexString.*")
         }
         // Fast configuration for WASM - runs only key benchmarks to avoid long run times
         register("wasmFast") {
@@ -692,11 +707,13 @@ afterEvaluate {
         }
     tasks.withType(kotlinx.benchmark.gradle.NativeSourceGeneratorTask::class.java).configureEach {
         val gradleTarget = name.substringBefore("Benchmark")
-        val cinteropKlib =
-            project.file(
-                "${project.layout.buildDirectory.get()}/classes/kotlin/$gradleTarget/main/cinterop/buffer-cinterop-simd",
-            )
-        inputDependencies = inputDependencies + project.files(cinteropKlib)
+        val cinteropKlibs =
+            listOf("simd", "simdutf").map {
+                project.file(
+                    "${project.layout.buildDirectory.get()}/classes/kotlin/$gradleTarget/main/cinterop/buffer-cinterop-$it",
+                )
+            }
+        inputDependencies = inputDependencies + project.files(cinteropKlibs)
     }
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinNativeLink::class.java).configureEach {
         if (name.contains("BenchmarkBenchmark")) {
@@ -708,11 +725,13 @@ afterEvaluate {
                     name.contains("LinuxArm64", ignoreCase = true) -> "linuxArm64"
                     else -> return@configureEach
                 }
-            val cinteropKlib =
-                project.file(
-                    "${project.layout.buildDirectory.get()}/classes/kotlin/$targetName/main/cinterop/buffer-cinterop-simd",
-                )
-            libraries.from(cinteropKlib)
+            val cinteropKlibs =
+                listOf("simd", "simdutf").map {
+                    project.file(
+                        "${project.layout.buildDirectory.get()}/classes/kotlin/$targetName/main/cinterop/buffer-cinterop-$it",
+                    )
+                }
+            libraries.from(cinteropKlibs)
         }
     }
 }

--- a/buffer/src/commonBenchmark/kotlin/com/ditchoom/buffer/benchmark/HexBenchmark.kt
+++ b/buffer/src/commonBenchmark/kotlin/com/ditchoom/buffer/benchmark/HexBenchmark.kt
@@ -5,6 +5,9 @@ import com.ditchoom.buffer.Default
 import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.decodeHexInto
 import com.ditchoom.buffer.encodeHexInto
+import com.ditchoom.buffer.fromHexString
+import com.ditchoom.buffer.managed
+import com.ditchoom.buffer.toHexString
 import kotlinx.benchmark.Benchmark
 import kotlinx.benchmark.BenchmarkMode
 import kotlinx.benchmark.BenchmarkTimeUnit
@@ -17,17 +20,22 @@ import kotlinx.benchmark.State
 import kotlinx.benchmark.Warmup
 
 /**
- * Benchmarks for buffer-to-buffer hex encode/decode.
+ * Benchmarks for hex encode/decode — buffer-to-buffer, and the String conversions.
  *
- * Each direction has two variants on the SAME Direct buffer type:
+ * The buffer-to-buffer pair has two variants on the SAME Direct buffer type:
  * - "Primitive" = current encodeHexInto/decodeHexInto (SIMD C cinterop on native, optimized on JVM/JS)
  * - "Baseline" = naive per-byte loop via get()/writeByte() (what a caller would hand-write)
  *
  * Both run native-memory source -> native-memory dest, so the primitive variants exercise the
  * pointer-to-pointer C fast path (buf_hex_encode / buf_hex_decode) on native targets.
  *
+ * The String pair (toHexString / fromHexString) is measured against the shapes it replaced —
+ * "Staged" allocates an intermediate buffer and reads it back, "SubstringParse" is the per-byte
+ * `substring(i, i + 2).toInt(16)` loop hand-rolled decoders reach for.
+ *
  * Run with: ./gradlew macosArm64BenchmarkBenchmark -Pbenchmark.filter=Hex
  */
+@Suppress("TooManyFunctions") // one @Benchmark per variant under test, plus the two baseline helpers
 @State(Scope.Benchmark)
 @Warmup(iterations = 3)
 @Measurement(iterations = 5)
@@ -36,6 +44,17 @@ import kotlinx.benchmark.Warmup
 open class HexBenchmark {
     private val size64k = 64 * 1024
     private val hexSize = size64k * 2
+
+    /** Payload size for the String conversions — a realistic log line / crypto blob, not a 64K blast. */
+    private val stringSize = 1024
+    private lateinit var hexText: String
+
+    /**
+     * The String benchmarks allocate per invocation. On WasmJs `BufferFactory.Default` is a
+     * non-reclaiming bump allocator over a 256MB arena, so a Default-backed loop OOMs long before the
+     * measurement window closes — these variants are pinned to managed() so every target can run them.
+     */
+    private val managed = BufferFactory.managed()
 
     private lateinit var raw: PlatformBuffer
     private lateinit var hex: PlatformBuffer
@@ -57,6 +76,8 @@ open class HexBenchmark {
         raw.encodeHexInto(hex)
         hex.resetForRead()
         raw.resetForRead()
+
+        hexText = raw.toHexString(0, stringSize)
     }
 
     // ========================================================================= encode
@@ -107,6 +128,46 @@ open class HexBenchmark {
         return decodeDest.get(0).toInt()
     }
 
+    // ========================================================================= String conversions
+    //
+    // toHexString / fromHexString against the shapes they replaced. "Staged" is the
+    // allocate-a-buffer-encode-read-it-back dance; "SubstringParse" is the per-byte
+    // `substring(i, i+2).toInt(16)` loop that hand-rolled decoders reach for.
+
+    @Benchmark
+    fun toHexStringDirect(): Int = raw.toHexString(0, stringSize).length
+
+    @Benchmark
+    fun toHexStringStaged(): Int {
+        val dest = managed.allocate(stringSize * 2)
+        raw.encodeHexInto(dest, 0, stringSize)
+        dest.resetForRead()
+        return dest.readString(stringSize * 2).length
+    }
+
+    @Benchmark
+    fun fromHexStringDirect(): Int = managed.fromHexString(hexText).remaining()
+
+    @Benchmark
+    fun fromHexStringStaged(): Int {
+        val ascii = managed.allocate(hexText.length)
+        ascii.writeString(hexText)
+        ascii.resetForRead()
+        val out = managed.allocate(hexText.length / 2)
+        ascii.decodeHexInto(out, 0, hexText.length)
+        out.resetForRead()
+        return out.remaining()
+    }
+
+    @Benchmark
+    fun fromHexStringSubstringParse(): Int {
+        val n = hexText.length / 2
+        val out = managed.allocate(n)
+        for (i in 0 until n) out.writeByte(hexText.substring(i * 2, i * 2 + 2).toInt(HEX_RADIX).toByte())
+        out.resetForRead()
+        return out.remaining()
+    }
+
     private fun nibble(n: Int): Byte {
         val ascii = if (n < DECIMAL_BASE) n + ASCII_ZERO else n - DECIMAL_BASE + ASCII_LOWER_A
         return ascii.toByte()
@@ -129,5 +190,6 @@ open class HexBenchmark {
         private const val ASCII_LOWER_F = 0x66
         private const val ASCII_UPPER_A = 0x41
         private const val ASCII_UPPER_F = 0x46
+        private const val HEX_RADIX = 16
     }
 }

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/HexCodec.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/HexCodec.kt
@@ -30,10 +30,10 @@ private const val ASCII_ZERO = 0x30
 private const val HEX_ALPHA_BASE = 10
 
 /** Mask isolating the low nibble (4 bits) of a byte. */
-private const val LOW_NIBBLE_MASK = 0x0F
+internal const val LOW_NIBBLE_MASK = 0x0F
 
 /** Bit width of a single hex nibble. */
-private const val NIBBLE_BITS = 4
+internal const val NIBBLE_BITS = 4
 
 internal fun hexEncodeNibble(
     nibble: Int,

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/HexString.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/HexString.kt
@@ -1,0 +1,207 @@
+package com.ditchoom.buffer
+
+/*
+ * Hex <-> String conversions.
+ *
+ * The buffer-to-buffer primitives live in HexCodec.kt and are the right tool for hex onto a wire.
+ * These are for the call sites whose result genuinely has to *be* a String — a log line, an assertion
+ * message, a toString(), a JSON field. Neither direction stages an intermediate buffer.
+ */
+
+/**
+ * Encodes one nibble straight to its ASCII hex `Char` — the same branchless math as [hexEncodeNibble],
+ * so the `String` form can never drift from the buffer form.
+ *
+ * Deliberately **not** `Char(code)`: that constructor emits a `0..0xFFFF` range check plus a cold
+ * exception-message builder, and this runs twice per byte in [toHexString]'s inner loop. The check is
+ * dead by construction — [hexEncodeNibble] returns an ASCII digit in `0x30..0x66` — so the direct
+ * widening (a single `i2c` on the JVM) is what we want.
+ */
+@Suppress("DEPRECATION")
+private fun hexEncodeNibbleChar(
+    nibble: Int,
+    alphaDelta: Int,
+): Char = hexEncodeNibble(nibble, alphaDelta).toInt().toChar()
+
+/**
+ * Maps a single hex `Char` to its 0..15 nibble value, or -1 if it is not a hex digit. Anything outside
+ * ASCII is rejected up front: narrowing a `Char` to a `Byte` first would fold e.g. U+0161 onto `'a'`
+ * and silently decode a non-hex character as 10.
+ */
+private fun hexDecodeNibble(c: Char): Int = if (c.code > MAX_ASCII) -1 else hexDecodeNibble(c.code.toByte())
+
+/** Largest code point that is still ASCII; above it, a `Char` cannot be a hex digit. */
+private const val MAX_ASCII = 0x7F
+
+/** Number of distinct byte values, i.e. the size of the two-char pair tables. */
+private const val BYTE_VALUE_COUNT = 256
+
+/**
+ * The 256 two-character hex strings, one per byte value, in each case.
+ *
+ * Lives in an `object` rather than as a top-level `val` so the 512 small strings are built on first
+ * use of the `String` conversions, not on first touch of anything in this file — callers who only ever
+ * use the buffer-to-buffer [encodeHexInto] never pay for it.
+ */
+private object HexPairs {
+    val lower: Array<String> = build(HEX_LOWER_ALPHA_DELTA)
+    val upper: Array<String> = build(HEX_UPPER_ALPHA_DELTA)
+
+    private fun build(alphaDelta: Int): Array<String> =
+        Array(BYTE_VALUE_COUNT) { b ->
+            "" + hexEncodeNibbleChar(b ushr NIBBLE_BITS, alphaDelta) +
+                hexEncodeNibbleChar(b and LOW_NIBBLE_MASK, alphaDelta)
+        }
+}
+
+/**
+ * Selects the encode body for this platform. Both bodies produce identical output from the same
+ * [hexEncodeNibble] math; they differ only in how they feed the `StringBuilder`, and the platforms
+ * disagree sharply about which is cheaper (measured at 1 KiB, direct-vs-direct):
+ *
+ * | | JVM | JS | WasmJs | linuxX64 |
+ * |---|---|---|---|---|
+ * | [hexStringViaCharAppend] | **387,680** | 142,396 | 37,365 | 120,435 |
+ * | [hexStringViaPairTable] | 226,302 | **258,791** | **190,688** | **143,653** |
+ *
+ * `append(Char)` writes two chars straight into the builder's storage, which the JVM does better than
+ * anything else; everywhere else the per-append overhead dominates and halving the append count wins —
+ * by 5.1x on WasmJs. Same shape as [encodeHexInto], which the native backends already override.
+ */
+internal expect fun ReadBuffer.hexStringOf(
+    offset: Int,
+    length: Int,
+    upperCase: Boolean,
+): String
+
+/** Two `append(Char)` per byte. Fastest on the JVM. See [hexStringOf]. */
+internal fun ReadBuffer.hexStringViaCharAppend(
+    offset: Int,
+    length: Int,
+    upperCase: Boolean,
+): String {
+    val alphaDelta = if (upperCase) HEX_UPPER_ALPHA_DELTA else HEX_LOWER_ALPHA_DELTA
+    return buildString(length * 2) {
+        var i = 0
+        while (i < length) {
+            val b = getUnchecked(offset + i).toInt() and BufferConstants.BYTE_MASK
+            append(hexEncodeNibbleChar(b ushr NIBBLE_BITS, alphaDelta))
+            append(hexEncodeNibbleChar(b and LOW_NIBBLE_MASK, alphaDelta))
+            i++
+        }
+    }
+}
+
+/** One `append(String)` per byte from [HexPairs]. Fastest everywhere but the JVM. See [hexStringOf]. */
+internal fun ReadBuffer.hexStringViaPairTable(
+    offset: Int,
+    length: Int,
+    upperCase: Boolean,
+): String {
+    val pairs = if (upperCase) HexPairs.upper else HexPairs.lower
+    return buildString(length * 2) {
+        var i = 0
+        while (i < length) {
+            append(pairs[getUnchecked(offset + i).toInt() and BufferConstants.BYTE_MASK])
+            i++
+        }
+    }
+}
+
+/**
+ * Hex-encodes the absolute source range `[offset, offset + length)` and returns it as a `String`.
+ *
+ * The buffer-to-buffer [encodeHexInto] is the primitive for hex onto a wire; this is the form for the
+ * cases whose result genuinely has to *be* a `String` — a log line, an assertion message, a
+ * `toString()`, a JSON field. Without it every such call site hand-rolls the same "allocate a
+ * destination, encode, read it back" dance, and the ones that don't instead write a per-byte format
+ * loop, which is precisely the pattern this library exists to avoid.
+ *
+ * **No buffer is allocated**, and so no [BufferFactory] is taken. Staging through an intermediate ASCII
+ * buffer to reach the bulk path would cost an allocation the caller then has to free — and on WasmJs
+ * cannot free, since that target's default allocator is a non-reclaiming bump allocator over a fixed
+ * arena. It is also slower on three of the four measured targets (see [hexStringOf]). Callers who do
+ * want the bulk path are already served — they want hex in a buffer, which is [encodeHexInto].
+ *
+ * Does not change this buffer's [position].
+ *
+ * @param offset absolute index of the first source byte
+ * @param length number of source bytes to encode
+ * @param upperCase emit 'A'-'F' instead of 'a'-'f'
+ * @throws BufferUnderflowException if `[offset, offset + length)` is not within this buffer.
+ */
+fun ReadBuffer.toHexString(
+    offset: Int,
+    length: Int,
+    upperCase: Boolean = false,
+): String {
+    requireRange(offset, length)
+    if (length == 0) return ""
+    return hexStringOf(offset, length, upperCase)
+}
+
+/**
+ * Relative: hex-encodes this buffer's remaining bytes (`position()` until `limit()`) and returns them
+ * as a `String`. Unlike the relative [encodeHexInto], this does **not** advance [position] — a value
+ * conversion should not consume its receiver, so the same buffer can be logged and then still read.
+ *
+ * @param upperCase emit 'A'-'F' instead of 'a'-'f'
+ */
+fun ReadBuffer.toHexString(upperCase: Boolean = false): String = toHexString(position(), remaining(), upperCase)
+
+/**
+ * Hex-decodes [hex] (an even count of ASCII hex characters) into a buffer allocated by this factory,
+ * returned read-ready with its limit at the decoded length. The inverse of [toHexString], and the
+ * counterpart every test fixture and config parser that writes a hex literal needs.
+ *
+ * The factory is the **receiver**, not a parameter: the one allocation this makes is the buffer being
+ * returned, so a caller with a pooled or deterministic allocator gets the result on their own memory,
+ * and the call reads as what it is — a factory producing a buffer. Nothing is staged, so there is no
+ * intermediate to leak: the characters are decoded directly out of [hex].
+ *
+ * @param hex the ASCII hex characters; must be an even count
+ * @param byteOrder byte order of the returned buffer
+ * @throws IllegalArgumentException if [hex] has an odd length or contains a non-hex character.
+ */
+fun BufferFactory.fromHexString(
+    hex: CharSequence,
+    byteOrder: ByteOrder = ByteOrder.BIG_ENDIAN,
+): PlatformBuffer {
+    // Hoisted: `hex.length` on a CharSequence receiver is a dispatching helper call on the JS/WASM
+    // backends, so leaving it in the loop condition would pay for it once per character.
+    val n = hex.length
+    require(n % 2 == 0) { "hex length must be even, got $n" }
+    val decoded = allocate(n / 2, byteOrder)
+    // Indexing a String is direct; indexing a bare CharSequence goes through a dispatching helper per
+    // character on the JS/WASM backends. Splitting on the smart cast is worth +39% on JS and +60% on
+    // WasmJs, and is a single folded instanceof on the JVM. Both arms are the same inlined loop.
+    if (hex is String) {
+        decodeHexCharsInto(n, decoded) { hex[it] }
+    } else {
+        decodeHexCharsInto(n, decoded) { hex[it] }
+    }
+    decoded.resetForRead()
+    return decoded
+}
+
+/**
+ * Decodes [length] hex characters supplied by [charAt] into [dest]. Inline so the caller's indexing
+ * expression is compiled in place — that is the whole point of the `String` split in [fromHexString].
+ *
+ * @throws IllegalArgumentException if a character is not a hex digit.
+ */
+private inline fun decodeHexCharsInto(
+    length: Int,
+    dest: WriteBuffer,
+    charAt: (Int) -> Char,
+) {
+    var i = 0
+    while (i < length) {
+        val hi = hexDecodeNibble(charAt(i))
+        val lo = hexDecodeNibble(charAt(i + 1))
+        require(hi >= 0) { "invalid hex character at index $i" }
+        require(lo >= 0) { "invalid hex character at index ${i + 1}" }
+        dest.writeByte(((hi shl NIBBLE_BITS) or lo).toByte())
+        i += 2
+    }
+}

--- a/buffer/src/commonTest/kotlin/com/ditchoom/buffer/HexCodecTest.kt
+++ b/buffer/src/commonTest/kotlin/com/ditchoom/buffer/HexCodecTest.kt
@@ -213,4 +213,131 @@ class HexCodecTest {
     }
 
     // endregion
+
+    // region String conversions
+
+    @Test
+    fun toHexStringMatchesTheBufferToBufferEncoder() {
+        val bytes = listOf(0x00, 0x0F, 0xF0, 0xFF, 0x12, 0xAB)
+        val viaBuffer = BufferFactory.Default.allocate(bytes.size * 2)
+        bytesBuffer(bytes).encodeHexInto(viaBuffer)
+        viaBuffer.resetForRead()
+
+        assertEquals(
+            viaBuffer.readString(bytes.size * 2),
+            bytesBuffer(bytes).toHexString(),
+            "the String form must agree with the buffer-to-buffer primitive",
+        )
+    }
+
+    @Test
+    fun toHexStringEncodesKnownVectorInBothCases() {
+        val src = bytesBuffer(listOf(0x00, 0x0F, 0xF0, 0xFF, 0x12, 0xAB))
+        assertEquals("000ff0ff12ab", src.toHexString())
+        assertEquals("000FF0FF12AB", src.toHexString(upperCase = true))
+    }
+
+    /**
+     * A value conversion must not consume its receiver — unlike the relative `encodeHexInto`, which
+     * deliberately advances. Logging a buffer and then reading it is the whole point.
+     */
+    @Test
+    fun toHexStringDoesNotAdvancePosition() {
+        val src = bytesBuffer(listOf(0x01, 0x02, 0x03))
+        val before = src.position()
+        assertEquals("010203", src.toHexString())
+        assertEquals(before, src.position(), "toHexString must not consume the buffer")
+        assertEquals(0x01, src.readByte().toInt() and 0xFF, "the buffer is still fully readable")
+    }
+
+    @Test
+    fun toHexStringHonoursAnAbsoluteRange() {
+        val src = bytesBuffer(listOf(0xDE, 0xAD, 0xBE, 0xEF))
+        assertEquals("adbe", src.toHexString(offset = 1, length = 2))
+    }
+
+    @Test
+    fun toHexStringOfEmptyIsEmpty() {
+        assertEquals("", bytesBuffer(emptyList()).also { it.setLimit(0) }.toHexString())
+    }
+
+    @Test
+    fun toHexStringRejectsAnOutOfRangeWindow() {
+        val src = bytesBuffer(listOf(0x01, 0x02))
+        assertFailsWith<BufferUnderflowException> { src.toHexString(offset = 1, length = 4) }
+    }
+
+    /**
+     * `toHexString` builds the `String` directly and stages nothing, so a caller's allocator is never
+     * touched. Guards the shape: reintroducing an intermediate buffer would either leak it (the
+     * allocator never sees it back) or make this count non-zero.
+     */
+    @Test
+    fun toHexStringAllocatesNoBuffer() {
+        val counting = BufferFactory.Default.counting()
+        val src = counting.allocate(2)
+        src.writeByte(0x01)
+        src.writeByte(0x02)
+        src.resetForRead()
+        val before = counting.allocationCount
+        assertEquals("0102", src.toHexString())
+        assertEquals(before, counting.allocationCount, "toHexString must not allocate a buffer")
+    }
+
+    /**
+     * The factory is the receiver, and the sole allocation is the buffer handed back — so a pooled or
+     * deterministic allocator owns the result, and there is no staged intermediate to leak.
+     */
+    @Test
+    fun fromHexStringAllocatesOnlyTheResultThroughItsReceiver() {
+        val counting = BufferFactory.Default.counting()
+        val decoded = counting.fromHexString("0102")
+        assertEquals(1, counting.allocationCount, "only the returned buffer may be allocated")
+        assertEquals("0102", decoded.toHexString())
+    }
+
+    @Test
+    fun fromHexStringRoundTripsThroughToHexString() {
+        val hex = "000ff0ff12ab"
+        val decoded = BufferFactory.Default.fromHexString(hex)
+        assertEquals(hex.length / 2, decoded.remaining())
+        assertEquals(hex, decoded.toHexString())
+    }
+
+    @Test
+    fun fromHexStringAcceptsUpperCase() {
+        assertEquals("deadbeef", BufferFactory.Default.fromHexString("DEADBEEF").toHexString())
+    }
+
+    @Test
+    fun fromHexStringOfEmptyIsAnEmptyBuffer() {
+        assertEquals(0, BufferFactory.Default.fromHexString("").remaining())
+    }
+
+    @Test
+    fun fromHexStringHonoursTheRequestedByteOrder() {
+        val le = BufferFactory.Default.fromHexString("0102", ByteOrder.LITTLE_ENDIAN)
+        assertEquals(0x0201.toShort(), le.readShort())
+    }
+
+    @Test
+    fun fromHexStringRejectsOddLength() {
+        assertFailsWith<IllegalArgumentException> { BufferFactory.Default.fromHexString("abc") }
+    }
+
+    @Test
+    fun fromHexStringRejectsNonHexCharacter() {
+        assertFailsWith<IllegalArgumentException> { BufferFactory.Default.fromHexString("zz") }
+    }
+
+    /**
+     * Non-ASCII must be rejected as a non-hex character, not narrowed to a byte first: U+0161 truncates
+     * to `'a'` and would otherwise decode as the nibble 10.
+     */
+    @Test
+    fun fromHexStringRejectsNonAsciiThatNarrowsOntoAHexDigit() {
+        assertFailsWith<IllegalArgumentException> { BufferFactory.Default.fromHexString("š0") }
+    }
+
+    // endregion
 }

--- a/buffer/src/jsMain/kotlin/com/ditchoom/buffer/HexString.js.kt
+++ b/buffer/src/jsMain/kotlin/com/ditchoom/buffer/HexString.js.kt
@@ -1,0 +1,11 @@
+package com.ditchoom.buffer
+
+/**
+ * See [hexStringOf]. One `append(String)` per byte from the pair table beats two `append(Char)` by
+ * 1.82x on JS. Stated separately from the nonJvm actual because jsMain is not part of nonJvmMain.
+ */
+internal actual fun ReadBuffer.hexStringOf(
+    offset: Int,
+    length: Int,
+    upperCase: Boolean,
+): String = hexStringViaPairTable(offset, length, upperCase)

--- a/buffer/src/jvmCommonMain/kotlin/com/ditchoom/buffer/HexString.jvmCommon.kt
+++ b/buffer/src/jvmCommonMain/kotlin/com/ditchoom/buffer/HexString.jvmCommon.kt
@@ -1,0 +1,12 @@
+package com.ditchoom.buffer
+
+/**
+ * See [hexStringOf]. The JVM's `append(Char)` writes two chars straight into the builder's storage,
+ * which beats one `append(String)` from the pair table by 1.71x here — the opposite of every other
+ * target.
+ */
+internal actual fun ReadBuffer.hexStringOf(
+    offset: Int,
+    length: Int,
+    upperCase: Boolean,
+): String = hexStringViaCharAppend(offset, length, upperCase)

--- a/buffer/src/nonJvmMain/kotlin/com/ditchoom/buffer/HexString.nonJvm.kt
+++ b/buffer/src/nonJvmMain/kotlin/com/ditchoom/buffer/HexString.nonJvm.kt
@@ -1,0 +1,11 @@
+package com.ditchoom.buffer
+
+/**
+ * See [hexStringOf]. Native and WasmJs both pay heavily per append, so halving the append count with
+ * the pair table wins — 1.19x on linuxX64 and 5.10x on WasmJs.
+ */
+internal actual fun ReadBuffer.hexStringOf(
+    offset: Int,
+    length: Int,
+    upperCase: Boolean,
+): String = hexStringViaPairTable(offset, length, upperCase)


### PR DESCRIPTION
`encodeHexInto` / `decodeHexInto` are buffer-to-buffer, which is exactly right for the case they were built for — hex onto a wire. But plenty of call sites genuinely need the result to **be** a `String`: a log line, an assertion message, a `toString()`, a JSON field. This repo already had **six hand-rolled copies** of that loop in buffer-crypto's WebCrypto bridge; they are all deleted here.

## API

```kotlin
fun ReadBuffer.toHexString(offset: Int, length: Int, upperCase: Boolean = false): String
fun ReadBuffer.toHexString(upperCase: Boolean = false): String                        // relative
fun BufferFactory.fromHexString(hex: CharSequence, byteOrder: ByteOrder = BIG_ENDIAN): PlatformBuffer
```

**Neither side stages an intermediate buffer.** That is the whole shape of the change, and it decides where the factory goes.

### `toHexString` takes no factory, because it allocates no buffer

The result has to end up as `Char`s regardless, so staging costs an allocation, the encode, **and** a UTF-8 decode of the staged bytes, where filling the `String` directly costs the encode alone. It also has to be *freed* — miss that and it leaks on a `deterministic()` allocator and permanently drains a chunk on a pooled one, which is strictly worse than never taking the caller's factory.

On **WasmJs it cannot be freed at all**: that target's default allocator is a non-reclaiming bump allocator over a fixed arena. The benchmark proved it — the staged variants died with `kotlin.OutOfMemoryError: LinearBuffer allocation exceeded 256MB pre-allocated memory` before the measurement window closed, and had to be pinned to `managed()`. A per-call staging buffer is not a viable shape there.

Callers who genuinely want the bulk path want hex **in a buffer** — that is `encodeHexInto`, unchanged.

### `fromHexString` takes the factory as the *receiver*

Its only allocation is the buffer it hands back, so the call reads as what it is — a factory producing a buffer — and a pooled or deterministic caller owns the result outright with nothing transient in between.

Decoding straight out of the `CharSequence` also closes two traps the staged version had:
- staging via `writeString(hex, UTF8)` into a buffer sized by `hex.length` **overflows** on any multi-byte character;
- narrowing a `Char` to a `Byte` before decoding folds U+0161 onto `'a'` and **silently decodes it as the nibble 10**.

Both are now a plain `IllegalArgumentException: invalid hex character`.

## Position semantics

Deliberately different from the relative `encodeHexInto`, which advances: **`toHexString` does not consume its receiver.** A value conversion that ate the buffer would make "log it, then read it" a bug — the single most likely way anyone uses this.

## What the compiled output caught

Two costs in the inner loop, both found by reading the bytecode rather than the source:

**`Char(code)` is not free.** It emits a `0..0xFFFF` range check plus a cold exception-message builder, and this ran **twice per byte**. The check is dead by construction (`hexEncodeNibble` returns `0x30..0x66`). Worse on JS than JVM — the generated JS was two `_Char___init__impl__6a9atx(...)` constructions plus two unwraps **per nibble**, on the happy path. Replaced with the direct widening:

```
hexEncodeNibbleChar(int, int):
  invokestatic hexEncodeNibble
  i2c
  ireturn                       // 3 instructions, was 20
```

**`hex.length` in a loop condition on a `CharSequence` receiver** compiles to `charSequenceLength(hex)` — a dispatching helper call — re-evaluated every iteration on JS/WASM. Hoisted to a local.

`toHexString`'s JVM body is now at the allocation floor: one pre-sized `StringBuilder` plus the returned `String`, `append(C)` (the char overload — no boxing, no `valueOf`), no `invokedynamic`/StringConcatFactory, no lambda class (`buildString` fully inlined).

## What the compiled output and the benchmarks caught

Four costs, none of them visible in the source:

**`Char(code)` is not free.** It emits a `0..0xFFFF` range check plus a cold exception-message builder, and this ran **twice per byte**. The check is dead by construction (`hexEncodeNibble` returns `0x30..0x66`). Worse on JS than JVM — the generated JS was two `_Char___init__impl__6a9atx(...)` constructions plus two unwraps **per nibble**, on the happy path. Replaced with the direct widening: `invokestatic / i2c / ireturn`, down from 20 instructions.

**`hex.length` in a loop condition** on a `CharSequence` receiver compiles to a dispatching `charSequenceLength(hex)` call, re-evaluated every iteration on JS/WASM. Hoisted.

**Indexing a bare `CharSequence`** is likewise a dispatching helper per character. Splitting on a `hex is String` smart cast into an `inline` loop is worth **+51% JS, +29% WasmJs**, and is a folded `instanceof` on the JVM. Common code — `fromHexString` needs no platform split.

**Two `append(Char)` per byte is fastest on the JVM and slowest everywhere else.** One `append(String)` per byte from a 256-entry pair table measured **2.60x JS, 6.85x WasmJs, 1.18x linuxX64 — and 0.58x JVM**. So encode genuinely needs a split: both bodies live in `commonMain` and an `internal expect fun hexStringOf` picks per platform, the same shape `encodeHexInto` already uses for its native overrides. The public signature is unchanged and still factory-free. The pair table sits behind an `object` so callers who only use the buffer-to-buffer path never build its 512 strings.

## Benchmarks

1 KiB payload, 5 warmups x 10 iterations x 1s, `managed()` allocator throughout. Raw throughput (ops/s) and the ratio against the shapes being replaced:

| | JVM | JS | WasmJs | linuxX64 |
|---|---|---|---|---|
| **`toHexString`** | **393,074** | **265,923** | **202,828** | **154,395** |
| vs staged | 0.89x | 1.86x | 7.95x | 2.01x |
| **`fromHexString`** | **1,077,060** | **149,856** | **150,443** | **179,705** |
| vs staged | 2.82x | 1.03x | 2.36x | 1.70x |
| vs per-byte `substring().toInt(16)` | 9.37x | 1.92x | 3.87x | 3.82x |

**Staging still wins JVM encode by ~11%, and that is deliberately left on the table** — taking it would reintroduce a per-call buffer allocation, which is the property the whole design rests on, for 11% on a marshalling path. Apple targets are unmeasured (no Mac available locally); they take the `nonJvmMain` pair-table body, the same one linuxX64 measures 2.01x on.

An earlier revision of this PR was ~10% *slower* than staging on JS in both directions. The `is String` cast and the pair table are what closed that, and they turned it into a 1.86x / 1.03x win instead.

## buffer-crypto: six duplicate implementations deleted

| File | Was | Now |
|---|---|---|
| `Signatures.jsAndWasmJs` | private `toHexString` + `hexToBuffer` | public API |
| `KeyAgreement.jsAndWasmJs` | private `toHex` + `hexToBuffer` | public API |
| `Aead.jsAndWasmJs` | `toHexRemaining` (31 call sites) | `toHexString()` |
| `EcInterop.jsAndWasmJs` | `readFieldHex` + `hexToReadBuffer` | one-line delegates |
| `HardwareKeys.jsAndWasmJs` | private `hexBuffer` | `factory.fromHexString(…)` |
| `CryptoDemo` / `CryptoTestVectors` | hand-rolled | delegates |

Three decoded with a **String allocation and a radix parse per byte**. The worst is `Sha512Core.hexBufferOf`, which parses the 640-byte SHA-512 round-constant table at class init — 640 throwaway Strings on every web-target load, now zero.

`WriteBuffer.writeHex(String)` is deliberately left alone: it decodes *in place* into an existing buffer and allocates nothing, so it is not a duplicate of either new function.

## Build fix

kotlinx-benchmark's `NativeSourceGeneratorTask` and the benchmark link task were handed the `buffer-cinterop-simd` klib but not `buffer-cinterop-simdutf`, so **any** native benchmark on Linux failed with `KLIB resolver: Could not find "com.ditchoom:buffer-cinterop-simdutf"`. Both now take a list. Also registers a local-only (`!isRunningOnGithub`) `linuxX64Benchmark` target, so native numbers are reachable off a Mac — CI is unaffected.

## Tests — 14 new, on top of the existing `HexCodecTest` suite

- **agreement with the buffer-to-buffer encoder**, so the String form can never drift from the primitive
- known vector in both cases, absolute-range form, out-of-range rejection, empty input
- position is not advanced, and the buffer is still fully readable afterwards
- `fromHexString` round trip, upper-case input, requested byte order honoured
- typed rejects for odd length, non-hex, and the non-ASCII character that narrows onto a hex digit
- two allocation assertions pin the no-staging shape: `toHexString` allocates **nothing** through a `CountingBufferFactory`, `fromHexString` allocates **exactly one** buffer — the one it returns

## Verification

`:buffer` jvmTest + jsNodeTest, `:buffer-crypto` jvmTest + jsNodeTest + wasmJsNodeTest all green; wasmJs and linuxX64 compile; ktlint and detekt clean. Rebased onto `main`, no merge commit. `buffer` core has no `.api` file, so there is no binary-compatibility dump to regenerate; the change is purely additive regardless.
