### PR TITLE
feat(buffer-flow)!: connected/addressed datagram split — no more nullable to, typed absent states, typed close reason

### DIFF
--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/Datagram.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/Datagram.kt
@@ -2,6 +2,7 @@ package com.ditchoom.buffer.flow
 
 import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.ReadBuffer
+import kotlin.jvm.JvmInline
 
 // File-level so the [Ecn] entry constructors can reference them (an enum's entries are initialized
 // before its companion object, so companion consts are off-limits in entry arguments).
@@ -14,6 +15,12 @@ private const val UNKNOWN_CODEPOINT = -1
 
 /** Mask selecting the ECN field — the low 2 bits — of a TOS / Traffic-Class octet. */
 private const val ECN_FIELD_MASK = 0x3
+
+/** Read-side absent-state raw encoding for [HopLimit] (kept private; the type is the contract). */
+private const val HOP_LIMIT_UNKNOWN_RAW = -1
+
+/** Largest value of a TTL / Hop Limit octet. */
+private const val HOP_LIMIT_MAX = 255
 
 /**
  * The ECN (Explicit Congestion Notification) codepoint of a datagram — RFC 3168 / RFC 9331 (L4S).
@@ -53,28 +60,106 @@ enum class Ecn(
 }
 
 /**
+ * A received TTL / hop limit (RFC 791 §3.1 TTL / RFC 8200 §3 Hop Limit), or the typed absent state
+ * [Unknown] when the platform cannot report it (the §7.2 degradation policy — availability is
+ * advertised by [DatagramCapabilities.hopLimitReceive]).
+ *
+ * Zero-alloc by construction: `@JvmInline` over the raw octet, stored as a bare `Int` field in
+ * [Datagram]. Never use `HopLimit?` or put it in a generic position — that boxes.
+ */
+@ExperimentalDatagramApi
+@JvmInline
+value class HopLimit private constructor(
+    private val raw: Int,
+) {
+    /** Whether the platform reported a hop limit for this datagram. */
+    val isKnown: Boolean get() = raw != HOP_LIMIT_UNKNOWN_RAW
+
+    /** The reported hop limit (0..255). @throws IllegalStateException when [isKnown] is false. */
+    val value: Int
+        get() {
+            check(isKnown) { "hop limit was not reported by the platform" }
+            return raw
+        }
+
+    @ExperimentalDatagramApi
+    companion object {
+        /** The platform did not report a hop limit — the §7.2 typed absent state. */
+        val Unknown: HopLimit = HopLimit(HOP_LIMIT_UNKNOWN_RAW)
+
+        /** A reported hop limit; [value] must be a valid octet (0..255). */
+        fun of(value: Int): HopLimit {
+            require(value in 0..HOP_LIMIT_MAX) { "hop limit must be 0..255: $value" }
+            return HopLimit(value)
+        }
+    }
+}
+
+/**
+ * A maybe-known local IP endpoint — the typed absent state that replaces `SocketAddress?` on the
+ * read side. Two uses:
+ * - per-datagram [Datagram.localAddress]: which local IP received the packet (IP_PKTINFO), absent when
+ *   the platform cannot report it ([DatagramCapabilities.localAddressReceive], §7.2);
+ * - per-endpoint [ConnectedDatagramSource.localAddress]: absent when the transport does not surface
+ *   its local UDP endpoint at all (a QUIC datagram flow).
+ *
+ * Zero-alloc by construction: `@JvmInline` over the nullable reference, stored as a bare
+ * `SocketAddress` reference field. Never use `LocalAddress?` or a generic position — that boxes
+ * (nullable-of-value-class-over-nullable-underlying cannot stay flat). One more boxing position is
+ * easy to miss: the **default-arguments bridge** of a constructor that defaults a `LocalAddress`
+ * parameter routes it through a transient box (HopLimit's `Int` underlying stays flat there;
+ * a nullable underlying cannot). HotSpot's escape analysis eliminates it, but JS and Native make no
+ * such promise — so hot-path [Datagram] constructions pass every argument explicitly rather than
+ * leaning on defaults.
+ */
+@ExperimentalDatagramApi
+@JvmInline
+value class LocalAddress private constructor(
+    private val ref: SocketAddress?,
+) {
+    /** Whether the local address is known. */
+    val isKnown: Boolean get() = ref != null
+
+    /** The known local address, or `null` — the single explicit escape hatch to nullable-land. */
+    fun orNull(): SocketAddress? = ref
+
+    @ExperimentalDatagramApi
+    companion object {
+        /** The local address is not known / not surfaced — the §7.2 typed absent state. */
+        val Unknown: LocalAddress = LocalAddress(null)
+
+        /** A known local address. */
+        fun of(address: SocketAddress): LocalAddress = LocalAddress(address)
+    }
+}
+
+/**
  * One received datagram: a zero-copy [payload] plus who sent it plus the read-side control plane.
  *
  * **Ownership:** [payload] transfers to the caller exactly like a [ReadResult.Data] buffer — release
  * or pool it as usual. Each [DatagramSource.receive] returns exactly one whole message; datagram
  * boundaries are never dissolved (contrast the byte-stream shape, where reads are an unframed river).
  *
- * Control-plane read fields ([ecn], [localAddress], [hopLimit]) carry the §7.2 **sentinels** when the
- * platform cannot report them ([Ecn.Unknown], `null`, `-1`) — consumers query, never assume. Whether a
- * field is *ever* populated is advertised by [DatagramSource.capabilities].
+ * Control-plane read fields ([ecn], [localAddress], [hopLimit]) carry the §7.2 **typed absent states**
+ * ([Ecn.Unknown], [LocalAddress.Unknown], [HopLimit.Unknown]) when the platform cannot report them —
+ * consumers query [HopLimit.isKnown] / [LocalAddress.isKnown], never assume. Whether a field is *ever*
+ * populated is advertised by [DatagramSource.capabilities]. The absent states are flat (bare `Int` /
+ * bare reference fields): a received datagram still costs exactly one allocation — provided the
+ * receive path passes all five constructor arguments explicitly; a defaulted [localAddress] rides
+ * the default-arguments bridge, which boxes it transiently (see [LocalAddress]'s KDoc).
  */
 @ExperimentalDatagramApi
 class Datagram(
     /** The message bytes; ownership transfers to the caller. */
     val payload: PlatformBuffer,
-    /** The source endpoint. For a connected source this is the fixed peer. */
+    /** The source endpoint. On a connected source this equals [ConnectedDatagramSource.peer]. */
     val peer: SocketAddress,
     /** Received ECN codepoint, or [Ecn.Unknown] if the platform cannot report it. */
     val ecn: Ecn = Ecn.Unknown,
-    /** Which local IP received this datagram (IP_PKTINFO), or `null` if unavailable. */
-    val localAddress: SocketAddress? = null,
-    /** Received TTL / hop limit, or `-1` if unavailable. */
-    val hopLimit: Int = -1,
+    /** Which local IP received this datagram (IP_PKTINFO), or [LocalAddress.Unknown]. */
+    val localAddress: LocalAddress = LocalAddress.Unknown,
+    /** Received TTL / hop limit, or [HopLimit.Unknown]. */
+    val hopLimit: HopLimit = HopLimit.Unknown,
 )
 
 /**
@@ -105,11 +190,48 @@ class DatagramSendOptions(
 }
 
 /**
+ * Why a datagram source stopped producing — the typed, non-null [DatagramReadResult.Closed.reason].
+ *
+ * **Deliberately an open interface, not sealed:** downstream transports participate by supertyping —
+ * e.g. `:socket-quic` declares `sealed interface QuicError : DatagramCloseReason`, so a QUIC datagram
+ * flow's close reason IS the connection's structured close error and `reason as? QuicError` is the
+ * downcast. buffer-flow never needs to know the downstream taxonomy; it only ships the two generic
+ * arms every raw-socket implementation needs.
+ */
+@ExperimentalDatagramApi
+interface DatagramCloseReason {
+    /**
+     * Orderly shutdown: the endpoint was closed by its owner or drained after a local close.
+     * Carries no error. The default reason — a bare `Closed()` means exactly this.
+     */
+    @ExperimentalDatagramApi
+    object Normal : DatagramCloseReason {
+        override fun toString(): String = "Normal"
+    }
+
+    /**
+     * The OS reported a terminal error identified by a raw platform code — e.g. a negative errno
+     * from `recvfrom`, or an io_uring CQE `res` (-EBADF / -ECANCELED). Terminal path, once per
+     * socket, so the allocation is irrelevant.
+     */
+    @ExperimentalDatagramApi
+    class OsError(
+        val code: Int,
+    ) : DatagramCloseReason {
+        override fun equals(other: Any?): Boolean = other is OsError && other.code == code
+
+        override fun hashCode(): Int = code
+
+        override fun toString(): String = "OsError(code=$code)"
+    }
+}
+
+/**
  * The unified result of a datagram read — the §2.1 datagram analogue of [ReadResult].
  *
  * [Received] carries the whole [Datagram]; [Closed] signals the source will yield no more datagrams
- * (the socket/connection ended), optionally with a structured [Closed.reason] the consumer can
- * downcast (e.g. a QUIC error). This is the one result type that replaces both raw UDP's ad-hoc
+ * (the socket/connection ended), always with a typed [Closed.reason] the consumer can downcast
+ * (e.g. a QUIC error). This is the one result type that replaces both raw UDP's ad-hoc
  * signalling and QUIC's hand-rolled `DatagramReceiveResult (Received | ConnectionClosed)`.
  */
 @ExperimentalDatagramApi
