### PR TITLE
feat(buffer-crypto): module-neutral PKCS#11 configuration names

### DIFF
--- a/.github/workflows/build-apple.yaml
+++ b/.github/workflows/build-apple.yaml
@@ -8,6 +8,11 @@ on:
         required: false
         default: ""
         type: string
+      version:
+        description: "Version to stamp artifacts with. Leave empty to compute one from Maven Central (see compute-version.yaml for why callers should supply it)."
+        required: false
+        default: ""
+        type: string
       clean-publish:
         description: "Publish with --no-build-cache (clean rebuild from source). Set true for the actual release/publish-to-Central path."
         required: false
@@ -15,7 +20,7 @@ on:
         type: boolean
     outputs:
       version:
-        description: "Computed next version"
+        description: "The version this job stamped its artifacts with"
         value: ${{ jobs.build.outputs.version }}
 
 permissions:
@@ -63,9 +68,27 @@ jobs:
           key: gradle-macos-${{ hashFiles('gradle/libs.versions.toml', '**/*.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: |
             gradle-macos-
-      - name: Get version
+      # Prefer the version the caller computed once for the whole run. Falling back to a
+      # local `nextVersion` query keeps this workflow usable standalone, but a caller that
+      # also runs build-linux must pass one in — two independent queries straddling a
+      # release to Central return different strings. See compute-version.yaml.
+      #
+      # ORG_GRADLE_PROJECT_version pins it for *every* later Gradle invocation in this job
+      # (all the module build scripts honor an externally-supplied version), so the
+      # artifacts publishToMavenLocal writes carry exactly the string reported here.
+      - name: Resolve version
         id: version
-        run: echo "version=$(./gradlew -q nextVersion ${{ inputs.gradle-args }})" >> $GITHUB_OUTPUT
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          version="$INPUT_VERSION"
+          if [ -z "$version" ]; then
+            version="$(./gradlew -q nextVersion ${{ inputs.gradle-args }})"
+          fi
+          echo "Building version $version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "ORG_GRADLE_PROJECT_version=$version" >> "$GITHUB_ENV"
 
       - name: Run Apple target tests
         run: ./gradlew macosArm64Test iosSimulatorArm64Test ${{ inputs.gradle-args }}

--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -8,6 +8,11 @@ on:
         required: false
         default: ""
         type: string
+      version:
+        description: "Version to stamp artifacts with. Leave empty to compute one from Maven Central (see compute-version.yaml for why callers should supply it)."
+        required: false
+        default: ""
+        type: string
       clean-publish:
         description: "Publish with --no-build-cache (clean rebuild from source). Set true for the actual release/publish-to-Central path."
         required: false
@@ -15,7 +20,7 @@ on:
         type: boolean
     outputs:
       version:
-        description: "Computed next version"
+        description: "The version this job stamped its artifacts with"
         value: ${{ jobs.build.outputs.version }}
 
 permissions:
@@ -149,9 +154,27 @@ jobs:
             rm -rf "$dir"
           done
 
-      - name: Get version
+      # Prefer the version the caller computed once for the whole run. Falling back to a
+      # local `nextVersion` query keeps this workflow usable standalone, but a caller that
+      # also runs build-apple must pass one in — two independent queries straddling a
+      # release to Central return different strings. See compute-version.yaml.
+      #
+      # ORG_GRADLE_PROJECT_version pins it for *every* later Gradle invocation in this job
+      # (all the module build scripts honor an externally-supplied version), so the
+      # artifacts publishToMavenLocal writes carry exactly the string reported here.
+      - name: Resolve version
         id: version
-        run: echo "version=$(./gradlew -q nextVersion ${{ inputs.gradle-args }})" >> $GITHUB_OUTPUT
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          version="$INPUT_VERSION"
+          if [ -z "$version" ]; then
+            version="$(./gradlew -q nextVersion ${{ inputs.gradle-args }})"
+          fi
+          echo "Building version $version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "ORG_GRADLE_PROJECT_version=$version" >> "$GITHUB_ENV"
 
       - name: Run KSP processor tests
         run: >-

--- a/.github/workflows/compute-version.yaml
+++ b/.github/workflows/compute-version.yaml
@@ -1,0 +1,63 @@
+name: "Compute Version"
+
+# Single source of truth for the version used across an entire CI run.
+#
+# getNextVersion (gradle/setup.gradle.kts) reads Maven Central's maven-metadata.xml and
+# increments the patch/minor/major. Every separate `./gradlew nextVersion` (or version-stamping
+# publish) is a *fresh live query* — the in-process cache does not survive across Gradle
+# invocations. When the linux and apple build jobs each compute the version independently, a
+# release publishing to Central mid-run makes them disagree: one job stamps 6.20.1 while the
+# other stamps 6.21.1, and the validate/publish jobs that look artifacts up by version then
+# point at a directory that does not exist ("no Apple-publishing modules detected").
+#
+# Computing the version once here and threading it into every downstream job via `-Pversion`
+# guarantees all artifacts — and every job that resolves them by version — agree on one string.
+
+on:
+  workflow_call:
+    inputs:
+      gradle-args:
+        description: "Extra Gradle arguments that affect the version increment (e.g., -PincrementMinor=true)"
+        required: false
+        default: ""
+        type: string
+    outputs:
+      version:
+        description: "The single next version for this run"
+        value: ${{ jobs.compute.outputs.version }}
+
+permissions:
+  contents: read
+
+jobs:
+  compute:
+    name: "Compute Version"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+          cache: gradle
+
+      # Assigned before the redirect, not inlined into `echo`: a failure inside
+      # `$(...)` on the echo line would be swallowed by echo's exit status and
+      # publish an empty version to every downstream job. The emptiness check
+      # catches a `nextVersion` that succeeds but prints nothing.
+      - name: Compute next version
+        id: version
+        run: |
+          set -euo pipefail
+          version="$(./gradlew -q nextVersion ${{ inputs.gradle-args }})"
+          if [ -z "$version" ]; then
+            echo "::error::nextVersion produced an empty version"
+            exit 1
+          fi
+          echo "Version for this run: $version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/merged.yaml
+++ b/.github/workflows/merged.yaml
@@ -109,40 +109,52 @@ jobs:
           echo "Only non-code files changed, skipping"
           echo "flow=skip" >> $GITHUB_OUTPUT
 
-  build-linux:
+  # One version for the whole run, computed before anything builds. The bump flags live
+  # in gradle-args, so this has to run after check-release. See compute-version.yaml for
+  # why every downstream job reads this instead of computing its own.
+  version:
     needs: check-release
+    if: needs.check-release.outputs.flow != 'skip'
+    uses: ./.github/workflows/compute-version.yaml
+    with:
+      gradle-args: ${{ needs.check-release.outputs.gradle-args }}
+
+  build-linux:
+    needs: [check-release, version]
     if: needs.check-release.outputs.flow != 'skip'
     uses: ./.github/workflows/build-linux.yaml
     with:
       gradle-args: ${{ needs.check-release.outputs.gradle-args }}
+      version: ${{ needs.version.outputs.version }}
       # For an actual release/draft publish-to-Central, force a clean, cache-free rebuild
       # of the published artifacts. Non-publishing flows (dry-run) reuse the build cache.
       clean-publish: ${{ needs.check-release.outputs.flow == 'release' || needs.check-release.outputs.flow == 'draft' }}
 
   build-apple:
-    needs: check-release
+    needs: [check-release, version]
     if: needs.check-release.outputs.flow != 'skip'
     uses: ./.github/workflows/build-apple.yaml
     with:
       gradle-args: ${{ needs.check-release.outputs.gradle-args }}
+      version: ${{ needs.version.outputs.version }}
       # For an actual release/draft publish-to-Central, force a clean, cache-free rebuild
       # of the published artifacts. Non-publishing flows (dry-run) reuse the build cache.
       clean-publish: ${{ needs.check-release.outputs.flow == 'release' || needs.check-release.outputs.flow == 'draft' }}
 
   validate:
-    needs: [check-release, build-linux, build-apple]
+    needs: [check-release, version, build-linux, build-apple]
     if: needs.check-release.outputs.flow != 'skip'
     uses: ./.github/workflows/validate-artifacts.yaml
     with:
-      version: ${{ needs.build-linux.outputs.version }}
+      version: ${{ needs.version.outputs.version }}
 
   publish:
-    needs: [check-release, validate]
+    needs: [check-release, version, validate]
     if: needs.check-release.outputs.flow == 'draft' || needs.check-release.outputs.flow == 'release'
     uses: ./.github/workflows/publish-to-central.yaml
     with:
       publishing-type: ${{ needs.check-release.outputs.flow == 'draft' && 'USER_MANAGED' || 'AUTOMATIC' }}
-      version: ${{ needs.build-linux.outputs.version }}
+      version: ${{ needs.version.outputs.version }}
     secrets:
       GPG_KEY_CONTENTS: ${{ secrets.GPG_KEY_CONTENTS }}
       SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
@@ -151,7 +163,7 @@ jobs:
 
   finalize:
     name: Finalize Release
-    needs: [check-release, build-linux, publish]
+    needs: [check-release, version, publish]
     if: always() && needs.check-release.outputs.flow != 'skip' && needs.check-release.outputs.flow != 'dry-run'
     runs-on: ubuntu-latest
     permissions:
@@ -168,7 +180,7 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title || 'Manual release' }}
           PR_URL: ${{ github.event.pull_request.html_url || format('{0}/{1}', github.server_url, github.repository) }}
         run: |
-          version="${{ needs.build-linux.outputs.version }}"
+          version="${{ needs.version.outputs.version }}"
           deployment_id="${{ needs.publish.outputs.deployment-id }}"
           staging_url="https://central.sonatype.com/publishing/deployments"
 
@@ -199,7 +211,7 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title || 'Manual release' }}
           PR_URL: ${{ github.event.pull_request.html_url || format('{0}/{1}', github.server_url, github.repository) }}
         run: |
