### PR TITLE
fix(buffer-crypto): X25519 is reported unavailable on every Android, and it is not

### DIFF
--- a/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/KeyAgreement.jvmCommon.kt
+++ b/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/KeyAgreement.jvmCommon.kt
@@ -82,26 +82,36 @@ private fun x25519KeyPairGenerator(): KeyPairGenerator =
         }
     }
 
-private val supportsSyncX25519: Boolean =
-    probe {
-        // Generate, rather than merely constructing the generator. The previous probe stopped at
-        // `initialize`, so Conscrypt's refusal of the spec made it report X25519 UNAVAILABLE on every
-        // Android API level — including the ones where it is fully present and working. Anything
-        // consuming this flag to pick a curve (a DTLS 1.3 key_share, say) was therefore told Android
-        // could not do X25519 at all, which is false. Generating proves the whole path.
-        x25519KeyPairGenerator().generateKeyPair()
-        JcaKeyAgreement.getInstance("XDH")
+/**
+ * Every probe below **generates a key pair** rather than stopping at `initialize`, and each is `lazy`
+ * so only the curves a caller actually asks about are paid for.
+ *
+ * Generating is the whole point: `probe {}` swallows `Throwable`, so a probe that stops short of the
+ * real call turns any provider disagreement into a silent "unavailable" that nothing can see is wrong.
+ * That is exactly how X25519 came to be reported missing on every Android API level — Conscrypt's
+ * `XDH` generator refuses the `AlgorithmParameterSpec` the JDK's requires — and the same shape of
+ * disagreement is possible on the EC side, so [probeEc] is held to the same standard. `lazy` covers
+ * the added cost: a caller that only ever uses P-256 no longer generates a P-521 key to find out.
+ */
+private val supportsSyncX25519: Boolean by
+    lazy {
+        probe {
+            x25519KeyPairGenerator().generateKeyPair()
+            JcaKeyAgreement.getInstance("XDH")
+        }
     }
 
 private fun probeEc(curve: String): Boolean =
     probe {
-        KeyPairGenerator.getInstance("EC").initialize(ECGenParameterSpec(curve))
+        val generator = KeyPairGenerator.getInstance("EC")
+        generator.initialize(ECGenParameterSpec(curve))
+        generator.generateKeyPair()
         JcaKeyAgreement.getInstance("ECDH")
     }
 
-private val supportsSyncEcdhP256: Boolean = probeEc("secp256r1")
-private val supportsSyncEcdhP384: Boolean = probeEc("secp384r1")
-private val supportsSyncEcdhP521: Boolean = probeEc("secp521r1")
+private val supportsSyncEcdhP256: Boolean by lazy { probeEc("secp256r1") }
+private val supportsSyncEcdhP384: Boolean by lazy { probeEc("secp384r1") }
+private val supportsSyncEcdhP521: Boolean by lazy { probeEc("secp521r1") }
 
 /** Whether [curve] has a synchronous JCA path on this runtime (X25519 needs XDH; Android 14+). */
 private fun jvmSupportsSync(curve: KeyAgreementCurve): Boolean =
@@ -209,14 +219,22 @@ private fun x25519PrivateKeyFrom(scalar: ByteArray): java.security.PrivateKey {
  * encoding is [x25519SpkiPrefix] followed by the raw little-endian u — which is exactly what
  * [x25519PublicKey] writes when going the other way, so the two are now inverses by construction
  * rather than by coincidence. Measured encoding length is 44 = 12 + 32.
+ *
+ * That exact shape is *asserted*, not assumed. Taking the trailing 32 bytes of whatever a provider
+ * hands back would turn an unexpected encoding into silently wrong key material — the same class of
+ * quiet wrongness this function exists to fix. A provider that disagrees now fails loudly instead.
  */
 private fun rawX25519(pub: java.security.PublicKey): ByteArray {
     val encoded =
         requireNotNull(pub.encoded) { "X25519 public key exposes no encoding" }
-    require(encoded.size >= X25519_RAW_BYTES) {
-        "X25519 SPKI is ${encoded.size} bytes, too short to carry a $X25519_RAW_BYTES-byte u"
+    val spkiSize = x25519SpkiPrefix.size + X25519_RAW_BYTES
+    require(encoded.size == spkiSize) {
+        "X25519 public key encoding is ${encoded.size} bytes, expected $spkiSize (SPKI prefix + u)"
     }
-    return encoded.copyOfRange(encoded.size - X25519_RAW_BYTES, encoded.size)
+    require(x25519SpkiPrefix.indices.all { encoded[it] == x25519SpkiPrefix[it] }) {
+        "X25519 public key is not in the expected X.509/SPKI form (format=${pub.format})"
+    }
+    return encoded.copyOfRange(x25519SpkiPrefix.size, encoded.size)
 }
 
 // ---- ECDH -------------------------------------------------------------------

--- a/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/KeyAgreement.jvmCommon.kt
+++ b/buffer-crypto/src/jvmCommonMain/kotlin/com/ditchoom/buffer/crypto/KeyAgreement.jvmCommon.kt
@@ -7,10 +7,10 @@ import com.ditchoom.buffer.ReadBuffer
 import java.math.BigInteger
 import java.security.AlgorithmParameters
 import java.security.GeneralSecurityException
+import java.security.InvalidAlgorithmParameterException
 import java.security.KeyFactory
 import java.security.KeyPairGenerator
 import java.security.interfaces.ECPublicKey
-import java.security.interfaces.XECPublicKey
 import java.security.spec.ECGenParameterSpec
 import java.security.spec.ECParameterSpec
 import java.security.spec.ECPoint
@@ -24,9 +24,17 @@ import javax.crypto.KeyAgreement as JcaKeyAgreement
  * P-curves. Public keys are converted between the pinned raw encoding ([KeyAgreementCurve]) and
  * JCA's SPKI/X.509 / `ECPoint` forms here.
  *
- * Android note: X25519 is only present from API 34 (Conscrypt added it in Android 14). The
- * capability flags below probe the provider at class-load time, so on API 28–33 [supportsSyncX25519]
+ * Android note: X25519 arrives with Conscrypt in Android 14 (API 34); below that [supportsSyncX25519]
  * is `false` and the X25519 entry points throw [UnsupportedOperationException] — JVM is unaffected.
+ *
+ * Where Conscrypt is present it differs from the JDK in two ways that both used to break it here, and
+ * both are silent rather than loud, so they are worth stating: its `XDH` [KeyPairGenerator] accepts no
+ * `AlgorithmParameterSpec` at all (see [x25519KeyPairGenerator]), and its public key does not implement
+ * `XECPublicKey` (see [rawX25519]). Between them, X25519 reported *unavailable on every Android API
+ * level* — including 34+, where it works — and the one consumer that picked a curve from that flag
+ * could not negotiate X25519 on any Android device. Measured on API 35, not inferred: the capability
+ * flags below are class-load-time probes, so a probe that stops short of the real call is a capability
+ * answer nobody can see is wrong.
  *
  * `ByteArray` appears in this file at the unavoidable JCA seam (X509EncodedKeySpec / generateSecret /
  * BigInteger) — the same system-API boundary the landed `JvmCryptoBridge` lives at; it is never used
@@ -51,9 +59,37 @@ private fun probe(block: () -> Unit): Boolean =
         false
     }
 
+/**
+ * An `XDH` [KeyPairGenerator] pinned to X25519 on **both** JCA implementations we run on.
+ *
+ * The JDK's `XDH` generator is multi-curve (X25519 / X448) and must be told which one via
+ * [NamedParameterSpec]. Conscrypt's is X25519-only and supports **no** `AlgorithmParameterSpec`
+ * whatsoever — `initialize(NamedParameterSpec.X25519)` raises
+ * `InvalidAlgorithmParameterException: No AlgorithmParameterSpec classes are supported`. Measured on
+ * an API 35 emulator: the generator itself is `OpenSSLXDHKeyPairGenerator`, and `generateKeyPair()`
+ * with no `initialize` returns a working X25519 pair.
+ *
+ * So: ask for the spec, and treat a refusal as "this provider is already X25519". Swallowing the
+ * exception is safe precisely because it is the *parameterless* generator that refuses — a provider
+ * that supported X448 through this entry point would have accepted the spec.
+ */
+private fun x25519KeyPairGenerator(): KeyPairGenerator =
+    KeyPairGenerator.getInstance("XDH").apply {
+        try {
+            initialize(NamedParameterSpec.X25519)
+        } catch (_: InvalidAlgorithmParameterException) {
+            // Conscrypt: X25519-only, nothing to select.
+        }
+    }
+
 private val supportsSyncX25519: Boolean =
     probe {
-        KeyPairGenerator.getInstance("XDH").initialize(NamedParameterSpec.X25519)
+        // Generate, rather than merely constructing the generator. The previous probe stopped at
+        // `initialize`, so Conscrypt's refusal of the spec made it report X25519 UNAVAILABLE on every
+        // Android API level — including the ones where it is fully present and working. Anything
+        // consuming this flag to pick a curve (a DTLS 1.3 key_share, say) was therefore told Android
+        // could not do X25519 at all, which is false. Generating proves the whole path.
+        x25519KeyPairGenerator().generateKeyPair()
         JcaKeyAgreement.getInstance("XDH")
     }
 
@@ -161,20 +197,26 @@ private fun x25519PrivateKeyFrom(scalar: ByteArray): java.security.PrivateKey {
     return KeyFactory.getInstance("XDH").generatePrivate(java.security.spec.PKCS8EncodedKeySpec(der))
 }
 
-/** Little-endian 32-byte raw u from an XEC public key's BigInteger u-coordinate. */
+/**
+ * The little-endian 32-byte raw u of an X25519 public key.
+ *
+ * Reads the **X.509/SPKI encoding** rather than casting to [XECPublicKey], because that cast is not
+ * portable: Conscrypt's key is `com.android.org.conscrypt.OpenSSLX25519PublicKey`, which does **not**
+ * implement [XECPublicKey] (measured on API 35 — `isXEC=false`), so the cast is a
+ * `ClassCastException` on Android even where X25519 works perfectly.
+ *
+ * The SPKI tail is well-defined and identical across providers: `getFormat() == "X.509"`, and the
+ * encoding is [x25519SpkiPrefix] followed by the raw little-endian u — which is exactly what
+ * [x25519PublicKey] writes when going the other way, so the two are now inverses by construction
+ * rather than by coincidence. Measured encoding length is 44 = 12 + 32.
+ */
 private fun rawX25519(pub: java.security.PublicKey): ByteArray {
-    val u = (pub as XECPublicKey).u
-    val be = u.toByteArray() // big-endian, possibly with sign byte / shorter than 32
-    val raw = ByteArray(X25519_RAW_BYTES)
-    // copy big-endian magnitude into the low bytes, then reverse to little-endian
-    var src = be.size - 1
-    var dst = 0
-    while (src >= 0 && dst < X25519_RAW_BYTES) {
-        raw[dst] = be[src]
-        src--
-        dst++
+    val encoded =
+        requireNotNull(pub.encoded) { "X25519 public key exposes no encoding" }
+    require(encoded.size >= X25519_RAW_BYTES) {
+        "X25519 SPKI is ${encoded.size} bytes, too short to carry a $X25519_RAW_BYTES-byte u"
     }
-    return raw
+    return encoded.copyOfRange(encoded.size - X25519_RAW_BYTES, encoded.size)
 }
 
 // ---- ECDH -------------------------------------------------------------------
@@ -232,9 +274,7 @@ internal actual fun generateKeyPairPlatform(curve: KeyAgreementCurve): KeyAgreem
     requireSupported(curve)
     return when (curve) {
         KeyAgreementCurve.X25519 -> {
-            val kpg = KeyPairGenerator.getInstance("XDH")
-            kpg.initialize(NamedParameterSpec.X25519)
-            val kp = kpg.generateKeyPair()
+            val kp = x25519KeyPairGenerator().generateKeyPair()
             val rawPub = rawX25519(kp.public)
             // Private scalar lives in a wiped SecureBuffer. JCA does not expose the raw XDH scalar
             // via a stable API, so we re-import the PKCS#8 octet string we'll need for agreement;

--- a/buffer-crypto/src/jvmCommonTest/kotlin/com/ditchoom/buffer/crypto/X25519CapabilityHonestyTest.kt
+++ b/buffer-crypto/src/jvmCommonTest/kotlin/com/ditchoom/buffer/crypto/X25519CapabilityHonestyTest.kt
@@ -1,0 +1,106 @@
+package com.ditchoom.buffer.crypto
+
+import java.security.KeyPairGenerator
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import javax.crypto.KeyAgreement as JcaKeyAgreement
+
+/**
+ * The capability flag must not disagree with the provider.
+ *
+ * **Why this is not covered by [KeyAgreementTest].** That suite *skips* any curve the target reports as
+ * unavailable — a sound design for a genuinely absent primitive, but it makes the suite structurally
+ * blind to the failure where the primitive is present and the flag says otherwise. Every X25519 test
+ * passed on Android for exactly that reason while X25519 was reported `Unavailable` on every API level,
+ * including those where it works. A green run said nothing.
+ *
+ * The bug had two independent causes, both from writing Conscrypt code to the JDK's shape:
+ *  - the probe called `KeyPairGenerator.getInstance("XDH").initialize(NamedParameterSpec.X25519)`, and
+ *    Conscrypt's X25519-only generator supports no `AlgorithmParameterSpec` at all; and
+ *  - `rawX25519` cast the public key to `XECPublicKey`, which `OpenSSLX25519PublicKey` does not
+ *    implement, so even a corrected probe would have thrown at the first key generation.
+ *
+ * So this asserts the **agreement between the two**, in the only direction that can be checked
+ * portably: where the JCA can really produce an X25519 keypair, the capability must say so — and then
+ * the whole documented path (generate → encode → agree) must actually run.
+ */
+class X25519CapabilityHonestyTest {
+    /** Whether this runtime's JCA can genuinely produce an X25519 keypair, asked without our own flags. */
+    private fun jcaCanReallyDoX25519(): Boolean =
+        try {
+            // Deliberately mirrors neither branch of the production helper: no AlgorithmParameterSpec at
+            // all, which both the JDK (defaults to X25519) and Conscrypt (X25519-only) accept.
+            KeyPairGenerator.getInstance("XDH").generateKeyPair()
+            JcaKeyAgreement.getInstance("XDH")
+            true
+        } catch (_: Throwable) {
+            false
+        }
+
+    @Test
+    fun a_provider_that_can_do_x25519_is_reported_as_able_to_do_x25519() {
+        if (!jcaCanReallyDoX25519()) return // genuinely absent (e.g. Android < 34); nothing to contradict
+        assertTrue(
+            CryptoCapabilities.keyAgreement(KeyAgreementCurve.X25519) is KeyAgreementSupport.Blocking,
+            "the JCA produced an X25519 keypair, so the capability flag claiming Unavailable is a lie — " +
+                "this is the Conscrypt regression: an AlgorithmParameterSpec-shaped probe reporting a " +
+                "working primitive as missing",
+        )
+    }
+
+    @Test
+    fun the_reported_capability_can_complete_a_real_agreement() {
+        val support = CryptoCapabilities.keyAgreement(KeyAgreementCurve.X25519)
+        if (support !is KeyAgreementSupport.Blocking) return
+        // Not merely "the flag is true": generate two pairs through our own ops and agree, so a flag that
+        // is honest about the probe but wrong about the key encoding (the `XECPublicKey` half of the bug)
+        // still fails here rather than at a consumer.
+        val a = support.ops.generateKeyPairBlocking()
+        val b = support.ops.generateKeyPairBlocking()
+        try {
+            assertEquals(
+                32,
+                a.publicKey.encoded.remaining(),
+                "X25519 raw public point is 32 bytes; a different width means the SPKI tail was misread",
+            )
+            val ab =
+                runBlockingCompat {
+                    support.ops.deriveTlsPremasterSecret(
+                        a.privateKey,
+                        KeyAgreementPublicKey.of(KeyAgreementCurve.X25519, b.publicKey.encoded),
+                    )
+                }
+            val ba =
+                runBlockingCompat {
+                    support.ops.deriveTlsPremasterSecret(
+                        b.privateKey,
+                        KeyAgreementPublicKey.of(KeyAgreementCurve.X25519, a.publicKey.encoded),
+                    )
+                }
+            try {
+                assertEquals(hex(ab), hex(ba), "both sides must derive the same X25519 secret")
+                assertTrue(hex(ab).any { it != '0' }, "the shared secret must not be all-zero")
+            } finally {
+                ab.freeNativeMemory()
+                ba.freeNativeMemory()
+            }
+        } finally {
+            a.close()
+            b.close()
+        }
+    }
+
+    private fun hex(buf: com.ditchoom.buffer.ReadBuffer): String {
+        val start = buf.position()
+        val sb = StringBuilder()
+        while (buf.remaining() > 0) {
+            val v = buf.readByte().toInt() and 0xFF
+            sb.append("0123456789abcdef"[v ushr 4]).append("0123456789abcdef"[v and 0xF])
+        }
+        buf.position(start)
+        return sb.toString()
+    }
+
+    private fun <T> runBlockingCompat(block: suspend () -> T): T = kotlinx.coroutines.runBlocking { block() }
+}

--- a/buffer-crypto/src/jvmCommonTest/kotlin/com/ditchoom/buffer/crypto/X25519CapabilityHonestyTest.kt
+++ b/buffer-crypto/src/jvmCommonTest/kotlin/com/ditchoom/buffer/crypto/X25519CapabilityHonestyTest.kt
@@ -1,5 +1,7 @@
 package com.ditchoom.buffer.crypto
 
+import com.ditchoom.buffer.toHexString
+import kotlinx.coroutines.runBlocking
 import java.security.KeyPairGenerator
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -39,7 +41,7 @@ class X25519CapabilityHonestyTest {
         }
 
     @Test
-    fun a_provider_that_can_do_x25519_is_reported_as_able_to_do_x25519() {
+    fun providerThatCanDoX25519IsReportedAsAbleToDoX25519() {
         if (!jcaCanReallyDoX25519()) return // genuinely absent (e.g. Android < 34); nothing to contradict
         assertTrue(
             CryptoCapabilities.keyAgreement(KeyAgreementCurve.X25519) is KeyAgreementSupport.Blocking,
@@ -50,7 +52,7 @@ class X25519CapabilityHonestyTest {
     }
 
     @Test
-    fun the_reported_capability_can_complete_a_real_agreement() {
+    fun reportedCapabilityCanCompleteARealAgreement() {
         val support = CryptoCapabilities.keyAgreement(KeyAgreementCurve.X25519)
         if (support !is KeyAgreementSupport.Blocking) return
         // Not merely "the flag is true": generate two pairs through our own ops and agree, so a flag that
@@ -60,27 +62,16 @@ class X25519CapabilityHonestyTest {
         val b = support.ops.generateKeyPairBlocking()
         try {
             assertEquals(
-                32,
+                X25519_RAW_PUBLIC_BYTES,
                 a.publicKey.encoded.remaining(),
-                "X25519 raw public point is 32 bytes; a different width means the SPKI tail was misread",
+                "X25519 raw public point is $X25519_RAW_PUBLIC_BYTES bytes; a different width means the " +
+                    "SPKI tail was misread",
             )
-            val ab =
-                runBlockingCompat {
-                    support.ops.deriveTlsPremasterSecret(
-                        a.privateKey,
-                        KeyAgreementPublicKey.of(KeyAgreementCurve.X25519, b.publicKey.encoded),
-                    )
-                }
-            val ba =
-                runBlockingCompat {
-                    support.ops.deriveTlsPremasterSecret(
-                        b.privateKey,
-                        KeyAgreementPublicKey.of(KeyAgreementCurve.X25519, a.publicKey.encoded),
-                    )
-                }
+            val ab = agree(support, a, b)
+            val ba = agree(support, b, a)
             try {
-                assertEquals(hex(ab), hex(ba), "both sides must derive the same X25519 secret")
-                assertTrue(hex(ab).any { it != '0' }, "the shared secret must not be all-zero")
+                assertEquals(ab.toHexString(), ba.toHexString(), "both sides must derive the same X25519 secret")
+                assertTrue(ab.toHexString().any { it != '0' }, "the shared secret must not be all-zero")
             } finally {
                 ab.freeNativeMemory()
                 ba.freeNativeMemory()
@@ -91,16 +82,20 @@ class X25519CapabilityHonestyTest {
         }
     }
 
-    private fun hex(buf: com.ditchoom.buffer.ReadBuffer): String {
-        val start = buf.position()
-        val sb = StringBuilder()
-        while (buf.remaining() > 0) {
-            val v = buf.readByte().toInt() and 0xFF
-            sb.append("0123456789abcdef"[v ushr 4]).append("0123456789abcdef"[v and 0xF])
-        }
-        buf.position(start)
-        return sb.toString()
+    /** [own]'s private key agreed against [peer]'s public point, through the reported blocking ops. */
+    private fun agree(
+        support: KeyAgreementSupport.Blocking,
+        own: KeyAgreementKeyPair,
+        peer: KeyAgreementKeyPair,
+    ) = runBlocking {
+        support.ops.deriveTlsPremasterSecret(
+            own.privateKey,
+            KeyAgreementPublicKey.of(KeyAgreementCurve.X25519, peer.publicKey.encoded),
+        )
     }
 
-    private fun <T> runBlockingCompat(block: suspend () -> T): T = kotlinx.coroutines.runBlocking { block() }
+    private companion object {
+        /** RFC 7748 X25519 public keys are a 32-byte u-coordinate. */
+        const val X25519_RAW_PUBLIC_BYTES = 32
+    }
 }

--- a/buffer-crypto/src/jvmCommonTest/kotlin/com/ditchoom/buffer/crypto/X25519CapabilityHonestyTest.kt
+++ b/buffer-crypto/src/jvmCommonTest/kotlin/com/ditchoom/buffer/crypto/X25519CapabilityHonestyTest.kt
@@ -3,6 +3,7 @@ package com.ditchoom.buffer.crypto
 import com.ditchoom.buffer.toHexString
 import kotlinx.coroutines.runBlocking
 import java.security.KeyPairGenerator
+import java.security.spec.ECGenParameterSpec
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -26,6 +27,10 @@ import javax.crypto.KeyAgreement as JcaKeyAgreement
  * So this asserts the **agreement between the two**, in the only direction that can be checked
  * portably: where the JCA can really produce an X25519 keypair, the capability must say so — and then
  * the whole documented path (generate → encode → agree) must actually run.
+ *
+ * X25519 keeps its own named tests because that is the curve that regressed and the one whose key
+ * encoding the fix rewrote, but the honesty check itself is applied to every curve — nothing about a
+ * probe disagreeing with its provider was specific to X25519.
  */
 class X25519CapabilityHonestyTest {
     /** Whether this runtime's JCA can genuinely produce an X25519 keypair, asked without our own flags. */
@@ -49,6 +54,64 @@ class X25519CapabilityHonestyTest {
                 "this is the Conscrypt regression: an AlgorithmParameterSpec-shaped probe reporting a " +
                 "working primitive as missing",
         )
+    }
+
+    /**
+     * Whether the JCA can genuinely produce a key pair on [curve], asked without our own flags.
+     *
+     * Generates rather than merely initializing, for the same reason the production probes do: a
+     * provider can accept a spec and still refuse to produce a key, and only generating tells them
+     * apart. Deliberately does not share code with the production helper — a check that reuses the
+     * thing it is checking cannot detect the thing being wrong.
+     */
+    private fun jcaCanReallyDo(curve: KeyAgreementCurve): Boolean =
+        try {
+            when (curve) {
+                // No AlgorithmParameterSpec at all, which both the JDK (defaults to X25519) and
+                // Conscrypt (X25519-only) accept.
+                KeyAgreementCurve.X25519 -> {
+                    KeyPairGenerator.getInstance("XDH").generateKeyPair()
+                    JcaKeyAgreement.getInstance("XDH")
+                }
+
+                else -> {
+                    val generator = KeyPairGenerator.getInstance("EC")
+                    generator.initialize(ECGenParameterSpec(sec1Name(curve)))
+                    generator.generateKeyPair()
+                    JcaKeyAgreement.getInstance("ECDH")
+                }
+            }
+            true
+        } catch (_: Throwable) {
+            false
+        }
+
+    private fun sec1Name(curve: KeyAgreementCurve): String =
+        when (curve) {
+            KeyAgreementCurve.P256 -> "secp256r1"
+            KeyAgreementCurve.P384 -> "secp384r1"
+            KeyAgreementCurve.P521 -> "secp521r1"
+            KeyAgreementCurve.X25519 -> error("X25519 is not an EC named curve")
+        }
+
+    /**
+     * The same honesty check across every curve, not just the one that regressed.
+     *
+     * X25519 is where the under-reporting was found, but nothing about the failure was specific to
+     * it: any capability probe that disagrees with its provider produces a flag whose wrongness is
+     * invisible to a suite that skips on the flag. Asserting it per curve means the next divergence
+     * — a provider that drops P-521, say — surfaces here rather than at a consumer.
+     */
+    @Test
+    fun everyCurveTheProviderCanGenerateIsReportedAsSupported() {
+        curves.filter { jcaCanReallyDo(it) }.forEach { curve ->
+            assertTrue(
+                CryptoCapabilities.keyAgreement(curve) is KeyAgreementSupport.Blocking,
+                "the JCA produced a ${curve.curveName} key pair, so reporting the curve as Unavailable " +
+                    "is a capability lie — a consumer choosing a curve from this flag would skip one " +
+                    "that works",
+            )
+        }
     }
 
     @Test
@@ -97,5 +160,13 @@ class X25519CapabilityHonestyTest {
     private companion object {
         /** RFC 7748 X25519 public keys are a 32-byte u-coordinate. */
         const val X25519_RAW_PUBLIC_BYTES = 32
+
+        val curves =
+            listOf(
+                KeyAgreementCurve.X25519,
+                KeyAgreementCurve.P256,
+                KeyAgreementCurve.P384,
+                KeyAgreementCurve.P521,
+            )
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -157,20 +157,11 @@ tasks.register("connectedAndroidTestCompatible") {
     // (emulator timings are not representative) and which therefore stays excluded here.
     // When a new module is added (e.g. buffer-crypto, minSdk 28), add it here with its
     // minSdk so the API-21 leg cleanly skips it instead of failing.
-    //
-    // `:buffer-crypto` is the module where NOT being in this list has actually cost something. It is
-    // the one whose behaviour differs most between JCA implementations — the JDK's providers on a host
-    // JVM versus Conscrypt on a device — and it was the only module absent here, so none of that
-    // divergence was ever executed. That is how a probe written to the JDK's shape came to report
-    // X25519 `Unavailable` on every Android API level while Conscrypt implemented it fine, and why the
-    // regression test guarding it (`X25519CapabilityHonestyTest`) would otherwise run only on the JVM,
-    // where the bug cannot reproduce. minSdk 28, so the API-21 leg skips it and the API-35 leg runs it.
     val androidConnectedTests =
         listOf(
             Triple(":buffer-compression", ":buffer-compression:connectedDebugAndroidTest", 21),
             Triple(":buffer-flow", ":buffer-flow:connectedDebugAndroidTest", 21),
             Triple(":buffer-codec", ":buffer-codec:connectedDebugAndroidTest", 21),
-            Triple(":buffer-crypto", ":buffer-crypto:connectedDebugAndroidTest", 28),
         )
 
     androidConnectedTests.forEach { (_, testTaskPath, minSdk) ->

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -157,11 +157,20 @@ tasks.register("connectedAndroidTestCompatible") {
     // (emulator timings are not representative) and which therefore stays excluded here.
     // When a new module is added (e.g. buffer-crypto, minSdk 28), add it here with its
     // minSdk so the API-21 leg cleanly skips it instead of failing.
+    //
+    // `:buffer-crypto` is the module where NOT being in this list has actually cost something. It is
+    // the one whose behaviour differs most between JCA implementations — the JDK's providers on a host
+    // JVM versus Conscrypt on a device — and it was the only module absent here, so none of that
+    // divergence was ever executed. That is how a probe written to the JDK's shape came to report
+    // X25519 `Unavailable` on every Android API level while Conscrypt implemented it fine, and why the
+    // regression test guarding it (`X25519CapabilityHonestyTest`) would otherwise run only on the JVM,
+    // where the bug cannot reproduce. minSdk 28, so the API-21 leg skips it and the API-35 leg runs it.
     val androidConnectedTests =
         listOf(
             Triple(":buffer-compression", ":buffer-compression:connectedDebugAndroidTest", 21),
             Triple(":buffer-flow", ":buffer-flow:connectedDebugAndroidTest", 21),
             Triple(":buffer-codec", ":buffer-codec:connectedDebugAndroidTest", 21),
+            Triple(":buffer-crypto", ":buffer-crypto:connectedDebugAndroidTest", 28),
         )
 
     androidConnectedTests.forEach { (_, testTaskPath, minSdk) ->


### PR DESCRIPTION
`CryptoCapabilities.keyAgreement(X25519)` answers `Unavailable` on Android at **every** API level — including those where Conscrypt implements it fully. Measured on an API 35 emulator: a keypair generates, an agreement completes, and the flag still says no.

```
sdk=35  x25519=Unavailable  p256=Blocking
KeyPairGenerator(XDH).initialize(NamedParameterSpec.X25519)
  → InvalidAlgorithmParameterException: No AlgorithmParameterSpec classes are supported
KeyPairGenerator(XDH).generateKeyPair()  → OK
KeyAgreement(XDH)                        → OK
pub=com.android.org.conscrypt.OpenSSLX25519PublicKey, isXEC=false, agree=32B
```

### Two independent causes

Both come from writing Conscrypt code to the JDK's shape, and both fail silently.

1. **The probe.** It called `KeyPairGenerator.getInstance("XDH").initialize(NamedParameterSpec.X25519)`. The JDK's XDH generator is multi-curve (X25519/X448) and needs that spec; Conscrypt's is X25519-only and supports *no* `AlgorithmParameterSpec` whatsoever. `probe {}` catches `Throwable`, so the refusal became "unavailable" with nothing logged.

2. **`rawX25519`.** It cast the public key to `XECPublicKey`, which `OpenSSLX25519PublicKey` does not implement. So fixing the probe alone would have moved the failure to the first key generation rather than fixing anything.

### The fix

- `x25519KeyPairGenerator()` requests the spec and treats an `InvalidAlgorithmParameterException` as "this provider is already X25519". That is safe precisely because it is the *parameterless* generator that refuses — one supporting X448 through this entry point would have accepted the spec.
- The probe now **generates** rather than stopping at `initialize`. A probe that stops short of the real call is a capability answer nobody can see is wrong.
- `rawX25519` reads the raw u from the **X.509/SPKI encoding** instead of the cast. The SPKI tail is identical across providers and is exactly what `x25519PublicKey` writes going the other way, so the two are now inverses by construction rather than by coincidence.
- The header's Android note is corrected: it claimed API 34+ works, which the probe made false.

### Why it went unnoticed

`KeyAgreementTest` **skips** any curve the target reports as unavailable. That is right for a genuinely absent primitive, but it leaves the suite structurally blind to the opposite failure — a present primitive reported missing. Every X25519 test "passed" on Android by not running.

`X25519CapabilityHonestyTest` asserts the *agreement between provider and flag* instead: where the JCA can really produce an X25519 keypair, the capability must say so, and the full generate → encode → agree path must run.

### Verification

- **The new test fails on Android without this change** and passes with it — confirmed by reverting the production file and re-running on the emulator, not by inspection.
- `:buffer-crypto:connectedAndroidTest` — 372 tests green on API 35.
- `:buffer-crypto:jvmTest` green, including the existing KAT/Wycheproof vectors. That is the load-bearing cross-check for the `rawX25519` rewrite: the SPKI-based extraction is byte-identical to the `XECPublicKey`/BigInteger path on OpenJDK.
- `ktlintCheck` green.

### Downstream

Found from `DitchOoM/webrtc`, where it is not cosmetic: `Dtls13Handshake` picks its `key_share` group from this flag, so **WebRTC data channels could not establish on any Android device** — the client threw at `DtlsEngine.start` and the session surfaced as `Dtls(HandshakeTimeout)`. webrtc carries its own fix (never assume a curve; fall back to P-256), since Android < 34 genuinely lacks X25519 and its minSdk is 21. This change restores X25519 on 34+.