@@ -120,27 +242,35 @@ sealed interface DatagramReadResult {
         val datagram: Datagram,
     ) : DatagramReadResult
 
-    /** The source is closed and will produce no further datagrams. [reason] is optional structured detail. */
+    /**
+     * The source is closed and will produce no further datagrams. [reason] is always non-null and
+     * typed: [DatagramCloseReason.Normal] for an orderly close (the default — bare `Closed()` stays
+     * source-compatible), [DatagramCloseReason.OsError] for a raw platform failure, or a downstream
+     * taxonomy arm (e.g. a QUIC error) via [DatagramCloseReason] supertyping. Implementations may
+     * cache their terminal instance; repeated post-close receives may return the same object.
+     */
     @ExperimentalDatagramApi
     class Closed(
-        val reason: Any? = null,
+        val reason: DatagramCloseReason = DatagramCloseReason.Normal,
     ) : DatagramReadResult
 }
 
 /**
- * An outbound datagram for [DatagramSink.sendBatch]: payload, optional destination (`null` on a
- * connected sink), and its control plane. Mirrors the arguments of [DatagramSink.send].
+ * An outbound datagram for [AddressedDatagramSink.sendBatch]: payload, its REQUIRED destination, and
+ * its control plane. Mirrors the arguments of [AddressedDatagramSink.send]; a connected batch has no
+ * per-element type at all (see [ConnectedDatagramSink.sendBatch]) because a fixed-peer batch has
+ * nothing per-element left but the payload.
  */
 @ExperimentalDatagramApi
 class OutboundDatagram(
     val payload: ReadBuffer,
-    val to: SocketAddress? = null,
+    val to: SocketAddress,
     val options: DatagramSendOptions = DatagramSendOptions.Default,
 )
 
 /**
  * A decoded message tagged with the peer that sent it — the result element of
- * [DatagramSource.typedAddressed]. Exactly what an SFU/ICE stack wants: `Addressed<StunMessage>`,
+ * [AddressedDatagramSource.typedAddressed]. Exactly what an SFU/ICE stack wants: `Addressed<StunMessage>`,
  * `Addressed<RtpPacket>`.
  */
 @ExperimentalDatagramApi

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/Datagram.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/Datagram.kt
@@ -25,9 +25,10 @@ private const val HOP_LIMIT_MAX = 255
 /**
  * The ECN (Explicit Congestion Notification) codepoint of a datagram — RFC 3168 / RFC 9331 (L4S).
  *
- * The two low bits of the IP TOS / Traffic Class octet. On the read side [Unknown] is the sentinel
- * for a platform that cannot report the received codepoint (per the §7.2 degradation policy); it is
- * never a valid *send* value.
+ * The two low bits of the IP TOS / Traffic Class octet. **Read-side only**: [Unknown] is the typed
+ * absent state for a platform that cannot report the received codepoint (per the §7.2 degradation
+ * policy). The send side speaks [EcnPreference], which has no unknown to misuse — "never a valid
+ * send value" used to be documentation on this type; now it is a type distinction.
  */
 @ExperimentalDatagramApi
 enum class Ecn(
@@ -57,6 +58,54 @@ enum class Ecn(
             return entries.firstOrNull { it.codepoint == field } ?: Unknown
         }
     }