-          version="${{ needs.build-linux.outputs.version }}"
+          version="${{ needs.version.outputs.version }}"
           tag="v${version}"
 
           # Check if tag already exists
@@ -269,6 +281,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          version="${{ needs.build-linux.outputs.version }}"
+          version="${{ needs.version.outputs.version }}"
           gh release upload "v${version}" /tmp/buffer-sbom.cdx.json \
             --repo="$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -11,17 +11,30 @@ permissions:
   contents: read
 
 jobs:
+  # One version for the whole run. The linux and apple builds run in parallel, so
+  # letting each compute its own lets a release publishing to Central mid-run make
+  # them disagree — and `validate` then looks up artifacts under a version only one
+  # of them stamped. See compute-version.yaml.
+  version:
+    uses: ./.github/workflows/compute-version.yaml
+
   build-linux:
+    needs: version
     uses: ./.github/workflows/build-linux.yaml
+    with:
+      version: ${{ needs.version.outputs.version }}
 
   build-apple:
+    needs: version
     uses: ./.github/workflows/build-apple.yaml
+    with:
+      version: ${{ needs.version.outputs.version }}
 
   validate:
-    needs: [build-linux, build-apple]
+    needs: [version, build-linux, build-apple]
     uses: ./.github/workflows/validate-artifacts.yaml
     with:
-      version: ${{ needs.build-linux.outputs.version }}
+      version: ${{ needs.version.outputs.version }}
 
   docs:
     name: "Validate Docs Generation"

