### PR TITLE
feat(buffer-flow): DatagramCapabilities.requiresNativeMemoryBuffers

### DIFF
--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/DatagramCapabilities.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/DatagramCapabilities.kt
@@ -1,7 +1,9 @@
 package com.ditchoom.buffer.flow
 
 /**
- * The control-plane capabilities a datagram endpoint actually supports on its platform.
+ * The capabilities a datagram endpoint actually supports on its platform: the control-plane fields it
+ * can set or report, plus the one data-plane requirement its send path imposes
+ * ([requiresNativeMemoryBuffers]).
  *
  * Decision §10.2: the full control-plane **surface** ships everywhere ([Datagram] read fields,
  * [DatagramSendOptions] send fields), but each field is implemented to the platform's real ceiling
@@ -19,6 +21,10 @@ package com.ditchoom.buffer.flow
  * - [localAddressReceive] / [sourceAddressSelect] (IP_PKTINFO) absence is the only *functional*
  *   limit, and only for a multi-homed single-socket server; single-homed servers and ICE
  *   (socket-per-candidate) don't need it, and high-scale relays deploy where it exists.
+ *
+ * [requiresNativeMemoryBuffers] inverts that reading: it is the one field whose **presence**
+ * constrains the caller rather than whose absence degrades a feature. It is not a control-plane
+ * feature at all — see its own doc.
  *
  * The empirically-measured platform values (used to seed platform actuals in `:socket-udp`) are:
  *
@@ -59,6 +65,28 @@ class DatagramCapabilities(
      * precludes multicast, but the shipped default is `false` until a later additive minor.
      */
     val multicast: Boolean = false,
