### PR TITLE
docs(buffer-flow): say which axis DatagramSink.send does not consume

### DIFF
--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/DatagramChannel.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/DatagramChannel.kt
@@ -88,6 +88,25 @@ interface AddressedDatagramSource : DatagramSource {
  * allowed both a runtime "no destination" error and a silently-ignored address; neither is
  * expressible now.
  *
+ * ## The payload contract, for every send on either refinement
+ *
+ * **A send reads its payload without consuming it.** The send transmits the readable window
+ * `[position, limit)` and leaves the caller's cursor exactly where it found it, so one buffer can be
+ * sent again — to the next peer in a fan-out, or as a retransmit — with no `resetForRead()` in
+ * between. A datagram send is all-or-nothing, so unlike a stream write (whose cursor is the resume
+ * point for a partial write's residue) a post-send cursor would carry no information; all that
+ * consuming could add is a forgotten reset silently putting a legal zero-length datagram on the wire.
+ * An implementation whose platform primitive is itself consuming (java.nio's `write`/`send` advance
+ * position) must therefore transmit through a *view*, never the caller's buffer. Enforced by
+ * `DatagramChannelConformanceTests.sendDoesNotConsumeCallerBuffer`.
+ *
+ * **Ownership is not transferred**: the sink borrows the payload for the duration of the call and
+ * never frees it — the caller frees it, or returns it to its pool, afterwards. Note this runs the
+ * opposite way from the receive side, where [Datagram.payload] ownership transfers *out*; either way
+ * the buffer belongs to whoever allocated it. A borrowing sink must also take no lasting reference on
+ * the payload: on a pooled buffer, a `slice()` retained past the call pins the chunk and quietly
+ * drains the pool.
+ *
  * **Thread safety:** implementations are NOT assumed thread-safe; confine sends to one coroutine.
  */
 @ExperimentalDatagramApi
@@ -119,9 +138,10 @@ interface ConnectedDatagramSink : DatagramSink {
     val peer: SocketAddress
 
     /**
-     * Sends [payload] to the fixed [peer] with the control plane [options]. [payload] is consumed
-     * as a [ReadBuffer]; ownership is not transferred (the caller may pool it). [options] defaults
-     * to the shared [DatagramSendOptions.Default] to keep the hot path allocation-free.
+     * Sends [payload] to the fixed [peer] with the control plane [options]. [payload] is read but
+     * neither consumed nor owned — see the payload contract on [DatagramSink] for both axes.
+     * [options] defaults to the shared [DatagramSendOptions.Default] to keep the hot path
+     * allocation-free.
      */
     suspend fun send(
         payload: ReadBuffer,
@@ -152,7 +172,12 @@ interface ConnectedDatagramSink : DatagramSink {
  */
 @ExperimentalDatagramApi
 interface AddressedDatagramSink : DatagramSink {
-    /** Sends [payload] to [to] with the control plane [options]. Ownership/options doc as above. */
+    /**
+     * Sends [payload] to [to] with the control plane [options]. [payload] is read but neither
+     * consumed nor owned — see the payload contract on [DatagramSink] for both axes. Fan-out to many
+     * peers is exactly what the non-consuming cursor rule buys: send the same buffer to each [to]
+     * with no `resetForRead()` in between.
+     */
     suspend fun send(
         payload: ReadBuffer,
         to: SocketAddress,


### PR DESCRIPTION
Docs only — no behavior change, no API change. Labelled `skip-release`.

## The gap

`DatagramSink.send`'s contract read:

> `[payload]` is consumed as a `[ReadBuffer]`; ownership is not transferred (the caller may pool it).

That pins **ownership**, but the word "consumed" invites exactly the opposite reading on **cursor semantics** — and cursor is the axis a backend author has to get right. The behavior itself was never in doubt: `DatagramChannelConformanceTests.sendDoesNotConsumeCallerBuffer` has always asserted it. Only the prose an implementor reads first was ambiguous, so the contract was specified by test and mis-specified by comment.

## The change

Rebased onto #325's connected/addressed split, which removed the single mode-agnostic `send` this originally annotated. There are now two sends with different arities and no shared declaration to hang the contract off — so it is stated **once** on the `DatagramSink` base interface, under a "payload contract" heading that both refinements' `send` KDocs point at. That is better than where it started: `AddressedDatagramSink.send` previously said only *"Ownership/options doc as above"*, and `ConnectedDatagramSink.send` still carried the original ambiguous "is consumed" wording. Both now name both axes.

- **Cursor** — the send transmits the readable window `[position, limit)` and leaves the caller's cursor where it found it, so one buffer can be sent again (fan-out to the next peer, or a retransmit) with no `resetForRead()` in between. A datagram send is all-or-nothing, so unlike a stream write — whose cursor *is* the resume point for a partial write's residue — a post-send cursor carries no information. All that consuming could add is a forgotten reset silently putting a legal zero-length datagram on the wire.
- **Implementor note** — a platform primitive that is itself consuming (java.nio's `write`/`send` advance position) must transmit through a *view*, never the caller's buffer.
- **Ownership** — the sink borrows for the duration of the call and never frees; the caller frees or returns to its pool. Called out as running the opposite way from the receive side, where `Datagram.payload` transfers *out*. Plus: a borrowing sink must take no *lasting* reference either — on a pooled payload a `slice()` retained past the call pins the chunk and quietly drains the pool.

The addressed `send` additionally names the fan-out case, since sending one buffer to many `to` values is exactly what the non-consuming cursor rule buys.

## Why now

That last clause is [DitchOoM/socket#277](https://github.com/DitchOoM/socket/issues/277), found in precisely this gap. socket-udp's JVM/NIO and Node backends staged their send through `ReadBuffer.slice()` — correct on the cursor axis, wrong on the reference axis — and never released the resulting `TrackedSlice`, so every send permanently removed one chunk from the caller's `BufferPool`. Fixed on the socket side in DitchOoM/socket#275; this makes the contract that fix restores legible to the next backend author instead of discoverable only by running the conformance suite.

## Verification

`:buffer-flow:ktlintCheck` and `:buffer-flow:compileKotlinJvm` green. Nothing else to run — the diff is a KDoc block.