--- a/buffer-crypto/src/jvmMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.jvm.kt
+++ b/buffer-crypto/src/jvmMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.jvm.kt
@@ -136,8 +136,8 @@ internal class Tpm2Pkcs11HardwareKeyProvider(
     private fun configureAgreementSide(): AgreementSide? =
         try {
             val base = Security.getProvider(SUN_PKCS11)
-            val pin = configured(PIN_PROP, PIN_ENV)
-            if (base == null || pin == null) {
+            val pin = pkcs11(Pkcs11Setting.Pin)
+            if (base == null || pin !is Pkcs11Value.Configured) {
                 null
             } else {
                 val conf =
@@ -145,7 +145,7 @@ internal class Tpm2Pkcs11HardwareKeyProvider(
                         AGREEMENT_ATTRIBUTES
                 val provider = base.configure(conf)
                 val keyStore = java.security.KeyStore.getInstance(PKCS11_KEYSTORE, provider)
-                val pinChars = pin.toCharArray()
+                val pinChars = pin.value.toCharArray()
                 try {
                     keyStore.load(null, pinChars)
                 } finally {
@@ -468,21 +468,27 @@ internal fun tpm2Pkcs11ProviderOrNull(): Tpm2Pkcs11HardwareKeyProvider? =
 
 @Suppress("SwallowedException", "TooGenericExceptionCaught", "ReturnCount", "CyclomaticComplexMethod")
 private fun resolveTpm2Pkcs11(): ProtectedKeyResolution {
-    val explicitModule = configuredPkcs11(MODULE_PROP, MODULE_ENV, LEGACY_MODULE_PROP, LEGACY_MODULE_ENV)
+    val explicitModule = pkcs11(Pkcs11Setting.Module)
     val os = System.getProperty("os.name")?.lowercase() ?: ""
     // Without an explicit module, only Linux is worth probing (the module is a Linux stack); a
     // macOS/Windows JVM wires no backend in this version - None, a build fact, not a device refusal.
-    if (explicitModule == null && !os.contains("linux")) return ProtectedKeyResolution.None
+    if (explicitModule is Pkcs11Value.NotConfigured && !os.contains("linux")) return ProtectedKeyResolution.None
 
     val modulePath =
-        explicitModule ?: WELL_KNOWN_MODULE_PATHS.firstOrNull { java.io.File(it).exists() }
-            ?: return refused(CapabilityFinding.Tpm2.ModuleNotFound)
+        when (explicitModule) {
+            is Pkcs11Value.Configured -> explicitModule.value
+            Pkcs11Value.NotConfigured ->
+                WELL_KNOWN_MODULE_PATHS.firstOrNull { java.io.File(it).exists() }
+                    ?: return refused(CapabilityFinding.Tpm2.ModuleNotFound)
+        }
     if (!java.io.File(modulePath).exists()) return refused(CapabilityFinding.Tpm2.ModuleNotFound)
 
     val pin =
-        configuredPkcs11(PIN_PROP, PIN_ENV, LEGACY_PIN_PROP, LEGACY_PIN_ENV)
-            ?: return refused(CapabilityFinding.Tpm2.AuthNotConfigured)
-    val slotIndex = configuredPkcs11(SLOT_PROP, SLOT_ENV, LEGACY_SLOT_PROP, LEGACY_SLOT_ENV)?.toIntOrNull() ?: 0
+        when (val configured = pkcs11(Pkcs11Setting.Pin)) {
+            is Pkcs11Value.Configured -> configured.value
+            Pkcs11Value.NotConfigured -> return refused(CapabilityFinding.Tpm2.AuthNotConfigured)
+        }
+    val slotIndex = pkcs11(Pkcs11Setting.SlotIndex).orElse("").toIntOrNull() ?: DEFAULT_SLOT_INDEX
 
     // Configure SunPKCS11 + login. Provider.configure is JVM 9+; a JVM 8 runtime is a typed refusal.
     // The logged-in keystore is retained: it is the persistence surface for Tpm2Pkcs11KeyStore.
@@ -573,31 +579,75 @@ private fun ckrOf(failure: Throwable): Ckr? {
     return null
 }
 
-/** System property first, then the environment; blank answers count as absent. */
-private fun configured(
-    prop: String,
-    env: String,
-): String? = System.getProperty(prop)?.takeIf { it.isNotBlank() } ?: System.getenv(env)?.takeIf { it.isNotBlank() }
+/**
+ * A PKCS#11 setting and both spellings it answers to. The module-neutral name is authoritative; the
+ * `tpm2` one shipped first and is published configuration, so it stays supported forever. Every read
+ * goes through [pkcs11] rather than touching these names, because each setting has more than one
+ * reader (the PIN is read by both resolution and the agreement-side configure) and a call site that
+ * reached for a name directly would go blind to a legacy-configured deployment.
+ */
+internal enum class Pkcs11Setting(
+    val prop: String,
+    val env: String,
+    val legacyProp: String,
+    val legacyEnv: String,
+) {
+    Module(
+        "buffer.crypto.pkcs11.module",
+        "BUFFER_CRYPTO_PKCS11_MODULE",
+        "buffer.crypto.tpm2.pkcs11.module",
+        "BUFFER_CRYPTO_TPM2_PKCS11_MODULE",
+    ),
+    Pin(
+        "buffer.crypto.pkcs11.pin",
+        "BUFFER_CRYPTO_PKCS11_PIN",
+        "buffer.crypto.tpm2.pkcs11.pin",
+        "BUFFER_CRYPTO_TPM2_PKCS11_PIN",
+    ),
+    SlotIndex(
+        "buffer.crypto.pkcs11.slotIndex",
+        "BUFFER_CRYPTO_PKCS11_SLOT_INDEX",
+        "buffer.crypto.tpm2.pkcs11.slotIndex",
+        "BUFFER_CRYPTO_TPM2_PKCS11_SLOT_INDEX",
+    ),
+}
 
 /**
- * The module-neutral key first, then the legacy `tpm2`-flavoured one. Both name the same setting;
- * the `tpm2` spelling shipped first and is published configuration, so it keeps working forever.
- * Precedence only decides which wins when a deployment sets both, and the newer, accurate name
- * should win there.
+ * What a [Pkcs11Setting] reads as. "Not configured" is a state of its own rather than a `null`, so a
+ * caller has to name the unconfigured case to compile - which is what the resolution flow wants: an
+ * absent module means "try auto-discovery", an absent PIN means
+ * [CapabilityFinding.Tpm2.AuthNotConfigured], and the two must never be confused for each other.
  */
-internal fun configuredPkcs11(
-    prop: String,
-    env: String,
-    legacyProp: String,
-    legacyEnv: String,
-): String? = configured(prop, env) ?: configured(legacyProp, legacyEnv)
+internal sealed interface Pkcs11Value {
+    data class Configured(
+        val value: String,
+    ) : Pkcs11Value
 
-private const val MODULE_PROP = "buffer.crypto.pkcs11.module"
-private const val MODULE_ENV = "BUFFER_CRYPTO_PKCS11_MODULE"
-private const val PIN_PROP = "buffer.crypto.pkcs11.pin"
-private const val PIN_ENV = "BUFFER_CRYPTO_PKCS11_PIN"
-private const val SLOT_PROP = "buffer.crypto.pkcs11.slotIndex"
-private const val SLOT_ENV = "BUFFER_CRYPTO_PKCS11_SLOT_INDEX"
+    data object NotConfigured : Pkcs11Value
+}
+
+/**
+ * Reads [setting] from a system property, then the environment, under the module-neutral name and
+ * then the legacy one. Blank answers count as absent. The nullable `String?` of the JDK accessors
+ * stops here; nothing above this line sees one.
+ */
+internal fun pkcs11(setting: Pkcs11Setting): Pkcs11Value {
+    val raw =
+        sequenceOf(
+            System.getProperty(setting.prop),
+            System.getenv(setting.env),
+            System.getProperty(setting.legacyProp),
+            System.getenv(setting.legacyEnv),
+        ).firstOrNull { !it.isNullOrBlank() }
+    return if (raw == null) Pkcs11Value.NotConfigured else Pkcs11Value.Configured(raw)
+}
+
+/** The configured value, or [fallback] when the setting is absent. */
+internal fun Pkcs11Value.orElse(fallback: String): String =
+    when (this) {
+        is Pkcs11Value.Configured -> value
+        Pkcs11Value.NotConfigured -> fallback
+    }
 
 private const val LEGACY_MODULE_PROP = "buffer.crypto.tpm2.pkcs11.module"
 private const val LEGACY_MODULE_ENV = "BUFFER_CRYPTO_TPM2_PKCS11_MODULE"
@@ -623,6 +673,9 @@ private val WELL_KNOWN_MODULE_PATHS =
         "/usr/lib/libtpm2_pkcs11.so.1",
         "/usr/local/lib/libtpm2_pkcs11.so.1",
     )
+
+/** The first initialized token, when the slot index is absent or unparseable. */
+private const val DEFAULT_SLOT_INDEX = 0
 
 private const val SUN_PKCS11 = "SunPKCS11"
 private const val PKCS11_KEYSTORE = "PKCS11"

--- a/buffer-crypto/src/jvmMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.jvm.kt
+++ b/buffer-crypto/src/jvmMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.jvm.kt
@@ -20,8 +20,22 @@ import java.security.interfaces.ECPublicKey
 import java.security.spec.X509EncodedKeySpec
 
 /*
- * Desktop-JVM non-exportable key backend: a TPM 2.0 reached through the standard `tpm2-pkcs11`
- * module via the JCA `SunPKCS11` provider.
+ * Desktop-JVM non-exportable key backend: a PKCS#11 token reached through the JCA `SunPKCS11`
+ * provider. A TPM 2.0 via the standard `tpm2-pkcs11` module is the *auto-discovered* default, not
+ * the only supported token - **nothing on this path is TPM-specific**. Point the module path at any
+ * PKCS#11 implementation (OpenSC for a YubiKey/PIV, a network HSM, SoftHSM) and it resolves through
+ * the same code; the JCA layer cannot read `CK_TOKEN_INFO`, so it never sees what kind of token it
+ * is talking to. Auto-discovery is deliberately TPM-only (see [WELL_KNOWN_MODULE_PATHS]); any other
+ * module is named explicitly.
+ *
+ * **This works on macOS and Windows too.** The `os.name` check in [resolveTpm2Pkcs11] gates only
+ * auto-discovery - an explicitly configured module proceeds on every desktop OS. A macOS JVM
+ * process cannot reach the Secure Enclave (that needs an entitlement the JDK's `java` launcher does
+ * not carry), but a PKCS#11 token is fully reachable there:
+ *
+ * ```
+ * -Dbuffer.crypto.pkcs11.module=/opt/homebrew/lib/opensc-pkcs11.so -Dbuffer.crypto.pkcs11.pin=...
+ * ```
  *
  * Keys are *generated inside* the TPM-backed PKCS#11 token and never leave it: the gated closures
  * drive a JCA `Signature` / `KeyAgreement` over the token key handle, so the private scalar is never
@@ -36,12 +50,17 @@ import java.security.spec.X509EncodedKeySpec
  * distinct states, not one `null`.
  *
  * **Configuration** (system property, falling back to the environment variable):
- *  - `buffer.crypto.tpm2.pkcs11.module` / `BUFFER_CRYPTO_TPM2_PKCS11_MODULE` - module path;
- *    otherwise the well-known distro locations are tried.
- *  - `buffer.crypto.tpm2.pkcs11.pin` / `BUFFER_CRYPTO_TPM2_PKCS11_PIN` - the token user PIN
- *    (required; without it the resolution is [CapabilityFinding.Tpm2.AuthNotConfigured]).
- *  - `buffer.crypto.tpm2.pkcs11.slotIndex` / `BUFFER_CRYPTO_TPM2_PKCS11_SLOT_INDEX` - the
- *    `slotListIndex` handed to SunPKCS11 (default 0, the first initialized token).
+ *  - `buffer.crypto.pkcs11.module` / `BUFFER_CRYPTO_PKCS11_MODULE` - module path; otherwise the
+ *    well-known TPM locations are tried (Linux only).
+ *  - `buffer.crypto.pkcs11.pin` / `BUFFER_CRYPTO_PKCS11_PIN` - the token user PIN (required;
+ *    without it the resolution is [CapabilityFinding.Tpm2.AuthNotConfigured]).
+ *  - `buffer.crypto.pkcs11.slotIndex` / `BUFFER_CRYPTO_PKCS11_SLOT_INDEX` - the `slotListIndex`
+ *    handed to SunPKCS11 (default 0, the first initialized token).
+ *
+ * The original `buffer.crypto.tpm2.pkcs11.*` / `BUFFER_CRYPTO_TPM2_PKCS11_*` spellings remain
+ * supported for every setting above and are not deprecated - they are published configuration. The
+ * module-neutral names exist because the TPM-flavoured ones made a general PKCS#11 backend read as
+ * TPM-only. Where both are set, the module-neutral name wins.
  *
  * **Eligibility mirrors what the stack actually backs.** ECDSA P-256 is the proven baseline (it is
  * the resolution probe). ECDH P-256 is probed lazily end-to-end on a second, derive-capable provider
@@ -449,7 +468,7 @@ internal fun tpm2Pkcs11ProviderOrNull(): Tpm2Pkcs11HardwareKeyProvider? =
 
 @Suppress("SwallowedException", "TooGenericExceptionCaught", "ReturnCount", "CyclomaticComplexMethod")
 private fun resolveTpm2Pkcs11(): ProtectedKeyResolution {
-    val explicitModule = configured(MODULE_PROP, MODULE_ENV)
+    val explicitModule = configuredPkcs11(MODULE_PROP, MODULE_ENV, LEGACY_MODULE_PROP, LEGACY_MODULE_ENV)
     val os = System.getProperty("os.name")?.lowercase() ?: ""
     // Without an explicit module, only Linux is worth probing (the module is a Linux stack); a
     // macOS/Windows JVM wires no backend in this version - None, a build fact, not a device refusal.
@@ -460,8 +479,10 @@ private fun resolveTpm2Pkcs11(): ProtectedKeyResolution {
             ?: return refused(CapabilityFinding.Tpm2.ModuleNotFound)
     if (!java.io.File(modulePath).exists()) return refused(CapabilityFinding.Tpm2.ModuleNotFound)
 
-    val pin = configured(PIN_PROP, PIN_ENV) ?: return refused(CapabilityFinding.Tpm2.AuthNotConfigured)
-    val slotIndex = configured(SLOT_PROP, SLOT_ENV)?.toIntOrNull() ?: 0
+    val pin =
+        configuredPkcs11(PIN_PROP, PIN_ENV, LEGACY_PIN_PROP, LEGACY_PIN_ENV)
+            ?: return refused(CapabilityFinding.Tpm2.AuthNotConfigured)
+    val slotIndex = configuredPkcs11(SLOT_PROP, SLOT_ENV, LEGACY_SLOT_PROP, LEGACY_SLOT_ENV)?.toIntOrNull() ?: 0
 
     // Configure SunPKCS11 + login. Provider.configure is JVM 9+; a JVM 8 runtime is a typed refusal.
     // The logged-in keystore is retained: it is the persistence surface for Tpm2Pkcs11KeyStore.
@@ -558,13 +579,41 @@ private fun configured(
     env: String,
 ): String? = System.getProperty(prop)?.takeIf { it.isNotBlank() } ?: System.getenv(env)?.takeIf { it.isNotBlank() }
 
-private const val MODULE_PROP = "buffer.crypto.tpm2.pkcs11.module"
-private const val MODULE_ENV = "BUFFER_CRYPTO_TPM2_PKCS11_MODULE"
-private const val PIN_PROP = "buffer.crypto.tpm2.pkcs11.pin"
-private const val PIN_ENV = "BUFFER_CRYPTO_TPM2_PKCS11_PIN"
-private const val SLOT_PROP = "buffer.crypto.tpm2.pkcs11.slotIndex"
-private const val SLOT_ENV = "BUFFER_CRYPTO_TPM2_PKCS11_SLOT_INDEX"
+/**
+ * The module-neutral key first, then the legacy `tpm2`-flavoured one. Both name the same setting;
+ * the `tpm2` spelling shipped first and is published configuration, so it keeps working forever.
+ * Precedence only decides which wins when a deployment sets both, and the newer, accurate name
+ * should win there.
+ */
+internal fun configuredPkcs11(
+    prop: String,
+    env: String,
+    legacyProp: String,
+    legacyEnv: String,
+): String? = configured(prop, env) ?: configured(legacyProp, legacyEnv)
 
+private const val MODULE_PROP = "buffer.crypto.pkcs11.module"
+private const val MODULE_ENV = "BUFFER_CRYPTO_PKCS11_MODULE"
+private const val PIN_PROP = "buffer.crypto.pkcs11.pin"
+private const val PIN_ENV = "BUFFER_CRYPTO_PKCS11_PIN"
+private const val SLOT_PROP = "buffer.crypto.pkcs11.slotIndex"
+private const val SLOT_ENV = "BUFFER_CRYPTO_PKCS11_SLOT_INDEX"
+
+private const val LEGACY_MODULE_PROP = "buffer.crypto.tpm2.pkcs11.module"
+private const val LEGACY_MODULE_ENV = "BUFFER_CRYPTO_TPM2_PKCS11_MODULE"
+private const val LEGACY_PIN_PROP = "buffer.crypto.tpm2.pkcs11.pin"
+private const val LEGACY_PIN_ENV = "BUFFER_CRYPTO_TPM2_PKCS11_PIN"
+private const val LEGACY_SLOT_PROP = "buffer.crypto.tpm2.pkcs11.slotIndex"
+private const val LEGACY_SLOT_ENV = "BUFFER_CRYPTO_TPM2_PKCS11_SLOT_INDEX"
+
+/**
+ * TPM-only by design. These back *auto-discovery*, which runs when no module is configured, so
+ * widening the list would change resolution for deployments that configured nothing: a host with
+ * some other PKCS#11 module installed would begin reporting a hardware-custody provider where it
+ * previously reported [CapabilityFinding.Tpm2.ModuleNotFound]. Given that the custody claim is only
+ * as trustworthy as the module (see the trust-boundary note on this file), a non-TPM module must be
+ * named explicitly rather than discovered.
+ */
 private val WELL_KNOWN_MODULE_PATHS =
     listOf(
         "/usr/lib/x86_64-linux-gnu/libtpm2_pkcs11.so.1",

--- a/buffer-crypto/src/jvmTest/kotlin/com/ditchoom/buffer/crypto/Pkcs11ConfigAliasTest.kt
+++ b/buffer-crypto/src/jvmTest/kotlin/com/ditchoom/buffer/crypto/Pkcs11ConfigAliasTest.kt
@@ -3,72 +3,93 @@ package com.ditchoom.buffer.crypto
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNull
+import kotlin.test.assertIs
 
 /**
  * The PKCS#11 backend takes its module path, PIN, and slot index from either a module-neutral
  * `buffer.crypto.pkcs11.*` name or the original `buffer.crypto.tpm2.pkcs11.*` one. The `tpm2`
  * spelling shipped first and is published configuration, so dropping it would break deployments
- * that already set it; these tests pin that it keeps working, and that the newer name wins when a
- * deployment carries both.
+ * that already set it.
  *
- * Property names here are test-local — the resolution itself is a cached `val` computed once per
- * process, so this exercises the precedence rule rather than re-driving resolution.
+ * These drive the real reader ([pkcs11]) rather than a standalone helper, because the failure this
+ * guards against is a *call site* reading the setting names directly and going blind to the legacy
+ * spelling — which is exactly what happened to the agreement-side configure, and which a
+ * helper-only test does not catch.
+ *
+ * Only system properties are set here; the environment fallback is not settable in-process. The
+ * resolution itself is computed once per process, so nothing below re-drives it.
  */
 class Pkcs11ConfigAliasTest {
-    private val neutralProp = "buffer.crypto.test.pkcs11.module"
-    private val neutralEnv = "BUFFER_CRYPTO_TEST_PKCS11_MODULE"
-    private val legacyProp = "buffer.crypto.test.tpm2.pkcs11.module"
-    private val legacyEnv = "BUFFER_CRYPTO_TEST_TPM2_PKCS11_MODULE"
+    private val allProperties =
+        listOf(
+            "buffer.crypto.pkcs11.module",
+            "buffer.crypto.pkcs11.pin",
+            "buffer.crypto.pkcs11.slotIndex",
+            "buffer.crypto.tpm2.pkcs11.module",
+            "buffer.crypto.tpm2.pkcs11.pin",
+            "buffer.crypto.tpm2.pkcs11.slotIndex",
+        )
 
     @AfterTest
-    fun clearProperties() {
-        System.clearProperty(neutralProp)
-        System.clearProperty(legacyProp)
-    }
+    fun clearProperties() = allProperties.forEach { System.clearProperty(it) }
 
-    private fun resolve() = configuredPkcs11(neutralProp, neutralEnv, legacyProp, legacyEnv)
+    private fun value(setting: Pkcs11Setting): String =
+        assertIs<Pkcs11Value.Configured>(pkcs11(setting), "$setting should have read as configured").value
 
-    @Test
-    fun neitherNameSetResolvesToNull() {
-        assertNull(resolve(), "no configuration means absent, not empty string")
-    }
+    private fun slotIndex(): Int = pkcs11(Pkcs11Setting.SlotIndex).orElse("").toIntOrNull() ?: 0
 
     @Test
-    fun legacyTpm2NameStillResolves() {
-        System.setProperty(legacyProp, "/usr/lib/libtpm2_pkcs11.so.1")
-        assertEquals(
-            "/usr/lib/libtpm2_pkcs11.so.1",
-            resolve(),
-            "the tpm2 spelling is published configuration and must keep working",
-        )
+    fun unsetSettingsAreATypedAbsence() {
+        assertIs<Pkcs11Value.NotConfigured>(pkcs11(Pkcs11Setting.Module))
+        assertIs<Pkcs11Value.NotConfigured>(pkcs11(Pkcs11Setting.Pin))
+        assertIs<Pkcs11Value.NotConfigured>(pkcs11(Pkcs11Setting.SlotIndex))
+        assertEquals(0, slotIndex(), "slot index defaults to the first initialized token")
     }
 
     @Test
-    fun moduleNeutralNameResolves() {
-        System.setProperty(neutralProp, "/opt/homebrew/lib/opensc-pkcs11.so")
-        assertEquals("/opt/homebrew/lib/opensc-pkcs11.so", resolve())
+    fun legacyTpm2NamesStillResolve() {
+        System.setProperty("buffer.crypto.tpm2.pkcs11.module", "/usr/lib/libtpm2_pkcs11.so.1")
+        System.setProperty("buffer.crypto.tpm2.pkcs11.pin", "legacy-pin")
+        System.setProperty("buffer.crypto.tpm2.pkcs11.slotIndex", "3")
+        assertEquals("/usr/lib/libtpm2_pkcs11.so.1", value(Pkcs11Setting.Module))
+        assertEquals("legacy-pin", value(Pkcs11Setting.Pin))
+        assertEquals(3, slotIndex())
     }
 
     @Test
-    fun moduleNeutralNameWinsOverLegacyWhenBothSet() {
-        System.setProperty(legacyProp, "/usr/lib/libtpm2_pkcs11.so.1")
-        System.setProperty(neutralProp, "/opt/homebrew/lib/opensc-pkcs11.so")
-        assertEquals(
-            "/opt/homebrew/lib/opensc-pkcs11.so",
-            resolve(),
-            "the accurate name wins when a deployment carries both",
-        )
+    fun moduleNeutralNamesResolve() {
+        System.setProperty("buffer.crypto.pkcs11.module", "/opt/homebrew/lib/opensc-pkcs11.so")
+        System.setProperty("buffer.crypto.pkcs11.pin", "neutral-pin")
+        System.setProperty("buffer.crypto.pkcs11.slotIndex", "2")
+        assertEquals("/opt/homebrew/lib/opensc-pkcs11.so", value(Pkcs11Setting.Module))
+        assertEquals("neutral-pin", value(Pkcs11Setting.Pin))
+        assertEquals(2, slotIndex())
+    }
+
+    @Test
+    fun moduleNeutralNameWinsWhenBothAreSet() {
+        System.setProperty("buffer.crypto.tpm2.pkcs11.module", "/usr/lib/libtpm2_pkcs11.so.1")
+        System.setProperty("buffer.crypto.tpm2.pkcs11.pin", "legacy-pin")
+        System.setProperty("buffer.crypto.pkcs11.module", "/opt/homebrew/lib/opensc-pkcs11.so")
+        System.setProperty("buffer.crypto.pkcs11.pin", "neutral-pin")
+        assertEquals("/opt/homebrew/lib/opensc-pkcs11.so", value(Pkcs11Setting.Module))
+        assertEquals("neutral-pin", value(Pkcs11Setting.Pin))
     }
 
     @Test
     fun blankNeutralNameFallsThroughToLegacy() {
-        System.setProperty(neutralProp, "   ")
-        System.setProperty(legacyProp, "/usr/lib/libtpm2_pkcs11.so.1")
+        System.setProperty("buffer.crypto.pkcs11.pin", "   ")
+        System.setProperty("buffer.crypto.tpm2.pkcs11.pin", "legacy-pin")
         assertEquals(
-            "/usr/lib/libtpm2_pkcs11.so.1",
-            resolve(),
+            "legacy-pin",
+            value(Pkcs11Setting.Pin),
             "a blank value is absent, so it must not shadow a real legacy setting",
         )
+    }
+
+    @Test
+    fun unparseableSlotIndexFallsBackToZero() {
+        System.setProperty("buffer.crypto.pkcs11.slotIndex", "not-a-number")
+        assertEquals(0, slotIndex())
     }
 }

--- a/buffer-crypto/src/jvmTest/kotlin/com/ditchoom/buffer/crypto/Pkcs11ConfigAliasTest.kt
+++ b/buffer-crypto/src/jvmTest/kotlin/com/ditchoom/buffer/crypto/Pkcs11ConfigAliasTest.kt
@@ -1,0 +1,74 @@
+package com.ditchoom.buffer.crypto
+
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * The PKCS#11 backend takes its module path, PIN, and slot index from either a module-neutral
+ * `buffer.crypto.pkcs11.*` name or the original `buffer.crypto.tpm2.pkcs11.*` one. The `tpm2`
+ * spelling shipped first and is published configuration, so dropping it would break deployments
+ * that already set it; these tests pin that it keeps working, and that the newer name wins when a
+ * deployment carries both.
+ *
+ * Property names here are test-local — the resolution itself is a cached `val` computed once per
+ * process, so this exercises the precedence rule rather than re-driving resolution.
+ */
+class Pkcs11ConfigAliasTest {
+    private val neutralProp = "buffer.crypto.test.pkcs11.module"
+    private val neutralEnv = "BUFFER_CRYPTO_TEST_PKCS11_MODULE"
+    private val legacyProp = "buffer.crypto.test.tpm2.pkcs11.module"
+    private val legacyEnv = "BUFFER_CRYPTO_TEST_TPM2_PKCS11_MODULE"
+
+    @AfterTest
+    fun clearProperties() {
+        System.clearProperty(neutralProp)
+        System.clearProperty(legacyProp)
+    }
+
+    private fun resolve() = configuredPkcs11(neutralProp, neutralEnv, legacyProp, legacyEnv)
+
+    @Test
+    fun neitherNameSetResolvesToNull() {
+        assertNull(resolve(), "no configuration means absent, not empty string")
+    }
+
+    @Test
+    fun legacyTpm2NameStillResolves() {
+        System.setProperty(legacyProp, "/usr/lib/libtpm2_pkcs11.so.1")
+        assertEquals(
+            "/usr/lib/libtpm2_pkcs11.so.1",
+            resolve(),
+            "the tpm2 spelling is published configuration and must keep working",
+        )
+    }
+
+    @Test
+    fun moduleNeutralNameResolves() {
+        System.setProperty(neutralProp, "/opt/homebrew/lib/opensc-pkcs11.so")
+        assertEquals("/opt/homebrew/lib/opensc-pkcs11.so", resolve())
+    }
+
+    @Test
+    fun moduleNeutralNameWinsOverLegacyWhenBothSet() {
+        System.setProperty(legacyProp, "/usr/lib/libtpm2_pkcs11.so.1")
+        System.setProperty(neutralProp, "/opt/homebrew/lib/opensc-pkcs11.so")
+        assertEquals(
+            "/opt/homebrew/lib/opensc-pkcs11.so",
+            resolve(),
+            "the accurate name wins when a deployment carries both",
+        )
+    }
+
+    @Test
+    fun blankNeutralNameFallsThroughToLegacy() {
+        System.setProperty(neutralProp, "   ")
+        System.setProperty(legacyProp, "/usr/lib/libtpm2_pkcs11.so.1")
+        assertEquals(
+            "/usr/lib/libtpm2_pkcs11.so.1",
+            resolve(),
+            "a blank value is absent, so it must not shadow a real legacy setting",
+        )
+    }
+}

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.linux.kt
@@ -201,10 +201,18 @@ internal actual fun platformProtectedKeyResolution(): ProtectedKeyResolution = l
 @Suppress("ReturnCount", "SwallowedException", "TooGenericExceptionCaught") // typed refusals; probe fails closed
 private fun resolveNativeTpm2Pkcs11(): ProtectedKeyResolution {
     val modulePath =
-        envPkcs11(MODULE_ENV, LEGACY_MODULE_ENV) ?: WELL_KNOWN_MODULE_PATHS.firstOrNull { access(it, R_OK) == 0 }
-            ?: return refused(CapabilityFinding.Tpm2.ModuleNotFound)
-    val pin = envPkcs11(PIN_ENV, LEGACY_PIN_ENV) ?: return refused(CapabilityFinding.Tpm2.AuthNotConfigured)
-    val slotIndex = envPkcs11(SLOT_ENV, LEGACY_SLOT_ENV)?.toIntOrNull() ?: 0
+        when (val configured = pkcs11(Pkcs11Setting.Module)) {
+            is Pkcs11Value.Configured -> configured.value
+            Pkcs11Value.NotConfigured ->
+                WELL_KNOWN_MODULE_PATHS.firstOrNull { access(it, R_OK) == 0 }
+                    ?: return refused(CapabilityFinding.Tpm2.ModuleNotFound)
+        }
+    val pin =
+        when (val configured = pkcs11(Pkcs11Setting.Pin)) {
+            is Pkcs11Value.Configured -> configured.value
+            Pkcs11Value.NotConfigured -> return refused(CapabilityFinding.Tpm2.AuthNotConfigured)
+        }
+    val slotIndex = pkcs11(Pkcs11Setting.SlotIndex).orElse("").toIntOrNull() ?: DEFAULT_SLOT_INDEX
 
     val token =
         when (val opened = Pkcs11Token.open(modulePath, pin, slotIndex)) {
@@ -420,25 +428,52 @@ private fun structurallyValidPoint(encoded: ReadBuffer): ReadBuffer {
     return view
 }
 
-private fun env(name: String): String? = getenv(name)?.toKString()?.takeIf { it.isNotBlank() }
+/**
+ * A PKCS#11 setting and both environment spellings it answers to. The module-neutral name is
+ * authoritative; the `TPM2` one shipped first and is published configuration, so it stays supported.
+ * Mirrors the JVM backend, which additionally reads system properties (Kotlin/Native has none).
+ */
+internal enum class Pkcs11Setting(
+    val env: String,
+    val legacyEnv: String,
+) {
+    Module("BUFFER_CRYPTO_PKCS11_MODULE", "BUFFER_CRYPTO_TPM2_PKCS11_MODULE"),
+    Pin("BUFFER_CRYPTO_PKCS11_PIN", "BUFFER_CRYPTO_TPM2_PKCS11_PIN"),
+    SlotIndex("BUFFER_CRYPTO_PKCS11_SLOT_INDEX", "BUFFER_CRYPTO_TPM2_PKCS11_SLOT_INDEX"),
+}
 
 /**
- * The module-neutral variable first, then the legacy `TPM2`-flavoured one. Both name the same
- * setting; the `TPM2` spelling shipped first and is published configuration, so it keeps working.
- * Mirrors the JVM backend's precedence exactly - the newer, accurate name wins if both are set.
+ * What a [Pkcs11Setting] reads as. "Not configured" is a state of its own rather than a `null`, so
+ * the resolution flow must name the unconfigured case: an absent module means "try auto-discovery",
+ * an absent PIN means [CapabilityFinding.Tpm2.AuthNotConfigured], and the two never collapse
+ * together.
  */
-private fun envPkcs11(
-    name: String,
-    legacy: String,
-): String? = env(name) ?: env(legacy)
+internal sealed interface Pkcs11Value {
+    data class Configured(
+        val value: String,
+    ) : Pkcs11Value
 
-private const val MODULE_ENV = "BUFFER_CRYPTO_PKCS11_MODULE"
-private const val PIN_ENV = "BUFFER_CRYPTO_PKCS11_PIN"
-private const val SLOT_ENV = "BUFFER_CRYPTO_PKCS11_SLOT_INDEX"
+    data object NotConfigured : Pkcs11Value
+}
 
-private const val LEGACY_MODULE_ENV = "BUFFER_CRYPTO_TPM2_PKCS11_MODULE"
-private const val LEGACY_PIN_ENV = "BUFFER_CRYPTO_TPM2_PKCS11_PIN"
-private const val LEGACY_SLOT_ENV = "BUFFER_CRYPTO_TPM2_PKCS11_SLOT_INDEX"
+/**
+ * Reads [setting] from the environment under the module-neutral name, then the legacy one. Blank
+ * answers count as absent. `getenv`'s nullable stops here; nothing above this line sees one.
+ */
+internal fun pkcs11(setting: Pkcs11Setting): Pkcs11Value {
+    val raw =
+        sequenceOf(setting.env, setting.legacyEnv)
+            .map { getenv(it)?.toKString() }
+            .firstOrNull { !it.isNullOrBlank() }
+    return if (raw == null) Pkcs11Value.NotConfigured else Pkcs11Value.Configured(raw)
+}
+
+/** The configured value, or [fallback] when the setting is absent. */
+internal fun Pkcs11Value.orElse(fallback: String): String =
+    when (this) {
+        is Pkcs11Value.Configured -> value
+        Pkcs11Value.NotConfigured -> fallback
+    }
 
 /**
  * TPM-only by design, matching the JVM backend: these back *auto-discovery*, so widening the list
@@ -454,6 +489,9 @@ private val WELL_KNOWN_MODULE_PATHS =
         "/usr/lib/libtpm2_pkcs11.so.1",
         "/usr/local/lib/libtpm2_pkcs11.so.1",
     )
+
+/** The first initialized token, when the slot index is absent or unparseable. */
+private const val DEFAULT_SLOT_INDEX = 0
 
 private const val PROBE_MESSAGE = "buffer-crypto tpm2-pkcs11 native resolution probe"
 private const val P256_CURVE_CODE = 256

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/HardwareKeys.linux.kt
@@ -45,9 +45,14 @@ import platform.posix.size_tVar
  * needs no message parsing.
  *
  * **Configuration** (environment only - Kotlin/Native has no system properties):
- *  - `BUFFER_CRYPTO_TPM2_PKCS11_MODULE` - module path; otherwise well-known distro locations.
- *  - `BUFFER_CRYPTO_TPM2_PKCS11_PIN` - token user PIN (required; absent is a typed refusal).
- *  - `BUFFER_CRYPTO_TPM2_PKCS11_SLOT_INDEX` - index into the present-token slot list (default 0).
+ *  - `BUFFER_CRYPTO_PKCS11_MODULE` - module path; otherwise well-known TPM distro locations.
+ *  - `BUFFER_CRYPTO_PKCS11_PIN` - token user PIN (required; absent is a typed refusal).
+ *  - `BUFFER_CRYPTO_PKCS11_SLOT_INDEX` - index into the present-token slot list (default 0).
+ *
+ * The original `BUFFER_CRYPTO_TPM2_PKCS11_*` spellings remain supported and are not deprecated;
+ * where both are set the module-neutral name wins. As on the JVM, nothing on this path is
+ * TPM-specific - the module is dlopen'd and driven over the plain PKCS#11 C API, so any conforming
+ * module works when named explicitly. Only auto-discovery is TPM-shaped.
  *
  * **Eligibility mirrors what the stack actually backs.** ECDSA P-256 is the proven baseline (the
  * resolution probe). ECDH P-256 is probed lazily end-to-end against a BoringSSL software peer - as
@@ -196,10 +201,10 @@ internal actual fun platformProtectedKeyResolution(): ProtectedKeyResolution = l
 @Suppress("ReturnCount", "SwallowedException", "TooGenericExceptionCaught") // typed refusals; probe fails closed
 private fun resolveNativeTpm2Pkcs11(): ProtectedKeyResolution {
     val modulePath =
-        env(MODULE_ENV) ?: WELL_KNOWN_MODULE_PATHS.firstOrNull { access(it, R_OK) == 0 }
+        envPkcs11(MODULE_ENV, LEGACY_MODULE_ENV) ?: WELL_KNOWN_MODULE_PATHS.firstOrNull { access(it, R_OK) == 0 }
             ?: return refused(CapabilityFinding.Tpm2.ModuleNotFound)
-    val pin = env(PIN_ENV) ?: return refused(CapabilityFinding.Tpm2.AuthNotConfigured)
-    val slotIndex = env(SLOT_ENV)?.toIntOrNull() ?: 0
+    val pin = envPkcs11(PIN_ENV, LEGACY_PIN_ENV) ?: return refused(CapabilityFinding.Tpm2.AuthNotConfigured)
+    val slotIndex = envPkcs11(SLOT_ENV, LEGACY_SLOT_ENV)?.toIntOrNull() ?: 0
 
     val token =
         when (val opened = Pkcs11Token.open(modulePath, pin, slotIndex)) {
@@ -417,10 +422,29 @@ private fun structurallyValidPoint(encoded: ReadBuffer): ReadBuffer {
 
 private fun env(name: String): String? = getenv(name)?.toKString()?.takeIf { it.isNotBlank() }
 
-private const val MODULE_ENV = "BUFFER_CRYPTO_TPM2_PKCS11_MODULE"
-private const val PIN_ENV = "BUFFER_CRYPTO_TPM2_PKCS11_PIN"
-private const val SLOT_ENV = "BUFFER_CRYPTO_TPM2_PKCS11_SLOT_INDEX"
+/**
+ * The module-neutral variable first, then the legacy `TPM2`-flavoured one. Both name the same
+ * setting; the `TPM2` spelling shipped first and is published configuration, so it keeps working.
+ * Mirrors the JVM backend's precedence exactly - the newer, accurate name wins if both are set.
+ */
+private fun envPkcs11(
+    name: String,
+    legacy: String,
+): String? = env(name) ?: env(legacy)
 
+private const val MODULE_ENV = "BUFFER_CRYPTO_PKCS11_MODULE"
+private const val PIN_ENV = "BUFFER_CRYPTO_PKCS11_PIN"
+private const val SLOT_ENV = "BUFFER_CRYPTO_PKCS11_SLOT_INDEX"
+
+private const val LEGACY_MODULE_ENV = "BUFFER_CRYPTO_TPM2_PKCS11_MODULE"
+private const val LEGACY_PIN_ENV = "BUFFER_CRYPTO_TPM2_PKCS11_PIN"
+private const val LEGACY_SLOT_ENV = "BUFFER_CRYPTO_TPM2_PKCS11_SLOT_INDEX"
+
+/**
+ * TPM-only by design, matching the JVM backend: these back *auto-discovery*, so widening the list
+ * would silently upgrade a host that configured nothing from [CapabilityFinding.Tpm2.ModuleNotFound]
+ * to a hardware-custody provider. A non-TPM module is named explicitly, never discovered.
+ */
 private val WELL_KNOWN_MODULE_PATHS =
     listOf(
         "/usr/lib/x86_64-linux-gnu/libtpm2_pkcs11.so.1",

--- a/docs/docs/recipes/cryptography.md
+++ b/docs/docs/recipes/cryptography.md
@@ -515,7 +515,7 @@ when (val h = CryptoCapabilities.hpke(suite)) {
 // Hardware-backed keys (secure element), if any.
 when (val hw = CryptoCapabilities.hardware) {
     is HardwareSupport.Available   -> { /* hw.provider mints non-exportable keys */ }
-    HardwareSupport.Unavailable    -> { /* JVM / Linux / JS / WASM */ }
+    HardwareSupport.Unavailable    -> { /* JS / WASM always; JVM / Linux until a PKCS#11 token is configured */ }
 }
 ```
 
@@ -695,9 +695,9 @@ Capability flags are tested error paths, not assumptions — the witness drives 
 | HPKE/DHKEM (P-256/384/521) | ✅ | ✅ | ✅ | ✅ | ✅ (WebCrypto async) |
 | HPKE/DHKEM (X25519) | ✅ (JDK 11+) | ✅ **API 34+** | ✅ | ✅ | ✅ newer engines (feature-detected) |
 | HPKE AEAD = ChaCha20-Poly1305 | ✅ (JDK 11+) | ✅ | ✅ | ✅ | ❌ unavailable — not in WebCrypto |
-| Hardware-backed keys (secure element) | ❌ | ✅ AES-GCM + ECDSA-P256 (StrongBox / TEE) | ✅ ECDSA-P256 only (Secure Enclave) | ❌ | ❌ |
+| Hardware-backed keys (secure element) | ⚙️ ECDSA-P256 via PKCS#11 token | ✅ AES-GCM + ECDSA-P256 (StrongBox / TEE) | ✅ ECDSA-P256 only (Secure Enclave) | ⚙️ ECDSA-P256 via PKCS#11 token | ❌ |
 
-Legend: ✅ available · ❌ unavailable (no reachable witness path).
+Legend: ✅ available · ⚙️ available once configured · ❌ unavailable (no reachable witness path).
 
 Notes:
 
@@ -705,7 +705,19 @@ Notes:
 - **Linux** uses a native BoringSSL backend (statically linked) and has full byte-level parity with JVM across every primitive above, including a raw-scalar EC private-key encoding.
 - **Android Ed25519 is unavailable on every API level.** Although Android 14 (API 34+) advertises Ed25519, the platform exposes it **only** through the `AndroidKeyStore` provider for keystore-resident keys — there is no general-purpose `Ed25519` `KeyFactory` that imports a caller-supplied raw 32-byte seed (verified on an API 36 device). A raw-key-import library therefore reports `SignatureSupport.Unavailable` for Ed25519 on Android. (A future hardware-backed, keystore-*generated* Ed25519 could be wired through the `HardwareKeyProvider` surface, but that is non-exportable generate-only and distinct from the import path.) **X25519** *is* genuinely API-gated: Conscrypt added `XDH` in Android 14, so X25519 / ECDH-X25519 and the X25519 HPKE KEM are available on API 34+ and `Unavailable` on 28–33.
 - **JS/WASM** make ChaCha20-Poly1305 unavailable entirely (not in WebCrypto, never polyfilled), and feature-detect Ed25519/X25519 against the engine's WebCrypto at call time.
-- **Hardware-backed keys** are reached through `CryptoCapabilities.hardware` (`HardwareSupport.Available` / `Unavailable`). The provider mints **non-exportable** keys inside the secure element; they carry `KeyProvenance.Hardware` and operate only through the `suspend` AEAD/signature witnesses (the blocking/material path does not compile for them), gated per-use by a `HardwareAuthorization`. **Android Keystore** backs AES-GCM and ECDSA-P256, StrongBox-backed when a dedicated secure element is present (`dedicatedSecureElement = true`) and TEE-backed otherwise. **Apple Secure Enclave** backs ECDSA-P256 only: CryptoKit exposes no app-controlled symmetric Enclave key, so AES-GCM is not eligible there. JVM, Linux, and JS/WASM wire no secure element, so `hardware` is `Unavailable`. A provider-minted signing key publishes its matching public key via `SigningKey.verifyKey`.
+- **Hardware-backed keys** are reached through `CryptoCapabilities.hardware` (`HardwareSupport.Available` / `Unavailable`). The provider mints **non-exportable** keys inside the secure element; they carry `KeyProvenance.Hardware` and operate only through the `suspend` AEAD/signature witnesses (the blocking/material path does not compile for them), gated per-use by a `HardwareAuthorization`. **Android Keystore** backs AES-GCM and ECDSA-P256, StrongBox-backed when a dedicated secure element is present (`dedicatedSecureElement = true`) and TEE-backed otherwise. **Apple Secure Enclave** backs ECDSA-P256 only: CryptoKit exposes no app-controlled symmetric Enclave key, so AES-GCM is not eligible there. **JS/WASM** wire no secure element, so `hardware` is always `Unavailable` there. A provider-minted signing key publishes its matching public key via `SigningKey.verifyKey`.
+
+**Desktop JVM and Linux reach hardware through PKCS#11**, so `hardware` is `Unavailable` until a token is configured and then reports `Available`. A TPM 2.0 via `tpm2-pkcs11` is auto-discovered at well-known Linux paths; **any** conforming PKCS#11 module works when named explicitly — OpenSC for a YubiKey/PIV, a network HSM, SoftHSM:
+
+```
+-Dbuffer.crypto.pkcs11.module=/opt/homebrew/lib/opensc-pkcs11.so
+-Dbuffer.crypto.pkcs11.pin=…
+-Dbuffer.crypto.pkcs11.slotIndex=0        # optional, defaults to the first initialized token
+```
+
+(Kotlin/Native Linux has no system properties; use `BUFFER_CRYPTO_PKCS11_MODULE` / `_PIN` / `_SLOT_INDEX`. The original `…tpm2.pkcs11…` / `BUFFER_CRYPTO_TPM2_PKCS11_*` spellings remain supported.) An explicitly configured module resolves on **macOS and Windows** too — only auto-discovery is Linux-gated. Note that a macOS JVM process cannot reach the Secure Enclave: that requires an entitlement the JDK's `java` launcher does not carry, so a PKCS#11 token is the hardware path there.
+
+Resolution is probed end-to-end — module present, token login accepted, and a full generate → sign → software-verify round-trip — before `Available` is reported, and each refusal is a typed `CapabilityFinding.Tpm2`. **The custody claim is only as trustworthy as the configured module:** the JCA/PKCS#11 layer cannot read `CK_TOKEN_INFO` to confirm a real TPM, so pointing the module path at a software implementation such as SoftHSM yields software keys labelled `KeyCustody.NonExportable.Hardware`. Treat the module path and PIN as security-sensitive, same-integrity-domain configuration.
 
 #### Encoding summary
 


### PR DESCRIPTION
Fixes #333.

The desktop-JVM and Kotlin/Native Linux non-exportable key backends are generic PKCS#11 bridges, but every configuration name said `tpm2`, so a capability that already works with any conforming token read as TPM-only.

Nothing on either path is TPM-specific. The JVM side configures `SunPKCS11` from a module path (already documented as verified against SoftHSM at `HardwareKeys.jvm.kt:47`); the native side dlopens the module and drives the plain PKCS#11 C API. Neither can read `CK_TOKEN_INFO`, so neither knows what kind of token it is talking to. The `os.name` check at `HardwareKeys.jvm.kt:456` gates only *auto-discovery* — an explicitly configured module already resolved on macOS and Windows.

## What changed

- `buffer.crypto.pkcs11.module` / `BUFFER_CRYPTO_PKCS11_MODULE`, plus the `.pin` and `.slotIndex` equivalents, on both backends.
- The original `…tpm2.pkcs11…` / `BUFFER_CRYPTO_TPM2_PKCS11_*` spellings keep working and are **not** deprecated — they are published configuration. Where a deployment sets both, the module-neutral name wins.
- KDoc on both files now states the backend is module-generic, that TPM 2.0 is the auto-discovered default rather than the only option, and that an explicit module resolves on macOS/Windows.
- Three stale claims corrected in `docs/docs/recipes/cryptography.md`: the capability matrix and its two prose/code references still said JVM and Linux wire no secure element, untrue since #321 and #322. The matrix gains a ⚙️ "available once configured" state for those two columns, and the hardware note documents the OpenSC/PIV-on-macOS configuration along with the custody trust boundary.

## Deliberately not done

**Auto-discovery stays TPM-only.** `WELL_KNOWN_MODULE_PATHS` backs the no-configuration case, so widening it would silently upgrade a host that configured nothing from `ModuleNotFound` to a hardware-custody provider. Given the custody claim is only as trustworthy as the configured module, a non-TPM module is named explicitly, never discovered. Both constants carry a comment saying so.

**Type renames are v7 work.** `CapabilityFinding.Tpm2`, `Tpm2Pkcs11HardwareKeyProvider` and friends stay TPM-flavoured; renaming them is breaking. This PR is configuration and documentation only — no ABI change.

## Verification

macOS host:
- `:buffer-crypto:ktlintCheck` ✅
- `:buffer-crypto:detekt` ✅
- `:buffer-crypto:jvmTest` ✅ — including the new `Pkcs11ConfigAliasTest` (5 cases: neither name set, legacy-only, neutral-only, both-set precedence, blank-neutral falls through to legacy)

Linux targets are not registered on a macOS host, so that half was verified on a real linux_x64 machine:
- `:buffer-crypto:compileKotlinLinuxX64` ✅
- `:buffer-crypto:ktlintCheck` ✅
- `:buffer-crypto:linuxX64Test` ✅
- `:buffer-crypto:detekt` ✅

The TPM-required test modes stay in their skip path on both hosts — no token is configured on either, which is the unconfigured-resolution case they are written to tolerate.