+    /**
+     * Sends require the payload to be backed by native memory (a raw address), because the send path
+     * hands that address straight to the OS — io_uring `sendmsg`, `NWConnection`. When `false`, a
+     * heap-backed buffer is accepted too (JVM NIO copies internally; an in-memory endpoint's "send"
+     * is itself a copy).
+     *
+     * **Correctness-critical, and a *data*-plane property, not a control-plane one:** a consumer that
+     * allocates its own outbound datagrams must honour this when choosing its
+     * [com.ditchoom.buffer.BufferFactory], or the send fails at transmit time — long after the
+     * endpoint was constructed and the application believed it had a working session. Reading it at
+     * construction lets that be rejected while the caller can still pick a different factory.
+     *
+     * **Only the channel can answer this.** It is deliberately not an `expect val`: one process can
+     * run both an in-memory endpoint (heap fine) and a real socket (heap fatal) on the same platform,
+     * so a platform-level flag would over-reject. Nor is it the same question as "is this buffer
+     * native" — the NIO path accepts a heap `ByteBuffer` quite happily, so a check phrased that way
+     * would reject a configuration that works. This is about the channel's requirement.
+     *
+     * Conservative default `false`: every endpoint that does not genuinely need a raw address stays
+     * correct without saying anything.
+     */
+    val requiresNativeMemoryBuffers: Boolean = false,
 ) {
     @ExperimentalDatagramApi
     companion object {
@@ -66,6 +94,10 @@ class DatagramCapabilities(
          * No control-plane capabilities — the conservative default. A minimal or in-memory endpoint
          * advertises this; every control-plane read yields a sentinel and every advisory send field
          * is a no-op. Correct on every platform.
+         *
+         * [requiresNativeMemoryBuffers] is `false` here, which is a real claim rather than an absent
+         * one: a capability-less endpoint accepts any buffer. A channel whose send path does need a
+         * raw address must say so, even if it advertises nothing else.
          */
         val None: DatagramCapabilities = DatagramCapabilities()
     }

--- a/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/DatagramChannelConformanceTests.kt
+++ b/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/DatagramChannelConformanceTests.kt
@@ -289,6 +289,22 @@ class DatagramChannelConformanceTests {
             assertTrue(MemoryDatagramNetwork(FullMemoryCapabilities).capabilities.dontFragment)
         }
 
+    @Test
+    fun nativeMemoryRequirementIsOrthogonalToTheControlPlane() =
+        runTest {
+            // A consumer allocating its own outbound datagrams reads this at construction to pick a
+            // BufferFactory, instead of discovering the requirement as a send-time failure.
+            // Defaulted false, so an endpoint that doesn't need a raw address says nothing.
+            assertFalse(DatagramCapabilities.None.requiresNativeMemoryBuffers)
+            // Full control-plane capability does not imply the requirement: an in-memory send copies.
+            assertFalse(MemoryDatagramNetwork(FullMemoryCapabilities).capabilities.requiresNativeMemoryBuffers)
+            // ...and the requirement does not imply any control-plane capability either.
+            val rawAddressOnly = DatagramCapabilities(requiresNativeMemoryBuffers = true)
+            assertTrue(rawAddressOnly.requiresNativeMemoryBuffers)
+            assertFalse(rawAddressOnly.dontFragment)
+            assertFalse(rawAddressOnly.ecnSend)
+        }
+
     // ---- typed views (§5) ----
 
     @Test

--- a/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/MemoryDatagram.kt
+++ b/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/MemoryDatagram.kt
@@ -209,4 +209,7 @@ internal val FullMemoryCapabilities =
         localAddressReceive = true,
         sourceAddressSelect = true,
         multicast = false,
+        // Stays false even at full control-plane capability: the send here is a copy into a Channel,
+        // so a heap buffer is fine. The two are orthogonal axes, not one "how capable is this" dial.
+        requiresNativeMemoryBuffers = false,
     )


### PR DESCRIPTION
Closes #328.

## The gap

`DatagramCapabilities` describes the control plane — ECN, DSCP, DF, hop limit, PKTINFO, multicast — but had no way to express the one property that decides whether a caller's buffers can be sent at all: **does this channel's send path require the buffer to have a native address?**

A consumer that allocates its own outbound datagrams can be handed a `BufferFactory` the channel cannot send from. Today that lands as an exception deep inside the socket at transmit time — after the endpoint was constructed and the application believes it has a working session. This flag lets that be rejected at construction, where the caller can still pick a different factory.

## Why it belongs on the channel

Two distinctions do the load-bearing work, and both are in the KDoc:

- **Not an `expect val`.** The same process runs both an in-memory endpoint (heap fine — the "send" is a copy) and a real socket (heap fatal). A platform-level flag would be `true` for the platform and over-reject every endpoint on it that is perfectly happy with a heap factory. Only the channel knows.
- **Not "is this buffer native".** The JVM/NIO path accepts a heap `ByteBuffer` quite happily, so a check phrased that way would reject a configuration that works. The question is about the channel's requirement, not the buffer's nature.

## Changes

- `requiresNativeMemoryBuffers: Boolean = false`, appended **last** so any positional construction downstream is unaffected.
- Class-level doc reframed from "the control-plane capabilities" to control plane **plus** this one data-plane requirement. The existing doc is organised around "each flag's absence degrades to a correct mode"; this field reads the other way — its *presence* constrains the caller — so that inversion is called out rather than left for a reader to trip over.
- `None`'s doc now states that its `false` is an affirmative claim (a capability-less endpoint accepts any buffer), not an absent one. A channel that needs a raw address must say so even if it advertises nothing else.
- `FullMemoryCapabilities` sets it explicitly `false` with a comment — every control-plane flag `true` and this one `false` documents that these are orthogonal axes, not one "how capable is this" dial.

## Compatibility

Additive with a conservative `false` default. Every existing implementation, `None`, and the in-memory endpoints stay correct untouched — hence `minor`, not `major`. No API dump change: the datagram surface is behind `@ExperimentalDatagramApi` and excluded from the dump (`:buffer-flow:apiCheck` passes unmodified).

## Tests

New `nativeMemoryRequirementIsOrthogonalToTheControlPlane` in `DatagramChannelConformanceTests` asserts both directions of the independence: full control-plane capability does not imply the requirement, and the requirement implies no control-plane capability.

`:buffer-flow:jvmTest` green (28 tests, 0 failures), `ktlintCheck` and `apiCheck` clean.

## Note on scope

This is the half that lets a channel **say** it. The actuals that should set it `true` (io_uring, Network.framework) live outside this repo, so #328's downstream story needs those wired separately.