### PR TITLE
chore(buffer-compression): resolve detekt complexity alerts in the zlib codepaths

### DIFF
--- a/buffer-compression/src/appleMain/kotlin/com/ditchoom/buffer/compression/AppleCompression.kt
+++ b/buffer-compression/src/appleMain/kotlin/com/ditchoom/buffer/compression/AppleCompression.kt
@@ -35,7 +35,6 @@ import platform.zlib.deflateInit2
 import platform.zlib.deflateSetDictionary
 import platform.zlib.inflate
 import platform.zlib.inflateEnd
-import platform.zlib.inflateInit2
 import platform.zlib.inflateSetDictionary
 import platform.zlib.z_stream
 
@@ -268,23 +267,7 @@ private fun decompressWithZStream(
 
     val s = nativeHeap.alloc<z_stream>()
     try {
-        s.zalloc = null
-        s.zfree = null
-        s.opaque = null
-
-        val windowBits = resolveWindowBits(algorithm, WindowBits.Default)
-
-        var result = inflateInit2(s.ptr, windowBits)
-
-        if (result != Z_OK) {
-            throw CompressionException("inflateInit2 failed with code: $result")
-        }
-
-        // Raw inflate has no in-band Z_NEED_DICT signal, so the dictionary must be applied
-        // eagerly. Zlib-wrapped streams signal via Z_NEED_DICT during the inflate loop below.
-        if (algorithm == CompressionAlgorithm.Raw) {
-            dictionary?.let { applyInflateDictionary(s.ptr, it) }
-        }
+        initInflateStream(s, algorithm, dictionary)
 
         // Start with estimate, grow if needed
         var outputSize = maxOf(inputSize * 4, 1024)
@@ -303,7 +286,7 @@ private fun decompressWithZStream(
                 s.next_out = (outputPtr + totalDecompressed)?.reinterpret()
                 s.avail_out = (outputSize - totalDecompressed).convert()
 
-                result = inflate(s.ptr, Z_FINISH)
+                val result = inflate(s.ptr, Z_FINISH)
 
                 totalDecompressed = outputSize - s.avail_out.toInt()
 
@@ -330,17 +313,7 @@ private fun decompressWithZStream(
                             outputSize = newSize
                         }
                     }
-                    Z_NEED_DICT -> {
-                        if (dictionary == null) {
-                            inflateEnd(s.ptr)
-                            throw CompressionException("Dictionary required")
-                        }
-                        val setResult = applyInflateDictionary(s.ptr, dictionary)
-                        if (setResult != Z_OK) {
-                            inflateEnd(s.ptr)
-                            throw CompressionException("inflateSetDictionary failed with code: $setResult")
-                        }
-                    }
+                    Z_NEED_DICT -> applyDictionaryOrEndAndThrow(s.ptr, dictionary)
                     else -> {
                         inflateEnd(s.ptr)
                         throw CompressionException("inflate failed with code: $result")

--- a/buffer-compression/src/appleMain/kotlin/com/ditchoom/buffer/compression/AppleInflateSupport.kt
+++ b/buffer-compression/src/appleMain/kotlin/com/ditchoom/buffer/compression/AppleInflateSupport.kt
@@ -1,0 +1,79 @@
+package com.ditchoom.buffer.compression
+
+import com.ditchoom.buffer.ReadBuffer
+import kotlinx.cinterop.CPointer
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.ptr
+import platform.zlib.Z_OK
+import platform.zlib.inflateEnd
+import platform.zlib.inflateInit2
+import platform.zlib.z_stream
+
+// Shared setup/refusal steps for the zlib inflate drivers in AppleCompression.kt (one-shot) and
+// AppleStreamingCompression.kt (streaming). Kept out of the inflate loops themselves: the loops are
+// the zlib state machine and are best read as such, while these steps are straight-line
+// initialisation and error mapping that would otherwise be copy-pasted at four call sites.
+
+/**
+ * Handles zlib's `Z_NEED_DICT` for the streaming inflate drivers: install [dictionary], or map the
+ * two possible refusals — none supplied, or one zlib rejects (wrong Adler-32) — onto a typed
+ * [CompressionException]. Shared by every `Z_NEED_DICT` branch so the mapping cannot drift.
+ */
+@OptIn(ExperimentalForeignApi::class)
+internal fun applyDictionaryOrThrow(
+    stream: CPointer<z_stream>,
+    dictionary: ReadBuffer?,
+) {
+    val dict = dictionary ?: throw CompressionException("Dictionary required")
+    val setResult = applyInflateDictionary(stream, dict)
+    if (setResult != Z_OK) {
+        throw CompressionException("inflateSetDictionary failed with code: $setResult")
+    }
+}
+
+/**
+ * [applyDictionaryOrThrow] for the one-shot inflate path, which owns [stream] outright: release
+ * zlib's internal state with `inflateEnd` before throwing, since the caller's `finally` only frees
+ * the `z_stream` struct itself.
+ */
+@OptIn(ExperimentalForeignApi::class)
+internal fun applyDictionaryOrEndAndThrow(
+    stream: CPointer<z_stream>,
+    dictionary: ReadBuffer?,
+) {
+    if (dictionary == null) {
+        inflateEnd(stream)
+        throw CompressionException("Dictionary required")
+    }
+    val setResult = applyInflateDictionary(stream, dictionary)
+    if (setResult != Z_OK) {
+        inflateEnd(stream)
+        throw CompressionException("inflateSetDictionary failed with code: $setResult")
+    }
+}
+
+/**
+ * Initialises [stream] for inflate: clear the allocator hooks, pick window bits for [algorithm],
+ * and eagerly install [dictionary] for raw deflate. Raw streams carry no in-band `Z_NEED_DICT`
+ * signal, so the dictionary must be set up front; zlib-wrapped streams signal reactively from the
+ * inflate loop instead.
+ */
+@OptIn(ExperimentalForeignApi::class)
+internal fun initInflateStream(
+    stream: z_stream,
+    algorithm: CompressionAlgorithm,
+    dictionary: ReadBuffer?,
+) {
+    stream.zalloc = null
+    stream.zfree = null
+    stream.opaque = null
+
+    val result = inflateInit2(stream.ptr, resolveWindowBits(algorithm, WindowBits.Default))
+    if (result != Z_OK) {
+        throw CompressionException("inflateInit2 failed with code: $result")
+    }
+
+    if (algorithm == CompressionAlgorithm.Raw) {
+        dictionary?.let { applyInflateDictionary(stream.ptr, it) }
+    }
+}

--- a/buffer-compression/src/appleMain/kotlin/com/ditchoom/buffer/compression/AppleStreamingCompression.kt
+++ b/buffer-compression/src/appleMain/kotlin/com/ditchoom/buffer/compression/AppleStreamingCompression.kt
@@ -334,13 +334,7 @@ private class AppleZlibStreamingDecompressor(
                         when (result) {
                             Z_OK -> {}
                             Z_STREAM_END -> streamEnded = true
-                            Z_NEED_DICT -> {
-                                val dict = dictionary ?: throw CompressionException("Dictionary required")
-                                val setResult = applyInflateDictionary(s, dict)
-                                if (setResult != Z_OK) {
-                                    throw CompressionException("inflateSetDictionary failed with code: $setResult")
-                                }
-                            }
+                            Z_NEED_DICT -> applyDictionaryOrThrow(s, dictionary)
                             else -> throw CompressionException("inflate failed with code: $result")
                         }
 
@@ -391,11 +385,7 @@ private class AppleZlibStreamingDecompressor(
                             streamEnded = true
                         }
                         Z_NEED_DICT -> {
-                            val dict = dictionary ?: throw CompressionException("Dictionary required")
-                            val setResult = applyInflateDictionary(s, dict)
-                            if (setResult != Z_OK) {
-                                throw CompressionException("inflateSetDictionary failed with code: $setResult")
-                            }
+                            applyDictionaryOrThrow(s, dictionary)
                             // Nothing was produced/consumed by this call; retry on the next
                             // outer loop iteration instead of falling through to the
                             // avail_out-based shouldBreak check below (which would

--- a/buffer-compression/src/jvmCommonMain/kotlin/com/ditchoom/buffer/compression/JvmCommonStreamingCompression.kt
+++ b/buffer-compression/src/jvmCommonMain/kotlin/com/ditchoom/buffer/compression/JvmCommonStreamingCompression.kt
@@ -648,6 +648,10 @@ private class JvmInflateStreamingDecompressor(
         }
     }
 
+    // Both jumps are distinct inflater states: `continue` retries after installing the dictionary
+    // the inflater just asked for (that call consumed and produced nothing), `break` stops once
+    // the inflater produces no output and wants no dictionary, i.e. it needs more input.
+    @Suppress("LoopWithTooManyJumpStatements")
     private fun drainInflater(onOutput: (ReadBuffer) -> Unit) {
         while (!inflater.needsInput() && !inflater.finished()) {
             if (currentOutput == null) {

--- a/buffer-compression/src/linuxMain/kotlin/com/ditchoom/buffer/compression/LinuxCompression.kt
+++ b/buffer-compression/src/linuxMain/kotlin/com/ditchoom/buffer/compression/LinuxCompression.kt
@@ -37,7 +37,6 @@ import platform.zlib.deflateInit2
 import platform.zlib.deflateSetDictionary
 import platform.zlib.inflate
 import platform.zlib.inflateEnd
-import platform.zlib.inflateInit2
 import platform.zlib.inflateSetDictionary
 import platform.zlib.z_stream
 
@@ -258,23 +257,7 @@ private fun decompressWithZStream(
 
     val s = nativeHeap.alloc<z_stream>()
     try {
-        s.zalloc = null
-        s.zfree = null
-        s.opaque = null
-
-        val windowBits = resolveWindowBits(algorithm, WindowBits.Default)
-
-        var result = inflateInit2(s.ptr, windowBits)
-
-        if (result != Z_OK) {
-            throw CompressionException("inflateInit2 failed with code: $result")
-        }
-
-        // Raw inflate has no in-band Z_NEED_DICT signal, so the dictionary must be applied
-        // eagerly. Zlib-wrapped streams signal via Z_NEED_DICT during the inflate loop below.
-        if (algorithm == CompressionAlgorithm.Raw) {
-            dictionary?.let { applyInflateDictionary(s.ptr, it) }
-        }
+        initInflateStream(s, algorithm, dictionary)
 
         // Start with estimate, grow if needed
         var outputSize = maxOf(inputSize * 4, 1024)
@@ -291,7 +274,7 @@ private fun decompressWithZStream(
                 s.next_out = (outputPtr + totalDecompressed)?.reinterpret()
                 s.avail_out = (outputSize - totalDecompressed).convert()
 
-                result = inflate(s.ptr, Z_FINISH)
+                val result = inflate(s.ptr, Z_FINISH)
 
                 totalDecompressed = outputSize - s.avail_out.toInt()
 
@@ -316,17 +299,7 @@ private fun decompressWithZStream(
                             outputSize = newSize
                         }
                     }
-                    Z_NEED_DICT -> {
-                        if (dictionary == null) {
-                            inflateEnd(s.ptr)
-                            throw CompressionException("Dictionary required")
-                        }
-                        val setResult = applyInflateDictionary(s.ptr, dictionary)
-                        if (setResult != Z_OK) {
-                            inflateEnd(s.ptr)
-                            throw CompressionException("inflateSetDictionary failed with code: $setResult")
-                        }
-                    }
+                    Z_NEED_DICT -> applyDictionaryOrEndAndThrow(s.ptr, dictionary)
                     else -> {
                         inflateEnd(s.ptr)
                         throw CompressionException("inflate failed with code: $result")

--- a/buffer-compression/src/linuxMain/kotlin/com/ditchoom/buffer/compression/LinuxInflateSupport.kt
+++ b/buffer-compression/src/linuxMain/kotlin/com/ditchoom/buffer/compression/LinuxInflateSupport.kt
@@ -1,0 +1,79 @@
+package com.ditchoom.buffer.compression
+
+import com.ditchoom.buffer.ReadBuffer
+import kotlinx.cinterop.CPointer
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.ptr
+import platform.zlib.Z_OK
+import platform.zlib.inflateEnd
+import platform.zlib.inflateInit2
+import platform.zlib.z_stream
+
+// Shared setup/refusal steps for the zlib inflate drivers in LinuxCompression.kt (one-shot) and
+// LinuxStreamingCompression.kt (streaming). Kept out of the inflate loops themselves: the loops are
+// the zlib state machine and are best read as such, while these steps are straight-line
+// initialisation and error mapping that would otherwise be copy-pasted at four call sites.
+
+/**
+ * Handles zlib's `Z_NEED_DICT` for the streaming inflate drivers: install [dictionary], or map the
+ * two possible refusals — none supplied, or one zlib rejects (wrong Adler-32) — onto a typed
+ * [CompressionException]. Shared by every `Z_NEED_DICT` branch so the mapping cannot drift.
+ */
+@OptIn(ExperimentalForeignApi::class)
+internal fun applyDictionaryOrThrow(
+    stream: CPointer<z_stream>,
+    dictionary: ReadBuffer?,
+) {
+    val dict = dictionary ?: throw CompressionException("Dictionary required")
+    val setResult = applyInflateDictionary(stream, dict)
+    if (setResult != Z_OK) {
+        throw CompressionException("inflateSetDictionary failed with code: $setResult")
+    }
+}
+
+/**
+ * [applyDictionaryOrThrow] for the one-shot inflate path, which owns [stream] outright: release
+ * zlib's internal state with `inflateEnd` before throwing, since the caller's `finally` only frees
+ * the `z_stream` struct itself.
+ */
+@OptIn(ExperimentalForeignApi::class)
+internal fun applyDictionaryOrEndAndThrow(
+    stream: CPointer<z_stream>,
+    dictionary: ReadBuffer?,
+) {
+    if (dictionary == null) {
+        inflateEnd(stream)
+        throw CompressionException("Dictionary required")
+    }
+    val setResult = applyInflateDictionary(stream, dictionary)
+    if (setResult != Z_OK) {
+        inflateEnd(stream)
+        throw CompressionException("inflateSetDictionary failed with code: $setResult")
+    }
+}
+
+/**
+ * Initialises [stream] for inflate: clear the allocator hooks, pick window bits for [algorithm],
+ * and eagerly install [dictionary] for raw deflate. Raw streams carry no in-band `Z_NEED_DICT`
+ * signal, so the dictionary must be set up front; zlib-wrapped streams signal reactively from the
+ * inflate loop instead.
+ */
+@OptIn(ExperimentalForeignApi::class)
+internal fun initInflateStream(
+    stream: z_stream,
+    algorithm: CompressionAlgorithm,
+    dictionary: ReadBuffer?,
+) {
+    stream.zalloc = null
+    stream.zfree = null
+    stream.opaque = null
+
+    val result = inflateInit2(stream.ptr, resolveWindowBits(algorithm, WindowBits.Default))
+    if (result != Z_OK) {
+        throw CompressionException("inflateInit2 failed with code: $result")
+    }
+
+    if (algorithm == CompressionAlgorithm.Raw) {
+        dictionary?.let { applyInflateDictionary(stream.ptr, it) }
+    }
+}

--- a/buffer-compression/src/linuxMain/kotlin/com/ditchoom/buffer/compression/LinuxStreamingCompression.kt
+++ b/buffer-compression/src/linuxMain/kotlin/com/ditchoom/buffer/compression/LinuxStreamingCompression.kt
@@ -438,6 +438,13 @@ private class LinuxZlibStreamingDecompressor(
         currentOutput = null
     }
 
+    // The branch count IS the zlib state machine: inflate()'s result set (Z_OK / Z_STREAM_END /
+    // Z_NEED_DICT / error) crossed with the output-chunk states (full / partial / no progress).
+    // The loop needs both jumps for distinct states — `continue` retries after installing a
+    // dictionary, `break` stops when inflate can make no further progress. Flattening either into
+    // a helper that signals loop control through a Boolean would hide the state machine, not
+    // clarify it.
+    @Suppress("CyclomaticComplexMethod", "LoopWithTooManyJumpStatements")
     override fun decompress(
         input: ReadBuffer,
         onOutput: (ReadBuffer) -> Unit,
@@ -469,11 +476,10 @@ private class LinuxZlibStreamingDecompressor(
                         Z_OK -> {}
                         Z_STREAM_END -> streamEnded = true
                         Z_NEED_DICT -> {
-                            val dict = dictionary ?: throw CompressionException("Dictionary required")
-                            val setResult = applyInflateDictionary(s, dict)
-                            if (setResult != Z_OK) {
-                                throw CompressionException("inflateSetDictionary failed with code: $setResult")
-                            }
+                            applyDictionaryOrThrow(s, dictionary)
+                            // Nothing was produced or consumed by this call; retry the same
+                            // inflate() rather than falling through to the produced == 0 check
+                            // below, which would read as "no more progress possible".
                             continue
                         }
                         else -> throw CompressionException("inflate failed with code: $result")
@@ -505,6 +511,10 @@ private class LinuxZlibStreamingDecompressor(
         emitPartialOutput(onOutput)
     }
 
+    // Both jumps are distinct zlib stream states: `continue` retries the same inflate() after
+    // installing a dictionary (Z_NEED_DICT consumes and produces nothing), `break` stops once
+    // zlib leaves output space unused, meaning the stream is drained.
+    @Suppress("LoopWithTooManyJumpStatements")
     override fun finish(onOutput: (ReadBuffer) -> Unit) {
         check(!closed) { "Decompressor is closed" }
         if (streamEnded) {
@@ -535,11 +545,10 @@ private class LinuxZlibStreamingDecompressor(
                     streamEnded = true
                 }
                 Z_NEED_DICT -> {
-                    val dict = dictionary ?: throw CompressionException("Dictionary required")
-                    val setResult = applyInflateDictionary(s, dict)
-                    if (setResult != Z_OK) {
-                        throw CompressionException("inflateSetDictionary failed with code: $setResult")
-                    }
+                    applyDictionaryOrThrow(s, dictionary)
+                    // Nothing was produced or consumed by this call; retry the same inflate()
+                    // rather than falling through to the avail_out check below, which would
+                    // read as "no more output pending".
                     continue
                 }
                 else -> throw CompressionException("inflate finish failed with code: $result")


### PR DESCRIPTION
## What

Clears all 15 detekt findings in `buffer-compression`. Zero behavior change, no API change.

No thresholds were raised, no baseline was regenerated, and no file-level suppressions were added.

| Where | Rule | Resolution |
|---|---|---|
| `LinuxCompression.kt:251` | ThrowsCount, LongMethod, CyclomaticComplexMethod | refactor (4→1 throws, 71→53 lines, 16→11) |
| `AppleCompression.kt:261` | ThrowsCount, LongMethod, CyclomaticComplexMethod | refactor (4→1 throws, 73→55 lines, 16→11) |
| `AppleStreamingCompression.kt:308, :367` | ThrowsCount | refactor (4→2 each) |
| `LinuxStreamingCompression.kt:441, :508` | ThrowsCount | refactor (4→2 each) |
| `LinuxStreamingCompression.kt:508` | CyclomaticComplexMethod | falls out of the refactor (15→13) |
| `LinuxStreamingCompression.kt:441` | CyclomaticComplexMethod | suppress (function scope) |
| `LinuxStreamingCompression.kt:460, :520` | LoopWithTooManyJumpStatements | suppress (function scope) |
| `JvmCommonStreamingCompression.kt:652` | LoopWithTooManyJumpStatements | suppress (function scope) |

**10 refactored, 5 suppressed.**

## Why

Every one of the six `ThrowsCount` sites carried the *same* `Z_NEED_DICT` handler — dictionary
missing → throw, `inflateSetDictionary` failed → throw. That is 2 of the 4 throws at each site, and
it is straight-line error mapping rather than state-machine logic. Hoisting it clears `ThrowsCount`
everywhere at once. The two one-shot decoders additionally hand their stream-init preamble
(`zalloc`/`zfree`/`opaque` + `inflateInit2` + eager raw-mode dictionary) to the same support file,
which is what also clears their `LongMethod` and `CyclomaticComplexMethod`.

New files: `linuxMain/.../LinuxInflateSupport.kt`, `appleMain/.../AppleInflateSupport.kt`.

They live in their own files rather than next to the drivers deliberately: adding three functions to
`LinuxCompression.kt` / `AppleCompression.kt` takes both from 11 to 14 functions and trips
`TooManyFunctions` (max 11). Putting them in-file trades 15 alerts for 2 — a net-zero move. Anyone
extending this should re-run detekt rather than assume a local extraction is free.

The five suppressions are all function-scoped with a rationale comment above them (matching the
repo idiom in `HardwareKeys.linux.kt`). The residual branch and jump counts in the streaming inflate
drivers *are* the zlib state machine: `inflate()`'s result set (`Z_OK` / `Z_STREAM_END` /
`Z_NEED_DICT` / error) crossed with the output-chunk states. In each loop the `continue` is
load-bearing — `Z_NEED_DICT` consumes and produces nothing, so removing it drops into the
"no progress" check and exits the loop early, which is a real bug. Satisfying the rule would require
a Boolean-returning "should I break?" helper that hides the state machine rather than clarifying it.

## Behavior equivalence

- `applyDictionaryOrThrow`, `applyDictionaryOrEndAndThrow` and `initInflateStream` are literal
  lifts: statement order, exception types and exception messages are unchanged.
- `initInflateStream` is called from *inside* the caller's `try`, so the existing
  `finally { nativeHeap.free(s.rawPtr) }` still runs on the init-failure path.
- `applyDictionaryOrEndAndThrow` duplicates four lines of `applyDictionaryOrThrow` rather than
  wrapping it in try/catch — a literal lift is lower risk than introducing exception control flow
  into a native cleanup path. The cost is that a future change to the dictionary error mapping must
  be made in two places per support file.
- `decompressWithZStream`'s `result` narrows from a function-scoped `var` (initialised by
  `inflateInit2`) to a loop-scoped `val` (assigned by `inflate`). It is never read after the loop in
  either file, so this is a variable-lifetime change only. This is the one edit that does more than
  move code.
- The Apple streaming `decompress()` `Z_NEED_DICT` branch still falls through rather than
  `continue`-ing, exactly as before — only Linux's version has the `continue`, and it is preserved.
- `JvmCommonStreamingCompression.kt` gains only a `@Suppress` annotation and a comment. Note this is
  the `JvmInflateStreamingDecompressor` copy of `drainInflater`, not the
  `JvmGzipStreamingDecompressor` copy (which has one jump and was never flagged).

Also drops a now-unused `inflateInit2` import from `LinuxCompression.kt`.

## Verification

| Command | Result |
|---|---|
| `./gradlew ktlintFormat` | BUILD SUCCESSFUL (no changes produced) |
| `./gradlew ktlintCheck` | BUILD SUCCESSFUL |
| `./gradlew detektAll --rerun-tasks` | BUILD SUCCESSFUL — **0** post-baseline findings across all 14 modules (was 15 in `buffer-compression`) |
| `./gradlew :buffer-compression:jvmTest --rerun-tasks` | **178** tests, 0 failures, 0 errors, 0 skipped |
| `./gradlew :buffer-compression:macosArm64Test --rerun-tasks` | **177** tests, 0 failures, 0 errors, 0 skipped |
| `./gradlew :buffer-compression:linuxX64Test --rerun-tasks` | **177** tests, 0 failures, 0 errors, 0 skipped |

Detekt findings were parsed programmatically from SARIF both before and after the change to confirm
the specific 15 alerts are gone and that no new alerts of any rule were introduced. Test counts were
parsed from the JUnit XML to prove the suites actually ran rather than no-op'd on an up-to-date task.

detekt sees `linuxMain` and `appleMain` from any host (`source.setFrom` points at every
`src/*/kotlin` dir, no compilation required), so the static analysis above covers every source set
this PR touches.

`linuxX64Test` was run on a Linux host. The `linuxX64` target is gated behind
`HostManager.hostIsLinux` in `buffer-compression/build.gradle.kts:90`, so on macOS neither
`linuxX64Test` nor even `compileKotlinLinuxX64` exists as a task.

These suites cover every path changed here — `DictionaryTests`, `RawDeflateTests`,
`StreamingCompressionTests`, `ContextTakeoverTests` and `CompressionStressTests` exercise the
`Z_NEED_DICT` handler and both inflate drivers directly, which is exactly where the extraction risk
lives.

### Not run

- Android instrumented tests and `testDebugUnitTest`. Android shares `jvmCommonMain`, where the only
  change is a `@Suppress` annotation plus a comment — no behavior change — but the suites were not
  executed to prove it.
- `jsNodeTest` / `wasmJsTest`. The JS and WASM source sets are untouched by this PR.
