### PR TITLE
feat(buffer-crypto): UserVerification — interactive biometric/credential availability with remedy closures

### DIFF
--- a/buffer-crypto/api/android/buffer-crypto.api
+++ b/buffer-crypto/api/android/buffer-crypto.api
@@ -191,6 +191,119 @@ public abstract interface class com/ditchoom/buffer/crypto/BiometricAuthorizatio
 	public abstract fun authenticate (Lcom/ditchoom/buffer/crypto/UserAuthenticationMethod;Landroidx/biometric/BiometricPrompt$CryptoObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public abstract interface class com/ditchoom/buffer/crypto/BiometricAvailability {
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/BiometricAvailability$Actionable : com/ditchoom/buffer/crypto/BiometricAvailability {
+}
+
+public final class com/ditchoom/buffer/crypto/BiometricAvailability$Actionable$DeviceLockNotSet : com/ditchoom/buffer/crypto/BiometricAvailability$Actionable {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/BiometricAvailability$Actionable$DeviceLockNotSet;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/BiometricAvailability$Actionable$LockedOutTemporarily : com/ditchoom/buffer/crypto/BiometricAvailability$Actionable {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/BiometricAvailability$Actionable$LockedOutTemporarily;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/BiometricAvailability$Actionable$LockedOutUntilCredential : com/ditchoom/buffer/crypto/BiometricAvailability$Actionable {
+	public abstract fun unlockWithDeviceCredential (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/BiometricAvailability$Actionable$NotEnrolled : com/ditchoom/buffer/crypto/BiometricAvailability$Actionable {
+	public abstract fun getModality ()Lcom/ditchoom/buffer/crypto/BiometricModality;
+	public abstract fun getOpenEnrollment ()Lkotlin/jvm/functions/Function1;
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/BiometricAvailability$Actionable$PermissionDenied : com/ditchoom/buffer/crypto/BiometricAvailability$Actionable {
+	public abstract fun openAppSettings (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/ditchoom/buffer/crypto/BiometricAvailability$Actionable$SecurityUpdateRequired : com/ditchoom/buffer/crypto/BiometricAvailability$Actionable {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/BiometricAvailability$Actionable$SecurityUpdateRequired;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/BiometricAvailability$Actionable$SensorDisconnected : com/ditchoom/buffer/crypto/BiometricAvailability$Actionable {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/BiometricAvailability$Actionable$SensorDisconnected;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/BiometricAvailability$Actionable$SensorNotPaired : com/ditchoom/buffer/crypto/BiometricAvailability$Actionable {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/BiometricAvailability$Actionable$SensorNotPaired;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/BiometricAvailability$Indeterminate : com/ditchoom/buffer/crypto/BiometricAvailability {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/BiometricAvailability$Indeterminate;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/BiometricAvailability$Ready : com/ditchoom/buffer/crypto/BiometricAvailability {
+	public fun <init> (Lcom/ditchoom/buffer/crypto/BiometricModality;)V
+	public final fun component1 ()Lcom/ditchoom/buffer/crypto/BiometricModality;
+	public final fun copy (Lcom/ditchoom/buffer/crypto/BiometricModality;)Lcom/ditchoom/buffer/crypto/BiometricAvailability$Ready;
+	public static synthetic fun copy$default (Lcom/ditchoom/buffer/crypto/BiometricAvailability$Ready;Lcom/ditchoom/buffer/crypto/BiometricModality;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/BiometricAvailability$Ready;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getModality ()Lcom/ditchoom/buffer/crypto/BiometricModality;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/BiometricAvailability$Unavailable : com/ditchoom/buffer/crypto/BiometricAvailability {
+}
+
+public final class com/ditchoom/buffer/crypto/BiometricAvailability$Unavailable$NoHardware : com/ditchoom/buffer/crypto/BiometricAvailability$Unavailable {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/BiometricAvailability$Unavailable$NoHardware;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/BiometricAvailability$Unavailable$NotSupportedByOs : com/ditchoom/buffer/crypto/BiometricAvailability$Unavailable {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/BiometricAvailability$Unavailable$NotSupportedByOs;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/BiometricAvailability$Unavailable$OnlyWeakBiometrics : com/ditchoom/buffer/crypto/BiometricAvailability$Unavailable {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/BiometricAvailability$Unavailable$OnlyWeakBiometrics;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/BiometricAvailability$Unavailable$TemporarilyUnavailable : com/ditchoom/buffer/crypto/BiometricAvailability$Unavailable {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/BiometricAvailability$Unavailable$TemporarilyUnavailable;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/BiometricModality : java/lang/Enum {
+	public static final field Face Lcom/ditchoom/buffer/crypto/BiometricModality;
+	public static final field Fingerprint Lcom/ditchoom/buffer/crypto/BiometricModality;
+	public static final field Iris Lcom/ditchoom/buffer/crypto/BiometricModality;
+	public static final field Unspecified Lcom/ditchoom/buffer/crypto/BiometricModality;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/ditchoom/buffer/crypto/BiometricModality;
+	public static fun values ()[Lcom/ditchoom/buffer/crypto/BiometricModality;
+}
+
 public final class com/ditchoom/buffer/crypto/BiometricPromptAuthenticator : com/ditchoom/buffer/crypto/BiometricAuthorization {
 	public fun <init> (Landroidx/fragment/app/FragmentActivity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Landroidx/fragment/app/FragmentActivity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -439,6 +552,14 @@ public final class com/ditchoom/buffer/crypto/CustodyTier : java/lang/Enum {
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/ditchoom/buffer/crypto/CustodyTier;
 	public static fun values ()[Lcom/ditchoom/buffer/crypto/CustodyTier;
+}
+
+public final class com/ditchoom/buffer/crypto/DeviceCredentialAvailability : java/lang/Enum {
+	public static final field Available Lcom/ditchoom/buffer/crypto/DeviceCredentialAvailability;
+	public static final field NotSet Lcom/ditchoom/buffer/crypto/DeviceCredentialAvailability;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/ditchoom/buffer/crypto/DeviceCredentialAvailability;
+	public static fun values ()[Lcom/ditchoom/buffer/crypto/DeviceCredentialAvailability;
 }
 
 public final class com/ditchoom/buffer/crypto/EcEncodingError : java/lang/Enum {
@@ -1360,6 +1481,15 @@ public abstract interface class com/ditchoom/buffer/crypto/PerUseAgreementCapabl
 	public abstract fun generateKeyAgreement (Lcom/ditchoom/buffer/crypto/KeyAgreementCurve;Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy$PerUse;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class com/ditchoom/buffer/crypto/PromptOutcome : java/lang/Enum {
+	public static final field Failed Lcom/ditchoom/buffer/crypto/PromptOutcome;
+	public static final field Succeeded Lcom/ditchoom/buffer/crypto/PromptOutcome;
+	public static final field UserCancelled Lcom/ditchoom/buffer/crypto/PromptOutcome;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/ditchoom/buffer/crypto/PromptOutcome;
+	public static fun values ()[Lcom/ditchoom/buffer/crypto/PromptOutcome;
+}
+
 public final class com/ditchoom/buffer/crypto/ProtectedKeyAlgorithm : java/lang/Enum {
 	public static final field AesGcm Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
 	public static final field EcdhP256 Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
@@ -1899,6 +2029,37 @@ public final class com/ditchoom/buffer/crypto/UserAuthenticationPolicy$Session :
 }
 
 public abstract interface class com/ditchoom/buffer/crypto/UserAuthenticationPolicy$Windowed : com/ditchoom/buffer/crypto/UserAuthenticationPolicy {
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/UserVerification {
+	public abstract fun availability ()Lcom/ditchoom/buffer/crypto/UserVerificationAvailability;
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/UserVerificationAvailability {
+}
+
+public final class com/ditchoom/buffer/crypto/UserVerificationAvailability$Supported : com/ditchoom/buffer/crypto/UserVerificationAvailability {
+	public fun <init> (Lcom/ditchoom/buffer/crypto/BiometricAvailability;Lcom/ditchoom/buffer/crypto/DeviceCredentialAvailability;)V
+	public final fun component1 ()Lcom/ditchoom/buffer/crypto/BiometricAvailability;
+	public final fun component2 ()Lcom/ditchoom/buffer/crypto/DeviceCredentialAvailability;
+	public final fun copy (Lcom/ditchoom/buffer/crypto/BiometricAvailability;Lcom/ditchoom/buffer/crypto/DeviceCredentialAvailability;)Lcom/ditchoom/buffer/crypto/UserVerificationAvailability$Supported;
+	public static synthetic fun copy$default (Lcom/ditchoom/buffer/crypto/UserVerificationAvailability$Supported;Lcom/ditchoom/buffer/crypto/BiometricAvailability;Lcom/ditchoom/buffer/crypto/DeviceCredentialAvailability;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/UserVerificationAvailability$Supported;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBiometric ()Lcom/ditchoom/buffer/crypto/BiometricAvailability;
+	public final fun getDeviceCredential ()Lcom/ditchoom/buffer/crypto/DeviceCredentialAvailability;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/UserVerificationAvailability$Unsupported : com/ditchoom/buffer/crypto/UserVerificationAvailability {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/UserVerificationAvailability$Unsupported;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/UserVerification_androidKt {
+	public static final fun userVerification (Landroidx/fragment/app/FragmentActivity;)Lcom/ditchoom/buffer/crypto/UserVerification;
 }
 
 public final class com/ditchoom/buffer/crypto/VerificationFailed : com/ditchoom/buffer/crypto/CryptoException {

--- a/buffer-crypto/api/android/buffer-crypto.api
+++ b/buffer-crypto/api/android/buffer-crypto.api
@@ -197,11 +197,8 @@ public abstract interface class com/ditchoom/buffer/crypto/BiometricAvailability
 public abstract interface class com/ditchoom/buffer/crypto/BiometricAvailability$Actionable : com/ditchoom/buffer/crypto/BiometricAvailability {
 }
 
-public final class com/ditchoom/buffer/crypto/BiometricAvailability$Actionable$DeviceLockNotSet : com/ditchoom/buffer/crypto/BiometricAvailability$Actionable {
-	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/BiometricAvailability$Actionable$DeviceLockNotSet;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
+public abstract interface class com/ditchoom/buffer/crypto/BiometricAvailability$Actionable$DeviceLockNotSet : com/ditchoom/buffer/crypto/BiometricAvailability$Actionable {
+	public abstract fun getOpenDeviceLockSetup ()Lkotlin/jvm/functions/Function1;
 }
 
 public final class com/ditchoom/buffer/crypto/BiometricAvailability$Actionable$LockedOutTemporarily : com/ditchoom/buffer/crypto/BiometricAvailability$Actionable {

--- a/buffer-crypto/api/jvm/buffer-crypto.api
+++ b/buffer-crypto/api/jvm/buffer-crypto.api
@@ -189,11 +189,8 @@ public abstract interface class com/ditchoom/buffer/crypto/BiometricAvailability
 public abstract interface class com/ditchoom/buffer/crypto/BiometricAvailability$Actionable : com/ditchoom/buffer/crypto/BiometricAvailability {
 }
 
-public final class com/ditchoom/buffer/crypto/BiometricAvailability$Actionable$DeviceLockNotSet : com/ditchoom/buffer/crypto/BiometricAvailability$Actionable {
-	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/BiometricAvailability$Actionable$DeviceLockNotSet;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
+public abstract interface class com/ditchoom/buffer/crypto/BiometricAvailability$Actionable$DeviceLockNotSet : com/ditchoom/buffer/crypto/BiometricAvailability$Actionable {
+	public abstract fun getOpenDeviceLockSetup ()Lkotlin/jvm/functions/Function1;
 }
 
 public final class com/ditchoom/buffer/crypto/BiometricAvailability$Actionable$LockedOutTemporarily : com/ditchoom/buffer/crypto/BiometricAvailability$Actionable {

--- a/buffer-crypto/api/jvm/buffer-crypto.api
+++ b/buffer-crypto/api/jvm/buffer-crypto.api
@@ -183,6 +183,119 @@ public final class com/ditchoom/buffer/crypto/AesGcmKey$DefaultImpls {
 public final class com/ditchoom/buffer/crypto/AuthorizationFailed : com/ditchoom/buffer/crypto/CryptoMisuseException {
 }
 
+public abstract interface class com/ditchoom/buffer/crypto/BiometricAvailability {
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/BiometricAvailability$Actionable : com/ditchoom/buffer/crypto/BiometricAvailability {
+}
+
+public final class com/ditchoom/buffer/crypto/BiometricAvailability$Actionable$DeviceLockNotSet : com/ditchoom/buffer/crypto/BiometricAvailability$Actionable {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/BiometricAvailability$Actionable$DeviceLockNotSet;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/BiometricAvailability$Actionable$LockedOutTemporarily : com/ditchoom/buffer/crypto/BiometricAvailability$Actionable {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/BiometricAvailability$Actionable$LockedOutTemporarily;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/BiometricAvailability$Actionable$LockedOutUntilCredential : com/ditchoom/buffer/crypto/BiometricAvailability$Actionable {
+	public abstract fun unlockWithDeviceCredential (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/BiometricAvailability$Actionable$NotEnrolled : com/ditchoom/buffer/crypto/BiometricAvailability$Actionable {
+	public abstract fun getModality ()Lcom/ditchoom/buffer/crypto/BiometricModality;
+	public abstract fun getOpenEnrollment ()Lkotlin/jvm/functions/Function1;
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/BiometricAvailability$Actionable$PermissionDenied : com/ditchoom/buffer/crypto/BiometricAvailability$Actionable {
+	public abstract fun openAppSettings (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/ditchoom/buffer/crypto/BiometricAvailability$Actionable$SecurityUpdateRequired : com/ditchoom/buffer/crypto/BiometricAvailability$Actionable {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/BiometricAvailability$Actionable$SecurityUpdateRequired;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/BiometricAvailability$Actionable$SensorDisconnected : com/ditchoom/buffer/crypto/BiometricAvailability$Actionable {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/BiometricAvailability$Actionable$SensorDisconnected;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/BiometricAvailability$Actionable$SensorNotPaired : com/ditchoom/buffer/crypto/BiometricAvailability$Actionable {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/BiometricAvailability$Actionable$SensorNotPaired;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/BiometricAvailability$Indeterminate : com/ditchoom/buffer/crypto/BiometricAvailability {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/BiometricAvailability$Indeterminate;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/BiometricAvailability$Ready : com/ditchoom/buffer/crypto/BiometricAvailability {
+	public fun <init> (Lcom/ditchoom/buffer/crypto/BiometricModality;)V
+	public final fun component1 ()Lcom/ditchoom/buffer/crypto/BiometricModality;
+	public final fun copy (Lcom/ditchoom/buffer/crypto/BiometricModality;)Lcom/ditchoom/buffer/crypto/BiometricAvailability$Ready;
+	public static synthetic fun copy$default (Lcom/ditchoom/buffer/crypto/BiometricAvailability$Ready;Lcom/ditchoom/buffer/crypto/BiometricModality;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/BiometricAvailability$Ready;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getModality ()Lcom/ditchoom/buffer/crypto/BiometricModality;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/BiometricAvailability$Unavailable : com/ditchoom/buffer/crypto/BiometricAvailability {
+}
+
+public final class com/ditchoom/buffer/crypto/BiometricAvailability$Unavailable$NoHardware : com/ditchoom/buffer/crypto/BiometricAvailability$Unavailable {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/BiometricAvailability$Unavailable$NoHardware;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/BiometricAvailability$Unavailable$NotSupportedByOs : com/ditchoom/buffer/crypto/BiometricAvailability$Unavailable {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/BiometricAvailability$Unavailable$NotSupportedByOs;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/BiometricAvailability$Unavailable$OnlyWeakBiometrics : com/ditchoom/buffer/crypto/BiometricAvailability$Unavailable {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/BiometricAvailability$Unavailable$OnlyWeakBiometrics;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/BiometricAvailability$Unavailable$TemporarilyUnavailable : com/ditchoom/buffer/crypto/BiometricAvailability$Unavailable {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/BiometricAvailability$Unavailable$TemporarilyUnavailable;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/BiometricModality : java/lang/Enum {
+	public static final field Face Lcom/ditchoom/buffer/crypto/BiometricModality;
+	public static final field Fingerprint Lcom/ditchoom/buffer/crypto/BiometricModality;
+	public static final field Iris Lcom/ditchoom/buffer/crypto/BiometricModality;
+	public static final field Unspecified Lcom/ditchoom/buffer/crypto/BiometricModality;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/ditchoom/buffer/crypto/BiometricModality;
+	public static fun values ()[Lcom/ditchoom/buffer/crypto/BiometricModality;
+}
+
 public abstract interface class com/ditchoom/buffer/crypto/CapabilityFinding {
 }
 
@@ -424,6 +537,14 @@ public final class com/ditchoom/buffer/crypto/CustodyTier : java/lang/Enum {
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/ditchoom/buffer/crypto/CustodyTier;
 	public static fun values ()[Lcom/ditchoom/buffer/crypto/CustodyTier;
+}
+
+public final class com/ditchoom/buffer/crypto/DeviceCredentialAvailability : java/lang/Enum {
+	public static final field Available Lcom/ditchoom/buffer/crypto/DeviceCredentialAvailability;
+	public static final field NotSet Lcom/ditchoom/buffer/crypto/DeviceCredentialAvailability;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/ditchoom/buffer/crypto/DeviceCredentialAvailability;
+	public static fun values ()[Lcom/ditchoom/buffer/crypto/DeviceCredentialAvailability;
 }
 
 public final class com/ditchoom/buffer/crypto/EcEncodingError : java/lang/Enum {
@@ -1345,6 +1466,15 @@ public abstract interface class com/ditchoom/buffer/crypto/PerUseAgreementCapabl
 	public abstract fun generateKeyAgreement (Lcom/ditchoom/buffer/crypto/KeyAgreementCurve;Lcom/ditchoom/buffer/crypto/UserAuthenticationPolicy$PerUse;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class com/ditchoom/buffer/crypto/PromptOutcome : java/lang/Enum {
+	public static final field Failed Lcom/ditchoom/buffer/crypto/PromptOutcome;
+	public static final field Succeeded Lcom/ditchoom/buffer/crypto/PromptOutcome;
+	public static final field UserCancelled Lcom/ditchoom/buffer/crypto/PromptOutcome;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/ditchoom/buffer/crypto/PromptOutcome;
+	public static fun values ()[Lcom/ditchoom/buffer/crypto/PromptOutcome;
+}
+
 public final class com/ditchoom/buffer/crypto/ProtectedKeyAlgorithm : java/lang/Enum {
 	public static final field AesGcm Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
 	public static final field EcdhP256 Lcom/ditchoom/buffer/crypto/ProtectedKeyAlgorithm;
@@ -1882,6 +2012,37 @@ public final class com/ditchoom/buffer/crypto/UserAuthenticationPolicy$Session :
 }
 
 public abstract interface class com/ditchoom/buffer/crypto/UserAuthenticationPolicy$Windowed : com/ditchoom/buffer/crypto/UserAuthenticationPolicy {
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/UserVerification {
+	public abstract fun availability ()Lcom/ditchoom/buffer/crypto/UserVerificationAvailability;
+}
+
+public abstract interface class com/ditchoom/buffer/crypto/UserVerificationAvailability {
+}
+
+public final class com/ditchoom/buffer/crypto/UserVerificationAvailability$Supported : com/ditchoom/buffer/crypto/UserVerificationAvailability {
+	public fun <init> (Lcom/ditchoom/buffer/crypto/BiometricAvailability;Lcom/ditchoom/buffer/crypto/DeviceCredentialAvailability;)V
+	public final fun component1 ()Lcom/ditchoom/buffer/crypto/BiometricAvailability;
+	public final fun component2 ()Lcom/ditchoom/buffer/crypto/DeviceCredentialAvailability;
+	public final fun copy (Lcom/ditchoom/buffer/crypto/BiometricAvailability;Lcom/ditchoom/buffer/crypto/DeviceCredentialAvailability;)Lcom/ditchoom/buffer/crypto/UserVerificationAvailability$Supported;
+	public static synthetic fun copy$default (Lcom/ditchoom/buffer/crypto/UserVerificationAvailability$Supported;Lcom/ditchoom/buffer/crypto/BiometricAvailability;Lcom/ditchoom/buffer/crypto/DeviceCredentialAvailability;ILjava/lang/Object;)Lcom/ditchoom/buffer/crypto/UserVerificationAvailability$Supported;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBiometric ()Lcom/ditchoom/buffer/crypto/BiometricAvailability;
+	public final fun getDeviceCredential ()Lcom/ditchoom/buffer/crypto/DeviceCredentialAvailability;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/UserVerificationAvailability$Unsupported : com/ditchoom/buffer/crypto/UserVerificationAvailability {
+	public static final field INSTANCE Lcom/ditchoom/buffer/crypto/UserVerificationAvailability$Unsupported;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/crypto/UserVerification_jvmKt {
+	public static final fun userVerification ()Lcom/ditchoom/buffer/crypto/UserVerification;
 }
 
 public final class com/ditchoom/buffer/crypto/VerificationFailed : com/ditchoom/buffer/crypto/CryptoException {

--- a/buffer-crypto/src/androidInstrumentedTest/AndroidManifest.xml
+++ b/buffer-crypto/src/androidInstrumentedTest/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Instrumented-test-only manifest: registers the host FragmentActivity that
+     UserVerificationInstrumentedTest launches via ActivityScenario. Merged into the test APK
+     only — nothing here ships in the library. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <activity
+            android:name="com.ditchoom.buffer.crypto.TestHostActivity"
+            android:exported="false" />
+    </application>
+</manifest>

--- a/buffer-crypto/src/androidInstrumentedTest/kotlin/com/ditchoom/buffer/crypto/TestHostActivity.kt
+++ b/buffer-crypto/src/androidInstrumentedTest/kotlin/com/ditchoom/buffer/crypto/TestHostActivity.kt
@@ -1,0 +1,11 @@
+package com.ditchoom.buffer.crypto
+
+import androidx.fragment.app.FragmentActivity
+
+/**
+ * Bare host for instrumented tests that need a real [FragmentActivity] — the platform boundary
+ * `userVerification(activity)` requires one (mirroring `BiometricPromptAuthenticator`). Declared in
+ * this source set's `AndroidManifest.xml`; launched with `ActivityScenario`. No UI, no theme
+ * requirements — `FragmentActivity` inflates against the default platform theme.
+ */
+class TestHostActivity : FragmentActivity()

--- a/buffer-crypto/src/androidInstrumentedTest/kotlin/com/ditchoom/buffer/crypto/UserVerificationInstrumentedTest.kt
+++ b/buffer-crypto/src/androidInstrumentedTest/kotlin/com/ditchoom/buffer/crypto/UserVerificationInstrumentedTest.kt
@@ -1,0 +1,111 @@
+package com.ditchoom.buffer.crypto
+
+import android.app.KeyguardManager
+import android.content.Context
+import android.util.Log
+import androidx.fragment.app.FragmentActivity
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Runs the REAL Android probe ([AndroidUserVerification]) on whatever device or emulator is
+ * attached — the common contract suite only exercises fakes, so this is the only place the
+ * `canAuthenticate` mapping, the `KeyguardManager` read, and the enrollment remedy execute against
+ * an actual OS. The assertions are device-state-agnostic: they hold on an enrolled Pixel, a
+ * lock-screen-less emulator, and an OEM build alike, because they check *internal consistency* and
+ * *platform-impossibility* rather than any particular state.
+ */
+@RunWith(AndroidJUnit4::class)
+class UserVerificationInstrumentedTest {
+    private fun <T> withVerification(block: (FragmentActivity, UserVerification) -> T): T {
+        ActivityScenario.launch(TestHostActivity::class.java).use { scenario ->
+            var result: T? = null
+            scenario.onActivity { activity ->
+                result = block(activity, userVerification(activity))
+            }
+            @Suppress("UNCHECKED_CAST")
+            return result as T
+        }
+    }
+
+    /** Android always has a verification facility: the probe must report [Supported], never throw. */
+    @Test
+    fun probeReportsSupported() {
+        val availability = withVerification { _, v -> v.availability() }
+        assertTrue(availability is UserVerificationAvailability.Supported, "Android is never Unsupported")
+        // The state itself is device-dependent; log it so a per-device run reports what this
+        // OS/OEM/enrollment combination actually produced.
+        Log.i("UserVerificationTest", "probe -> ${availability.biometric} / ${availability.deviceCredential}")
+    }
+
+    /**
+     * The probe must never report a state Android cannot produce: the Apple-only variants, or the
+     * two lockout states `canAuthenticate` is blind to (they surface post-prompt only, and this
+     * release wires no post-prompt mapping).
+     */
+    @Test
+    fun probeNeverReportsAndroidImpossibleStates() {
+        val supported = withVerification { _, v -> v.availability() } as UserVerificationAvailability.Supported
+        val impossible =
+            when (supported.biometric) {
+                is BiometricAvailability.Actionable.PermissionDenied,
+                BiometricAvailability.Actionable.SensorDisconnected,
+                BiometricAvailability.Actionable.SensorNotPaired,
+                is BiometricAvailability.Actionable.LockedOutUntilCredential,
+                BiometricAvailability.Actionable.LockedOutTemporarily,
+                -> true
+                else -> false
+            }
+        assertTrue(!impossible, "Android probe reported an Android-impossible state: ${supported.biometric}")
+    }
+
+    /** The credential field and the OS keyguard must agree — they are reads of the same fact. */
+    @Test
+    fun deviceCredentialAgreesWithKeyguard() {
+        val (supported, secure) =
+            withVerification { activity, v ->
+                val keyguard = activity.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
+                (v.availability() as UserVerificationAvailability.Supported) to keyguard.isDeviceSecure
+            }
+        val expected =
+            if (secure) DeviceCredentialAvailability.Available else DeviceCredentialAvailability.NotSet
+        assertEquals(expected, supported.deviceCredential)
+    }
+
+    /**
+     * Two probes of an unchanged device compare EQUAL — the value-equality contract
+     * `distinctUntilChanged`-style consumers rely on. This exercises the real impls' overridden
+     * `equals` (the action-carrying states are classes, not data objects).
+     */
+    @Test
+    fun reProbeOfUnchangedDeviceComparesEqual() {
+        val (first, second) = withVerification { _, v -> v.availability() to v.availability() }
+        assertEquals(first, second)
+    }
+
+    /**
+     * If this device is in [BiometricAvailability.Actionable.NotEnrolled], invoke the real
+     * enrollment remedy and record which way the OEM answered — `true` = the system enrollment
+     * screen resolved and launched, `false` = this OEM stripped/renamed it and consumers get the
+     * prose fallback. BOTH are contract-conformant; the assertion is only that the remedy returns
+     * instead of crashing or hanging. The printed line is the datum this test exists to collect
+     * (run it per OEM: stock, One UI, ColorOS...). Skips (trivially passes) on devices in any
+     * other state.
+     */
+    @Test
+    fun enrollmentRemedyReturnsHonestlyWhenNotEnrolled() {
+        val state = withVerification { _, v -> v.availability() } as UserVerificationAvailability.Supported
+        val notEnrolled = state.biometric as? BiometricAvailability.Actionable.NotEnrolled ?: return
+        val remedy = assertNotNull(notEnrolled.openEnrollment, "Android always publishes an enrollment route")
+        val launched = runBlocking { remedy() }
+        // Log, not println: instrumentation stdout is not reliably forwarded to logcat, and this
+        // line IS the test's product.
+        Log.i("UserVerificationTest", "openEnrollment -> $launched on this OEM build")
+    }
+}

--- a/buffer-crypto/src/androidInstrumentedTest/kotlin/com/ditchoom/buffer/crypto/UserVerificationInstrumentedTest.kt
+++ b/buffer-crypto/src/androidInstrumentedTest/kotlin/com/ditchoom/buffer/crypto/UserVerificationInstrumentedTest.kt
@@ -108,4 +108,20 @@ class UserVerificationInstrumentedTest {
         // line IS the test's product.
         Log.i("UserVerificationTest", "openEnrollment -> $launched on this OEM build")
     }
+
+    /**
+     * Same shape as the enrollment datum, for [BiometricAvailability.Actionable.DeviceLockNotSet]:
+     * on a device with no screen lock, invoke the real lock-setup remedy and record whether this
+     * OEM's `ACTION_BIOMETRIC_ENROLL`-or-`ACTION_SECURITY_SETTINGS` tiering launched. Skips
+     * (trivially passes) in any other state.
+     */
+    @Test
+    fun deviceLockSetupRemedyReturnsHonestlyWhenLockNotSet() {
+        val state = withVerification { _, v -> v.availability() } as UserVerificationAvailability.Supported
+        val lockNotSet =
+            state.biometric as? BiometricAvailability.Actionable.DeviceLockNotSet ?: return
+        val remedy = assertNotNull(lockNotSet.openDeviceLockSetup, "Android always publishes a lock-setup route")
+        val launched = runBlocking { remedy() }
+        Log.i("UserVerificationTest", "openDeviceLockSetup -> $launched on this OEM build")
+    }
 }

--- a/buffer-crypto/src/androidMain/kotlin/com/ditchoom/buffer/crypto/UserVerification.android.kt
+++ b/buffer-crypto/src/androidMain/kotlin/com/ditchoom/buffer/crypto/UserVerification.android.kt
@@ -111,7 +111,7 @@ internal class AndroidUserVerification(
                 if (isDeviceSecure()) {
                     AndroidNotEnrolled(activity)
                 } else {
-                    BiometricAvailability.Actionable.DeviceLockNotSet
+                    AndroidDeviceLockNotSet(activity)
                 }
 
             // "No Class 3 hardware" and "no hardware at all" are different UX stories: a device whose
@@ -203,27 +203,7 @@ internal class AndroidNotEnrolled(
      * screens, which surfaces as `ActivityNotFoundException`. A `false` is a signal to fall back to
      * prose ("Set up a fingerprint in Settings"), never a crash.
      */
-    private suspend fun launchEnrollment(): Boolean =
-        // Main-executor dispatch (not Dispatchers.Main): the module depends on coroutines-core only,
-        // and core's Main dispatcher throws without the kotlinx-coroutines-android artifact. Same
-        // choice, for the same reason, as BiometricPromptAuthenticator.
-        suspendCancellableCoroutine { cont ->
-            ContextCompat.getMainExecutor(activity).execute {
-                // RuntimeException, not just ActivityNotFoundException: OEM settings activities also
-                // throw SecurityException (activity not exported to third-party callers) and bare
-                // RuntimeExceptions. The contract promises launch-failure -> false, never a crash —
-                // and an escaped throwable here would both kill the main thread AND leave the
-                // continuation suspended forever.
-                val launched =
-                    try {
-                        activity.startActivity(enrollmentIntent())
-                        true
-                    } catch (_: RuntimeException) {
-                        false
-                    }
-                if (cont.isActive) cont.resume(launched)
-            }
-        }
+    private suspend fun launchEnrollment(): Boolean = activity.launchFirstResolvable(enrollmentIntent())
 
     /**
      * The canonical enrollment Intent for this API level, centralized here so no consumer has to
@@ -256,3 +236,72 @@ internal class AndroidNotEnrolled(
             else -> Intent(Settings.ACTION_SECURITY_SETTINGS)
         }
 }
+
+/**
+ * [BiometricAvailability.Actionable.DeviceLockNotSet] for Android: key-capable hardware exists but
+ * no screen lock is set, so enrollment is impossible until one is. Closes over the [activity] the
+ * remedy launches from.
+ */
+internal class AndroidDeviceLockNotSet(
+    private val activity: FragmentActivity,
+) : BiometricAvailability.Actionable.DeviceLockNotSet {
+    /**
+     * Non-`null` on Android. On API 30+ the first choice is [Settings.ACTION_BIOMETRIC_ENROLL]:
+     * stock Android's enroll flow detects the missing screen lock and walks the user through
+     * setting it *and* enrolling in one pass — a single tap can carry this state all the way to
+     * [BiometricAvailability.Ready]. OEM builds that strip that flow fall back to
+     * [Settings.ACTION_SECURITY_SETTINGS] (the screen-lock settings themselves); only if both
+     * refuse does this report `false` and the app falls back to prose.
+     */
+    override val openDeviceLockSetup: (suspend () -> Boolean)? = { launchDeviceLockSetup() }
+
+    private suspend fun launchDeviceLockSetup(): Boolean =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            activity.launchFirstResolvable(
+                Intent(Settings.ACTION_BIOMETRIC_ENROLL).putExtra(
+                    Settings.EXTRA_BIOMETRIC_AUTHENTICATORS_ALLOWED,
+                    BiometricManager.Authenticators.BIOMETRIC_STRONG,
+                ),
+                Intent(Settings.ACTION_SECURITY_SETTINGS),
+            )
+        } else {
+            activity.launchFirstResolvable(Intent(Settings.ACTION_SECURITY_SETTINGS))
+        }
+
+    /** Value equality over the reported state (see [AndroidNotEnrolled.equals]). */
+    override fun equals(other: Any?): Boolean = other is AndroidDeviceLockNotSet
+
+    override fun hashCode(): Int = this::class.hashCode()
+
+    override fun toString(): String = "DeviceLockNotSet"
+}
+
+/**
+ * Launches the first of [intents] that actually starts, on the main executor, resuming with whether
+ * any launched. Main-executor dispatch (not `Dispatchers.Main`): the module depends on
+ * coroutines-core only, and core's Main dispatcher throws without the kotlinx-coroutines-android
+ * artifact — same choice, for the same reason, as `BiometricPromptAuthenticator`.
+ *
+ * Catches [RuntimeException], not just `ActivityNotFoundException`: OEM settings activities also
+ * throw `SecurityException` (activity not exported to third-party callers) and bare
+ * RuntimeExceptions. The remedies' contract promises launch-failure -> `false`, never a crash — and
+ * an escaped throwable here would both kill the main thread AND leave the continuation suspended
+ * forever. Launch-time try-and-report is deliberate: since Android 11, `resolveActivity()` lies
+ * unless the *consumer app* declares `<queries>` for each action, while `startActivity()` may fire
+ * blind — so this is the one mechanism that needs nothing from the consumer's manifest.
+ */
+private suspend fun FragmentActivity.launchFirstResolvable(vararg intents: Intent): Boolean =
+    suspendCancellableCoroutine { cont ->
+        ContextCompat.getMainExecutor(this).execute {
+            val launched =
+                intents.any { intent ->
+                    try {
+                        startActivity(intent)
+                        true
+                    } catch (_: RuntimeException) {
+                        false
+                    }
+                }
+            if (cont.isActive) cont.resume(launched)
+        }
+    }

--- a/buffer-crypto/src/androidMain/kotlin/com/ditchoom/buffer/crypto/UserVerification.android.kt
+++ b/buffer-crypto/src/androidMain/kotlin/com/ditchoom/buffer/crypto/UserVerification.android.kt
@@ -183,6 +183,8 @@ internal class AndroidNotEnrolled(
 
     override fun hashCode(): Int = this::class.hashCode()
 
+    override fun toString(): String = "NotEnrolled(modality=$modality)"
+
     /**
      * Non-`null` on Android: unlike Apple, the platform publishes real enrollment deep links, so this
      * remedy is always reachable from this state.

--- a/buffer-crypto/src/androidMain/kotlin/com/ditchoom/buffer/crypto/UserVerification.android.kt
+++ b/buffer-crypto/src/androidMain/kotlin/com/ditchoom/buffer/crypto/UserVerification.android.kt
@@ -1,0 +1,256 @@
+@file:Suppress("MatchingDeclarationName") // MPP platform-suffixed boundary file
+
+package com.ditchoom.buffer.crypto
+
+import android.app.KeyguardManager
+import android.content.Intent
+import android.os.Build
+import android.provider.Settings
+import androidx.biometric.BiometricManager
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.FragmentActivity
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+
+/*
+ * Android's [UserVerification] — a thin, honest projection of `BiometricManager.canAuthenticate`
+ * plus `KeyguardManager` onto the module's shared vocabulary.
+ *
+ * Four things shape this file:
+ *
+ *  - **Probe only, never prompt.** [availability] is one `canAuthenticate` status query (plus a
+ *    second, narrower one to tell weak biometry from no biometry) and one `KeyguardManager` read.
+ *    Nothing here puts UI on screen; prompting lives in [BiometricPromptAuthenticator] and is bound
+ *    to a key operation via [androidx.biometric.BiometricPrompt.CryptoObject]. The probe is also
+ *    **re-run on every call and never cached** — enrollment, hardware availability, and the screen
+ *    lock all change while the app is backgrounded, and a stale `Ready` is a broken prompt.
+ *
+ *  - **Class 3 only.** The probe asks for `BIOMETRIC_STRONG` because the contract's scope is
+ *    *key-capable* biometry ([BiometricAvailability]). Class 2 biometry is real and works for screen
+ *    unlock but can never gate a keystore key, so it is deliberately reported as
+ *    [BiometricAvailability.Unavailable.OnlyWeakBiometrics] — the one place `BIOMETRIC_WEAK` is
+ *    probed at all, purely to distinguish "a sensor you can see but we cannot use" from "no sensor".
+ *
+ *  - **This probe cannot see lockout, so this file never reports it.** `canAuthenticate` keeps
+ *    returning `BIOMETRIC_SUCCESS` while biometry is locked out; lockout surfaces only *after* a
+ *    prompt attempt, as `ERROR_LOCKOUT` / `ERROR_LOCKOUT_PERMANENT`. Reporting
+ *    [BiometricAvailability.Actionable.LockedOutTemporarily] or
+ *    [BiometricAvailability.Actionable.LockedOutUntilCredential] from here would be a guess, so
+ *    androidMain constructs neither. That is the contract's "one vocabulary, two entry points":
+ *    Apple reaches those states from its probe, Android would reach them by mapping a prompt error —
+ *    and wiring the post-prompt vocabulary is deferred by design, not missing by accident.
+ *
+ *  - **Variants Android never constructs.** Beyond the two lockout states:
+ *    [BiometricAvailability.Actionable.PermissionDenied] has no Android equivalent (there is no
+ *    per-app biometry consent to revoke — it is Apple-produced), and
+ *    [BiometricAvailability.Actionable.SensorDisconnected] /
+ *    [BiometricAvailability.Actionable.SensorNotPaired] describe external Touch ID keyboards and are
+ *    macOS-produced. So androidMain implements exactly **one** of the contract's action-carrying
+ *    interfaces: [BiometricAvailability.Actionable.NotEnrolled]. Every other Android state is a
+ *    `data object` the contract already supplies.
+ *
+ * [UserVerificationAvailability.Unsupported] is likewise never returned: Android always has a
+ * verification facility, and the device's actual condition is described by the two nested statuses.
+ */
+
+/**
+ * The Android [UserVerification], reading the live status of this device's key-capable biometry and
+ * screen lock.
+ *
+ * [activity] is captured because both halves of the API need it: the probe needs a `Context` to
+ * reach `BiometricManager` / `KeyguardManager`, and the enrollment remedy
+ * ([BiometricAvailability.Actionable.NotEnrolled.openEnrollment]) starts a system `Activity` from
+ * it. This is the same platform-boundary shape as [userAuthenticated] — a plain Android-typed
+ * function, not an `expect`/`actual`, constructed by the app where a `FragmentActivity` is already
+ * in hand and then passed into common code as a [UserVerification].
+ *
+ * ```kotlin
+ * // In the Android app module, at the UI boundary:
+ * val verification = userVerification(activity)
+ * MyFeature(verification) // common code sees only the interface
+ * ```
+ *
+ * The returned instance holds no cached status: every [UserVerification.availability] call re-probes
+ * the OS.
+ */
+fun userVerification(activity: FragmentActivity): UserVerification = AndroidUserVerification(activity)
+
+/**
+ * Projects `BiometricManager` / `KeyguardManager` onto [UserVerificationAvailability]. `internal`:
+ * consumers see only the [UserVerification] interface and the shared result types.
+ */
+internal class AndroidUserVerification(
+    private val activity: FragmentActivity,
+) : UserVerification {
+    /** Fresh OS probe on every call — see the file header on why this is never cached. */
+    override fun availability(): UserVerificationAvailability =
+        UserVerificationAvailability.Supported(
+            biometric = probeBiometric(),
+            deviceCredential = probeDeviceCredential(),
+        )
+
+    /**
+     * Maps `canAuthenticate(BIOMETRIC_STRONG)` onto [BiometricAvailability].
+     *
+     * The `BIOMETRIC_SUCCESS` case reports [BiometricModality.Unspecified] because `BiometricManager`
+     * genuinely does not say which sensor will be used. The only alternative — inferring it from
+     * `PackageManager` features (`FEATURE_FINGERPRINT` / `FEATURE_FACE` / `FEATURE_IRIS`) — reports
+     * which sensors *exist*, not which is enrolled or which the prompt will pick, so it misreports
+     * every dual-sensor device. Since [BiometricModality] is explicitly for labelling and never for a
+     * security decision, an honest "unspecified" beats a confident wrong icon.
+     */
+    private fun probeBiometric(): BiometricAvailability {
+        val manager = BiometricManager.from(activity)
+        return when (manager.canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_STRONG)) {
+            BiometricManager.BIOMETRIC_SUCCESS -> BiometricAvailability.Ready(BiometricModality.Unspecified)
+
+            // Key-capable hardware exists but holds no enrollment. Enrollment requires a screen lock,
+            // so without one the honest CTA is "set a passcode" — sending the user to the enrollment
+            // screen from that state dead-ends them.
+            BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED ->
+                if (isDeviceSecure()) {
+                    AndroidNotEnrolled(activity)
+                } else {
+                    BiometricAvailability.Actionable.DeviceLockNotSet
+                }
+
+            // "No Class 3 hardware" and "no hardware at all" are different UX stories: a device whose
+            // only sensor is Class 2 has visible, working biometry this API can never use for a key.
+            BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE ->
+                if (manager.canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_WEAK) ==
+                    BiometricManager.BIOMETRIC_SUCCESS
+                ) {
+                    BiometricAvailability.Unavailable.OnlyWeakBiometrics
+                } else {
+                    BiometricAvailability.Unavailable.NoHardware
+                }
+
+            // Sensor busy / held by another app / transient service failure: no CTA, may work later.
+            BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE -> BiometricAvailability.Unavailable.TemporarilyUnavailable
+
+            BiometricManager.BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED ->
+                BiometricAvailability.Actionable.SecurityUpdateRequired
+
+            BiometricManager.BIOMETRIC_ERROR_UNSUPPORTED -> BiometricAvailability.Unavailable.NotSupportedByOs
+
+            // BIOMETRIC_STATUS_UNKNOWN, plus any future/OEM code we do not recognize: neither a
+            // remedy to offer nor a basis for hiding the feature, so attempting the prompt is
+            // legitimate and the prompt reports the real outcome.
+            else -> BiometricAvailability.Indeterminate
+        }
+    }
+
+    /**
+     * Reports whether the device has a credential the OS can verify.
+     *
+     * Deliberately `KeyguardManager.isDeviceSecure` rather than
+     * `canAuthenticate(DEVICE_CREDENTIAL)`: the credential-only `canAuthenticate` query is not
+     * supported below API 30 and misreports there (it can answer `BIOMETRIC_ERROR_UNSUPPORTED` on a
+     * device that plainly has a PIN), whereas `isDeviceSecure` is accurate on every supported API
+     * level, needs no permission, and is exactly the fact the contract asks for — a PIN / pattern /
+     * password is set. It is also the same underlying fact as
+     * [BiometricAvailability.Actionable.DeviceLockNotSet], read from the credential side, so both
+     * fields stay consistent by construction.
+     */
+    private fun probeDeviceCredential(): DeviceCredentialAvailability =
+        if (isDeviceSecure()) DeviceCredentialAvailability.Available else DeviceCredentialAvailability.NotSet
+
+    /** `true` when a PIN / pattern / password is set; `false` if the service is somehow absent. */
+    private fun isDeviceSecure(): Boolean {
+        val keyguard = ContextCompat.getSystemService(activity, KeyguardManager::class.java)
+        return keyguard?.isDeviceSecure == true
+    }
+}
+
+/**
+ * [BiometricAvailability.Actionable.NotEnrolled] for Android: key-capable hardware is present, a
+ * screen lock is set, and nothing is enrolled — so the OS does have an enrollment screen to send the
+ * user to. Closes over the [activity] the remedy launches from.
+ */
+internal class AndroidNotEnrolled(
+    private val activity: FragmentActivity,
+) : BiometricAvailability.Actionable.NotEnrolled {
+    /** Always [BiometricModality.Unspecified] — see the mapping note on [AndroidUserVerification]. */
+    override val modality: BiometricModality = BiometricModality.Unspecified
+
+    /**
+     * Value equality over the reported state, not the captured [activity]: two probes of an
+     * unchanged device must compare equal or `distinctUntilChanged`-style consumers re-render
+     * every probe. All Android [NotEnrolled][BiometricAvailability.Actionable.NotEnrolled] states
+     * read the same ([modality] is constant).
+     */
+    override fun equals(other: Any?): Boolean = other is AndroidNotEnrolled
+
+    override fun hashCode(): Int = this::class.hashCode()
+
+    /**
+     * Non-`null` on Android: unlike Apple, the platform publishes real enrollment deep links, so this
+     * remedy is always reachable from this state.
+     */
+    override val openEnrollment: (suspend () -> Boolean)? = { launchEnrollment() }
+
+    /**
+     * Opens the system biometric-enrollment screen on the main thread.
+     *
+     * **`true` means the screen opened, not that the user enrolled.** Nothing in the Android
+     * enrollment flow reports back a result this API could trust, so re-probe with
+     * [UserVerification.availability] when the app resumes rather than treating `true` as
+     * [BiometricAvailability.Ready].
+     *
+     * `false` means the Intent did not launch at all — some OEM builds strip or rename these
+     * screens, which surfaces as `ActivityNotFoundException`. A `false` is a signal to fall back to
+     * prose ("Set up a fingerprint in Settings"), never a crash.
+     */
+    private suspend fun launchEnrollment(): Boolean =
+        // Main-executor dispatch (not Dispatchers.Main): the module depends on coroutines-core only,
+        // and core's Main dispatcher throws without the kotlinx-coroutines-android artifact. Same
+        // choice, for the same reason, as BiometricPromptAuthenticator.
+        suspendCancellableCoroutine { cont ->
+            ContextCompat.getMainExecutor(activity).execute {
+                // RuntimeException, not just ActivityNotFoundException: OEM settings activities also
+                // throw SecurityException (activity not exported to third-party callers) and bare
+                // RuntimeExceptions. The contract promises launch-failure -> false, never a crash —
+                // and an escaped throwable here would both kill the main thread AND leave the
+                // continuation suspended forever.
+                val launched =
+                    try {
+                        activity.startActivity(enrollmentIntent())
+                        true
+                    } catch (_: RuntimeException) {
+                        false
+                    }
+                if (cont.isActive) cont.resume(launched)
+            }
+        }
+
+    /**
+     * The canonical enrollment Intent for this API level, centralized here so no consumer has to
+     * rediscover the branching:
+     *
+     *  - **API 30+** — [Settings.ACTION_BIOMETRIC_ENROLL] with
+     *    [Settings.EXTRA_BIOMETRIC_AUTHENTICATORS_ALLOWED] set to
+     *    [BiometricManager.Authenticators.BIOMETRIC_STRONG], so the user lands on enrollment for a
+     *    biometric that can actually gate a key rather than a Class 2 one this API would then refuse.
+     *  - **API 28-29** — `ACTION_FINGERPRINT_ENROLL`, the only enrollment action those releases
+     *    expose (the authenticator-class extra does not exist yet).
+     *  - **Below** — `ACTION_SECURITY_SETTINGS`, the nearest screen that exists. The module's
+     *    `minSdk` is 28, so this branch is unreachable today; it is kept so the mapping stays whole
+     *    if that floor ever moves.
+     */
+    private fun enrollmentIntent(): Intent =
+        when {
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.R ->
+                Intent(Settings.ACTION_BIOMETRIC_ENROLL).putExtra(
+                    Settings.EXTRA_BIOMETRIC_AUTHENTICATORS_ALLOWED,
+                    BiometricManager.Authenticators.BIOMETRIC_STRONG,
+                )
+
+            // Deprecated as of API 30 in favor of ACTION_BIOMETRIC_ENROLL above; on 28/29 it is the
+            // only enrollment action there is, which is precisely this branch.
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.P ->
+                @Suppress("DEPRECATION")
+                Intent(Settings.ACTION_FINGERPRINT_ENROLL)
+
+            else -> Intent(Settings.ACTION_SECURITY_SETTINGS)
+        }
+}

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/UserVerification.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/UserVerification.apple.kt
@@ -1,0 +1,221 @@
+@file:OptIn(ExperimentalForeignApi::class)
+@file:Suppress("MatchingDeclarationName") // MPP platform-suffixed boundary file; also holds the state impls
+
+package com.ditchoom.buffer.crypto
+
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.BCKS_BIO_DISCONNECTED
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.BCKS_BIO_LOCKOUT
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.BCKS_BIO_NOT_ENROLLED
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.BCKS_BIO_NOT_PAIRED
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.BCKS_BIO_PASSCODE_NOT_SET
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.BCKS_BIO_READY
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.BCKS_BIO_UNSUPPORTED
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.BCKS_ERR_CANCELED
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.BCKS_OK
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.bcks_la_biometric_availability
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.bcks_la_device_credential_available
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.bcks_la_unlock_with_credential
+import com.ditchoom.buffer.crypto.cinterop.cryptokit.bcks_open_app_settings
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.IntVar
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.value
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/*
+ * Apple [UserVerification] — LocalAuthentication `canEvaluatePolicy` as a UX probe.
+ *
+ * The probe never touches the [LocalAuthAuthenticator]'s long-lived LAContext: the shim builds a
+ * throwaway context per call, so asking "may this screen draw a Face ID button?" can never disturb
+ * an evaluated session context that is authorizing Secure Enclave signs. The authenticator is
+ * captured for exactly one reason — it owns the localized prompt reason, which the *remedy*
+ * ([BiometricAvailability.Actionable.LockedOutUntilCredential.unlockWithDeviceCredential]) needs
+ * because that one does put a system prompt on screen.
+ *
+ * Which states this platform can produce:
+ *  - Apple-only: [BiometricAvailability.Actionable.SensorDisconnected] and
+ *    [BiometricAvailability.Actionable.SensorNotPaired] (external Touch ID keyboards on macOS);
+ *    Android never produces either.
+ *  - Never produced here: [BiometricAvailability.Actionable.SecurityUpdateRequired] and
+ *    [BiometricAvailability.Unavailable.OnlyWeakBiometrics] (Android strength classes have no Apple
+ *    analogue — every biometry Apple exposes is key-capable), [BiometricAvailability.Indeterminate]
+ *    (`canEvaluatePolicy` always answers), and
+ *    [BiometricAvailability.Actionable.LockedOutTemporarily] — Apple's probe reports a lockout as
+ *    `LAError.biometryLockout`, which is the *until-credential* kind, so the temporary variant has
+ *    no Apple entry point.
+ *  - [UserVerificationAvailability.Unsupported] is reported on tvOS alone, where the OS ships no
+ *    usable LocalAuthentication at all. watchOS is [UserVerificationAvailability.Supported] with
+ *    [BiometricAvailability.Unavailable.NoHardware]: wrist detection is not discrete biometry an app
+ *    can name or gate a key on, but the passcode is a real credential the OS can verify.
+ */
+
+/**
+ * The Apple [UserVerification], probing this device's LocalAuthentication facility.
+ *
+ * [authenticator] supplies the localized reason shown by the one member that prompts,
+ * [BiometricAvailability.Actionable.LockedOutUntilCredential.unlockWithDeviceCredential]; probing
+ * itself puts nothing on screen and holds no context. Constructed at the platform boundary — the
+ * same seam as [userAuthenticated] — because the reason string is a UI concern common code cannot
+ * name. The result is **not** cacheable: see [UserVerification].
+ */
+fun userVerification(authenticator: LocalAuthAuthenticator): UserVerification = AppleUserVerification(authenticator)
+
+/** Biometry-type codes the shim writes out (`LABiometryType`), mirrored from CryptoKitShim.h. */
+private const val BIOMETRY_NONE = 0
+private const val BIOMETRY_TOUCH_ID = 1
+private const val BIOMETRY_FACE_ID = 2
+private const val BIOMETRY_OPTIC_ID = 3
+
+/** The shim's "a device credential exists" answer for [bcks_la_device_credential_available]. */
+private const val CREDENTIAL_AVAILABLE = 1
+
+/**
+ * Probes LocalAuthentication through the CryptoKit shim. Stateless: every call re-probes with a
+ * fresh context, which is exactly the contract [UserVerification.availability] asks for.
+ */
+internal class AppleUserVerification(
+    private val authenticator: LocalAuthAuthenticator,
+) : UserVerification {
+    override fun availability(): UserVerificationAvailability =
+        memScoped {
+            // The shim writes biometryType on every path, including the unsupported one, so the
+            // uninitialized native slot is never read back.
+            val biometryType = alloc<IntVar>()
+            val status = bcks_la_biometric_availability(biometryType.ptr)
+            if (status == BCKS_BIO_UNSUPPORTED) {
+                UserVerificationAvailability.Unsupported
+            } else {
+                UserVerificationAvailability.Supported(
+                    biometric = biometricAvailability(status, biometryType.value),
+                    deviceCredential = deviceCredentialAvailability(),
+                )
+            }
+        }
+
+    /**
+     * Maps a `BCKS_BIO_*` probe result plus the reported `LABiometryType` onto the contract's
+     * states. `BCKS_BIO_NOT_AVAILABLE` (the `else` branch, which also absorbs any code a future
+     * shim adds) is the one ambiguous result: a reported biometry type means the sensor is there
+     * and the app has been denied it, no type means there is no sensor at all.
+     */
+    private fun biometricAvailability(
+        status: Int,
+        biometryType: Int,
+    ): BiometricAvailability =
+        when (status) {
+            BCKS_BIO_READY -> BiometricAvailability.Ready(biometryType.toModality())
+            BCKS_BIO_NOT_ENROLLED -> AppleNotEnrolled(biometryType.toModality())
+            BCKS_BIO_PASSCODE_NOT_SET -> BiometricAvailability.Actionable.DeviceLockNotSet
+            BCKS_BIO_LOCKOUT -> AppleLockedOutUntilCredential(authenticator)
+            BCKS_BIO_DISCONNECTED -> BiometricAvailability.Actionable.SensorDisconnected
+            BCKS_BIO_NOT_PAIRED -> BiometricAvailability.Actionable.SensorNotPaired
+            else ->
+                if (biometryType != BIOMETRY_NONE) {
+                    AppleBiometryPermissionDenied
+                } else {
+                    BiometricAvailability.Unavailable.NoHardware
+                }
+        }
+
+    /**
+     * The credential half. The shim's third answer (`-1`, "no LocalAuthentication on this
+     * platform") cannot reach here: it can only occur where the biometric probe already returned
+     * `BCKS_BIO_UNSUPPORTED`, and that path returns [UserVerificationAvailability.Unsupported]
+     * without asking. Anything other than a plain "yes" is therefore
+     * [DeviceCredentialAvailability.NotSet].
+     */
+    private fun deviceCredentialAvailability(): DeviceCredentialAvailability =
+        if (bcks_la_device_credential_available() == CREDENTIAL_AVAILABLE) {
+            DeviceCredentialAvailability.Available
+        } else {
+            DeviceCredentialAvailability.NotSet
+        }
+}
+
+/**
+ * `LABiometryType` → [BiometricModality]. Optic ID is reported as [BiometricModality.Iris]: it is
+ * iris recognition, and the contract's modality is for labelling only, never a security decision.
+ */
+private fun Int.toModality(): BiometricModality =
+    when (this) {
+        BIOMETRY_TOUCH_ID -> BiometricModality.Fingerprint
+        BIOMETRY_FACE_ID -> BiometricModality.Face
+        BIOMETRY_OPTIC_ID -> BiometricModality.Iris
+        else -> BiometricModality.Unspecified
+    }
+
+/**
+ * Apple's [BiometricAvailability.Actionable.NotEnrolled]: hardware present, nothing enrolled.
+ *
+ * [openEnrollment] is `null` because Apple publishes **no** enrollment route — the `App-Prefs:`
+ * URLs that reach the Touch ID / Face ID pane are private API and get an App Store binary rejected
+ * — and the contract spells `null` as "no route exists", so the app falls back to prose.
+ */
+internal class AppleNotEnrolled(
+    override val modality: BiometricModality,
+) : BiometricAvailability.Actionable.NotEnrolled {
+    override val openEnrollment: (suspend () -> Boolean)? = null
+
+    /**
+     * Value equality over the reported state, not instance identity: two probes of an unchanged
+     * device must compare equal or `distinctUntilChanged`-style consumers re-render every probe.
+     */
+    override fun equals(other: Any?): Boolean = other is AppleNotEnrolled && other.modality == modality
+
+    override fun hashCode(): Int = modality.hashCode()
+}
+
+/**
+ * Apple's [BiometricAvailability.Actionable.PermissionDenied]: the sensor exists (the probe saw a
+ * non-`none` `LABiometryType`) but the user turned biometry off for this app in Settings.
+ *
+ * Stateless, hence an object: the settings deep link addresses the app itself.
+ */
+internal object AppleBiometryPermissionDenied : BiometricAvailability.Actionable.PermissionDenied {
+    /**
+     * Dispatches the OS settings-page launch. `true` means the launch was handed to the system, not
+     * that the page appeared or that consent was granted — re-probe with
+     * [UserVerification.availability]. `false` on macOS, which publishes no supported per-app
+     * settings URL, and on watchOS.
+     */
+    override suspend fun openAppSettings(): Boolean = withContext(Dispatchers.Default) { bcks_open_app_settings() == 1 }
+}
+
+/**
+ * Apple's [BiometricAvailability.Actionable.LockedOutUntilCredential]: `LAError.biometryLockout`
+ * from the probe. A successful device-credential evaluation is what re-enables biometry.
+ */
+internal class AppleLockedOutUntilCredential(
+    private val authenticator: LocalAuthAuthenticator,
+) : BiometricAvailability.Actionable.LockedOutUntilCredential {
+    /** Value equality over the state (see [AppleNotEnrolled.equals]): all lockouts read the same. */
+    override fun equals(other: Any?): Boolean = other is AppleLockedOutUntilCredential
+
+    override fun hashCode(): Int = this::class.hashCode()
+
+    /**
+     * Prompts for the device credential on a **fresh** context carrying the authenticator's reason,
+     * released as soon as the prompt resolves — the unlock authorizes nothing by itself, so there is
+     * no reason to keep an evaluated context alive past it. The shim call blocks until the user
+     * responds, hence [Dispatchers.Default]. A `0` handle means LocalAuthentication is absent on
+     * this platform, which is a [PromptOutcome.Failed], not a cancellation. (A *closed*
+     * authenticator still mints live handles — [LocalAuthAuthenticator.newContextHandle] is the
+     * per-use factory and deliberately ignores `closed`, matching the enclave sign path.)
+     */
+    override suspend fun unlockWithDeviceCredential(): PromptOutcome {
+        val handle = authenticator.newContextHandle()
+        if (handle == 0L) return PromptOutcome.Failed
+        return try {
+            when (withContext(Dispatchers.Default) { bcks_la_unlock_with_credential(handle) }) {
+                BCKS_OK -> PromptOutcome.Succeeded
+                BCKS_ERR_CANCELED -> PromptOutcome.UserCancelled
+                else -> PromptOutcome.Failed
+            }
+        } finally {
+            releaseContextHandle(handle)
+        }
+    }
+}

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/UserVerification.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/UserVerification.apple.kt
@@ -108,7 +108,7 @@ internal class AppleUserVerification(
         when (status) {
             BCKS_BIO_READY -> BiometricAvailability.Ready(biometryType.toModality())
             BCKS_BIO_NOT_ENROLLED -> AppleNotEnrolled(biometryType.toModality())
-            BCKS_BIO_PASSCODE_NOT_SET -> BiometricAvailability.Actionable.DeviceLockNotSet
+            BCKS_BIO_PASSCODE_NOT_SET -> AppleDeviceLockNotSet
             BCKS_BIO_LOCKOUT -> AppleLockedOutUntilCredential(authenticator)
             BCKS_BIO_DISCONNECTED -> BiometricAvailability.Actionable.SensorDisconnected
             BCKS_BIO_NOT_PAIRED -> BiometricAvailability.Actionable.SensorNotPaired
@@ -168,6 +168,20 @@ internal class AppleNotEnrolled(
     override fun hashCode(): Int = modality.hashCode()
 
     override fun toString(): String = "NotEnrolled(modality=$modality)"
+}
+
+/**
+ * Apple's [BiometricAvailability.Actionable.DeviceLockNotSet]: `LAError.passcodeNotSet`.
+ *
+ * [openDeviceLockSetup] is `null` — passcode setup has no public deep link on any Apple platform
+ * (`App-Prefs:` URLs are private API; macOS's `x-apple.systempreferences:` pane identifiers are
+ * undocumented and unstable across releases, so the library does not ship them — an app that
+ * accepts that brittleness can open the URL itself). Stateless, hence an object.
+ */
+internal object AppleDeviceLockNotSet : BiometricAvailability.Actionable.DeviceLockNotSet {
+    override val openDeviceLockSetup: (suspend () -> Boolean)? = null
+
+    override fun toString(): String = "DeviceLockNotSet"
 }
 
 /**

--- a/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/UserVerification.apple.kt
+++ b/buffer-crypto/src/appleMain/kotlin/com/ditchoom/buffer/crypto/UserVerification.apple.kt
@@ -166,6 +166,8 @@ internal class AppleNotEnrolled(
     override fun equals(other: Any?): Boolean = other is AppleNotEnrolled && other.modality == modality
 
     override fun hashCode(): Int = modality.hashCode()
+
+    override fun toString(): String = "NotEnrolled(modality=$modality)"
 }
 
 /**
@@ -195,6 +197,8 @@ internal class AppleLockedOutUntilCredential(
     override fun equals(other: Any?): Boolean = other is AppleLockedOutUntilCredential
 
     override fun hashCode(): Int = this::class.hashCode()
+
+    override fun toString(): String = "LockedOutUntilCredential"
 
     /**
      * Prompts for the device credential on a **fresh** context carrying the authenticator's reason,

--- a/buffer-crypto/src/appleTest/kotlin/com/ditchoom/buffer/crypto/UserVerificationAppleTest.kt
+++ b/buffer-crypto/src/appleTest/kotlin/com/ditchoom/buffer/crypto/UserVerificationAppleTest.kt
@@ -70,7 +70,7 @@ class UserVerificationAppleTest {
         when (state) {
             is BiometricAvailability.Ready -> true
             is BiometricAvailability.Actionable.NotEnrolled -> true
-            BiometricAvailability.Actionable.DeviceLockNotSet -> true
+            is BiometricAvailability.Actionable.DeviceLockNotSet -> true
             is BiometricAvailability.Actionable.PermissionDenied -> true
             is BiometricAvailability.Actionable.LockedOutUntilCredential -> true
             // macOS external Touch ID keyboards — Apple-only, never produced on Android.
@@ -100,7 +100,7 @@ class UserVerificationAppleTest {
         when (state) {
             is BiometricAvailability.Ready -> "ready:${state.modality}"
             is BiometricAvailability.Actionable.NotEnrolled -> "not-enrolled"
-            BiometricAvailability.Actionable.DeviceLockNotSet -> "device-lock-not-set"
+            is BiometricAvailability.Actionable.DeviceLockNotSet -> "device-lock-not-set"
             is BiometricAvailability.Actionable.PermissionDenied -> "permission-denied"
             BiometricAvailability.Actionable.SecurityUpdateRequired -> "security-update-required"
             BiometricAvailability.Actionable.SensorDisconnected -> "sensor-disconnected"

--- a/buffer-crypto/src/appleTest/kotlin/com/ditchoom/buffer/crypto/UserVerificationAppleTest.kt
+++ b/buffer-crypto/src/appleTest/kotlin/com/ditchoom/buffer/crypto/UserVerificationAppleTest.kt
@@ -1,0 +1,116 @@
+package com.ditchoom.buffer.crypto
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Runtime guard for the Apple [UserVerification] probe — the LocalAuthentication half that needs no
+ * entitled Secure Enclave, so it runs on the macOS CI test binary rather than being device-gated.
+ *
+ * A CI runner has whatever enrollment, permission, and lockout state it has, so the assertions are
+ * about the *shape* of the answer rather than a particular state: the probe returns a state this
+ * platform is documented to be able to produce, and it keeps returning the same one. Nothing here
+ * invokes a remedy — [BiometricAvailability.Actionable.PermissionDenied.openAppSettings] and
+ * [BiometricAvailability.Actionable.LockedOutUntilCredential.unlockWithDeviceCredential] put system
+ * UI on screen, which an unattended runner cannot dismiss.
+ */
+class UserVerificationAppleTest {
+    @Test
+    fun availabilityReportsAStateThisPlatformCanProduce() {
+        val auth = LocalAuthAuthenticator(reason = "test reason")
+        try {
+            // Skip only where LocalAuthentication itself is absent (no context handle minted); on any
+            // real macOS runner the context is created and the probe below runs for real.
+            if (!auth.available) return
+            when (val availability = userVerification(auth).availability()) {
+                // tvOS ships no usable LocalAuthentication; the probe says so rather than guessing.
+                UserVerificationAvailability.Unsupported -> Unit
+                is UserVerificationAvailability.Supported ->
+                    assertTrue(
+                        appleCanProduce(availability.biometric),
+                        "the Apple probe must not report a state it has no construction site for",
+                    )
+            }
+        } finally {
+            auth.close()
+        }
+    }
+
+    @Test
+    fun repeatedProbesReportTheSameState() {
+        val auth = LocalAuthAuthenticator(reason = "test reason")
+        try {
+            if (!auth.available) return
+            val verification = userVerification(auth)
+            // Stability, not caching: the implementation re-probes with a fresh context every call
+            // (that is the contract), and on an unattended machine nothing changes between the two —
+            // so a differing variant would mean the probe is not deterministic in the state it maps.
+            val first = verification.availability()
+            val second = verification.availability()
+            assertEquals(variantOf(first), variantOf(second), "two probes of an idle device must agree")
+        } finally {
+            auth.close()
+        }
+    }
+
+    /**
+     * Whether `UserVerification.apple.kt` has a construction site for [state].
+     *
+     * The four `false` arms are the ones its file header lists as never produced here:
+     * [BiometricAvailability.Actionable.SecurityUpdateRequired] and
+     * [BiometricAvailability.Unavailable.OnlyWeakBiometrics] (Android strength classes have no Apple
+     * analogue), [BiometricAvailability.Indeterminate] (`canEvaluatePolicy` always answers), and
+     * [BiometricAvailability.Actionable.LockedOutTemporarily] (Apple's probe reports lockout as the
+     * until-credential kind). The `when` is `else`-free so a state added later must be classified
+     * here rather than silently accepted.
+     */
+    @Suppress("CyclomaticComplexMethod")
+    private fun appleCanProduce(state: BiometricAvailability): Boolean =
+        when (state) {
+            is BiometricAvailability.Ready -> true
+            is BiometricAvailability.Actionable.NotEnrolled -> true
+            BiometricAvailability.Actionable.DeviceLockNotSet -> true
+            is BiometricAvailability.Actionable.PermissionDenied -> true
+            is BiometricAvailability.Actionable.LockedOutUntilCredential -> true
+            // macOS external Touch ID keyboards — Apple-only, never produced on Android.
+            BiometricAvailability.Actionable.SensorDisconnected -> true
+            BiometricAvailability.Actionable.SensorNotPaired -> true
+            BiometricAvailability.Unavailable.NoHardware -> true
+            BiometricAvailability.Unavailable.TemporarilyUnavailable -> true
+            BiometricAvailability.Unavailable.NotSupportedByOs -> true
+            // Android-only, per the file header on UserVerification.apple.kt:
+            BiometricAvailability.Actionable.SecurityUpdateRequired -> false
+            BiometricAvailability.Actionable.LockedOutTemporarily -> false
+            BiometricAvailability.Unavailable.OnlyWeakBiometrics -> false
+            BiometricAvailability.Indeterminate -> false
+        }
+
+    /** A stable name for the variant, ignoring the payload [BiometricAvailability.Ready] carries. */
+    private fun variantOf(availability: UserVerificationAvailability): String =
+        when (availability) {
+            UserVerificationAvailability.Unsupported -> "unsupported"
+            is UserVerificationAvailability.Supported ->
+                "${variantOf(availability.biometric)}/${availability.deviceCredential}"
+        }
+
+    // Exhaustive over the full 14-leaf vocabulary — the branch count IS the assertion.
+    @Suppress("CyclomaticComplexMethod")
+    private fun variantOf(state: BiometricAvailability): String =
+        when (state) {
+            is BiometricAvailability.Ready -> "ready:${state.modality}"
+            is BiometricAvailability.Actionable.NotEnrolled -> "not-enrolled"
+            BiometricAvailability.Actionable.DeviceLockNotSet -> "device-lock-not-set"
+            is BiometricAvailability.Actionable.PermissionDenied -> "permission-denied"
+            BiometricAvailability.Actionable.SecurityUpdateRequired -> "security-update-required"
+            BiometricAvailability.Actionable.SensorDisconnected -> "sensor-disconnected"
+            BiometricAvailability.Actionable.SensorNotPaired -> "sensor-not-paired"
+            is BiometricAvailability.Actionable.LockedOutUntilCredential -> "locked-out-until-credential"
+            BiometricAvailability.Actionable.LockedOutTemporarily -> "locked-out-temporarily"
+            BiometricAvailability.Unavailable.NoHardware -> "no-hardware"
+            BiometricAvailability.Unavailable.OnlyWeakBiometrics -> "only-weak-biometrics"
+            BiometricAvailability.Unavailable.TemporarilyUnavailable -> "temporarily-unavailable"
+            BiometricAvailability.Unavailable.NotSupportedByOs -> "not-supported-by-os"
+            BiometricAvailability.Indeterminate -> "indeterminate"
+        }
+}

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/UserVerification.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/UserVerification.kt
@@ -1,0 +1,367 @@
+package com.ditchoom.buffer.crypto
+
+/*
+ * Interactive user verification — "can this device ask a human to prove they are here, right now,
+ * and if not, what exactly should the app tell them to do about it?"
+ *
+ * This family answers a *UX* question, not a custody question. The custody surfaces already in this
+ * module ([ProtectedKeyResolution], [CryptoCapabilities.hardware], [KeyProvider.custodyFor]) say
+ * where key material lives and whether an operation can be bound to authentication. Neither of them
+ * can tell an app whether it is allowed to *draw a "Sign in with Face ID" button* — that needs the
+ * enrollment/lockout/permission state of the device's own verification facility, which is exactly
+ * what [UserVerification.availability] reports.
+ *
+ * Three decisions shape the whole hierarchy:
+ *
+ *  - **Probing is separate from prompting.** [UserVerification.availability] never puts UI on
+ *    screen; it is a cheap OS query (Android `BiometricManager.canAuthenticate`, Apple
+ *    `LAContext.canEvaluatePolicy`). There is deliberately **no** bare `authenticate()` here at all
+ *    — see the note on [BiometricAvailability.Actionable].
+ *  - **A remedy exists iff the state admits one.** Rather than a flat enum plus a grab-bag of
+ *    "maybe this helps" helpers, the actions are `suspend` members *on the states that have them*
+ *    ([BiometricAvailability.Actionable.NotEnrolled.openEnrollment],
+ *    [BiometricAvailability.Actionable.PermissionDenied.openAppSettings],
+ *    [BiometricAvailability.Actionable.LockedOutUntilCredential.unlockWithDeviceCredential]). An
+ *    unreachable remedy is not representable, so no consumer can call one into a no-op.
+ *  - **The first branch a consumer writes is CTA-vs-hide.** [BiometricAvailability.Actionable] means
+ *    "the user can fix this — show a call to action"; [BiometricAvailability.Unavailable] means
+ *    "nothing the user does here will help — hide the option". [BiometricAvailability.Ready] and
+ *    [BiometricAvailability.Indeterminate] are the two states where a prompt is worth attempting.
+ *
+ * Construction is a **platform-boundary** concern: an implementation captures live UI context
+ * (Android a `FragmentActivity`, Apple a `LocalAuthAuthenticator`), which common code cannot name.
+ * Each platform therefore exposes its own `userVerification(...)` function — plain functions with
+ * platform-shaped signatures, not `expect`/`actual` — exactly as the existing
+ * `userAuthenticated(...)` seam does for [UserAuthenticatedKeyProvider]. Common code takes a
+ * [UserVerification] as an injected parameter and never constructs one.
+ */
+
+/**
+ * The device's interactive user-verification facility: the OS asking a human to prove presence with
+ * a biometric or the device credential.
+ *
+ * **Re-query at the moment of need; never cache the result.** Enrollment, permission, and lockout
+ * all change while the app is backgrounded — a user can delete their last fingerprint, revoke Face
+ * ID for the app, or lock biometry out with failed attempts between two screens. Call
+ * [availability] when a screen is about to render its authentication affordance, and again after a
+ * remedy suspends and returns. The call is a cheap OS status query, so re-querying is not a cost
+ * worth optimizing away; a stale cached [BiometricAvailability.Ready] is a broken prompt.
+ *
+ * ```kotlin
+ * // `verification` was injected from the platform boundary; probe fresh on every render.
+ * when (val availability = verification.availability()) {
+ *     UserVerificationAvailability.Unsupported -> hideBiometricOption()
+ *     is UserVerificationAvailability.Supported -> when (val biometric = availability.biometric) {
+ *         is BiometricAvailability.Ready -> offerBiometricUnlock(biometric.modality)
+ *         is BiometricAvailability.Actionable.NotEnrolled ->
+ *             showCta(enrollLabel(biometric.modality), action = biometric.openEnrollment)
+ *         is BiometricAvailability.Actionable.PermissionDenied ->
+ *             showCta("Allow biometrics for this app", action = biometric::openAppSettings)
+ *         is BiometricAvailability.Actionable.LockedOutUntilCredential ->
+ *             showCta("Unlock with your device passcode") { biometric.unlockWithDeviceCredential() }
+ *         BiometricAvailability.Actionable.DeviceLockNotSet ->
+ *             showCta("Set a screen lock to use biometrics")
+ *         is BiometricAvailability.Actionable -> showGenericCta(biometric)
+ *         is BiometricAvailability.Unavailable -> hideBiometricOption()
+ *         // Status could not be determined — attempting the prompt is legitimate.
+ *         BiometricAvailability.Indeterminate -> offerBiometricUnlock(BiometricModality.Unspecified)
+ *     }
+ * }
+ * ```
+ *
+ * **Scope.** This reports *interactive* verification only. It is **not** "can a key be gated behind
+ * authentication": a PKCS#11 token PIN on the desktop JVM / Linux (`C_Login`, configured via
+ * `BUFFER_CRYPTO_PKCS11_PIN`) is genuine authentication, but it is process-to-token and set by
+ * deployment configuration — no human is verified at the point of use. That capability is reported
+ * by [ProtectedKeyResolution] / [CapabilityFinding], never here. Correspondingly,
+ * [UserVerificationAvailability.Unsupported] means *no interactive facility on this platform* and
+ * says nothing at all about token authentication or key custody.
+ */
+interface UserVerification {
+    /**
+     * Probes the current interactive-verification status. Cheap, non-prompting, and safe to call on
+     * a UI thread. **Never cache the returned value** — see the note on [UserVerification].
+     */
+    fun availability(): UserVerificationAvailability
+}
+
+/**
+ * Whether this platform has an interactive user-verification facility at all, and if so its two
+ * independent statuses.
+ *
+ * The split is a platform fact, not a device fact: [Unsupported] is reported where the OS ships no
+ * verification framework this library can drive (a desktop JVM, Linux, browsers/WASM engines,
+ * tvOS — where `LAContext` is marked unavailable). Everything else reports [Supported] and
+ * lets the two nested statuses describe the device. watchOS is the illustrative case: it is
+ * [Supported] with [BiometricAvailability.Unavailable.NoHardware] and
+ * [DeviceCredentialAvailability.Available] — no biometric sensor, but a real passcode the OS can
+ * verify.
+ */
+sealed interface UserVerificationAvailability {
+    /**
+     * No interactive user-verification facility on this platform. Says nothing about key custody or
+     * token authentication (see the scope note on [UserVerification]) — a JVM host holding
+     * TPM-backed PKCS#11 keys still reports [Unsupported] here.
+     */
+    data object Unsupported : UserVerificationAvailability
+
+    /**
+     * The platform has a verification facility; [biometric] and [deviceCredential] report its two
+     * halves independently. They compose: a [BiometricAvailability.Actionable] biometric state with
+     * [DeviceCredentialAvailability.Available] means the app can offer credential fallback *now*
+     * while surfacing the biometric remedy as a secondary CTA.
+     */
+    data class Supported(
+        val biometric: BiometricAvailability,
+        val deviceCredential: DeviceCredentialAvailability,
+    ) : UserVerificationAvailability
+}
+
+/**
+ * The status of **key-capable** biometry on this device.
+ *
+ * "Key-capable" is the load-bearing scope: only biometry strong enough to protect a hardware-backed
+ * key is considered (Android Class 3 / `BIOMETRIC_STRONG`; on Apple every biometry the OS exposes
+ * qualifies). So [Ready] carries a single, unqualified promise — *this biometry can gate a
+ * hardware-backed key* — and never needs a second strength check at the call site. A device whose
+ * only biometry is Class 2 (a weak face unlock) reports
+ * [Unavailable.OnlyWeakBiometrics]: real, working biometry that can nonetheless never protect a
+ * key, kept distinct from [Unavailable.NoHardware] precisely so the UX can say *why* the option is
+ * missing instead of claiming a sensor that visibly exists is absent.
+ *
+ * The consumer's first branch is [Actionable] (show a call to action) versus [Unavailable] (hide
+ * the option). [Indeterminate] sits outside both.
+ */
+sealed interface BiometricAvailability {
+    /**
+     * Key-capable biometry is enrolled and usable right now; [modality] is what the OS reports the
+     * user will see (fingerprint, face, iris, or [BiometricModality.Unspecified] where the platform
+     * declines to say). Still not a cached fact — re-probe before each use.
+     */
+    data class Ready(
+        val modality: BiometricModality,
+    ) : BiometricAvailability
+
+    /**
+     * States the **user can fix** — render a call to action rather than hiding the feature.
+     *
+     * Where a route to the fix exists, it rides on the state as a `suspend` member. There is
+     * deliberately **no** bare `authenticate()` / `prompt()` anywhere in this API: an authentication
+     * result that is not bound to a key operation is bypassable theater — code that skips the check
+     * gets the same crypto — so authentication lives *inside* key use, on
+     * [UserAuthenticatedKeyProvider], where the OS binds it to the operation itself
+     * (`BiometricPrompt.CryptoObject`, `SecAccessControl`). Remedies here fix *states*;
+     * authentication stays in *key use*.
+     *
+     * The action-carrying members are non-`sealed` interfaces on purpose: each platform source set
+     * supplies an `internal` implementation closing over its captured host (activity / `LAContext`),
+     * which a `sealed` supertype could not permit from outside this file. They are **implemented by
+     * the library, not by consumers** — treat them as closed and branch on them exhaustively; the
+     * same "sealed contract with internal implementations" posture the rest of this module uses.
+     */
+    sealed interface Actionable : BiometricAvailability {
+        /**
+         * The hardware is present and key-capable but nothing is enrolled — [modality] is what the
+         * user would be enrolling.
+         *
+         * [openEnrollment] launches the OS enrollment surface and returns `true` when it was
+         * actually presented. It is `null` **iff the OS offers no route at all**: Apple publishes no
+         * enrollment deep link (`App-Prefs:` URLs are private API and reject an App Store binary),
+         * so an Apple implementation supplies `null` and the app must fall back to prose ("Set up
+         * Face ID in Settings"). A `null` here is therefore information, not a missing feature.
+         * Returning from [openEnrollment] does not imply the user enrolled — re-probe with
+         * [UserVerification.availability].
+         */
+        interface NotEnrolled : Actionable {
+            /** Which biometry the user would enroll. */
+            val modality: BiometricModality
+
+            /** Opens OS enrollment, `true` if presented; `null` when the platform has no route. */
+            val openEnrollment: (suspend () -> Boolean)?
+        }
+
+        /**
+         * No screen lock is set, so biometric enrollment is impossible in the first place. The
+         * correct CTA is **"set a passcode"**, not "enroll a fingerprint" — sending the user to
+         * enrollment from this state dead-ends them. Setting a device credential also moves
+         * [DeviceCredentialAvailability] to [DeviceCredentialAvailability.Available].
+         */
+        data object DeviceLockNotSet : Actionable
+
+        /**
+         * The user revoked this app's permission to use biometry (Apple: Face ID toggled off for
+         * the app in Settings). Apple-produced: the implementation distinguishes it from
+         * [Unavailable.NoHardware] by checking that `LAContext.biometryType` is not `.none` — the
+         * sensor exists, the app just may not use it.
+         */
+        interface PermissionDenied : Actionable {
+            /**
+             * Asks the OS to open this app's settings page so the user can re-grant biometry;
+             * `true` means the launch was **dispatched** (the OS accepted the request), not that
+             * the page appeared — iOS offers no completion signal a library could trust. `false`
+             * means this platform has no route (macOS has no supported per-app settings URL).
+             * Returning does not imply consent was granted — re-probe with
+             * [UserVerification.availability] on resume.
+             */
+            suspend fun openAppSettings(): Boolean
+        }
+
+        /**
+         * Biometry is unusable until a pending OS/security update is installed (Android
+         * `BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED`). Android-produced; the CTA points at system
+         * updates.
+         */
+        data object SecurityUpdateRequired : Actionable
+
+        /**
+         * The biometric sensor is an external device that is currently disconnected (macOS external
+         * Touch ID keyboard; Apple `biometryDisconnected`). The CTA is "reconnect it" — the
+         * capability returns on its own once the hardware is back.
+         */
+        data object SensorDisconnected : Actionable
+
+        /**
+         * An external biometric sensor is present but not paired with this Mac (Apple
+         * `biometryNotPaired`). The CTA is to complete pairing in system settings.
+         */
+        data object SensorNotPaired : Actionable
+
+        /**
+         * Biometry is locked out until the user proves themselves with the **device credential**;
+         * repeated failures got it there. [unlockWithDeviceCredential] drives the system credential
+         * prompt, and on success biometry is re-enabled on both platforms — so the natural UX is to
+         * compose this with the sibling [UserVerificationAvailability.Supported.deviceCredential]
+         * field and offer credential entry as the fallback path.
+         *
+         * **Entry points differ by platform, vocabulary does not.** On Apple this state is visible
+         * to the *probe* (`LAError.biometryLockout` from `canEvaluatePolicy`). On Android the probe
+         * cannot see lockout at all — `canAuthenticate` still reports success, and lockout surfaces
+         * only *after* a prompt attempt (`ERROR_LOCKOUT_PERMANENT`). This release therefore never
+         * produces this state on Android; the vocabulary is defined platform-neutrally so a later
+         * minor can map Android's post-prompt errors onto it without inventing a second type.
+         * One vocabulary, two entry points; see also [LockedOutTemporarily].
+         */
+        interface LockedOutUntilCredential : Actionable {
+            /**
+             * Presents the system device-credential prompt; on [PromptOutcome.Succeeded] biometry is
+             * re-enabled. Re-probe with [UserVerification.availability] afterwards rather than
+             * assuming [Ready].
+             */
+            suspend fun unlockWithDeviceCredential(): PromptOutcome
+        }
+
+        /**
+         * Biometry is in a short cool-down after failed attempts and recovers by itself.
+         *
+         * It deliberately **carries no duration**: no platform discloses how long the cool-down has
+         * left (Android's 30s is an implementation detail it does not publish, Apple exposes
+         * nothing), so a field here could only ever be a guess rendered as a countdown the OS may
+         * contradict. Re-probe on resume instead. As with [LockedOutUntilCredential], Apple could
+         * report this from a probe while Android sees lockout only after a prompt attempt
+         * (`ERROR_LOCKOUT`) — so this release produces the state on no platform yet (Apple's
+         * probe-visible lockout is the until-credential kind); it names the transient cool-down so
+         * the post-prompt mapping of a later minor has a home for it.
+         */
+        data object LockedOutTemporarily : Actionable
+    }
+
+    /**
+     * States **no user action can fix** — hide the biometric option rather than offering a CTA that
+     * leads nowhere. Fall back to [UserVerificationAvailability.Supported.deviceCredential] or to
+     * the app's own authentication.
+     */
+    sealed interface Unavailable : BiometricAvailability {
+        /** The device has no biometric sensor at all (watchOS, many low-end and desktop devices). */
+        data object NoHardware : Unavailable
+
+        /**
+         * The device has biometry, but only weak biometry (Android Class 2 / `BIOMETRIC_WEAK`) —
+         * real and working for screen unlock, yet never permitted to gate a hardware-backed key, so
+         * it can never satisfy this API's key-capable scope. Distinct from [NoHardware] so the UX
+         * can explain a visibly-present sensor it is not offering.
+         */
+        data object OnlyWeakBiometrics : Unavailable
+
+        /**
+         * The sensor exists and is enrolled but the OS reports it unavailable right now for a reason
+         * outside the user's control (Android `BIOMETRIC_ERROR_HW_UNAVAILABLE` — hardware busy,
+         * another app holding it, a transient service failure). Not [Actionable]: there is no CTA,
+         * it simply may work later.
+         */
+        data object TemporarilyUnavailable : Unavailable
+
+        /** The OS version predates key-capable biometric APIs, so this library cannot drive it. */
+        data object NotSupportedByOs : Unavailable
+    }
+
+    /**
+     * The platform could not determine biometric status (Android
+     * `BIOMETRIC_STATUS_UNKNOWN`). Outside both [Actionable] and [Unavailable] on purpose: there is
+     * no remedy to offer *and* no basis for hiding the feature. **Attempting the prompt is
+     * legitimate** — the prompt itself will report the real outcome — so treat this like an
+     * optimistic [Ready] with an unknown [BiometricModality], and handle the prompt's failure path.
+     */
+    data object Indeterminate : BiometricAvailability
+}
+
+/**
+ * Which biometry the user will be shown, for labelling and iconography only — never for a security
+ * decision (key-capability is already guaranteed by [BiometricAvailability.Ready]'s scope).
+ */
+enum class BiometricModality {
+    /** Fingerprint (Touch ID, Android fingerprint sensors). */
+    Fingerprint,
+
+    /** Face recognition (Face ID, Android face unlock that meets Class 3). */
+    Face,
+
+    /** Iris recognition. */
+    Iris,
+
+    /** The platform reports key-capable biometry without naming the modality. */
+    Unspecified,
+}
+
+/**
+ * Whether the device has a credential (PIN / pattern / passcode) the OS can verify. Reported
+ * alongside [BiometricAvailability] so an app can offer credential fallback while a biometric state
+ * is being remedied — and because [DeviceCredentialAvailability.NotSet] is the same underlying fact
+ * as [BiometricAvailability.Actionable.DeviceLockNotSet], seen from the credential side.
+ */
+enum class DeviceCredentialAvailability {
+    /** A device credential is set and the OS can prompt for it. */
+    Available,
+
+    /** No screen lock is set; no credential prompt is possible (and biometry cannot be enrolled). */
+    NotSet,
+}
+
+/**
+ * The result of a system prompt this API drives — currently only
+ * [BiometricAvailability.Actionable.LockedOutUntilCredential.unlockWithDeviceCredential].
+ *
+ * Three outcomes because they need three different app responses: proceed, respect an explicit
+ * user decision, or report an error. It carries no error detail on purpose — the actionable
+ * follow-up is always to re-probe with [UserVerification.availability], never to branch on an OS
+ * error code.
+ */
+enum class PromptOutcome {
+    /** The user authenticated successfully. */
+    Succeeded,
+
+    /** The user dismissed the prompt or chose a negative action; do not retry unprompted. */
+    UserCancelled,
+
+    /** Authentication did not succeed for any other reason (attempt exhausted, system error). */
+    Failed,
+}
+
+/**
+ * The shared [UserVerification] every platform without an interactive verification facility hands
+ * out — a JVM host, Linux, and JS/WASM engines. Stateless and allocation-free, so a platform
+ * boundary function can return it unconditionally. `internal`: consumers only ever see the
+ * [UserVerification] interface and the [UserVerificationAvailability.Unsupported] value.
+ */
+internal object UnsupportedUserVerification : UserVerification {
+    override fun availability(): UserVerificationAvailability = UserVerificationAvailability.Unsupported
+}

--- a/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/UserVerification.kt
+++ b/buffer-crypto/src/commonMain/kotlin/com/ditchoom/buffer/crypto/UserVerification.kt
@@ -59,8 +59,8 @@ package com.ditchoom.buffer.crypto
  *             showCta("Allow biometrics for this app", action = biometric::openAppSettings)
  *         is BiometricAvailability.Actionable.LockedOutUntilCredential ->
  *             showCta("Unlock with your device passcode") { biometric.unlockWithDeviceCredential() }
- *         BiometricAvailability.Actionable.DeviceLockNotSet ->
- *             showCta("Set a screen lock to use biometrics")
+ *         is BiometricAvailability.Actionable.DeviceLockNotSet ->
+ *             showCta("Set a screen lock to use biometrics", action = biometric.openDeviceLockSetup)
  *         is BiometricAvailability.Actionable -> showGenericCta(biometric)
  *         is BiometricAvailability.Unavailable -> hideBiometricOption()
  *         // Status could not be determined — attempting the prompt is legitimate.
@@ -186,7 +186,17 @@ sealed interface BiometricAvailability {
          * enrollment from this state dead-ends them. Setting a device credential also moves
          * [DeviceCredentialAvailability] to [DeviceCredentialAvailability.Available].
          */
-        data object DeviceLockNotSet : Actionable
+        interface DeviceLockNotSet : Actionable {
+            /**
+             * Launches the OS flow that sets a device credential; `null` ⇔ the OS has no route
+             * (Apple — passcode setup has no public deep link). On Android API 30+ this is the
+             * biometric-enroll flow itself, which walks the user through setting the lock *and*
+             * enrolling in one pass, so a single tap can carry this state all the way to [Ready].
+             * `true` means the flow was launched, not completed — re-probe with
+             * [UserVerification.availability] on resume.
+             */
+            val openDeviceLockSetup: (suspend () -> Boolean)?
+        }
 
         /**
          * The user revoked this app's permission to use biometry (Apple: Face ID toggled off for

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/FakeUserVerification.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/FakeUserVerification.kt
@@ -66,6 +66,27 @@ internal class FakeNotEnrolled(
 }
 
 /**
+ * [BiometricAvailability.Actionable.DeviceLockNotSet] with a scripted lock-setup launch. `launches
+ * = null` models the Apple side (no public route to passcode setup); a Boolean models Android's
+ * launch-and-report remedy.
+ */
+internal class FakeDeviceLockNotSet(
+    launches: Boolean? = true,
+) : BiometricAvailability.Actionable.DeviceLockNotSet {
+    /** How many times the remedy was invoked — `0` proves the "no OS route" path skipped it. */
+    var lockSetupLaunches: Int = 0
+        private set
+
+    override val openDeviceLockSetup: (suspend () -> Boolean)? =
+        launches?.let { result ->
+            suspend {
+                lockSetupLaunches++
+                result
+            }
+        }
+}
+
+/**
  * [BiometricAvailability.Actionable.PermissionDenied] whose settings launch reports [presents]
  * (`false` is the honest answer on the Apple platforms that publish no per-app settings URL).
  */

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/FakeUserVerification.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/FakeUserVerification.kt
@@ -1,0 +1,98 @@
+package com.ditchoom.buffer.crypto
+
+/*
+ * Test doubles for the [UserVerification] vocabulary.
+ *
+ * [UserVerification.availability] answers a *device* question, so no real platform can be asked to
+ * produce a chosen state on demand: a CI runner has whatever enrollment, permission, and lockout it
+ * has, and eight of the fourteen [BiometricAvailability] variants are unreachable on any single one
+ * of them. What is testable everywhere — and is the part consumers actually depend on — is the
+ * *vocabulary*: that every state is reachable as a value, that a consumer's `when` over it is
+ * compile-time exhaustive, and that a remedy is present exactly where the contract says it is.
+ *
+ * These fakes therefore stand in for the platform implementations the same way [FakeHardware] stands
+ * in for a secure element: the fake supplies the state, the *contract* under test is the shape.
+ *
+ * Only the three action-carrying members need faking. The contract deliberately makes them
+ * non-`sealed` interfaces so each platform source set can supply an `internal` implementation closing
+ * over its captured host (`FragmentActivity` / `LAContext`); commonTest supplies its own for exactly
+ * the same reason, closing over a scripted outcome instead. Every other state is a `data object` or a
+ * `data class` the contract already hands out, and is used directly.
+ */
+
+/**
+ * A [UserVerification] that reports whatever state a test scripts.
+ *
+ * [scripted] is a `var` on purpose: the contract's headline rule is *never cache the result*, and the
+ * way to exercise that is to change the device's answer between two probes and prove a consumer sees
+ * the new one. [probes] counts calls so a test can show a consumer re-queried rather than reused.
+ */
+internal class FakeUserVerification(
+    var scripted: UserVerificationAvailability,
+) : UserVerification {
+    var probes: Int = 0
+        private set
+
+    override fun availability(): UserVerificationAvailability {
+        probes++
+        return scripted
+    }
+}
+
+/**
+ * [BiometricAvailability.Actionable.NotEnrolled] with a scripted enrollment route.
+ *
+ * [presents] models the two shapes the contract admits: a non-`null` value is a platform that
+ * publishes an enrollment route (Android), where `true` means the screen was presented and `false`
+ * means the Intent did not launch at all; `null` is a platform with **no route** (Apple, whose
+ * enrollment deep links are private API), where [openEnrollment] itself must be `null` so the app
+ * falls back to prose.
+ */
+internal class FakeNotEnrolled(
+    override val modality: BiometricModality = BiometricModality.Unspecified,
+    presents: Boolean? = true,
+) : BiometricAvailability.Actionable.NotEnrolled {
+    /** How many times the remedy was actually invoked — `0` proves the "no OS route" path skipped it. */
+    var enrollmentLaunches: Int = 0
+        private set
+
+    override val openEnrollment: (suspend () -> Boolean)? =
+        presents?.let { result -> suspend { recordLaunch(result) } }
+
+    private fun recordLaunch(result: Boolean): Boolean {
+        enrollmentLaunches++
+        return result
+    }
+}
+
+/**
+ * [BiometricAvailability.Actionable.PermissionDenied] whose settings launch reports [presents]
+ * (`false` is the honest answer on the Apple platforms that publish no per-app settings URL).
+ */
+internal class FakePermissionDenied(
+    private val presents: Boolean = true,
+) : BiometricAvailability.Actionable.PermissionDenied {
+    var settingsLaunches: Int = 0
+        private set
+
+    override suspend fun openAppSettings(): Boolean {
+        settingsLaunches++
+        return presents
+    }
+}
+
+/**
+ * [BiometricAvailability.Actionable.LockedOutUntilCredential] whose credential prompt resolves to a
+ * scripted [outcome] — the one place a [PromptOutcome] reaches a consumer at all.
+ */
+internal class FakeLockedOutUntilCredential(
+    private val outcome: PromptOutcome = PromptOutcome.Succeeded,
+) : BiometricAvailability.Actionable.LockedOutUntilCredential {
+    var prompts: Int = 0
+        private set
+
+    override suspend fun unlockWithDeviceCredential(): PromptOutcome {
+        prompts++
+        return outcome
+    }
+}

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/UserVerificationContractTest.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/UserVerificationContractTest.kt
@@ -1,0 +1,305 @@
+package com.ditchoom.buffer.crypto
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Conformance for the interactive user-verification vocabulary ([UserVerification] and the
+ * [UserVerificationAvailability] / [BiometricAvailability] hierarchy it reports). Runs on every
+ * target — the vocabulary is common, only the states a given device produces are not.
+ *
+ * The states are supplied by [FakeUserVerification] and friends rather than by a platform probe,
+ * because no runner can be asked to be locked out, unenrolled, and permission-denied in one test
+ * process. What is under test is therefore the part that *is* platform-independent and the part
+ * consumers actually compile against:
+ *
+ *  - every `when` a consumer writes over these types is **compile-time exhaustive with no `else`** —
+ *    the flat 14-branch form, the 4-branch CTA-vs-hide form, and the two-state top-level form. An
+ *    `else`-free `when` here is not a style preference: it is what makes a state added in a later
+ *    minor a compile error at every consumer instead of a silently-hidden feature;
+ *  - [BiometricAvailability.Actionable] and [BiometricAvailability.Unavailable] are **disjoint**, so
+ *    "show a CTA" and "hide the option" can never both be true of one state;
+ *  - a remedy exists **iff** the state admits one, and a `null`
+ *    [BiometricAvailability.Actionable.NotEnrolled.openEnrollment] is information ("no OS route"), not
+ *    a missing feature — the consumer's `?.let` simply does not run;
+ *  - the composition the design is shaped around: a lockout plus a device credential is a remedy, a
+ *    lockout without one is prose.
+ */
+class UserVerificationContractTest {
+    // ---------------------------------------------------------------------------------------------
+    // Exhaustiveness: each helper below is a consumer's `when`, written without `else` on purpose.
+    // ---------------------------------------------------------------------------------------------
+
+    /** What a screen does with a state: prompt, render a call to action, or hide the affordance. */
+    private enum class Ux { Prompt, Cta, Hide }
+
+    /**
+     * The **first** branch a consumer writes, over the four direct children of the sealed parent.
+     * Needs no `else`, which is the proof that [BiometricAvailability.Actionable] and
+     * [BiometricAvailability.Unavailable] partition the actionable/unactionable states between them
+     * with [BiometricAvailability.Ready] and [BiometricAvailability.Indeterminate] outside both.
+     */
+    private fun ux(state: BiometricAvailability): Ux =
+        when (state) {
+            is BiometricAvailability.Ready -> Ux.Prompt
+            is BiometricAvailability.Actionable -> Ux.Cta
+            is BiometricAvailability.Unavailable -> Ux.Hide
+            // Status unknown: no remedy to offer and no basis for hiding, so attempting is legitimate.
+            BiometricAvailability.Indeterminate -> Ux.Prompt
+        }
+
+    /**
+     * The **fully-resolved** branch, naming all fourteen leaves of the hierarchy with no `else`. The
+     * three action-carrying leaves are matched with `is` because they are interfaces the library
+     * implements per platform; the rest are the contract's own singletons.
+     */
+    @Suppress("CyclomaticComplexMethod")
+    private fun label(state: BiometricAvailability): String =
+        when (state) {
+            is BiometricAvailability.Ready -> "ready"
+            is BiometricAvailability.Actionable.NotEnrolled -> "not-enrolled"
+            BiometricAvailability.Actionable.DeviceLockNotSet -> "device-lock-not-set"
+            is BiometricAvailability.Actionable.PermissionDenied -> "permission-denied"
+            BiometricAvailability.Actionable.SecurityUpdateRequired -> "security-update-required"
+            BiometricAvailability.Actionable.SensorDisconnected -> "sensor-disconnected"
+            BiometricAvailability.Actionable.SensorNotPaired -> "sensor-not-paired"
+            is BiometricAvailability.Actionable.LockedOutUntilCredential -> "locked-out-until-credential"
+            BiometricAvailability.Actionable.LockedOutTemporarily -> "locked-out-temporarily"
+            BiometricAvailability.Unavailable.NoHardware -> "no-hardware"
+            BiometricAvailability.Unavailable.OnlyWeakBiometrics -> "only-weak-biometrics"
+            BiometricAvailability.Unavailable.TemporarilyUnavailable -> "temporarily-unavailable"
+            BiometricAvailability.Unavailable.NotSupportedByOs -> "not-supported-by-os"
+            BiometricAvailability.Indeterminate -> "indeterminate"
+        }
+
+    /** The top-level branch: a platform either has a verification facility or it does not. */
+    private fun label(availability: UserVerificationAvailability): String =
+        when (availability) {
+            UserVerificationAvailability.Unsupported -> "unsupported"
+            is UserVerificationAvailability.Supported ->
+                "${label(availability.biometric)}/${availability.deviceCredential}"
+        }
+
+    /** Every [BiometricAvailability.Actionable] leaf, fakes standing in for the three interfaces. */
+    private fun actionableStates(): List<BiometricAvailability.Actionable> =
+        listOf(
+            FakeNotEnrolled(),
+            BiometricAvailability.Actionable.DeviceLockNotSet,
+            FakePermissionDenied(),
+            BiometricAvailability.Actionable.SecurityUpdateRequired,
+            BiometricAvailability.Actionable.SensorDisconnected,
+            BiometricAvailability.Actionable.SensorNotPaired,
+            FakeLockedOutUntilCredential(),
+            BiometricAvailability.Actionable.LockedOutTemporarily,
+        )
+
+    /** Every [BiometricAvailability.Unavailable] leaf. */
+    private fun unavailableStates(): List<BiometricAvailability.Unavailable> =
+        listOf(
+            BiometricAvailability.Unavailable.NoHardware,
+            BiometricAvailability.Unavailable.OnlyWeakBiometrics,
+            BiometricAvailability.Unavailable.TemporarilyUnavailable,
+            BiometricAvailability.Unavailable.NotSupportedByOs,
+        )
+
+    /** All fourteen states: [BiometricAvailability.Ready], 8 actionable, 4 unavailable, indeterminate. */
+    private fun allBiometricStates(): List<BiometricAvailability> =
+        buildList {
+            BiometricModality.entries.forEach { add(BiometricAvailability.Ready(it)) }
+            addAll(actionableStates())
+            addAll(unavailableStates())
+            add(BiometricAvailability.Indeterminate)
+        }
+
+    // ---------------------------------------------------------------------------------------------
+    // Tests
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    fun topLevelAvailabilityHasExactlyTwoStates() {
+        val probed = FakeUserVerification(UserVerificationAvailability.Unsupported).availability()
+        assertEquals("unsupported", label(probed))
+        val supported =
+            UserVerificationAvailability.Supported(
+                biometric = BiometricAvailability.Ready(BiometricModality.Face),
+                deviceCredential = DeviceCredentialAvailability.Available,
+            )
+        assertEquals("ready/Available", label(FakeUserVerification(supported).availability()))
+    }
+
+    @Test
+    fun everyBiometricStateIsNamedByAnElseFreeWhen() {
+        // 4 Ready modalities + 8 Actionable + 4 Unavailable + Indeterminate.
+        val states = allBiometricStates()
+        assertEquals(BiometricModality.entries.size + 8 + 4 + 1, states.size, "every leaf must be represented")
+        // Distinct labels: the flat `when` above resolves each leaf to its own branch, so no two
+        // states collapse onto one another (a mis-ordered `is` branch would swallow a sibling).
+        val labels = states.map { label(it) }
+        assertEquals(14, labels.toSet().size, "the four Ready modalities share one label; all 14 leaves are distinct")
+        assertTrue(labels.none { it.isEmpty() })
+    }
+
+    @Test
+    fun actionableAndUnavailableAreDisjointBranchesOfTheSealedParent() {
+        actionableStates().forEach { state ->
+            assertEquals(Ux.Cta, ux(state), "an Actionable state must render a call to action: ${label(state)}")
+            assertTrue(state !is BiometricAvailability.Unavailable, "Actionable must never also be Unavailable")
+        }
+        unavailableStates().forEach { state ->
+            assertEquals(Ux.Hide, ux(state), "an Unavailable state must hide the option: ${label(state)}")
+            assertTrue(state !is BiometricAvailability.Actionable, "Unavailable must never also be Actionable")
+        }
+        // The two states outside both: a prompt is worth attempting.
+        assertEquals(Ux.Prompt, ux(BiometricAvailability.Ready(BiometricModality.Fingerprint)))
+        assertEquals(Ux.Prompt, ux(BiometricAvailability.Indeterminate))
+        assertOutsideBothBranches(BiometricAvailability.Ready(BiometricModality.Fingerprint))
+        assertOutsideBothBranches(BiometricAvailability.Indeterminate)
+    }
+
+    /** [BiometricAvailability.Ready] and [BiometricAvailability.Indeterminate] sit outside both branches. */
+    private fun assertOutsideBothBranches(state: BiometricAvailability) {
+        assertTrue(state !is BiometricAvailability.Actionable, "$state has no remedy to offer")
+        assertTrue(state !is BiometricAvailability.Unavailable, "$state is no basis for hiding the option")
+    }
+
+    @Test
+    fun enumsRoundTripThroughTheirNames() {
+        assertEquals(3, PromptOutcome.entries.size)
+        assertEquals(4, BiometricModality.entries.size)
+        assertEquals(2, DeviceCredentialAvailability.entries.size)
+        PromptOutcome.entries.forEach { assertEquals(it, PromptOutcome.valueOf(it.name)) }
+        BiometricModality.entries.forEach { assertEquals(it, BiometricModality.valueOf(it.name)) }
+        DeviceCredentialAvailability.entries.forEach { assertEquals(it, DeviceCredentialAvailability.valueOf(it.name)) }
+        // Ready carries the modality it was told, unchanged — it is a label, never a security decision.
+        BiometricModality.entries.forEach { assertEquals(it, BiometricAvailability.Ready(it).modality) }
+    }
+
+    @Test
+    fun platformsWithoutAFacilityShareOneStatelessInstance() {
+        // The object every Unsupported platform boundary hands out (JVM, Linux, JS/WASM).
+        assertEquals(UserVerificationAvailability.Unsupported, UnsupportedUserVerification.availability())
+        assertEquals(UserVerificationAvailability.Unsupported, UnsupportedUserVerification.availability())
+    }
+
+    @Test
+    fun aConsumerSeesTheStateChangeBetweenTwoProbes() {
+        // The contract's headline rule is "re-query at the moment of need, never cache": a device can
+        // lose its last enrollment between two screens, and a consumer that probes fresh must see it.
+        val verification =
+            FakeUserVerification(
+                UserVerificationAvailability.Supported(
+                    biometric = BiometricAvailability.Ready(BiometricModality.Fingerprint),
+                    deviceCredential = DeviceCredentialAvailability.Available,
+                ),
+            )
+        assertEquals("ready/Available", label(verification.availability()))
+        verification.scripted =
+            UserVerificationAvailability.Supported(
+                biometric = FakeNotEnrolled(BiometricModality.Fingerprint),
+                deviceCredential = DeviceCredentialAvailability.Available,
+            )
+        assertEquals("not-enrolled/Available", label(verification.availability()))
+        assertEquals(2, verification.probes, "each render probes the OS again")
+    }
+
+    @Test
+    fun notEnrolledWithoutAnOsRouteFallsBackToProse() {
+        // Apple publishes no enrollment deep link, so `openEnrollment` is null and the consumer's
+        // `?.let` never runs — the CTA becomes prose instead of a button.
+        val state = FakeNotEnrolled(modality = BiometricModality.Face, presents = null)
+        assertNull(state.openEnrollment, "a platform with no enrollment route reports null, not a no-op lambda")
+        var cta: String? = null
+        state.openEnrollment?.let { cta = "button" }
+        assertNull(cta, "no route means no button")
+        assertEquals(0, state.enrollmentLaunches, "nothing was launched")
+        assertEquals(BiometricModality.Face, state.modality, "the modality still names what would be enrolled")
+    }
+
+    @Test
+    fun notEnrolledWithAnOsRouteLaunchesEnrollment() =
+        runTest {
+            val presented = FakeNotEnrolled(modality = BiometricModality.Fingerprint)
+            val open = assertNotNull(presented.openEnrollment, "a platform with a route supplies the remedy")
+            assertTrue(open(), "true means the enrollment screen was presented")
+            assertEquals(1, presented.enrollmentLaunches)
+
+            // `false` is the OEM-stripped-Intent case: not a crash, a signal to fall back to prose.
+            val stripped = FakeNotEnrolled(presents = false)
+            val strippedOpen = assertNotNull(stripped.openEnrollment)
+            assertFalse(strippedOpen(), "false means the Intent never launched")
+            assertEquals(1, stripped.enrollmentLaunches)
+        }
+
+    @Test
+    fun permissionDeniedOpensThisAppsSettingsPage() =
+        runTest {
+            val granted = FakePermissionDenied()
+            assertTrue(granted.openAppSettings(), "true means the settings page was presented")
+            assertEquals(1, granted.settingsLaunches)
+            // macOS/watchOS publish no supported per-app settings URL; the state stays Actionable but
+            // the launch honestly reports false.
+            val noRoute = FakePermissionDenied(presents = false)
+            assertFalse(noRoute.openAppSettings())
+            assertEquals(Ux.Cta, ux(noRoute), "a failed launch does not change the state's UX class")
+        }
+
+    @Test
+    fun lockedOutReportsEveryPromptOutcome() =
+        runTest {
+            PromptOutcome.entries.forEach { scripted ->
+                val state = FakeLockedOutUntilCredential(scripted)
+                assertEquals(scripted, state.unlockWithDeviceCredential(), "the remedy surfaces $scripted verbatim")
+                assertEquals(1, state.prompts)
+            }
+        }
+
+    @Test
+    fun lockoutRemedyIsOfferedOnlyWhenTheDeviceHasACredential() =
+        runTest {
+            // The design's UX story, both halves. With a credential, the credential prompt IS the
+            // remedy that re-enables biometry; without one there is nothing to prompt for, so the app
+            // falls back to prose and the remedy is never invoked.
+            val withCredential = FakeLockedOutUntilCredential(PromptOutcome.Succeeded)
+            assertEquals(
+                "unlocked:Succeeded",
+                resolveLockout(
+                    UserVerificationAvailability.Supported(withCredential, DeviceCredentialAvailability.Available),
+                ),
+            )
+            assertEquals(1, withCredential.prompts)
+
+            val withoutCredential = FakeLockedOutUntilCredential(PromptOutcome.Succeeded)
+            assertEquals(
+                "set a screen lock to re-enable biometrics",
+                resolveLockout(
+                    UserVerificationAvailability.Supported(withoutCredential, DeviceCredentialAvailability.NotSet),
+                ),
+            )
+            assertEquals(0, withoutCredential.prompts, "no credential means no prompt to drive")
+
+            // A cancelled unlock is a distinct answer from a failed one: the app must not retry a
+            // deliberate dismissal, and both leave biometry locked out.
+            val cancelled = FakeLockedOutUntilCredential(PromptOutcome.UserCancelled)
+            assertEquals(
+                "unlocked:UserCancelled",
+                resolveLockout(
+                    UserVerificationAvailability.Supported(cancelled, DeviceCredentialAvailability.Available),
+                ),
+            )
+        }
+
+    /** The composed consumer path: lockout state × credential availability → what the app does. */
+    private suspend fun resolveLockout(state: UserVerificationAvailability.Supported): String {
+        val biometric = state.biometric
+        if (biometric !is BiometricAvailability.Actionable.LockedOutUntilCredential) return label(biometric)
+        return when (state.deviceCredential) {
+            DeviceCredentialAvailability.Available -> "unlocked:${biometric.unlockWithDeviceCredential()}"
+            DeviceCredentialAvailability.NotSet -> "set a screen lock to re-enable biometrics"
+        }
+    }
+}

--- a/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/UserVerificationContractTest.kt
+++ b/buffer-crypto/src/commonTest/kotlin/com/ditchoom/buffer/crypto/UserVerificationContractTest.kt
@@ -63,7 +63,7 @@ class UserVerificationContractTest {
         when (state) {
             is BiometricAvailability.Ready -> "ready"
             is BiometricAvailability.Actionable.NotEnrolled -> "not-enrolled"
-            BiometricAvailability.Actionable.DeviceLockNotSet -> "device-lock-not-set"
+            is BiometricAvailability.Actionable.DeviceLockNotSet -> "device-lock-not-set"
             is BiometricAvailability.Actionable.PermissionDenied -> "permission-denied"
             BiometricAvailability.Actionable.SecurityUpdateRequired -> "security-update-required"
             BiometricAvailability.Actionable.SensorDisconnected -> "sensor-disconnected"
@@ -89,7 +89,7 @@ class UserVerificationContractTest {
     private fun actionableStates(): List<BiometricAvailability.Actionable> =
         listOf(
             FakeNotEnrolled(),
-            BiometricAvailability.Actionable.DeviceLockNotSet,
+            FakeDeviceLockNotSet(),
             FakePermissionDenied(),
             BiometricAvailability.Actionable.SecurityUpdateRequired,
             BiometricAvailability.Actionable.SensorDisconnected,
@@ -233,6 +233,21 @@ class UserVerificationContractTest {
             val strippedOpen = assertNotNull(stripped.openEnrollment)
             assertFalse(strippedOpen(), "false means the Intent never launched")
             assertEquals(1, stripped.enrollmentLaunches)
+        }
+
+    @Test
+    fun deviceLockNotSetCarriesTheSameNullableRemedyShape() =
+        runTest {
+            // Android: a route exists (API 30+ walks lock-setup AND enrollment in one flow).
+            val launched = FakeDeviceLockNotSet()
+            val open = assertNotNull(launched.openDeviceLockSetup, "Android supplies a lock-setup route")
+            assertTrue(open(), "true means the flow was launched")
+            assertEquals(1, launched.lockSetupLaunches)
+
+            // Apple: passcode setup has no public deep link — null, prose fallback, remedy never runs.
+            val prose = FakeDeviceLockNotSet(launches = null)
+            assertNull(prose.openDeviceLockSetup, "no OS route reports null, not a no-op lambda")
+            assertEquals(0, prose.lockSetupLaunches, "nothing was launched")
         }
 
     @Test

--- a/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/UserVerification.jsAndWasmJs.kt
+++ b/buffer-crypto/src/jsAndWasmJsMain/kotlin/com/ditchoom/buffer/crypto/UserVerification.jsAndWasmJs.kt
@@ -1,0 +1,17 @@
+@file:Suppress("MatchingDeclarationName") // MPP platform-suffixed boundary file
+
+package com.ditchoom.buffer.crypto
+
+/**
+ * The browser / WASM engine [UserVerification] — always
+ * [UserVerificationAvailability.Unsupported].
+ *
+ * The web platform deliberately exposes no biometric *status*: a page cannot ask whether a
+ * fingerprint is enrolled, whether the user revoked a sensor, or whether biometry is locked out,
+ * because that is fingerprintable device state. User verification on the web only happens *inside* a
+ * WebAuthn ceremony, which is a prompt and not a probe — so none of [BiometricAvailability]'s states
+ * can be answered honestly here, and reporting `Unsupported` is truthful where guessing would not
+ * be. Key custody is unaffected: WebCrypto keys with `extractable:false` remain
+ * [KeyCustody.NonExportable.Software], reported through [ProtectedKeyResolution].
+ */
+fun userVerification(): UserVerification = UnsupportedUserVerification

--- a/buffer-crypto/src/jsAndWasmJsTest/kotlin/com/ditchoom/buffer/crypto/UserVerificationWebTest.kt
+++ b/buffer-crypto/src/jsAndWasmJsTest/kotlin/com/ditchoom/buffer/crypto/UserVerificationWebTest.kt
@@ -1,0 +1,17 @@
+package com.ditchoom.buffer.crypto
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The browser / WASM boundary reports [UserVerificationAvailability.Unsupported]. The web platform
+ * exposes no biometric *status* by design — enrollment, permission, and lockout are fingerprintable
+ * device state — so verification only ever happens inside a WebAuthn ceremony, which is a prompt and
+ * not a probe. None of [BiometricAvailability]'s states could be answered honestly here.
+ */
+class UserVerificationWebTest {
+    @Test
+    fun theWebHasNoInteractiveVerificationFacility() {
+        assertEquals(UserVerificationAvailability.Unsupported, userVerification().availability())
+    }
+}

--- a/buffer-crypto/src/jvmMain/kotlin/com/ditchoom/buffer/crypto/UserVerification.jvm.kt
+++ b/buffer-crypto/src/jvmMain/kotlin/com/ditchoom/buffer/crypto/UserVerification.jvm.kt
@@ -1,0 +1,17 @@
+@file:Suppress("MatchingDeclarationName") // MPP platform-suffixed boundary file
+
+package com.ditchoom.buffer.crypto
+
+/**
+ * The desktop JVM's [UserVerification] — always
+ * [UserVerificationAvailability.Unsupported].
+ *
+ * A JVM process has no OS facility for verifying a *human at the point of use*: there is no
+ * biometric prompt a plain `java` launcher may raise, and no way to probe enrollment or lockout.
+ * The authentication that does exist on this platform is the PKCS#11 token PIN
+ * (`C_Login`, configured through `BUFFER_CRYPTO_PKCS11_PIN`) — real authentication, but
+ * process-to-token and fixed by deployment configuration rather than interactive; it is reported by
+ * [ProtectedKeyResolution] / [CapabilityFinding], never here. `Unsupported` therefore says nothing
+ * about this host's key custody: a JVM holding TPM-backed, non-exportable keys still reports it.
+ */
+fun userVerification(): UserVerification = UnsupportedUserVerification

--- a/buffer-crypto/src/jvmTest/kotlin/com/ditchoom/buffer/crypto/UserVerificationJvmTest.kt
+++ b/buffer-crypto/src/jvmTest/kotlin/com/ditchoom/buffer/crypto/UserVerificationJvmTest.kt
@@ -1,0 +1,17 @@
+package com.ditchoom.buffer.crypto
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The desktop JVM boundary reports [UserVerificationAvailability.Unsupported]: a `java` launcher has
+ * no OS facility for verifying a *human at the point of use*, and nothing about this host's key
+ * custody changes that — a JVM holding TPM-backed PKCS#11 keys still has no biometric prompt to
+ * raise, and its token PIN is reported by [ProtectedKeyResolution], never here.
+ */
+class UserVerificationJvmTest {
+    @Test
+    fun jvmHasNoInteractiveVerificationFacility() {
+        assertEquals(UserVerificationAvailability.Unsupported, userVerification().availability())
+    }
+}

--- a/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/UserVerification.linux.kt
+++ b/buffer-crypto/src/linuxMain/kotlin/com/ditchoom/buffer/crypto/UserVerification.linux.kt
@@ -1,0 +1,15 @@
+@file:Suppress("MatchingDeclarationName") // MPP platform-suffixed boundary file
+
+package com.ditchoom.buffer.crypto
+
+/**
+ * Linux's [UserVerification] — always [UserVerificationAvailability.Unsupported].
+ *
+ * Linux has no OS-owned interactive verification facility a library can drive: what exists
+ * (`fprintd`, `polkit`, a desktop session's own lock screen) belongs to a particular desktop stack,
+ * cannot be probed for key-capable enrollment or lockout, and is absent entirely on the headless
+ * server targets this platform mostly serves. Where a Linux deployment does authenticate, it does so
+ * to a PKCS#11 token by configured PIN — process-to-token, not a human verified at the point of use
+ * — which is reported by [ProtectedKeyResolution] / [CapabilityFinding], never here.
+ */
+fun userVerification(): UserVerification = UnsupportedUserVerification

--- a/buffer-crypto/src/linuxTest/kotlin/com/ditchoom/buffer/crypto/UserVerificationLinuxTest.kt
+++ b/buffer-crypto/src/linuxTest/kotlin/com/ditchoom/buffer/crypto/UserVerificationLinuxTest.kt
@@ -1,0 +1,17 @@
+package com.ditchoom.buffer.crypto
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The Linux boundary reports [UserVerificationAvailability.Unsupported]: there is no OS facility this
+ * library can drive to verify a human at the point of use. A TPM-backed PKCS#11 token PIN is real
+ * authentication but process-to-token and set by deployment configuration, so it is reported by
+ * [ProtectedKeyResolution] / [CapabilityFinding] rather than here.
+ */
+class UserVerificationLinuxTest {
+    @Test
+    fun linuxHasNoInteractiveVerificationFacility() {
+        assertEquals(UserVerificationAvailability.Unsupported, userVerification().availability())
+    }
+}

--- a/buffer-crypto/src/nativeInterop/swift/CryptoKitShim.h
+++ b/buffer-crypto/src/nativeInterop/swift/CryptoKitShim.h
@@ -21,6 +21,9 @@
 #define BCKS_ERR_BUFFER (-3)
 #define BCKS_ERR_INTERNAL (-4)
 #define BCKS_ERR_PEER (-5)
+// The user (or the system) dismissed an interactive prompt — a decision, not a failure. Only
+// bcks_la_unlock_with_credential returns it; see PromptOutcome.UserCancelled on the Kotlin side.
+#define BCKS_ERR_CANCELED (-6)
 
 // ChaCha20-Poly1305.
 int32_t bcks_chachapoly_seal(
@@ -210,5 +213,50 @@ int32_t bcks_keychain_delete(const char *service, const char *account);
 int32_t bcks_keychain_aliases(
     const char *service,
     uint8_t *out, size_t outCap, size_t *outLenOut);
+
+// Interactive user verification — probing (and remedying) the device's biometric / device-credential
+// facility, for UserVerification.apple.kt. The probes create their own throwaway LAContext and never
+// touch the registry behind bcks_la_context_create, so asking "may this app draw a Face ID button?"
+// can never disturb an evaluated session context that is authorizing Secure Enclave signs.
+
+// Probe results for bcks_la_biometric_availability. These are a SEPARATE space from the BCKS_ERR_*
+// statuses above: they report device *state*, not call failure, so every real state is non-negative
+// and only "this platform has no LocalAuthentication at all" is negative. BCKS_BIO_UNSUPPORTED
+// therefore shares the numeric value of BCKS_ERR_INPUT — the two can never appear on the same return.
+#define BCKS_BIO_READY 0            // key-capable biometry is enrolled and usable right now
+#define BCKS_BIO_NOT_ENROLLED 1     // sensor present and usable, nothing enrolled
+#define BCKS_BIO_PASSCODE_NOT_SET 2 // no device credential, so biometry cannot be enrolled at all
+#define BCKS_BIO_NOT_AVAILABLE 3    // no sensor, or the app may not use it (disambiguate via biometryTypeOut)
+#define BCKS_BIO_LOCKOUT 4          // locked out until the device credential is verified
+#define BCKS_BIO_DISCONNECTED 5     // external biometric sensor currently disconnected (macOS only)
+#define BCKS_BIO_NOT_PAIRED 6       // external biometric sensor present but not paired (macOS only)
+#define BCKS_BIO_UNSUPPORTED (-1)   // no LocalAuthentication on this platform (tvOS)
+
+// Probes key-capable biometry with a fresh, throwaway LAContext and returns a BCKS_BIO_* code.
+// Non-prompting: nothing is put on screen. Writes the biometry type into biometryTypeOut on every
+// path — 0 none, 1 Touch ID, 2 Face ID, 3 Optic ID — which is what distinguishes "no sensor" from
+// "sensor present, this app may not use it" when BCKS_BIO_NOT_AVAILABLE is returned. watchOS has no
+// discrete biometric policy (wrist detection is not biometry an app can name or gate a key on), so
+// it reports BCKS_BIO_NOT_AVAILABLE with type 0.
+int32_t bcks_la_biometric_availability(int32_t *biometryTypeOut);
+
+// 1 when the device has a credential (passcode / PIN) the OS can verify, 0 when it does not or the
+// probe failed for any other reason, -1 where LocalAuthentication does not exist (tvOS).
+// Non-prompting.
+int32_t bcks_la_device_credential_available(void);
+
+// Drives the system DEVICE-CREDENTIAL prompt (passcode / PIN — never biometry) on the context behind
+// `handle`, which carries the localized reason. A successful deviceOwnerAuthentication evaluation is
+// what clears a biometry lockout, so this is the remedy for BCKS_BIO_LOCKOUT. BLOCKING — call off the
+// main thread. BCKS_OK on success, BCKS_ERR_CANCELED when the prompt was dismissed, BCKS_ERR_AUTH on
+// any other denial, BCKS_ERR_INPUT for an unknown handle.
+int32_t bcks_la_unlock_with_credential(int64_t handle);
+
+// Opens this app's own OS settings page so the user can re-grant biometry (iOS family only).
+// Fire-and-forget: 1 means the launch was DISPATCHED, never that the page appeared or that the user
+// changed anything — the caller re-probes afterwards regardless. Returns 0 where no such route
+// exists: macOS publishes no supported per-app settings URL (so a permission-denied state there
+// reports openAppSettings() == false), and watchOS / tvOS have none at all.
+int32_t bcks_open_app_settings(void);
 
 #endif // BUFFER_CRYPTO_CRYPTOKIT_SHIM_H

--- a/buffer-crypto/src/nativeInterop/swift/CryptoKitShim.swift
+++ b/buffer-crypto/src/nativeInterop/swift/CryptoKitShim.swift
@@ -22,6 +22,12 @@ import Foundation
 // so the os() clause is load-bearing.
 import LocalAuthentication
 #endif
+#if canImport(UIKit) && !os(watchOS) && !os(tvOS)
+// Imported for one thing only: the per-app settings deep link (bcks_open_app_settings). watchOS
+// ships a partial UIKit that has no UIApplication, and tvOS has no settings URL, so both are
+// excluded from the canImport clause rather than relying on canImport alone.
+import UIKit
+#endif
 
 // Status codes — kept in sync with CryptoKitShim.h.
 private let BCKS_OK: Int32 = 0
@@ -30,6 +36,7 @@ private let BCKS_ERR_AUTH: Int32 = -2 // AEAD tag mismatch / signature did not v
 private let BCKS_ERR_BUFFER: Int32 = -3 // output buffer too small
 private let BCKS_ERR_INTERNAL: Int32 = -4 // unexpected CryptoKit failure
 private let BCKS_ERR_PEER: Int32 = -5 // peer public key rejected (malformed / off-curve)
+private let BCKS_ERR_CANCELED: Int32 = -6 // user/system dismissed an interactive prompt (a decision, not a failure)
 
 // Copy a CryptoKit Data result into a caller-provided output buffer, writing the length out.
 private func emit(_ data: Data, _ out: UnsafeMutablePointer<UInt8>?, _ outCap: Int, _ outLen: UnsafeMutablePointer<Int>?) -> Int32 {
@@ -732,4 +739,163 @@ public func bcks_keychain_aliases(
     guard status == errSecSuccess, let array = items as? [[String: Any]] else { return BCKS_ERR_INTERNAL }
     let names = array.compactMap { $0[kSecAttrAccount as String] as? String }
     return emit(Data(names.joined(separator: "\n").utf8), out, outCap, outLenOut)
+}
+
+// =============================================================================
+// Interactive user verification — probing (and remedying) the device's biometric /
+// device-credential facility. Consumed by UserVerification.apple.kt.
+// =============================================================================
+//
+// Everything here is probe-shaped except the two remedies (bcks_la_unlock_with_credential,
+// bcks_open_app_settings). The probes build their own throwaway LAContext and never touch
+// LAContextRegistry, so asking "may this app draw a Face ID button?" can never disturb an evaluated
+// session context that is authorizing Enclave signs.
+
+// Probe results — a SEPARATE space from the BCKS_ERR_* statuses above (device state, not call
+// failure), so only "no LocalAuthentication at all" is negative. Kept in sync with CryptoKitShim.h.
+private let BCKS_BIO_READY: Int32 = 0
+private let BCKS_BIO_NOT_ENROLLED: Int32 = 1
+private let BCKS_BIO_PASSCODE_NOT_SET: Int32 = 2
+private let BCKS_BIO_NOT_AVAILABLE: Int32 = 3
+private let BCKS_BIO_LOCKOUT: Int32 = 4
+private let BCKS_BIO_DISCONNECTED: Int32 = 5
+private let BCKS_BIO_NOT_PAIRED: Int32 = 6
+private let BCKS_BIO_UNSUPPORTED: Int32 = -1
+
+#if canImport(LocalAuthentication) && !os(tvOS) && !os(watchOS)
+// LABiometryType -> the modality codes UserVerification.apple.kt maps: 0 none, 1 touchID, 2 faceID,
+// 3 opticID. `biometryType` does not exist on watchOS/tvOS at all, hence this guard.
+private func biometryTypeCode(_ ctx: LAContext) -> Int32 {
+    #if os(iOS)
+    // Optic ID is spelled only in the iOS-family SDK (an iOS binary running on visionOS reports it),
+    // and only from iOS 17 — below the deployment target here — so it needs both guards.
+    if #available(iOS 17.0, *), ctx.biometryType == .opticID { return 3 }
+    #endif
+    switch ctx.biometryType {
+    case .touchID: return 1
+    case .faceID: return 2
+    default: return 0
+    }
+}
+#endif
+
+// Probe key-capable biometry with a FRESH LAContext and report a BCKS_BIO_* state. Non-prompting.
+// biometryTypeOut is written on every path (0 none, 1 touchID, 2 faceID, 3 opticID) — it is what
+// tells "no sensor" apart from "sensor present, this app may not use it" under BCKS_BIO_NOT_AVAILABLE.
+@_cdecl("bcks_la_biometric_availability")
+public func bcks_la_biometric_availability(_ biometryTypeOut: UnsafeMutablePointer<Int32>?) -> Int32 {
+    #if canImport(LocalAuthentication) && !os(tvOS)
+    #if os(watchOS)
+    // watchOS exposes no discrete biometric policy at all (wrist detection stands in for biometrics
+    // and is not something an app can name or gate a key on), so there is nothing to probe: report
+    // "no biometry" and let the device-credential half carry the platform.
+    biometryTypeOut?.pointee = 0
+    return BCKS_BIO_NOT_AVAILABLE
+    #else
+    let ctx = LAContext()
+    var probeError: NSError?
+    let ok = ctx.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &probeError)
+    // ORDER MATTERS: biometryType is only populated once canEvaluatePolicy has run on the context —
+    // read before that, it reports .none no matter what hardware is present.
+    biometryTypeOut?.pointee = biometryTypeCode(ctx)
+    if ok { return BCKS_BIO_READY }
+    guard let ns = probeError, ns.domain == LAError.errorDomain, let code = LAError.Code(rawValue: ns.code) else {
+        return BCKS_BIO_NOT_AVAILABLE
+    }
+    #if os(macOS)
+    // External-sensor states exist only on macOS (an external Touch ID keyboard) and only from
+    // macOS 12, which is above this shim's macOS 11 deployment target — so both guards are needed.
+    if #available(macOS 12.0, *) {
+        switch code {
+        case .biometryDisconnected: return BCKS_BIO_DISCONNECTED
+        case .biometryNotPaired: return BCKS_BIO_NOT_PAIRED
+        default: break
+        }
+    }
+    #endif
+    switch code {
+    case .biometryNotEnrolled: return BCKS_BIO_NOT_ENROLLED
+    case .passcodeNotSet: return BCKS_BIO_PASSCODE_NOT_SET
+    case .biometryLockout: return BCKS_BIO_LOCKOUT
+    case .biometryNotAvailable: return BCKS_BIO_NOT_AVAILABLE
+    default: return BCKS_BIO_NOT_AVAILABLE
+    }
+    #endif
+    #else
+    biometryTypeOut?.pointee = 0
+    return BCKS_BIO_UNSUPPORTED
+    #endif
+}
+
+// Whether the device has a credential (passcode / PIN) the OS can verify, probed with a FRESH
+// LAContext. 1 = yes, 0 = no or the probe failed, -1 where LocalAuthentication does not exist
+// (tvOS). Non-prompting.
+@_cdecl("bcks_la_device_credential_available")
+public func bcks_la_device_credential_available() -> Int32 {
+    #if canImport(LocalAuthentication) && !os(tvOS)
+    return LAContext().canEvaluatePolicy(.deviceOwnerAuthentication, error: nil) ? 1 : 0
+    #else
+    return -1
+    #endif
+}
+
+#if canImport(LocalAuthentication) && !os(tvOS)
+// Map an evaluatePolicy failure onto the status Kotlin turns into a PromptOutcome: an explicit
+// dismissal (by the user, this app, or the system) is a decision, everything else is a failure.
+private func classifyEvaluateFailure(_ error: Error?) -> Int32 {
+    guard let error = error else { return BCKS_ERR_AUTH }
+    let ns = error as NSError
+    guard ns.domain == LAError.errorDomain, let code = LAError.Code(rawValue: ns.code) else {
+        return BCKS_ERR_AUTH
+    }
+    switch code {
+    case .userCancel, .appCancel, .systemCancel: return BCKS_ERR_CANCELED
+    default: return BCKS_ERR_AUTH
+    }
+}
+#endif
+
+// Drive the system DEVICE-CREDENTIAL prompt (passcode / PIN — never biometry) on the context behind
+// `handle`, which carries the localized reason. A successful deviceOwnerAuthentication is what
+// clears a biometry lockout, so this is the remedy for BCKS_BIO_LOCKOUT. BLOCKING — call off the
+// main thread. BCKS_OK, BCKS_ERR_CANCELED on dismissal, BCKS_ERR_AUTH otherwise, BCKS_ERR_INPUT for
+// an unknown handle.
+@_cdecl("bcks_la_unlock_with_credential")
+public func bcks_la_unlock_with_credential(_ handle: Int64) -> Int32 {
+    #if canImport(LocalAuthentication) && !os(tvOS)
+    guard let (ctx, reason) = LAContextRegistry.shared.get(handle) else { return BCKS_ERR_INPUT }
+    // The whole point is to put the credential prompt on screen, so interaction is always allowed.
+    ctx.interactionNotAllowed = false
+    let sem = DispatchSemaphore(value: 0)
+    var status: Int32 = BCKS_ERR_AUTH
+    ctx.evaluatePolicy(
+        .deviceOwnerAuthentication,
+        localizedReason: reason.isEmpty ? "unlock biometrics with your device passcode" : reason
+    ) { success, error in
+        status = success ? BCKS_OK : classifyEvaluateFailure(error)
+        sem.signal()
+    }
+    sem.wait()
+    return status
+    #else
+    return BCKS_ERR_INTERNAL
+    #endif
+}
+
+// Open this app's own OS settings page so the user can re-grant biometry (iOS family only).
+// Fire-and-forget: 1 means the launch was DISPATCHED, never that the page appeared or that anything
+// changed — the caller re-probes afterwards regardless. 0 where no route exists: macOS publishes no
+// supported per-app settings URL, and watchOS / tvOS have none at all.
+@_cdecl("bcks_open_app_settings")
+public func bcks_open_app_settings() -> Int32 {
+    #if canImport(UIKit) && !os(watchOS) && !os(tvOS)
+    // UIApplication is main-thread-only and this is called from a background dispatcher.
+    DispatchQueue.main.async {
+        guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+        UIApplication.shared.open(url)
+    }
+    return 1
+    #else
+    return 0
+    #endif
 }


### PR DESCRIPTION
Adds `UserVerification` to `buffer-crypto`: a commonMain vocabulary that reports whether the OS can verify a human at point of use, scoped to **key-capable** biometry (Class 3 on Android, all Apple biometry).

```kotlin
UserVerification.availability() ->
  Unsupported | Supported(biometric, deviceCredential)
```

`BiometricAvailability`'s three branches map to the three UX decisions a consumer actually makes:

- **`Ready(modality)`** — offer the feature.
- **`Actionable`** — the user can fix this, and each state carries exactly one remedy as a suspend closure: `openEnrollment`, `openDeviceLockSetup`, `openAppSettings`, `unlockWithDeviceCredential`. An action exists iff the state admits it; the closure is nullable only where the OS genuinely has no route.
- **`Unavailable`** — hide the option, with `OnlyWeakBiometrics` kept distinct from `NoHardware`.

`Indeterminate` sits outside all three (`STATUS_UNKNOWN` — attempting a prompt is legitimate).

### Why there is no `authenticate()`

Deliberately absent. Authentication unbound to a key operation is bypassable — the caller can ignore the result. The bound gate already exists inside `UserAuthenticatedKeyProvider`, where the closures embed the authorization. This API offers **remedies only**.

### Design notes

- **No `strength` field.** `Available(strength = Weak)` was an impossible-to-act-on in-between state: it reads as available but can never gate a `CryptoObject` key. Weak-only devices report `Unavailable.OnlyWeakBiometrics`.
- **No `retryAfter` / attempts-remaining.** No platform discloses them; they would be invented numbers. The probe is non-prompting, so re-probe on resume instead.
- **No raw error codes.** Follows the `Pkcs11Token` precedent — a code worth acting on earns a named variant at the boundary.
- **`Unsupported` means no *interactive* verification.** A PKCS#11 token PIN is real auth, but it is process-to-token and deployment-configured; it stays reported through `ProtectedKeyResolution` / `CapabilityFinding`. The two channels are not conflated.
- **Probes are never cached** — re-run per call. Action-carrying states use value equality so an unchanged probe compares equal for `distinctUntilChanged` consumers.

Construction is platform-boundary only, mirroring `userAuthenticated()`: Android captures a `FragmentActivity`, Apple wraps a `LocalAuthAuthenticator` over four new shim entry points, and JVM/Linux/web return the shared `Unsupported` instance.

### `DeviceLockNotSet` carries its own remedy

`DeviceLockNotSet` was the one `Actionable` state violating the contract's own rule — a call to action with no launcher. It now carries `openDeviceLockSetup`. Android tries `ACTION_BIOMETRIC_ENROLL` first on API 30+, whose stock flow walks the user through setting the lock *and* enrolling in one pass, falling back to `ACTION_SECURITY_SETTINGS`. Apple maps `LAError.passcodeNotSet` to a null route — passcode setup has no public deep link, and the `x-apple.systempreferences` pane ids are undocumented, so the library does not ship them.

The launch-and-report `Boolean` is deliberate: since Android 11, `resolveActivity()` lies unless the consumer app declares `<queries>`, while `startActivity()` may fire blind. Try-and-report is the one mechanism that needs nothing from the consumer's manifest. `false` = the OEM refused at tap time (show prose now); `true` = dispatched, re-probe on resume.

### Testing

- 11-test common contract suite, else-free exhaustive `when`s over all 14 leaves, on jvm/js/wasm/linux, plus per-platform `Unsupported` probes and a guarded appleTest.
- New instrumented suite driving the **real** Android probe (the common suite only exercises fakes), with the `FragmentActivity` host the instrumented source set was missing. Assertions are device-state-agnostic — internal consistency plus platform-impossibility — so the same run works on any attached device.
- Verified on hardware: an API 35 OEM device (5/5, probe → `Ready`) and an API 35 AOSP emulator (5/5). With a PIN set the probe reports `NotEnrolled` and `openEnrollment` → `true`, confirming `ACTION_BIOMETRIC_ENROLL` resolves; from the no-lock state `openDeviceLockSetup` → `true`, landing on `ChooseLockGeneric`.

### ABI

Purely additive — 322 insertions, 0 removals; no existing enum gained a constant and no sealed hierarchy gained a subtype, so consumers' exhaustive `when`s still compile. `apiDump` regenerated, `apiCheck` green. Labeled `minor`.

### Not verified locally

The Apple and shim code is compile-verified only on Mac CI — it was written without a Mac in the loop. Behavioral Apple states (`Ready`, lockout) remain manually testable only on real devices.

### Deferred

- Post-prompt lockout wiring (Android `ERROR_LOCKOUT` / `ERROR_LOCKOUT_PERMANENT` → the `LockedOut*` vocabulary). Android's probe cannot see lockout — it arrives post-prompt only — so this release constructs neither `LockedOut*` state there. One vocabulary, two entry points.
- The Apple credential probe cannot distinguish probe-failure from no-passcode (headless macOS reports `NotSet`); the biometric half has `Indeterminate`, the credential half has no equivalent escape hatch.
- Unmapped `LAError` codes (`.invalidContext`, `.notInteractive`) should fold into `PermissionDenied` when a biometry type is present.