+}
+
+/**
+ * The send-side ECN request — what to ask the OS to stamp on an outgoing datagram, distinct from the
+ * read-side [Ecn] verdict. The split removes the surface's last double-booked value: [Ecn.Unknown]
+ * used to mean both "the platform could not report the received codepoint" (read) and "leave the OS
+ * default" (send), and only KDoc kept the two apart. Here an unstampable preference is
+ * unrepresentable — there is no `Unknown` entry to pass.
+ *
+ * Entries are singletons, so a [DatagramSendOptions] carrying one allocates nothing. The four
+ * stamping entries mirror [Ecn]'s codepoints and are frozen by RFC 3168 — ECN is two bits and the
+ * codepoint space is full — so the two types can never drift apart.
+ */
+@ExperimentalDatagramApi
+enum class EcnPreference {
+    /**
+     * Leave the OS default: no per-send TOS / Traffic Class change is requested. The
+     * [DatagramSendOptions.Default] value — a *choice*, not an unknown reading.
+     */
+    OsDefault,
+
+    /** Stamp Not ECN-Capable Transport (00). */
+    NotEct,
+
+    /** Stamp ECN-Capable Transport, ECT(1) (01). */
+    Ect1,
+
+    /** Stamp ECN-Capable Transport, ECT(0) (10). */
+    Ect0,
+
+    /** Stamp Congestion Experienced (11). */
+    Ce,
+    ;
+
+    /**
+     * The wire codepoint to stamp — total for the four stamping entries, and a caller bug for
+     * [OsDefault] surfaced eagerly (the same gated-accessor contract as [HopLimit.value]): a send
+     * path checks for [OsDefault] first and skips the sockopt entirely.
+     */
+    val codepoint: Int
+        get() =
+            when (this) {
+                OsDefault -> throw IllegalStateException("OsDefault stamps nothing; check for it before asking")
+                NotEct -> Ecn.NotEct.codepoint
+                Ect1 -> Ecn.Ect1.codepoint
+                Ect0 -> Ecn.Ect0.codepoint
+                Ce -> Ecn.Ce.codepoint
+            }
 }
 
 /**
@@ -171,8 +220,8 @@ class Datagram(
  */
 @ExperimentalDatagramApi
 class DatagramSendOptions(
-    /** ECN codepoint to stamp on the outgoing datagram. [Ecn.Unknown] means "leave OS default". */
-    val ecn: Ecn = Ecn.Unknown,
+    /** ECN request for the outgoing datagram; [EcnPreference.OsDefault] asks for no stamp. */
+    val ecn: EcnPreference = EcnPreference.OsDefault,
     /** DiffServ codepoint (0..63, the upper 6 TOS bits); `-1` leaves the OS default. Advisory. */
     val dscp: Int = -1,
     /** Set the IP Don't-Fragment bit (quiche sets this for PMTU). Correctness-critical. */

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/DatagramCapabilities.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/DatagramCapabilities.kt
@@ -15,7 +15,7 @@ package com.ditchoom.buffer.flow
  * - **Correctness-critical** ([dontFragment]) absent → advertised absent here, **never silently
  *   no-op'd**; quiche only grows datagram size past the 1200-byte floor when DF is truly present.
  * - **Read fields** ([ecnReceive], [hopLimitReceive], [localAddressReceive]) absent → the
- *   [Datagram] carries the sentinel ([Ecn.Unknown] / `-1` / `null`).
+ *   [Datagram] carries the typed absent state ([Ecn.Unknown] / [HopLimit.Unknown] / [LocalAddress.Unknown]).
  * - [localAddressReceive] / [sourceAddressSelect] (IP_PKTINFO) absence is the only *functional*
  *   limit, and only for a multi-homed single-socket server; single-homed servers and ICE
  *   (socket-per-candidate) don't need it, and high-scale relays deploy where it exists.

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/DatagramChannel.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/DatagramChannel.kt
@@ -11,9 +11,12 @@ import com.ditchoom.buffer.ReadBuffer
  * the way the byte-stream shape does. [receive] returns exactly one [Datagram] (with its source
  * [Datagram.peer]) or a [DatagramReadResult.Closed].
  *
- * - **Connected** (single peer): every [Datagram.peer] is the fixed peer — the QUIC/WebTransport
- *   datagram case and a `connect()`ed UDP socket.
- * - **Unconnected** (many peers): [Datagram.peer] is the per-packet source — raw UDP for SFU/TURN/ICE.
+ * The addressing mode is a *type*, not a runtime state: a [ConnectedDatagramSource] has one fixed
+ * [ConnectedDatagramSource.peer]; an [AddressedDatagramSource] receives from many peers and is bound
+ * by construction. This base carries only the mode-agnostic receive machinery — each mode-specific
+ * field lives solely on the refinement that can honor it, so there is no `null` to interrogate. One
+ * class deliberately cannot implement both refinements (their `localAddress` types conflict): an
+ * endpoint's addressing mode is fixed at construction.
  *
  * **Thread safety:** implementations are NOT assumed thread-safe; confine [receive] to one coroutine.
  */
@@ -21,9 +24,6 @@ import com.ditchoom.buffer.ReadBuffer
 interface DatagramSource {
     /** Whether the source is open. Once closed, [receive] yields [DatagramReadResult.Closed]. */
     val isOpen: Boolean
-
-    /** The local endpoint this source is bound to, for ICE local-candidate gathering, or `null`. */
-    val localAddress: SocketAddress?
 
     /** The read-side control-plane capabilities of this source (§7.2). Consult, never assume. */
     val capabilities: DatagramCapabilities
@@ -50,11 +50,43 @@ interface DatagramSource {
 }
 
 /**
+ * The receive half of a **connected** (single fixed peer) datagram endpoint — a `connect()`ed UDP
+ * socket, a QUIC/WebTransport datagram flow. Every received [Datagram.peer] equals [peer].
+ */
+@ExperimentalDatagramApi
+interface ConnectedDatagramSource : DatagramSource {
+    /** The fixed remote peer, known at construction — hoisted here because only this shape has one. */
+    val peer: SocketAddress
+
+    /**
+     * The local endpoint, when the transport surfaces one. A `connect()`ed UDP socket knows it
+     * ([LocalAddress.of]); a QUIC datagram flow does not surface the underlying UDP endpoint and
+     * reports [LocalAddress.Unknown]. Typed absent state, never `null` (§7.2).
+     */
+    val localAddress: LocalAddress
+}
+
+/**
+ * The receive half of an **addressed** (many peers) datagram endpoint — raw UDP for SFU/TURN/ICE.
+ * [Datagram.peer] is the per-packet source. Bound by construction, so [localAddress] is simply
+ * non-null: ICE local-candidate gathering reads it with no unwrap. An implementation that cannot
+ * learn its bound address (getsockname failure) must fail at construction, not report an absent
+ * state here.
+ */
+@ExperimentalDatagramApi
+interface AddressedDatagramSource : DatagramSource {
+    /** The bound local endpoint (for ICE local-candidate gathering). Non-null by construction. */
+    val localAddress: SocketAddress
+}
+
+/**
  * The send half of a datagram endpoint — the analogue of [ByteSink].
  *
- * The 2-arg send is deliberate (§4): [to] is a pre-resolved [SocketAddress] that owns its platform
- * representation, so sending to many distinct peers is zero-alloc — no per-packet resolve, no address
- * reconstruction.
+ * The send verb lives only on [ConnectedDatagramSink] and [AddressedDatagramSink] — there is no
+ * mode-agnostic send, because the two modes have different arities: a connected sink has no address
+ * parameter at all and an addressed sink requires one. The old `to: SocketAddress? = null` conflation
+ * allowed both a runtime "no destination" error and a silently-ignored address; neither is
+ * expressible now.
  *
  * **Thread safety:** implementations are NOT assumed thread-safe; confine sends to one coroutine.
  */
@@ -64,7 +96,7 @@ interface DatagramSink {
     val isOpen: Boolean
 
     /**
-     * The largest payload a single [send] can carry — the link MTU for raw UDP, or the negotiated
+     * The largest payload a single send can carry — the link MTU for raw UDP, or the negotiated
      * `max_datagram_size` for QUIC/WebTransport datagrams. A payload larger than this may be rejected
      * or dropped.
      */
@@ -73,38 +105,74 @@ interface DatagramSink {
     /** The send-side control-plane capabilities of this sink (§7.2). Consult, never assume. */
     val capabilities: DatagramCapabilities
 
-    /**
-     * Sends [payload] to [to] (or the fixed peer when [to] is `null` on a connected sink) with the
-     * control plane [options].
-     *
-     * [payload] is consumed as a [ReadBuffer]; ownership is not transferred (the caller may pool it).
-     * [options] defaults to the shared [DatagramSendOptions.Default] to keep the hot path allocation-free.
-     */
-    suspend fun send(
-        payload: ReadBuffer,
-        to: SocketAddress? = null,
-        options: DatagramSendOptions = DatagramSendOptions.Default,
-    )
-
-    /**
-     * Batching hook: send many datagrams at once (sendmmsg / GSO where the platform offers it). The
-     * default fans out to [send]; real actuals override with a single syscall.
-     */
-    suspend fun sendBatch(datagrams: List<OutboundDatagram>) {
-        for (d in datagrams) send(d.payload, d.to, d.options)
-    }
-
     /** Close the send side. Idempotent. Defaults to a no-op (a simple sink needs nothing). */
     fun close() {}
 }
 
 /**
- * A bidirectional datagram endpoint — the common case (a bound UDP socket, a QUIC/WebTransport
- * datagram flow). Mirrors [ByteStream] over the byte trichotomy.
- *
- * A receive-only source is a [DatagramSource], a send-only sink is a [DatagramSink]; a duplex endpoint
- * is a [DatagramChannel]. No fake capabilities — the tightest type per direction, exactly as the byte
- * trichotomy.
+ * The send half of a **connected** datagram endpoint. There is no destination parameter — the peer
+ * was fixed at construction, so §4's per-send zero-alloc concern is moot (nothing to resolve, ever).
+ */
+@ExperimentalDatagramApi
+interface ConnectedDatagramSink : DatagramSink {
+    /** The fixed remote peer every [send] targets. */
+    val peer: SocketAddress
+
+    /**
+     * Sends [payload] to the fixed [peer] with the control plane [options]. [payload] is consumed
+     * as a [ReadBuffer]; ownership is not transferred (the caller may pool it). [options] defaults
+     * to the shared [DatagramSendOptions.Default] to keep the hot path allocation-free.
+     */
+    suspend fun send(
+        payload: ReadBuffer,
+        options: DatagramSendOptions = DatagramSendOptions.Default,
+    )
+
+    /**
+     * Batching hook (§10.5): send many payloads to the fixed peer with ONE shared control plane —
+     * exactly the UDP GSO contract (uniform destination, uniform options, equal-segment fan-out),
+     * which is the only kernel batching mechanism a connected sender has. No per-element wrapper
+     * type, so a batch allocates nothing beyond the caller's list; a caller needing per-datagram
+     * options on a connected sink loops [send]. The default fans out to [send]; real actuals
+     * override with a single syscall.
+     */
+    suspend fun sendBatch(
+        payloads: List<ReadBuffer>,
+        options: DatagramSendOptions = DatagramSendOptions.Default,
+    ) {
+        for (p in payloads) send(p, options)
+    }
+}
+
+/**
+ * The send half of an **addressed** datagram endpoint. [to] is REQUIRED: the 3-arg send is
+ * deliberate (§4) — a pre-resolved [SocketAddress] owns its platform representation, so sending to
+ * many distinct peers is zero-alloc (no per-packet resolve, no address reconstruction, and now no
+ * nullable branch either).
+ */
+@ExperimentalDatagramApi
+interface AddressedDatagramSink : DatagramSink {
+    /** Sends [payload] to [to] with the control plane [options]. Ownership/options doc as above. */
+    suspend fun send(
+        payload: ReadBuffer,
+        to: SocketAddress,
+        options: DatagramSendOptions = DatagramSendOptions.Default,
+    )
+
+    /**
+     * Batching hook (§10.5): sendmmsg-shaped — each element carries its own destination and control
+     * plane. The default fans out to [send]; real actuals override with a single syscall.
+     */
+    suspend fun sendBatch(datagrams: List<OutboundDatagram>) {
+        for (d in datagrams) send(d.payload, d.to, d.options)
+    }
+}
+
+/**
+ * A bidirectional datagram endpoint, mode-agnostic. Mirrors [ByteStream] over the byte trichotomy:
+ * the tightest type per direction AND per addressing mode. You cannot send through this base type —
+ * obtain a [ConnectedDatagramChannel] or [AddressedDatagramChannel], which know their destination
+ * story. (Receiving is mode-agnostic, so [receive] stays reachable here.)
  */
 @ExperimentalDatagramApi
 interface DatagramChannel :
@@ -113,3 +181,25 @@ interface DatagramChannel :
     /** Close the whole channel (re-abstracts [DatagramSink.close], which is send-side-only). */
     override fun close()
 }
+
+/**
+ * A duplex **connected** datagram endpoint — a `connect()`ed UDP socket, a QUIC/WebTransport
+ * datagram flow. One fixed [peer]; sends take no address; [localAddress] is the typed maybe-known
+ * state. What `UdpSocket.connect()` and [DatagramMux] flows return.
+ */
+@ExperimentalDatagramApi
+interface ConnectedDatagramChannel :
+    DatagramChannel,
+    ConnectedDatagramSource,
+    ConnectedDatagramSink
+
+/**
+ * A duplex **addressed** datagram endpoint — a bound UDP socket serving many peers (SFU/TURN/ICE,
+ * a shared QUIC server socket, multicast). Sends require [to]; bound by construction, so
+ * [localAddress] is plainly non-null. What `UdpSocket.bind()`/`bindMulticast()` return.
+ */
+@ExperimentalDatagramApi
+interface AddressedDatagramChannel :
+    DatagramChannel,
+    AddressedDatagramSource,
+    AddressedDatagramSink

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/DatagramMux.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/DatagramMux.kt
@@ -15,14 +15,19 @@ import kotlinx.coroutines.flow.Flow
  * The flow-id *semantics* (how the id is encoded on the wire, session lifecycle) live in the consumer
  * (`:socket-quic` / `socket-webtransport`); this interface is only the shared shape (decision §10.4).
  *
+ * Every muxed flow is **connected by construction**: its [ConnectedDatagramChannel.peer] is the
+ * underlying session's peer and a per-send address would be meaningless inside a flow id — so the mux
+ * hands out the connected refinement, typically with [LocalAddress.Unknown]. The mux itself rides one
+ * underlying (usually connected) datagram channel.
+ *
  * **Thread safety:** implementations are NOT assumed thread-safe; external synchronization is required
  * for concurrent [open] / [accept] unless an implementation documents otherwise.
  */
 @ExperimentalDatagramApi
 interface DatagramMux {
     /** Open a logical datagram flow identified by [flowId] over the underlying datagram channel. */
-    fun open(flowId: Long): DatagramChannel
+    fun open(flowId: Long): ConnectedDatagramChannel
 
     /** Peer-initiated datagram flows, demuxed by their leading id. */
-    fun accept(): Flow<DatagramChannel>
+    fun accept(): Flow<ConnectedDatagramChannel>
 }

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/SocketAddress.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/SocketAddress.kt
@@ -26,8 +26,9 @@ enum class AddressFamily {
  *    1-entry `lastDest` cache exists to amortize.
  *
  * **Resolved-only (decision §10.1):** DNS happens once, out of band, via [Companion.resolve] — the
- * sole suspending entry point — or [Companion.ofLiteral] for numeric IPs. A [send][DatagramSink.send]
- * therefore never suspends on resolution and stays zero-alloc; ICE gathers pre-resolved candidates.
+ * sole suspending entry point — or [Companion.ofLiteral] for numeric IPs. A
+ * [send][AddressedDatagramSink.send] therefore never suspends on resolution and stays zero-alloc; ICE
+ * gathers pre-resolved candidates.
  *
  * **Value semantics:** implementations must be usable as a map key (a demux routing table keys by
  * peer), so [equals] / [hashCode] compare the resolved endpoint, not object identity.

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/TypedDatagram.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/TypedDatagram.kt
@@ -20,12 +20,13 @@ import kotlinx.coroutines.flow.flow
  */
 
 /**
- * Views this **connected** datagram [DatagramSource] as a typed [Receiver] of [T]: each received
- * datagram's payload is decoded with [codec] and emitted; the source peer is dropped (connected case).
- * A [DatagramReadResult.Closed] completes the flow. Each payload buffer is freed after decode.
+ * Views this **connected** datagram source as a typed [Receiver] of [T]: each received datagram's
+ * payload is decoded with [codec] and emitted; the source peer is dropped (enforced by the receiver
+ * type — every peer is the fixed [ConnectedDatagramSource.peer]). A [DatagramReadResult.Closed]
+ * completes the flow. Each payload buffer is freed after decode.
  */
 @ExperimentalDatagramApi
-public fun <T> DatagramSource.typed(
+public fun <T> ConnectedDatagramSource.typed(
     codec: Codec<T>,
     context: DecodeContext = DecodeContext.Empty,
 ): Receiver<T> =
@@ -50,13 +51,13 @@ public fun <T> DatagramSource.typed(
     }
 
 /**
- * Views this **unconnected** datagram [DatagramSource] as a typed [Receiver] of [Addressed] messages:
+ * Views this **addressed** datagram source as a typed [Receiver] of [Addressed] messages:
  * each received datagram is decoded with [codec] and tagged with its source peer — exactly what an
  * SFU/ICE stack wants (`Receiver<Addressed<StunMessage>>`, `Receiver<Addressed<RtpPacket>>`). A
  * [DatagramReadResult.Closed] completes the flow. Each payload buffer is freed after decode.
  */
 @ExperimentalDatagramApi
-public fun <T> DatagramSource.typedAddressed(
+public fun <T> AddressedDatagramSource.typedAddressed(
     codec: Codec<T>,
     context: DecodeContext = DecodeContext.Empty,
 ): Receiver<Addressed<T>> =
@@ -81,12 +82,12 @@ public fun <T> DatagramSource.typedAddressed(
     }
 
 /**
- * Views this **connected** datagram [DatagramSink] as a typed [Sender] of [T]: each message is encoded
- * with [codec] into a fresh buffer and sent to the fixed peer (`to = null`). The encode buffer is freed
- * after each send. [Sender.close] delegates to [DatagramSink.close].
+ * Views this **connected** datagram sink as a typed [Sender] of [T]: each message is encoded with
+ * [codec] into a fresh buffer and sent to the fixed [ConnectedDatagramSink.peer]. The encode buffer
+ * is freed after each send. [Sender.close] delegates to [DatagramSink.close].
  */
 @ExperimentalDatagramApi
-public fun <T> DatagramSink.typed(
+public fun <T> ConnectedDatagramSink.typed(
     codec: Codec<T>,
     factory: BufferFactory = BufferFactory.Default,
     context: EncodeContext = EncodeContext.Empty,
@@ -96,7 +97,7 @@ public fun <T> DatagramSink.typed(
         override suspend fun send(message: T) {
             val buffer = codec.encodeToPlatformBuffer(message, factory, context)
             try {
-                this@typed.send(buffer, to = null, options = options)
+                this@typed.send(buffer, options = options)
             } finally {
                 buffer.freeNativeMemory()
             }
@@ -106,15 +107,36 @@ public fun <T> DatagramSink.typed(
     }
 
 /**
- * Encodes [message] with [codec] and sends it to [to] (the unconnected, many-dest case) with the
- * control plane [options]. The encode buffer is freed after the send. Mirrors [DatagramSink.typed] for
- * the case where the destination varies per message (SFU/TURN egress).
+ * Encodes [message] with [codec] and sends it to the fixed [ConnectedDatagramSink.peer] with the
+ * control plane [options] — the connected one-shot. The encode buffer is freed after the send.
  */
 @ExperimentalDatagramApi
-public suspend fun <T> DatagramSink.typedSend(
+public suspend fun <T> ConnectedDatagramSink.typedSend(
     message: T,
     codec: Codec<T>,
-    to: SocketAddress? = null,
+    options: DatagramSendOptions = DatagramSendOptions.Default,
+    factory: BufferFactory = BufferFactory.Default,
+    context: EncodeContext = EncodeContext.Empty,
+) {
+    val buffer = codec.encodeToPlatformBuffer(message, factory, context)
+    try {
+        send(buffer, options)
+    } finally {
+        buffer.freeNativeMemory()
+    }
+}
+
+/**
+ * Encodes [message] with [codec] and sends it to the REQUIRED [to] (the addressed, many-dest case)
+ * with the control plane [options]. The encode buffer is freed after the send. Mirrors
+ * [ConnectedDatagramSink.typed] for the case where the destination varies per message (SFU/TURN
+ * egress).
+ */
+@ExperimentalDatagramApi
+public suspend fun <T> AddressedDatagramSink.typedSend(
+    message: T,
+    codec: Codec<T>,
+    to: SocketAddress,
     options: DatagramSendOptions = DatagramSendOptions.Default,
     factory: BufferFactory = BufferFactory.Default,
     context: EncodeContext = EncodeContext.Empty,
@@ -128,12 +150,13 @@ public suspend fun <T> DatagramSink.typedSend(
 }
 
 /**
- * Views this **connected** duplex [DatagramChannel] as a typed [Connection] of [T]: the receive half
- * decodes inbound datagrams (see [typed] on [DatagramSource]) and the send half encodes outbound
- * messages to the fixed peer (see [typed] on [DatagramSink]). [Connection.close] closes the channel.
+ * Views this **connected** duplex [ConnectedDatagramChannel] as a typed [Connection] of [T]: the
+ * receive half decodes inbound datagrams (see [typed] on [ConnectedDatagramSource]) and the send half
+ * encodes outbound messages to the fixed peer (see [typed] on [ConnectedDatagramSink]).
+ * [Connection.close] closes the channel.
  */
 @ExperimentalDatagramApi
-public fun <T> DatagramChannel.typed(
+public fun <T> ConnectedDatagramChannel.typed(
     codec: Codec<T>,
     factory: BufferFactory = BufferFactory.Default,
     decodeContext: DecodeContext = DecodeContext.Empty,
@@ -141,8 +164,8 @@ public fun <T> DatagramChannel.typed(
     options: DatagramSendOptions = DatagramSendOptions.Default,
 ): Connection<T> {
     val channel = this
-    val receiver = (channel as DatagramSource).typed(codec, decodeContext)
-    val sender = (channel as DatagramSink).typed(codec, factory, encodeContext, options)
+    val receiver = (channel as ConnectedDatagramSource).typed(codec, decodeContext)
+    val sender = (channel as ConnectedDatagramSink).typed(codec, factory, encodeContext, options)
     return object : Connection<T> {
         override val id: Long get() = 0L
 

--- a/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/DatagramChannelConformanceTests.kt
+++ b/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/DatagramChannelConformanceTests.kt
@@ -184,6 +184,17 @@ class DatagramChannelConformanceTests {
         }
 
     @Test
+    fun ecnPreferenceStampsExactlyTheWireCodepointsAndGatesOsDefault() {
+        // The four stamping entries mirror Ecn's frozen RFC 3168 codepoints; OsDefault has nothing
+        // to stamp, and asking is a caller bug surfaced eagerly (same contract as HopLimit.value).
+        assertEquals(Ecn.NotEct.codepoint, EcnPreference.NotEct.codepoint)
+        assertEquals(Ecn.Ect1.codepoint, EcnPreference.Ect1.codepoint)
+        assertEquals(Ecn.Ect0.codepoint, EcnPreference.Ect0.codepoint)
+        assertEquals(Ecn.Ce.codepoint, EcnPreference.Ce.codepoint)
+        assertFailsWith<IllegalStateException> { EcnPreference.OsDefault.codepoint }
+    }
+
+    @Test
     fun hopLimitRejectsOutOfRangeAndGatesValueOnIsKnown() {
         // The typed absent state's accessor contract: of() only admits a real octet, and reading
         // value through Unknown is a caller bug surfaced eagerly — not a -1 leaking downstream.
@@ -231,7 +242,7 @@ class DatagramChannelConformanceTests {
             val b = net.bind(addrB)
             val opts =
                 DatagramSendOptions(
-                    ecn = Ecn.Ect0,
+                    ecn = EcnPreference.Ect0,
                     hopLimit = 55,
                     fromLocal = addrB,
                 )
@@ -260,7 +271,7 @@ class DatagramChannelConformanceTests {
             b.send(
                 payload("cp"),
                 to = addrA,
-                options = DatagramSendOptions(ecn = Ecn.Ect0, hopLimit = 55, fromLocal = addrB),
+                options = DatagramSendOptions(ecn = EcnPreference.Ect0, hopLimit = 55, fromLocal = addrB),
             )
             val d = assertIs<DatagramReadResult.Received>(a.receive()).datagram
             // Absent read capabilities → typed absent states, never fabricated values.

--- a/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/DatagramChannelConformanceTests.kt
+++ b/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/DatagramChannelConformanceTests.kt
@@ -16,6 +16,8 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 /**
@@ -91,7 +93,7 @@ class DatagramChannelConformanceTests {
         runTest {
             val net = MemoryDatagramNetwork()
             val (a, b) = net.connectedPair(addrA, addrB)
-            a.send(payload("ping")) // to = null → fixed peer addrB
+            a.send(payload("ping"))
             val atB = assertIs<DatagramReadResult.Received>(b.receive()).datagram
             assertEquals("ping", atB.payload.readByteArray(atB.payload.remaining()).decodeToString())
             assertEquals(addrA, atB.peer)
@@ -99,6 +101,34 @@ class DatagramChannelConformanceTests {
             b.send(payload("pong"))
             val atA = assertIs<DatagramReadResult.Received>(a.receive()).datagram
             assertEquals(addrB, atA.peer)
+        }
+
+    @Test
+    fun connectedChannelExposesFixedPeerAndStampsItOnEveryDatagram() =
+        runTest {
+            val net = MemoryDatagramNetwork()
+            val (a, b) = net.connectedPair(addrA, addrB)
+            // The peer is a non-null type-level fact, hoisted onto the connected refinement.
+            assertEquals(addrB, a.peer)
+            assertEquals(addrA, b.peer)
+            repeat(2) { a.send(payload("n$it")) }
+            repeat(2) {
+                val d = assertIs<DatagramReadResult.Received>(b.receive()).datagram
+                // Every received Datagram.peer on a connected source equals the channel's fixed peer.
+                assertEquals(b.peer, d.peer)
+            }
+            // The memory pair knows its local endpoint — a known, typed LocalAddress.
+            assertEquals(LocalAddress.of(addrA), a.localAddress)
+            assertEquals(addrB, b.localAddress.orNull())
+        }
+
+    @Test
+    fun addressedLocalAddressIsBoundAddressWithNoUnwrap() =
+        runTest {
+            val net = MemoryDatagramNetwork()
+            // Non-null by construction: what ICE local-candidate gathering reads, no unwrap needed.
+            val bound: SocketAddress = net.bind(addrA).localAddress
+            assertEquals(addrA, bound)
         }
 
     // ---- lifecycle ----
@@ -122,6 +152,54 @@ class DatagramChannelConformanceTests {
             a.close()
             assertFailsWith<IllegalStateException> { a.send(payload("x"), to = addrB) }
         }
+
+    @Test
+    fun closedReasonDefaultsToNormal() {
+        // A bare Closed() carries the shared typed Normal arm — never null, never untyped.
+        assertSame(DatagramCloseReason.Normal, DatagramReadResult.Closed().reason)
+    }
+
+    @Test
+    fun closeWithTypedReasonPropagatesToReceive() =
+        runTest {
+            val net = MemoryDatagramNetwork()
+            val a = net.bind(addrA)
+            a.close(DatagramCloseReason.OsError(-9))
+            val r = a.receive()
+            assertEquals(DatagramCloseReason.OsError(-9), assertIs<DatagramReadResult.Closed>(r).reason)
+        }
+
+    @Test
+    fun closeReasonIsDownstreamExtensibleViaSupertyping() =
+        runTest {
+            // The whole reason DatagramCloseReason is an open interface, not sealed: a transport
+            // module buffer-flow cannot import (socket-quic's QuicError) participates by supertyping
+            // and its consumers downcast with `as?`. FakeTransportError stands in for that module.
+            val net = MemoryDatagramNetwork()
+            val a = net.bind(addrA)
+            a.close(FakeTransportError)
+            val reason = assertIs<DatagramReadResult.Closed>(a.receive()).reason
+            assertSame(FakeTransportError, reason as? FakeTransportError)
+            assertNull(reason as? DatagramCloseReason.OsError)
+        }
+
+    @Test
+    fun hopLimitRejectsOutOfRangeAndGatesValueOnIsKnown() {
+        // The typed absent state's accessor contract: of() only admits a real octet, and reading
+        // value through Unknown is a caller bug surfaced eagerly — not a -1 leaking downstream.
+        assertFailsWith<IllegalArgumentException> { HopLimit.of(-1) }
+        assertFailsWith<IllegalArgumentException> { HopLimit.of(256) }
+        assertEquals(0, HopLimit.of(0).value)
+        assertEquals(255, HopLimit.of(255).value)
+        assertFailsWith<IllegalStateException> { HopLimit.Unknown.value }
+    }
+
+    @Test
+    fun localAddressUnknownIsTheOneExplicitEscapeToNull() {
+        assertNull(LocalAddress.Unknown.orNull())
+        assertFalse(LocalAddress.Unknown.isKnown)
+        assertEquals(addrA, LocalAddress.of(addrA).orNull())
+    }
 
     @Test
     fun sendDoesNotConsumeCallerBuffer() =
@@ -164,10 +242,12 @@ class DatagramChannelConformanceTests {
                 assertEquals(Ecn.Ect0, d.ecn)
             }
             if (net.capabilities.hopLimitSend && net.capabilities.hopLimitReceive) {
-                assertEquals(55, d.hopLimit)
+                assertEquals(55, d.hopLimit.value)
+                assertEquals(HopLimit.of(55), d.hopLimit)
             }
             if (net.capabilities.localAddressReceive) {
-                assertEquals(addrB, d.localAddress)
+                assertEquals(addrB, d.localAddress.orNull())
+                assertEquals(LocalAddress.of(addrB), d.localAddress)
             }
         }
 
@@ -183,10 +263,10 @@ class DatagramChannelConformanceTests {
                 options = DatagramSendOptions(ecn = Ecn.Ect0, hopLimit = 55, fromLocal = addrB),
             )
             val d = assertIs<DatagramReadResult.Received>(a.receive()).datagram
-            // Absent read capabilities → sentinels, never fabricated values.
+            // Absent read capabilities → typed absent states, never fabricated values.
             assertEquals(Ecn.Unknown, d.ecn)
-            assertEquals(-1, d.hopLimit)
-            assertEquals(null, d.localAddress)
+            assertFalse(d.hopLimit.isKnown)
+            assertFalse(d.localAddress.isKnown)
         }
 
     @Test
@@ -235,6 +315,23 @@ class DatagramChannelConformanceTests {
             assertEquals("ping", received)
         }
 
+    @Test
+    fun typedSendConnectedRoundTrips() =
+        runTest {
+            val net = MemoryDatagramNetwork()
+            val (a, b) = net.connectedPair(addrA, addrB)
+            // The connected one-shot: no destination parameter exists to pass.
+            a.typedSend("one-shot", WholeStringCodec)
+            val received =
+                b
+                    .typed(WholeStringCodec)
+                    .receive()
+                    .take(1)
+                    .toList()
+                    .single()
+            assertEquals("one-shot", received)
+        }
+
     // ---- batching hooks (§10.5) ----
 
     @Test
@@ -250,6 +347,18 @@ class DatagramChannelConformanceTests {
                     OutboundDatagram(payload("3"), to = addrB),
                 ),
             )
+            assertEquals("1", b.receive().text())
+            assertEquals("2", b.receive().text())
+            assertEquals("3", b.receive().text())
+        }
+
+    @Test
+    fun connectedSendBatchSharesOneControlPlaneAndFansOutToFixedPeer() =
+        runTest {
+            val net = MemoryDatagramNetwork()
+            val (a, b) = net.connectedPair(addrA, addrB)
+            // The GSO-shaped connected batch: bare payloads, one shared options, fixed destination.
+            a.sendBatch(listOf(payload("1"), payload("2"), payload("3")))
             assertEquals("1", b.receive().text())
             assertEquals("2", b.receive().text())
             assertEquals("3", b.receive().text())
@@ -280,6 +389,16 @@ class DatagramChannelConformanceTests {
             assertIs<DatagramReadResult.Closed>(batch.last())
             assertTrue(batch.size <= 2)
         }
+}
+
+/**
+ * A downstream transport's close reason, as a module buffer-flow cannot import would declare it —
+ * the stand-in that pins [DatagramCloseReason]'s open-interface supertyping contract (socket-quic's
+ * `QuicError : DatagramCloseReason` is the real instance of this shape).
+ */
+@OptIn(ExperimentalDatagramApi::class)
+private object FakeTransportError : DatagramCloseReason {
+    override fun toString(): String = "FakeTransportError"
 }
 
 /**

--- a/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/MemoryDatagram.kt
+++ b/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/MemoryDatagram.kt
@@ -103,8 +103,9 @@ internal class MemoryDatagramCore(
 
         // Carry each control-plane field only if the capability set advertises both ends of it.
         val ecn =
-            if (capabilities.ecnSend && capabilities.ecnReceive && options.ecn != Ecn.Unknown) {
-                options.ecn
+            if (capabilities.ecnSend && capabilities.ecnReceive && options.ecn != EcnPreference.OsDefault) {
+                // The stamped preference arrives as the read-side verdict — the loopback of a real stack.
+                Ecn.fromCodepoint(options.ecn.codepoint)
             } else {
                 Ecn.Unknown
             }

--- a/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/MemoryDatagram.kt
+++ b/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/MemoryDatagram.kt
@@ -13,14 +13,15 @@ import kotlinx.coroutines.channels.Channel
  * deterministic-simulation story stands on.
  *
  * Datagram semantics are honored faithfully:
- * - **Boundaries preserved** — each [DatagramSink.send] delivers exactly one [Datagram]; nothing is
- *   concatenated.
+ * - **Boundaries preserved** — each send delivers exactly one [Datagram]; nothing is concatenated.
  * - **Per-packet source** — the delivered [Datagram.peer] is the *sender's* local address.
  * - **Copy on send** — the payload is copied into a fresh buffer the receiver owns, so the caller may
  *   keep/pool its buffer (a real socket copies into the kernel).
  * - **Unreliable** — a datagram addressed to an unbound endpoint is silently dropped.
  * - **Capability-honest** — a read-side control-plane field is carried only when [capabilities]
- *   advertises it; otherwise the receiver sees the §7.2 sentinel.
+ *   advertises it; otherwise the receiver sees the §7.2 typed absent state.
+ * - **Mode is a type** — [bind] returns an [AddressedDatagramChannel]; [connectedPair] returns two
+ *   [ConnectedDatagramChannel]s whose sends target the fixed peer with no address parameter.
  */
 @OptIn(ExperimentalDatagramApi::class)
 internal class MemoryDatagramNetwork(
@@ -28,24 +29,24 @@ internal class MemoryDatagramNetwork(
 ) {
     private val endpoints = HashMap<SocketAddress, Channel<Datagram>>()
 
-    /** Bind an **unconnected** endpoint at [local]; sends addressed to [local] arrive here. */
-    fun bind(local: SocketAddress): DatagramChannel {
+    /** Bind an **addressed** endpoint at [local]; sends addressed to [local] arrive here. */
+    fun bind(local: SocketAddress): MemoryAddressedDatagramChannel {
         val inbound = Channel<Datagram>(Channel.UNLIMITED)
         endpoints[local] = inbound
-        return MemoryDatagramChannel(local, inbound, this, capabilities, connectedPeer = null)
+        return MemoryAddressedDatagramChannel(MemoryDatagramCore(local, inbound, this, capabilities))
     }
 
-    /** A **connected** pair: each channel's `to = null` sends reach the other; peers are fixed. */
+    /** A **connected** pair: each channel's sends reach the other; peers are fixed by the type. */
     fun connectedPair(
         addrA: SocketAddress,
         addrB: SocketAddress,
-    ): Pair<DatagramChannel, DatagramChannel> {
+    ): Pair<MemoryConnectedDatagramChannel, MemoryConnectedDatagramChannel> {
         val inA = Channel<Datagram>(Channel.UNLIMITED)
         val inB = Channel<Datagram>(Channel.UNLIMITED)
         endpoints[addrA] = inA
         endpoints[addrB] = inB
-        val a = MemoryDatagramChannel(addrA, inA, this, capabilities, connectedPeer = addrB)
-        val b = MemoryDatagramChannel(addrB, inB, this, capabilities, connectedPeer = addrA)
+        val a = MemoryConnectedDatagramChannel(MemoryDatagramCore(addrA, inA, this, capabilities), peer = addrB)
+        val b = MemoryConnectedDatagramChannel(MemoryDatagramCore(addrB, inB, this, capabilities), peer = addrA)
         return a to b
     }
 
@@ -58,37 +59,42 @@ internal class MemoryDatagramNetwork(
     }
 }
 
+/**
+ * The shared mailbox / capability / close plumbing behind both memory channel modes. The addressing
+ * mode itself lives ONLY in the thin wrappers ([MemoryAddressedDatagramChannel] /
+ * [MemoryConnectedDatagramChannel]) — the core has no `to ?: connectedPeer` fallback because the
+ * destination always arrives already resolved by the wrapper's type.
+ */
 @OptIn(ExperimentalDatagramApi::class)
-internal class MemoryDatagramChannel(
-    override val localAddress: SocketAddress,
+internal class MemoryDatagramCore(
+    val localAddress: SocketAddress,
     private val inbound: Channel<Datagram>,
     private val network: MemoryDatagramNetwork,
-    override val capabilities: DatagramCapabilities,
-    private val connectedPeer: SocketAddress?,
-) : DatagramChannel {
+    val capabilities: DatagramCapabilities,
+) {
     private var closed = false
+    private var closeReason: DatagramCloseReason = DatagramCloseReason.Normal
 
-    override val isOpen: Boolean get() = !closed && !inbound.isClosedForReceive
+    val isOpen: Boolean get() = !closed && !inbound.isClosedForReceive
 
     /** The classic UDP payload ceiling (65535 − 8 UDP − 20 IP). */
-    override val maxWritableSize: Int = 65507
+    val maxWritableSize: Int = 65507
 
-    override suspend fun receive(): DatagramReadResult {
+    suspend fun receive(): DatagramReadResult {
         val result = inbound.receiveCatching()
         val datagram = result.getOrNull()
         return when {
             datagram != null -> DatagramReadResult.Received(datagram)
-            else -> DatagramReadResult.Closed()
+            else -> DatagramReadResult.Closed(closeReason)
         }
     }
 
-    override suspend fun send(
+    fun sendTo(
+        dest: SocketAddress,
         payload: ReadBuffer,
-        to: SocketAddress?,
         options: DatagramSendOptions,
     ) {
         check(!closed) { "sink is closed" }
-        val dest = to ?: connectedPeer ?: error("no destination on an unconnected sink")
 
         // Copy the payload so the caller keeps ownership of its buffer.
         val slice = payload.slice()
@@ -104,12 +110,16 @@ internal class MemoryDatagramChannel(
             }
         val hopLimit =
             if (capabilities.hopLimitSend && capabilities.hopLimitReceive && options.hopLimit >= 0) {
-                options.hopLimit
+                HopLimit.of(options.hopLimit)
             } else {
-                -1
+                HopLimit.Unknown
             }
         val localAddr =
-            if (capabilities.localAddressReceive) options.fromLocal ?: localAddress else null
+            if (capabilities.localAddressReceive) {
+                LocalAddress.of(options.fromLocal ?: localAddress)
+            } else {
+                LocalAddress.Unknown
+            }
 
         network.deliver(
             dest,
@@ -123,10 +133,66 @@ internal class MemoryDatagramChannel(
         )
     }
 
-    override fun close() {
+    fun close(reason: DatagramCloseReason = DatagramCloseReason.Normal) {
         closed = true
+        closeReason = reason
         inbound.close()
     }
+}
+
+/** The addressed memory endpoint: bound by construction, sends REQUIRE `to`. */
+@OptIn(ExperimentalDatagramApi::class)
+internal class MemoryAddressedDatagramChannel(
+    private val core: MemoryDatagramCore,
+) : AddressedDatagramChannel {
+    override val localAddress: SocketAddress get() = core.localAddress
+
+    override val isOpen: Boolean get() = core.isOpen
+
+    override val capabilities: DatagramCapabilities get() = core.capabilities
+
+    override val maxWritableSize: Int get() = core.maxWritableSize
+
+    override suspend fun receive(): DatagramReadResult = core.receive()
+
+    override suspend fun send(
+        payload: ReadBuffer,
+        to: SocketAddress,
+        options: DatagramSendOptions,
+    ) = core.sendTo(to, payload, options)
+
+    override fun close() = core.close()
+
+    /** Test hook: close with an explicit typed [reason] so reason propagation can be asserted. */
+    fun close(reason: DatagramCloseReason) = core.close(reason)
+}
+
+/** The connected memory endpoint: one fixed [peer], sends take no address. */
+@OptIn(ExperimentalDatagramApi::class)
+internal class MemoryConnectedDatagramChannel(
+    private val core: MemoryDatagramCore,
+    override val peer: SocketAddress,
+) : ConnectedDatagramChannel {
+    /** The memory pair knows its local endpoint, so it is a known [LocalAddress]. */
+    override val localAddress: LocalAddress = LocalAddress.of(core.localAddress)
+
+    override val isOpen: Boolean get() = core.isOpen
+
+    override val capabilities: DatagramCapabilities get() = core.capabilities
+
+    override val maxWritableSize: Int get() = core.maxWritableSize
+
+    override suspend fun receive(): DatagramReadResult = core.receive()
+
+    override suspend fun send(
+        payload: ReadBuffer,
+        options: DatagramSendOptions,
+    ) = core.sendTo(peer, payload, options)
+
+    override fun close() = core.close()
+
+    /** Test hook: close with an explicit typed [reason] so reason propagation can be asserted. */
+    fun close(reason: DatagramCloseReason) = core.close(reason)
 }
 
 /** A full-capability in-memory endpoint: every control-plane field round-trips through memory. */

--- a/buffer-flow/src/jvmTest/kotlin/com/ditchoom/buffer/flow/DatagramValueClassAllocationTest.kt
+++ b/buffer-flow/src/jvmTest/kotlin/com/ditchoom/buffer/flow/DatagramValueClassAllocationTest.kt
@@ -1,0 +1,118 @@
+package com.ditchoom.buffer.flow
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.sun.management.ThreadMXBean
+import java.lang.management.ManagementFactory
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * The runtime witness for the §1 unboxing guarantee: [HopLimit] and [LocalAddress] are `@JvmInline`
+ * value classes stored as bare `Int` / bare reference fields of [Datagram], so a received datagram
+ * with *known* control-plane values costs exactly the same single allocation as one built from the
+ * all-Unknown defaults. If either value class boxed (nullable position, generic position, or a
+ * non-flattened field), the known-values loop would allocate a wrapper per datagram and the
+ * per-iteration delta below would blow past the slack.
+ *
+ * Mirrors [SocketAddressAllocationTest]'s HotSpot `ThreadMXBean` methodology.
+ */
+class DatagramValueClassAllocationTest {
+    private val bean = ManagementFactory.getThreadMXBean() as ThreadMXBean
+
+    private inline fun allocatedBytes(block: () -> Unit): Long {
+        val tid = Thread.currentThread().threadId()
+        val before = bean.getThreadAllocatedBytes(tid)
+        block()
+        val after = bean.getThreadAllocatedBytes(tid)
+        return after - before
+    }
+
+    /** Take the minimum over several trials to squeeze out measurement/JIT noise. */
+    private inline fun minAllocatedBytes(
+        trials: Int,
+        block: () -> Unit,
+    ): Long {
+        var min = Long.MAX_VALUE
+        repeat(trials) {
+            val b = allocatedBytes(block)
+            if (b < min) min = b
+        }
+        return min
+    }
+
+    @OptIn(ExperimentalDatagramApi::class)
+    @Test
+    fun knownControlPlaneValuesAddNoAllocationOverTheDatagramItself() {
+        if (!bean.isThreadAllocatedMemorySupported) return // HotSpot only; skip elsewhere.
+        bean.isThreadAllocatedMemoryEnabled = true
+
+        val n = 1000
+        val sharedPayload: PlatformBuffer = BufferFactory.Default.allocate(1)
+        val peer = SocketAddress.ofLiteral("10.0.0.1", 1111)
+        val local = SocketAddress.ofLiteral("10.0.0.2", 2222)
+
+        var blackhole = 0L
+
+        // N datagrams with fully-known control plane: HopLimit.of + LocalAddress.of + Ecn.Ce.
+        // The hop limit varies per iteration so nothing can be constant-folded away.
+        val knownLoop: () -> Unit = {
+            for (i in 0 until n) {
+                val d =
+                    Datagram(
+                        payload = sharedPayload,
+                        peer = peer,
+                        ecn = Ecn.Ce,
+                        localAddress = LocalAddress.of(local),
+                        hopLimit = HopLimit.of(i % 256),
+                    )
+                blackhole += d.hopLimit.value.toLong()
+                if (d.localAddress.isKnown) blackhole++
+            }
+        }
+
+        // N datagrams with the all-Unknown control plane — the baseline single-allocation cost.
+        // All five arguments are EXPLICIT, per the hot-path discipline in Datagram's KDoc: leaning on
+        // the defaults routes construction through the default-arguments bridge, which transiently
+        // boxes LocalAddress (~16 bytes/datagram whenever escape analysis doesn't elide it) — this
+        // test caught exactly that when it used `Datagram(payload, peer)` here.
+        val unknownLoop: () -> Unit = {
+            for (i in 0 until n) {
+                val d =
+                    Datagram(
+                        payload = sharedPayload,
+                        peer = peer,
+                        ecn = Ecn.Unknown,
+                        localAddress = LocalAddress.Unknown,
+                        hopLimit = HopLimit.Unknown,
+                    )
+                if (d.hopLimit.isKnown) blackhole++
+                if (d.localAddress.isKnown) blackhole++
+            }
+        }
+
+        // Warm up both paths (JIT, class init, first ThreadMXBean call).
+        repeat(20) {
+            knownLoop()
+            unknownLoop()
+        }
+
+        val knownBytes = minAllocatedBytes(10, knownLoop)
+        val unknownBytes = minAllocatedBytes(10, unknownLoop)
+
+        // Keep blackhole observable so the loops can't be optimized away.
+        assertTrue(blackhole != Long.MIN_VALUE)
+
+        // The value classes must add ~zero allocation over the Datagram instance itself: the delta
+        // between known-values and all-Unknown loops stays within measurement slack, nowhere near
+        // the >= 16 bytes/instance a boxed HopLimit or LocalAddress would cost across N datagrams.
+        val delta = abs(knownBytes - unknownBytes)
+        assertTrue(
+            delta < 1024,
+            "known-control-plane datagrams must allocate the same as all-Unknown ones " +
+                "(known=$knownBytes, unknown=$unknownBytes, delta=$delta over $n datagrams)",
+        )
+    }
+}

--- a/buffer-flow/src/jvmTest/kotlin/com/ditchoom/buffer/flow/SocketAddressAllocationTest.kt
+++ b/buffer-flow/src/jvmTest/kotlin/com/ditchoom/buffer/flow/SocketAddressAllocationTest.kt
@@ -10,7 +10,8 @@ import kotlin.test.assertTrue
 /**
  * The **make-or-break** (§4): sending to MANY distinct destinations must be zero-alloc.
  *
- * `send(payload, to)` on a relay fanning out to N peers must not allocate per packet. The design's
+ * `AddressedDatagramSink.send(payload, to)` on a relay fanning out to N peers must not allocate per
+ * packet. The design's
  * answer is that a [SocketAddress] *owns* its resolved platform representation from construction — on
  * JVM, an interned `InetSocketAddress` — so a platform sink extracts the send target with a field
  * read, never a resolve-and-pin. This is exactly what deletes the `PathKey → InetSocketAddress`


### PR DESCRIPTION
De-nulls the `@ExperimentalDatagramApi` surface ahead of the socket major (DitchOoM/socket#272). **Breaking, no shim** — the surface is experimental, so no deprecation cycle and no `api/` churn (`apiCheck` clean).

## The move

The byte trichotomy already argues "the tightest type per direction — no fake capabilities". This applies the same rule to the datagram surface's second axis, its **addressing mode**, and hoists each field onto the only shape that can honor it (the same move `NetworkState.Up` makes in socket#272):

```kotlin
// before                                          // after
sink.send(payload, to = null)      // "connected"   connectedSink.send(payload)
sink.send(payload, to = addr)      // addressed     addressedSink.send(payload, to = addr)
source.localAddress!!              // bound          addressedSource.localAddress          // non-null
d.hopLimit == -1                   // sentinel       d.hopLimit.isKnown / .value           // HopLimit, bare Int field
d.localAddress == null             // sentinel       d.localAddress.isKnown / .orNull()    // LocalAddress, bare ref field
Closed(reason = /* Any? */ null)                    Closed()  // reason: DatagramCloseReason = Normal
```

- **`ConnectedDatagramSource/Sink/Channel`** — fixed `peer`, no address parameter anywhere. `sendBatch(payloads, options)` is GSO-shaped: uniform destination, one shared control plane, the only kernel batching a connected sender has.
- **`AddressedDatagramSource/Sink/Channel`** — `send` requires `to` (sendmmsg-shaped batch via `OutboundDatagram`, whose `to` is now non-null); bound by construction, so `localAddress` is plainly non-null — ICE candidate gathering reads it with no unwrap.
- One class deliberately **cannot** implement both source refinements (their `localAddress` types conflict): an endpoint's addressing mode is fixed at construction.
- `DatagramMux` hands out `ConnectedDatagramChannel` — a muxed flow is connected by construction.
- `DatagramCloseReason` is deliberately an **open** interface: `Normal` and `OsError(code)` ship here; downstream transports participate by supertyping (`sealed interface QuicError : DatagramCloseReason` is one line in socket-quic), pinned by a conformance test with a test-source stand-in implementor.

What this deletes downstream: four runtime guards (`check(channel.isConnected)`, `checkNotNull(to)`, …), one silent-ignore path, and an `assertFailsWith<IllegalStateException>` that existed only to police the conflation. The surveys found **no** call site anywhere that sends both connected and addressed on the same object.

## Zero-alloc proof

The read sentinels become `@JvmInline` value classes with zero added allocation. `javap -p` witness on `Datagram.class`:

```
private final com.ditchoom.buffer.PlatformBuffer payload;
private final com.ditchoom.buffer.flow.SocketAddress peer;
private final com.ditchoom.buffer.flow.Ecn ecn;
private final com.ditchoom.buffer.flow.SocketAddress localAddress;   // bare ref — no LocalAddress wrapper
private final int hopLimit;                                          // bare I  — no HopLimit wrapper
```

The one boxing position is the **default-arguments bridge** (a defaulted `localAddress` transiently boxes; `HopLimit`'s `Int` underlying stays flat there). HotSpot escape analysis usually elides it, but JS/Native make no promise — so hot receive paths construct `Datagram` with all five arguments explicit. This is documented in the KDoc and enforced by `DatagramValueClassAllocationTest` (ThreadMXBean, known-vs-Unknown delta < 1 KB over 1000 datagrams), which caught exactly that bridge when its baseline loop leaned on defaults.

## Deliberately not changed

- ~~`Ecn`~~ **Split after review** (`182a04af`): `DatagramSendOptions.ecn` is now `EcnPreference` (`OsDefault | NotEct | Ect1 | Ect0 | Ce`) — `Ecn.Unknown` was the surface's last double-booked value (read-side "can't report" AND send-side "leave OS default", kept apart only by KDoc). An unstampable preference is now unrepresentable; `codepoint` is gated like `HopLimit.value`; entries are singletons so the zero-alloc `Default` is unaffected. `Ecn` itself stays read-side with `Unknown` as its typed absent state.
- **`DatagramSendOptions`** (`dscp = -1`, `fromLocal = null`, …) — send-side "unset" is a deliberate *choice* ("leave the OS default"), not an unknown reading; the types permit no runtime error and no ambiguity, and retyping would complicate the shared zero-alloc `Default` instance for zero safety gain. `HopLimit` is not reused there: "unset" and "unknown" are different semantics.
- **`Datagram` stays one class** — `peer` is genuinely present in both modes, so there is no absent field to hoist.

## Migration (socket repo — follow-up PR after this releases)

| Socket-side pattern today | Mechanical rewrite |
|---|---|
| `UdpSocket.bind(...)` / `bindMulticast(...)` return `DatagramChannel` / `MulticastDatagramChannel` | return `AddressedDatagramChannel`; `MulticastDatagramChannel : AddressedDatagramChannel` |
| `UdpSocket.connect(...)` returns `DatagramChannel` | returns `ConnectedDatagramChannel` |
| `channel.send(buffer, to = null)` (DatagramChannelUdpChannel, QuicScope shims, TypedDatagram) | `channel.send(buffer)` |
| `channel.send(buffer, to = target)` (ServerConnectionUdpChannel, UdpToxiServer, addressed tests) | unchanged text; `to` now required by type |
| Runtime guards `check(channel.isConnected)` / `checkNotNull(to)` / `check(connectedPeer != null)` (Nio/IoUring/Posix/Node) | delete — compile-time impossible |
| `assertFailsWith<IllegalStateException> { sender.send(p, to = null) }` (MulticastFabricTests) | delete — no longer expressible |
| Dual-mode impl classes (NioDatagramChannel, IoUringDatagramChannel, NodeDatagramChannel) | split: internal core + connected/addressed wrappers; factory sites already know the mode statically. Apple is already split (`NwUdpDatagramChannel` → connected, `PosixUdpDatagramChannel` → addressed) |
| `DriverDatagramAdapter : DatagramChannel` (to/options ignored; `localAddress = null`) | `: ConnectedDatagramChannel`; `peer = remote`; `localAddress = LocalAddress.Unknown`; drop ignored params |
| `sealed interface QuicError` | `sealed interface QuicError : DatagramCloseReason` (one line) |
| `Closed(reason = n)` errno Int (Posix, IoUring) | `Closed(DatagramCloseReason.OsError(n))` |
| Bare `Closed()` (all normal close paths + sims) | unchanged (defaults to `Normal`) |
| `result.reason as? QuicError ?: QuicError.NoError` (QuicScope) | unchanged verbatim |
| `channel.localAddress ?: error(...)` on **bind()** results | `channel.localAddress` (non-null) |
| `channel.localAddress ?: error(...)` on **connect()** results | `channel.localAddress.orNull() ?: error(...)` |
| `private fun DatagramChannel.addr() = localAddress!!` test helpers (UdpConformanceTests + Node/Native twins) — invoked on **both** bound and connected channels | split per mode: `AddressedDatagramChannel.addr() = localAddress` and `ConnectedDatagramChannel.addr() = localAddress.orNull()!!` (the base type no longer has `localAddress`) |
| `Datagram(..., ecn = Ecn.Unknown, localAddress = null, hopLimit = -1)` receive sites (Nio, Node) | pass explicit typed Unknowns — **all five args, not defaults** (the default-args bridge boxes `LocalAddress`; see Datagram's KDoc) |
| IoUring cmsg parse (real values) | `LocalAddress.of(addr)` / `HopLimit.of(ttl)` |
| Sentinel asserts (`assertEquals(-1, d.hopLimit)`, `assertEquals(null, d.localAddress)`) | `assertFalse(d.hopLimit.isKnown)` / `assertFalse(d.localAddress.isKnown)`; real values via `.value` / `.orNull()` |
| `QuicScope.datagramChannel(): DatagramChannel` | `: ConnectedDatagramChannel` |
| `SharedQuicheServer(channel: DatagramChannel)` | `channel: AddressedDatagramChannel` |
| `DatagramChannelUdpChannel(channel: DatagramChannel)` | `channel: ConnectedDatagramChannel` |
| getsockname-may-fail on bind paths | fail fast inside `UdpSocket.bind()` before constructing the addressed channel (per the `AddressedDatagramSource` contract) |

## Verification

- `:buffer-flow:jvmTest` 78/78 (conformance 17 → 26 tests: peer hoisting, non-null bound `localAddress`, `Normal`-default + `OsError` + downstream-supertyped close-reason propagation, connected `sendBatch`, connected `typedSend` round-trip, value-class edge arms), `:jsNodeTest` + `:linuxX64Test` green, `compileKotlinLinuxArm64` clean, `ktlintCheck` clean, `apiCheck` no churn.
- Apple targets need macOS CI.
