### PR TITLE
perf(ci): make main's build caches reachable, then fan out apple/linux

### DIFF
--- a/.github/workflows/android_integration.yaml
+++ b/.github/workflows/android_integration.yaml
@@ -11,7 +11,64 @@ permissions:
   contents: read
 
 jobs:
+  # Skip both emulator legs when the diff provably cannot reach ART.
+  #
+  # Each leg boots a cold emulator and runs the full instrumented suite (~6-7 min), and a
+  # change confined to a foreign platform's actuals — appleMain, linuxMain, jsMain,
+  # wasmJsMain — cannot alter a single byte the emulator executes. Anything that touches
+  # the build itself, the version catalog, or common/JVM-shared/Android source is treated
+  # as reaching ART. This workflow is NOT a required status check, so a skipped run
+  # reports no status and blocks no merge.
+  #
+  # Uses the paginated "list PR files" API rather than `gh pr diff`: the latter hits the
+  # .diff endpoint, which GitHub caps at 300 files and returns HTTP 406 for larger PRs.
+  # The PR-files API returns objects with a `filename` field, not `path`.
+  changes:
+    name: "Classify changed paths"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      android: ${{ steps.filter.outputs.android }}
+    steps:
+      - name: Classify
+        id: filter
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          files=$(gh api --paginate \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[].filename')
+
+          android=false
+          while IFS= read -r f; do
+            [ -n "$f" ] || continue
+            case "$f" in
+              *.gradle.kts|gradle/*|gradle.properties|settings.gradle.kts|.github/workflows/*|.ci/*)
+                android=true ;;
+              # ONE line of explicit source-set names on purpose: a `\`-continued pattern
+              # list folds the next line's indentation INTO the pattern, so every glob
+              # after the first would silently never match, and a wildcard-in-the-middle
+              # form like `*/src/*osMain/*` can over-match — which fails in the dangerous
+              # direction, dropping real Android coverage. Anything under src/ not
+              # recognised here falls through to android=true below, so a source set added
+              # later errs toward running the tests.
+              */src/appleMain/*|*/src/appleTest/*|*/src/appleLp64Main/*|*/src/macosMain/*|*/src/iosMain/*|*/src/tvosMain/*|*/src/watchosMain/*|*/src/linuxMain/*|*/src/linuxTest/*|*/src/nativeMain/*|*/src/nativeTest/*|*/src/nonJvmMain/*|*/src/jsMain/*|*/src/jsTest/*|*/src/wasmJsMain/*|*/src/wasmJsTest/*|*/src/webMain/*)
+                ;;
+              */src/*)
+                android=true ;;
+            esac
+          done <<< "$files"
+
+          echo "android=$android" >> "$GITHUB_OUTPUT"
+          echo "android=$android"
+
   test:
+    needs: changes
+    if: needs.changes.outputs.android == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:

--- a/.github/workflows/build-apple.yaml
+++ b/.github/workflows/build-apple.yaml
@@ -23,18 +23,22 @@ on:
         description: "The version this job stamped its artifacts with"
         value: ${{ jobs.publish.outputs.version }}
 
-# `actions: write` is what lets the cache steps below actually SAVE. Without a single
-# writable scope on the token, GitHub's cache service refuses every write with
-# `cache write denied: token has no writable scopes` — which is precisely what every
-# merged.yaml (pull_request_target) run was hitting, silently, for both this workflow
-# and build-linux. The consequence was that `refs/heads/main` never held a
-# gradle-macos-*/konan-macos-* entry, so every PR's FIRST run restored nothing and paid
-# a fully cold Kotlin/Native build (~47 min vs ~7 min warm). A reusable workflow can only
-# ever narrow what the caller grants, so the callers (review.yaml, merged.yaml) must grant
-# `actions: write` on their job too — this line alone is not enough.
+# Deliberately read-only, and deliberately NOT granting `actions: write`.
+#
+# Cache writability here is decided by the REF, not by the token's declared scopes.
+# Proof from this repo's own logs, same cache key, same printed token
+# (`Contents: read, Metadata: read`) in both:
+#   * pull_request run        -> `Cache saved with key: gradle-macos-1f607f18…`
+#   * pull_request_target run -> `cache write denied: token has no writable scopes`
+# A closed PR's `refs/pull/N/merge` is simply not a writable cache scope. Granting
+# `actions: write` therefore changes nothing, and adding an inert permission to the
+# most security-sensitive trigger type would just mislead the next reader.
+#
+# What actually keeps `refs/heads/main` warm — and so keeps every PR's first run off a
+# cold ~47-minute Kotlin/Native build — is warm-cache.yaml, which runs on
+# `push: branches: [main]` where the ref genuinely is writable.
 permissions:
   contents: read
-  actions: write
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/.github/workflows/build-apple.yaml
+++ b/.github/workflows/build-apple.yaml
@@ -21,23 +21,171 @@ on:
     outputs:
       version:
         description: "The version this job stamped its artifacts with"
-        value: ${{ jobs.build.outputs.version }}
+        value: ${{ jobs.publish.outputs.version }}
 
+# `actions: write` is what lets the cache steps below actually SAVE. Without a single
+# writable scope on the token, GitHub's cache service refuses every write with
+# `cache write denied: token has no writable scopes` — which is precisely what every
+# merged.yaml (pull_request_target) run was hitting, silently, for both this workflow
+# and build-linux. The consequence was that `refs/heads/main` never held a
+# gradle-macos-*/konan-macos-* entry, so every PR's FIRST run restored nothing and paid
+# a fully cold Kotlin/Native build (~47 min vs ~7 min warm). A reusable workflow can only
+# ever narrow what the caller grants, so the callers (review.yaml, merged.yaml) must grant
+# `actions: write` on their job too — this line alone is not enough.
 permissions:
   contents: read
+  actions: write
 
 jobs:
-  build:
-    name: "Apple Targets"
+  # ---------------------------------------------------------------------------
+  # Per-OS test shards. These run CONCURRENTLY with `publish` below, so the job's
+  # wall clock is max(slowest shard, publish) rather than their sum.
+  #
+  # Every shard registers the FULL 12-target Apple matrix (the build scripts key off
+  # GITHUB_REPOSITORY, which is always set on a runner). That is deliberate and is NOT
+  # something to "optimize" by giving each shard only its own targets: appleMain is ONE
+  # shared metadata artifact spanning every registered Apple target, so narrowing the
+  # registered set would narrow `compileAppleMainKotlinMetadata` to match and stop it
+  # catching cross-target mismatches. That is exactly the failure mode of the
+  # watchosArm64/arm64_32 work (see buffer-crypto/build.gradle.kts) — per-target compiles
+  # all pass; only the shared metadata compile rejects it. Shards differ ONLY in which
+  # test/link tasks they run.
+  #
+  # Concurrency note: this matrix plus `publish` is 5 macOS jobs. GitHub's per-plan cap on
+  # concurrent macOS jobs is 5 on Free/Team (higher on Enterprise), and review.yaml's
+  # `docs` job is a 6th macOS job — which is why that one is gated behind the change
+  # filter. Exceeding the cap only queues a job, it never fails one.
+  test:
+    name: "Test (${{ matrix.name }})"
     runs-on: macos-latest
-    # The test step (macosArm64 + iosSimulatorArm64) finishes in ~20 min, but the subsequent
-    # `publishToMavenLocal` rebuilds the per-target CryptoKit Swift shims, CommonCrypto cinterops,
-    # and Kotlin/Native klibs for the full ~10-target Apple matrix (macos/ios/tvos/watchos ×
-    # arm64/x64/sim) with `--no-build-cache`. Only Konan is cached, so this is ~50+ min of cold
-    # native compilation. Since buffer-crypto landed those per-target shims, 60 min is no longer
-    # enough and the job was being killed mid-publish (timeout, not a code failure). Raised to 120
-    # to fit the cold run with headroom; cache the native shim archives to bring this back down.
-    timeout-minutes: 120
+    timeout-minutes: 60
+    strategy:
+      # One OS family failing should still report the others — the whole point of
+      # sharding is to see WHICH Apple family broke without re-running the rest.
+      fail-fast: false
+      matrix:
+        include:
+          # macosArm64 and iosSimulatorArm64 are the two families with a hosted runner
+          # that can actually EXECUTE tests. Everything else is compile-and-link only:
+          # there is no hosted watchOS/tvOS/iOS-device runner, so those shards link the
+          # test binaries without running them (the same compile-only gate build-linux
+          # applies via linkDebugTestLinuxArm64 before its QEMU steps).
+          #
+          # The link tasks are MODULE-QUALIFIED, matching the five-module set build-linux
+          # runs under QEMU (:buffer, :buffer-compression, :buffer-flow, :buffer-codec-test,
+          # :buffer-crypto) — i.e. the modules that actually have native test binaries.
+          # Do NOT "simplify" these to bare task names: an unqualified `linkDebugTestMacosX64`
+          # also selects :buffer-1brc, which registers macosX64 but cannot resolve it
+          # (androidx.collection:collection:1.6.0 publishes no macos_x64 variant), so the
+          # shard dies during dependency resolution before compiling anything. The current
+          # CI never trips over that only because :buffer-1brc has nothing to publish and so
+          # never enters the publishToMavenLocal graph.
+          - name: macos
+            tasks: >-
+              macosArm64Test
+              :buffer:linkDebugTestMacosX64 :buffer-compression:linkDebugTestMacosX64
+              :buffer-flow:linkDebugTestMacosX64 :buffer-codec-test:linkDebugTestMacosX64
+              :buffer-crypto:linkDebugTestMacosX64
+          - name: ios
+            tasks: >-
+              iosSimulatorArm64Test
+              :buffer:linkDebugTestIosArm64 :buffer-compression:linkDebugTestIosArm64
+              :buffer-flow:linkDebugTestIosArm64 :buffer-codec-test:linkDebugTestIosArm64
+              :buffer-crypto:linkDebugTestIosArm64
+              :buffer:linkDebugTestIosX64 :buffer-compression:linkDebugTestIosX64
+              :buffer-flow:linkDebugTestIosX64 :buffer-codec-test:linkDebugTestIosX64
+              :buffer-crypto:linkDebugTestIosX64
+          # watchosArm64 is arm64_32 — the only Apple target with 32-bit pointers and a
+          # 32-bit size_t, which is exactly where an appleTest helper that assumes 64-bit
+          # widths would break. Note the asymmetry in the module lists: :buffer-crypto is
+          # absent from the watchosArm64 line and present on every other, because that
+          # module registers watchosDeviceArm64 but NOT watchosArm64 — arm64_32 breaks its
+          # compileAppleMainKotlinMetadata. See the target list in buffer-crypto/build.gradle.kts.
+          - name: watchos
+            tasks: >-
+              :buffer:linkDebugTestWatchosArm64 :buffer-compression:linkDebugTestWatchosArm64
+              :buffer-flow:linkDebugTestWatchosArm64 :buffer-codec-test:linkDebugTestWatchosArm64
+              :buffer:linkDebugTestWatchosDeviceArm64 :buffer-compression:linkDebugTestWatchosDeviceArm64
+              :buffer-flow:linkDebugTestWatchosDeviceArm64 :buffer-codec-test:linkDebugTestWatchosDeviceArm64
+              :buffer-crypto:linkDebugTestWatchosDeviceArm64
+              :buffer:linkDebugTestWatchosSimulatorArm64 :buffer-compression:linkDebugTestWatchosSimulatorArm64
+              :buffer-flow:linkDebugTestWatchosSimulatorArm64 :buffer-codec-test:linkDebugTestWatchosSimulatorArm64
+              :buffer-crypto:linkDebugTestWatchosSimulatorArm64
+              :buffer:linkDebugTestWatchosX64 :buffer-compression:linkDebugTestWatchosX64
+              :buffer-flow:linkDebugTestWatchosX64 :buffer-codec-test:linkDebugTestWatchosX64
+              :buffer-crypto:linkDebugTestWatchosX64
+          - name: tvos
+            tasks: >-
+              :buffer:linkDebugTestTvosArm64 :buffer-compression:linkDebugTestTvosArm64
+              :buffer-flow:linkDebugTestTvosArm64 :buffer-codec-test:linkDebugTestTvosArm64
+              :buffer-crypto:linkDebugTestTvosArm64
+              :buffer:linkDebugTestTvosSimulatorArm64 :buffer-compression:linkDebugTestTvosSimulatorArm64
+              :buffer-flow:linkDebugTestTvosSimulatorArm64 :buffer-codec-test:linkDebugTestTvosSimulatorArm64
+              :buffer-crypto:linkDebugTestTvosSimulatorArm64
+              :buffer:linkDebugTestTvosX64 :buffer-compression:linkDebugTestTvosX64
+              :buffer-flow:linkDebugTestTvosX64 :buffer-codec-test:linkDebugTestTvosX64
+              :buffer-crypto:linkDebugTestTvosX64
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # No `cache: gradle` here on purpose: setup-java's Gradle cache covers
+      # ~/.gradle/caches — the SAME path as the explicit cache step below — so enabling
+      # both stored the tree twice (839 MB of pure duplication on macOS) against a 10 GB
+      # per-repo cache budget that was already sitting at 9.6 GB, and the two racing to
+      # save produced `Unable to reserve cache ... another job may be creating this cache`
+      # on real runs. The explicit step is the one that's keyed and tuned for this build.
+      - name: Set up JDK 21
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+
+      # RESTORE-ONLY in the shards. Five macOS jobs racing to save the same key is the
+      # `another job may be creating this cache` failure above: one wins and the rest log
+      # a warning. `publish` is the single saver — it builds the expensive shared prefix
+      # (commonizer, appleMain metadata, all 12 targets' main klibs) that the shards want
+      # back next run, whereas a shard's marginal output is mostly linkDebugTest*, which
+      # Gradle does not cache anyway.
+      - name: Restore Konan
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.konan
+          key: konan-macos-${{ hashFiles('gradle/libs.versions.toml') }}
+          restore-keys: konan-macos-
+
+      - name: Restore Gradle build outputs
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.gradle/caches
+          key: gradle-macos-${{ hashFiles('gradle/libs.versions.toml', '**/*.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-macos-
+
+      # Pin the version for every Gradle invocation in this job. This is not cosmetic on a
+      # test shard: with no externally-supplied version each module's build script calls
+      # getNextVersion(), which queries Maven Central AT CONFIGURATION TIME — once per
+      # module, in every shard. Callers always pass `version` in, so this is a plain echo.
+      - name: Resolve version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          version="$INPUT_VERSION"
+          if [ -z "$version" ]; then
+            version="$(./gradlew -q nextVersion ${{ inputs.gradle-args }})"
+          fi
+          echo "Building version $version"
+          echo "ORG_GRADLE_PROJECT_version=$version" >> "$GITHUB_ENV"
+
+      - name: Run ${{ matrix.name }} tests
+        run: ./gradlew ${{ matrix.tasks }} ${{ inputs.gradle-args }}
+
+  # ---------------------------------------------------------------------------
+  # The artifact producer. Runs concurrently with the test shards.
+  publish:
+    name: "Publish (Apple targets)"
+    runs-on: macos-latest
+    timeout-minutes: 90
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -48,8 +196,9 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '21'
-          cache: gradle
 
+      # This job is the single SAVER for both macOS caches (see the shards' restore-only
+      # note above), so it uses the full restore+save action rather than cache/restore.
       - name: Cache Konan
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -57,10 +206,6 @@ jobs:
           key: konan-macos-${{ hashFiles('gradle/libs.versions.toml') }}
           restore-keys: konan-macos-
 
-      # Cache the Gradle module caches + local build cache (~/.gradle/caches/build-cache-1)
-      # so compiled klibs, cinterop klibs, and the per-target native shim archives survive
-      # across runs. Keyed on the build definition (version catalog, build scripts, wrapper);
-      # restore-keys fall back to the most recent partial match when those change.
       - name: Cache Gradle build outputs
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -68,6 +213,7 @@ jobs:
           key: gradle-macos-${{ hashFiles('gradle/libs.versions.toml', '**/*.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: |
             gradle-macos-
+
       # Prefer the version the caller computed once for the whole run. Falling back to a
       # local `nextVersion` query keeps this workflow usable standalone, but a caller that
       # also runs build-linux must pass one in — two independent queries straddling a
@@ -90,36 +236,37 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "ORG_GRADLE_PROJECT_version=$version" >> "$GITHUB_ENV"
 
-      - name: Run Apple target tests
-        run: ./gradlew macosArm64Test iosSimulatorArm64Test ${{ inputs.gradle-args }}
-
-      # Compile-and-link the appleTest sources for watchOS. `publishToMavenLocal` below builds
-      # every registered target, but MAIN sources only — so without this step no watchOS test code
-      # is ever compiled, and the tested targets above (macosArm64, iosSimulatorArm64) are both
-      # 64-bit arm64. watchosArm64 is arm64_32: the only Apple target with 32-bit pointers and a
-      # 32-bit `size_t`, which is exactly where an appleTest helper that assumes 64-bit widths
-      # would break. There is no hosted watchOS device runner, so this links the test binaries
-      # without running them — the same compile-only gate the Linux workflow applies via
-      # linkDebugTestLinuxArm64 before its QEMU steps. Module set mirrors that Linux set.
+      # Publish ONLY the Apple publications, not `publishToMavenLocal`.
       #
-      # The two lists differ by one module on purpose: buffer-crypto registers watchosDeviceArm64
-      # but NOT watchosArm64, because arm64_32 breaks its compileAppleMainKotlinMetadata. See the
-      # target list in buffer-crypto/build.gradle.kts. Note that this step would not have caught
-      # that on its own — per-target linking succeeds; only the shared metadata compilation fails.
-      - name: Build watchOS test binaries (link-only, no device runner)
+      # validate-artifacts.yaml takes the LINUX repo as its base and, from this job's
+      # upload, consumes exactly three things: the per-target Apple leaf directories
+      # (buffer-macosarm64, buffer-iosarm64, …), the umbrella .module file's `variants`,
+      # and the umbrella metadata JAR's Apple klib dirs + PSM sourceSets/variants. It
+      # explicitly SKIPS anything already present from Linux ("Skipping $target_name
+      # (already from Linux)").
+      #
+      # `publishToMavenLocal` nonetheless also built this runner's jvm/js/wasmJs/android
+      # publications — measured at 2,268 of 2,923 tasks (78%) in the publish step — and
+      # every byte of that was discarded by the merge. Naming the Apple publications
+      # explicitly cuts the graph from 2,908 tasks to 1,660 (-43%); the JS bucket alone
+      # drops 324 -> 23 tasks, which is where the webpack/browser-distribution work lived.
+      #
+      # The umbrella publication (publishKotlinMultiplatformPublicationToMavenLocal) is
+      # what produces the PSM the merge reads, so it stays. Task names are unqualified so
+      # Gradle runs each in every project that has it — buffer-crypto has no
+      # watchosArm64 publication and is skipped for that one target automatically.
+      - name: Publish Apple publications to Maven Local
         run: >-
           ./gradlew
-          :buffer:linkDebugTestWatchosArm64 :buffer-compression:linkDebugTestWatchosArm64
-          :buffer-flow:linkDebugTestWatchosArm64 :buffer-codec-test:linkDebugTestWatchosArm64
-          :buffer:linkDebugTestWatchosDeviceArm64 :buffer-compression:linkDebugTestWatchosDeviceArm64
-          :buffer-flow:linkDebugTestWatchosDeviceArm64 :buffer-codec-test:linkDebugTestWatchosDeviceArm64
-          :buffer-crypto:linkDebugTestWatchosDeviceArm64
-          ${{ inputs.gradle-args }}
-
-      # The release/publish-to-Central path passes clean-publish: true to force a cold,
-      # cache-free rebuild of the published artifacts. PR validation reuses the build cache.
-      - name: Publish to Maven Local
-        run: ./gradlew publishToMavenLocal ${{ inputs.clean-publish && '--no-build-cache' || '' }} ${{ inputs.gradle-args }}
+          publishKotlinMultiplatformPublicationToMavenLocal
+          publishMacosArm64PublicationToMavenLocal publishMacosX64PublicationToMavenLocal
+          publishIosArm64PublicationToMavenLocal publishIosSimulatorArm64PublicationToMavenLocal
+          publishIosX64PublicationToMavenLocal
+          publishTvosArm64PublicationToMavenLocal publishTvosSimulatorArm64PublicationToMavenLocal
+          publishTvosX64PublicationToMavenLocal
+          publishWatchosArm64PublicationToMavenLocal publishWatchosDeviceArm64PublicationToMavenLocal
+          publishWatchosSimulatorArm64PublicationToMavenLocal publishWatchosX64PublicationToMavenLocal
+          ${{ inputs.clean-publish && '--no-build-cache' || '' }} ${{ inputs.gradle-args }}
 
       - name: Upload Maven local artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -127,3 +274,30 @@ jobs:
           name: maven-local-apple
           path: ~/.m2/repository/com/ditchoom
           retention-days: 3
+
+  # ---------------------------------------------------------------------------
+  # Branch-protection gate. `build-apple / Apple Targets` is one of exactly three required
+  # status checks on main (alongside `build-linux / Linux / JVM / JS / WASM / Android` and
+  # `scan`), and the context string is `<caller job id> / <this job's name>`. Fanning the
+  # real work out into `test`/`publish` would have retired that context and left every PR
+  # unmergeable, so this job keeps the name and stands in for the whole matrix.
+  #
+  # `if: always()` + explicit result checks, NOT a bare `needs:`. A job whose `needs`
+  # failed is SKIPPED, and a skipped job reports no status at all — the required check
+  # would then sit at "Expected — waiting for status to be reported" forever instead of
+  # going red. Same trap review-docs-only.yaml documents from the other direction.
+  apple:
+    name: "Apple Targets"
+    needs: [test, publish]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Assert every Apple job succeeded
+        run: |
+          echo "test shards: ${{ needs.test.result }}"
+          echo "publish:     ${{ needs.publish.result }}"
+          # A matrix job's aggregate result is `success` only when every leg succeeded.
+          [ "${{ needs.test.result }}" = "success" ] || { echo "::error::Apple test shards did not all pass"; exit 1; }
+          [ "${{ needs.publish.result }}" = "success" ] || { echo "::error::Apple publish did not pass"; exit 1; }
+          echo "All Apple targets passed."

--- a/.github/workflows/build-apple.yaml
+++ b/.github/workflows/build-apple.yaml
@@ -65,15 +65,34 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # macosArm64 and iosSimulatorArm64 are the two families with a hosted runner
-          # that can actually EXECUTE tests. Everything else is compile-and-link only:
-          # there is no hosted watchOS/tvOS/iOS-device runner, so those shards link the
-          # test binaries without running them (the same compile-only gate build-linux
-          # applies via linkDebugTestLinuxArm64 before its QEMU steps).
+          # Four target groups actually EXECUTE tests on a hosted arm64 macOS runner:
+          # macosArm64, iosSimulatorArm64, tvosSimulatorArm64, watchosSimulatorArm64. The
+          # last two are easy to miss — they ran only as a side effect of the old job's
+          # publishToMavenLocal, and dropping them here would have silently retired 10
+          # executing test tasks. (The x64 simulator variants are a different story: the
+          # old CI's own log shows macosX64Test/iosX64Test/tvosX64Test/watchosX64Test all
+          # reporting SKIPPED, because an x64 simulator cannot run on an arm64 runner.)
           #
-          # The link tasks are MODULE-QUALIFIED, matching the five-module set build-linux
-          # runs under QEMU (:buffer, :buffer-compression, :buffer-flow, :buffer-codec-test,
-          # :buffer-crypto) — i.e. the modules that actually have native test binaries.
+          # Device ABIs have no hosted runner at all, so those are compile-and-link only —
+          # the same gate build-linux applies via linkDebugTestLinuxArm64 before its QEMU
+          # steps. The x64 simulator targets are likewise link-only here, matching what the
+          # old job effectively did once its *Test tasks skipped.
+          #
+          # The four *Test tasks are left UNQUALIFIED: they resolve across all ten modules
+          # that register the target (verified), which is broader than the six-module link
+          # set below, and a *Test task already depends on its own linkDebugTest*, so the
+          # simulator targets need no separate link entry.
+          #
+          # The link tasks are MODULE-QUALIFIED, covering the six modules that have native
+          # test binaries: :buffer, :buffer-codec, :buffer-codec-test, :buffer-compression,
+          # :buffer-flow, :buffer-crypto. That is build-linux's QEMU set PLUS :buffer-codec —
+          # which the QEMU set omits but which does have Apple test binaries for all 12
+          # targets, and which the old `publishToMavenLocal` graph compiled and linked as a
+          # side effect. Dropping it here would have been a silent coverage regression; it
+          # was caught by diffing the old job's task graph against the new one's, not by
+          # anything failing. If you add a module with native tests, add it to all four
+          # shards and re-run that diff.
+          #
           # Do NOT "simplify" these to bare task names: an unqualified `linkDebugTestMacosX64`
           # also selects :buffer-1brc, which registers macosX64 but cannot resolve it
           # (androidx.collection:collection:1.6.0 publishes no macos_x64 variant), so the
@@ -83,16 +102,16 @@ jobs:
           - name: macos
             tasks: >-
               macosArm64Test
-              :buffer:linkDebugTestMacosX64 :buffer-compression:linkDebugTestMacosX64
+              :buffer:linkDebugTestMacosX64 :buffer-codec:linkDebugTestMacosX64 :buffer-compression:linkDebugTestMacosX64
               :buffer-flow:linkDebugTestMacosX64 :buffer-codec-test:linkDebugTestMacosX64
               :buffer-crypto:linkDebugTestMacosX64
           - name: ios
             tasks: >-
               iosSimulatorArm64Test
-              :buffer:linkDebugTestIosArm64 :buffer-compression:linkDebugTestIosArm64
+              :buffer:linkDebugTestIosArm64 :buffer-codec:linkDebugTestIosArm64 :buffer-compression:linkDebugTestIosArm64
               :buffer-flow:linkDebugTestIosArm64 :buffer-codec-test:linkDebugTestIosArm64
               :buffer-crypto:linkDebugTestIosArm64
-              :buffer:linkDebugTestIosX64 :buffer-compression:linkDebugTestIosX64
+              :buffer:linkDebugTestIosX64 :buffer-codec:linkDebugTestIosX64 :buffer-compression:linkDebugTestIosX64
               :buffer-flow:linkDebugTestIosX64 :buffer-codec-test:linkDebugTestIosX64
               :buffer-crypto:linkDebugTestIosX64
           # watchosArm64 is arm64_32 — the only Apple target with 32-bit pointers and a
@@ -103,26 +122,22 @@ jobs:
           # compileAppleMainKotlinMetadata. See the target list in buffer-crypto/build.gradle.kts.
           - name: watchos
             tasks: >-
-              :buffer:linkDebugTestWatchosArm64 :buffer-compression:linkDebugTestWatchosArm64
+              :buffer:linkDebugTestWatchosArm64 :buffer-codec:linkDebugTestWatchosArm64 :buffer-compression:linkDebugTestWatchosArm64
               :buffer-flow:linkDebugTestWatchosArm64 :buffer-codec-test:linkDebugTestWatchosArm64
-              :buffer:linkDebugTestWatchosDeviceArm64 :buffer-compression:linkDebugTestWatchosDeviceArm64
+              :buffer:linkDebugTestWatchosDeviceArm64 :buffer-codec:linkDebugTestWatchosDeviceArm64 :buffer-compression:linkDebugTestWatchosDeviceArm64
               :buffer-flow:linkDebugTestWatchosDeviceArm64 :buffer-codec-test:linkDebugTestWatchosDeviceArm64
               :buffer-crypto:linkDebugTestWatchosDeviceArm64
-              :buffer:linkDebugTestWatchosSimulatorArm64 :buffer-compression:linkDebugTestWatchosSimulatorArm64
-              :buffer-flow:linkDebugTestWatchosSimulatorArm64 :buffer-codec-test:linkDebugTestWatchosSimulatorArm64
-              :buffer-crypto:linkDebugTestWatchosSimulatorArm64
-              :buffer:linkDebugTestWatchosX64 :buffer-compression:linkDebugTestWatchosX64
+              watchosSimulatorArm64Test
+              :buffer:linkDebugTestWatchosX64 :buffer-codec:linkDebugTestWatchosX64 :buffer-compression:linkDebugTestWatchosX64
               :buffer-flow:linkDebugTestWatchosX64 :buffer-codec-test:linkDebugTestWatchosX64
               :buffer-crypto:linkDebugTestWatchosX64
           - name: tvos
             tasks: >-
-              :buffer:linkDebugTestTvosArm64 :buffer-compression:linkDebugTestTvosArm64
+              :buffer:linkDebugTestTvosArm64 :buffer-codec:linkDebugTestTvosArm64 :buffer-compression:linkDebugTestTvosArm64
               :buffer-flow:linkDebugTestTvosArm64 :buffer-codec-test:linkDebugTestTvosArm64
               :buffer-crypto:linkDebugTestTvosArm64
-              :buffer:linkDebugTestTvosSimulatorArm64 :buffer-compression:linkDebugTestTvosSimulatorArm64
-              :buffer-flow:linkDebugTestTvosSimulatorArm64 :buffer-codec-test:linkDebugTestTvosSimulatorArm64
-              :buffer-crypto:linkDebugTestTvosSimulatorArm64
-              :buffer:linkDebugTestTvosX64 :buffer-compression:linkDebugTestTvosX64
+              tvosSimulatorArm64Test
+              :buffer:linkDebugTestTvosX64 :buffer-codec:linkDebugTestTvosX64 :buffer-compression:linkDebugTestTvosX64
               :buffer-flow:linkDebugTestTvosX64 :buffer-codec-test:linkDebugTestTvosX64
               :buffer-crypto:linkDebugTestTvosX64
     steps:

--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -23,14 +23,13 @@ on:
         description: "The version this job stamped its artifacts with"
         value: ${{ jobs.publish.outputs.version }}
 
-# See the identical block in build-apple.yaml: without a writable scope on the token,
-# GitHub's cache service refuses every save with `cache write denied: token has no
-# writable scopes`, which is why refs/heads/main never held a gradle-linux-*/konan-linux-*
-# entry and every PR's first run started cold. Callers must grant this too — a reusable
-# workflow can only narrow the caller's permissions, never widen them.
+# Read-only on purpose — see the extended note in build-apple.yaml. Cache writability is
+# decided by the ref, not the token's scopes (a read-only token saves fine on a
+# pull_request ref and is denied on a closed PR's pull_request_target ref), so
+# `actions: write` would be inert here. warm-cache.yaml is what keeps refs/heads/main
+# populated for these keys.
 permissions:
   contents: read
-  actions: write
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -123,16 +122,19 @@ jobs:
             gradle-linux-
 
       # ---- linux-leg-only native prerequisites -------------------------------------
-      - name: Cache simdutf x64
+      # Restore-only, like the Gradle/Konan caches above: `publish` and warm-cache.yaml
+      # are the savers. Giving this leg its own save key would store a second copy of
+      # identical content under a different name.
+      - name: Restore simdutf x64
         if: matrix.name == 'linux'
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: buffer/build/simdutf/libs/linux-x64
           key: simdutf-linux-x64-${{ hashFiles('gradle/libs.versions.toml', 'buffer/src/nativeInterop/cinterop/simdutf_wrapper.cpp') }}
 
-      - name: Cache simdutf ARM64
+      - name: Restore simdutf ARM64
         if: matrix.name == 'linux'
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: buffer/build/simdutf/libs/linux-arm64
           key: simdutf-linux-arm64-${{ hashFiles('gradle/libs.versions.toml', 'buffer/src/nativeInterop/cinterop/simdutf_wrapper.cpp') }}
@@ -325,13 +327,13 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: buffer/build/simdutf/libs/linux-x64
-          key: simdutf-publish-linux-x64-${{ hashFiles('gradle/libs.versions.toml', 'buffer/src/nativeInterop/cinterop/simdutf_wrapper.cpp') }}
+          key: simdutf-linux-x64-${{ hashFiles('gradle/libs.versions.toml', 'buffer/src/nativeInterop/cinterop/simdutf_wrapper.cpp') }}
 
       - name: Cache simdutf ARM64
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: buffer/build/simdutf/libs/linux-arm64
-          key: simdutf-publish-linux-arm64-${{ hashFiles('gradle/libs.versions.toml', 'buffer/src/nativeInterop/cinterop/simdutf_wrapper.cpp') }}
+          key: simdutf-linux-arm64-${{ hashFiles('gradle/libs.versions.toml', 'buffer/src/nativeInterop/cinterop/simdutf_wrapper.cpp') }}
 
       # Prefer the version the caller computed once for the whole run. Falling back to a
       # local `nextVersion` query keeps this workflow usable standalone, but a caller that

--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -21,35 +21,75 @@ on:
     outputs:
       version:
         description: "The version this job stamped its artifacts with"
-        value: ${{ jobs.build.outputs.version }}
+        value: ${{ jobs.publish.outputs.version }}
 
+# See the identical block in build-apple.yaml: without a writable scope on the token,
+# GitHub's cache service refuses every save with `cache write denied: token has no
+# writable scopes`, which is why refs/heads/main never held a gradle-linux-*/konan-linux-*
+# entry and every PR's first run started cold. Callers must grant this too — a reusable
+# workflow can only narrow the caller's permissions, never widen them.
 permissions:
   contents: read
+  actions: write
 
 jobs:
-  build:
-    name: "Linux / JVM / JS / WASM / Android"
+  # ---------------------------------------------------------------------------
+  # Four test legs, all concurrent with each other and with `publish`.
+  #
+  # Only the `linux` leg installs the apt/QEMU/aarch64 toolchain and only the `js-wasm`
+  # leg needs a browser, so each leg's setup is gated on `matrix.name` rather than every
+  # leg paying for every other leg's prerequisites.
+  test:
+    name: "Test (${{ matrix.name }})"
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
-    outputs:
-      version: ${{ steps.version.outputs.version }}
+    timeout-minutes: 45
+    strategy:
+      # A JS failure should not hide a Linux-native failure: report every leg.
+      fail-fast: false
+      matrix:
+        include:
+          # The KSP processor's own compile-time validation suite plus the JVM buffer
+          # tests. Pure JVM — no SDK, no browser, no cross-toolchain.
+          - name: jvm
+            tasks: ":buffer-codec-processor:test jvmTest"
+          - name: js-wasm
+            tasks: "jsNodeTest jsBrowserTest wasmJsNodeTest wasmJsBrowserTest"
+          # The host-JVM Android unit tasks run here so contributors can reproduce them on
+          # the desktop without an emulator — a convenience signal. Under AGP 9, a KMP
+          # androidTarget creates a unit-test task only for its testBuildType:
+          # compression/flow/codec default to "debug" (testDebugUnitTest), while :buffer
+          # pins testBuildType="benchmark" (testBenchmarkUnitTest). There is no
+          # testReleaseUnitTest. They are NOT authoritative for Android: the host JDK 21
+          # differs from ART (its own Unsafe / libcore surface, the legacy
+          # java.nio.DirectByteBuffer `(long, int)` ctor, different `Unsafe.invokeCleaner`
+          # resolution). The dedicated "Android Emulator Integration Test" workflow runs
+          # the full suite on a real emulator (ART, API 21 + 35) and is the source of
+          # truth for Android behavior.
+          - name: android-ktlint
+            tasks: "ktlintCheck testDebugUnitTest testBenchmarkUnitTest"
+          - name: linux
+            tasks: ""  # driven by explicit steps below (QEMU runs are not Gradle tasks)
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      # No `cache: gradle` — it caches ~/.gradle/caches, the same path as the explicit
+      # restore below, so enabling both stored the tree twice (482 MB on Linux) against a
+      # 10 GB per-repo budget and had the two racing to save it. See build-apple.yaml.
       - name: Set up JDK 21
         uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
         with:
           distribution: 'zulu'
           java-version: '21'
-          cache: gradle
 
-      # GitHub-hosted ubuntu runners ship Google Chrome + Chromium preinstalled, so point Karma's
-      # jsBrowserTest / wasmJsBrowserTest at the preinstalled binary via CHROME_BIN instead of
-      # re-downloading a fresh Chrome through browser-actions/setup-chrome. That action pulls from
-      # Google's CDN on every run and intermittently fails with `read ECONNRESET` — a network flake
-      # entirely unrelated to anything under test. Resolving the on-image browser removes the
-      # download (and the flake class) while keeping the browser tests running.
+      # GitHub-hosted ubuntu runners ship Google Chrome + Chromium preinstalled, so point
+      # Karma's jsBrowserTest / wasmJsBrowserTest at the preinstalled binary via CHROME_BIN
+      # instead of re-downloading a fresh Chrome through browser-actions/setup-chrome. That
+      # action pulls from Google's CDN on every run and intermittently fails with
+      # `read ECONNRESET` — a network flake entirely unrelated to anything under test.
+      # Resolving the on-image browser removes the download (and the flake class) while
+      # keeping the browser tests running.
       - name: Locate preinstalled Chrome
+        if: matrix.name == 'js-wasm'
         run: |
           CHROME_BIN="$(command -v google-chrome || command -v google-chrome-stable || command -v chromium-browser || command -v chromium || true)"
           test -n "$CHROME_BIN" || { echo "::error::No preinstalled Chrome/Chromium found on the runner"; exit 1; }
@@ -57,38 +97,41 @@ jobs:
           echo "Using preinstalled browser: $CHROME_BIN ($("$CHROME_BIN" --version 2>/dev/null || echo version-unknown))"
 
       - name: Setup Android SDK
+        if: matrix.name == 'android-ktlint'
         uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4
 
-      - name: Cache Konan
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # Restore-only in the test legs: five concurrent jobs racing to save one key is the
+      # `Unable to reserve cache ... another job may be creating this cache` warning. The
+      # `publish` job is the single saver — it produces the widest set of reusable outputs.
+      - name: Restore Konan
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.konan
           key: konan-linux-${{ hashFiles('gradle/libs.versions.toml') }}
           restore-keys: konan-linux-
 
+      - name: Restore Gradle build outputs
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.gradle/caches
+          key: gradle-linux-${{ hashFiles('gradle/libs.versions.toml', '**/*.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-linux-
+
+      # ---- linux-leg-only native prerequisites -------------------------------------
       - name: Cache simdutf x64
+        if: matrix.name == 'linux'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: buffer/build/simdutf/libs/linux-x64
           key: simdutf-linux-x64-${{ hashFiles('gradle/libs.versions.toml', 'buffer/src/nativeInterop/cinterop/simdutf_wrapper.cpp') }}
 
       - name: Cache simdutf ARM64
+        if: matrix.name == 'linux'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: buffer/build/simdutf/libs/linux-arm64
           key: simdutf-linux-arm64-${{ hashFiles('gradle/libs.versions.toml', 'buffer/src/nativeInterop/cinterop/simdutf_wrapper.cpp') }}
-
-      # Cache the Gradle module caches + local build cache (~/.gradle/caches/build-cache-1)
-      # so compiled klibs, cinterop klibs, and KSP/codegen outputs survive across runs.
-      # Keyed on the build definition (version catalog, build scripts, wrapper); restore-keys
-      # fall back to the most recent partial match when those change.
-      - name: Cache Gradle build outputs
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.gradle/caches
-          key: gradle-linux-${{ hashFiles('gradle/libs.versions.toml', '**/*.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-linux-
 
       # Two ARM64 runtime libs that the QEMU-emulated test binaries need inside the
       # cross sysroot (`qemu-aarch64-static -L /usr/aarch64-linux-gnu`, below).
@@ -103,6 +146,7 @@ jobs:
       # Cached because they are version-pinned: refetched only when this workflow
       # changes, not once per run.
       - name: Cache ARM64 runtime libraries
+        if: matrix.name == 'linux'
         id: cache-arm64-libs
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -116,7 +160,7 @@ jobs:
       # enough from Azure-hosted runners that "fail fast and retry" has to be
       # explicit; curl's default is to wait forever.
       - name: Download ARM64 runtime libraries
-        if: steps.cache-arm64-libs.outputs.cache-hit != 'true'
+        if: matrix.name == 'linux' && steps.cache-arm64-libs.outputs.cache-hit != 'true'
         timeout-minutes: 10
         run: |
           set -euo pipefail
@@ -131,6 +175,7 @@ jobs:
           done
 
       - name: Install ARM64 dependencies
+        if: matrix.name == 'linux'
         timeout-minutes: 15
         run: |
           set -euo pipefail
@@ -154,6 +199,136 @@ jobs:
             rm -rf "$dir"
           done
 
+      # ---- shared -------------------------------------------------------------------
+      # Pin the version for every Gradle invocation in this job. Not cosmetic even on a
+      # test leg: with no externally-supplied version each module's build script calls
+      # getNextVersion(), which queries Maven Central AT CONFIGURATION TIME, once per
+      # module, in every leg. Callers always pass `version` in, so this is a plain echo.
+      - name: Resolve version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          version="$INPUT_VERSION"
+          if [ -z "$version" ]; then
+            version="$(./gradlew -q nextVersion ${{ inputs.gradle-args }})"
+          fi
+          echo "Building version $version"
+          echo "ORG_GRADLE_PROJECT_version=$version" >> "$GITHUB_ENV"
+
+      - name: Run ${{ matrix.name }} tests
+        if: matrix.name != 'linux'
+        run: ./gradlew ${{ matrix.tasks }} ${{ inputs.gradle-args }}
+
+      # ---- linux-leg-only test steps -------------------------------------------------
+      # BoringSSL is provisioned by the com.ditchoom.boringssl.provision plugin (resolved from the
+      # Plugin Portal / Maven Central at the pinned version): it downloads the checksum-pinned
+      # linuxX64/linuxArm64 bundle from the boringssl-kmp GitHub Release and verifies it against its
+      # baked-in SHA-256 before use — no in-repo BoringSSL build, no TOFU.
+      - name: Run Linux x64 tests
+        if: matrix.name == 'linux'
+        # :buffer-crypto:linuxX64Test runs the full common crypto suite (KAT + Wycheproof +
+        # tamper/negative + capability) over the BoringSSL backend. BoringSSL's libcrypto.a is now
+        # provisioned by the com.ditchoom.boringssl.provision plugin (download + sha256-verify), not
+        # built in-repo — this is also the pin-downgrade (API42 -> API21) validation gate.
+        run: >-
+          ./gradlew :buffer:linuxX64Test :buffer-compression:linuxX64Test :buffer-flow:linuxX64Test
+          :buffer-codec:linuxX64Test :buffer-codec-test:linuxX64Test :buffer-crypto:linuxX64Test
+          ${{ inputs.gradle-args }}
+
+      - name: Build ARM64 test binaries
+        if: matrix.name == 'linux'
+        # buffer-crypto's arm64 BoringSSL is the prebuilt linuxArm64 tarball from the provision bundle
+        # (no in-repo cross-build); :buffer's simdutf is still cross-built with the aarch64 toolchain
+        # installed above. The linkDebugTestLinuxArm64 output is then QEMU-run below.
+        run: >-
+          ./gradlew :buffer:linkDebugTestLinuxArm64 :buffer-compression:linkDebugTestLinuxArm64 :buffer-flow:linkDebugTestLinuxArm64
+          :buffer-codec-test:linkDebugTestLinuxArm64 :buffer-crypto:linkDebugTestLinuxArm64
+          ${{ inputs.gradle-args }}
+
+      - name: Run buffer ARM64 tests via QEMU
+        if: matrix.name == 'linux'
+        run: qemu-aarch64-static -L /usr/aarch64-linux-gnu ./buffer/build/bin/linuxArm64/debugTest/test.kexe
+
+      - name: Run buffer-compression ARM64 tests via QEMU
+        if: matrix.name == 'linux'
+        run: qemu-aarch64-static -L /usr/aarch64-linux-gnu ./buffer-compression/build/bin/linuxArm64/debugTest/test.kexe
+
+      - name: Run buffer-flow ARM64 tests via QEMU
+        if: matrix.name == 'linux'
+        run: qemu-aarch64-static -L /usr/aarch64-linux-gnu ./buffer-flow/build/bin/linuxArm64/debugTest/test.kexe
+
+      - name: Run buffer-codec-test ARM64 tests via QEMU
+        if: matrix.name == 'linux'
+        run: qemu-aarch64-static -L /usr/aarch64-linux-gnu ./buffer-codec-test/build/bin/linuxArm64/debugTest/test.kexe
+
+      - name: Run buffer-crypto ARM64 tests via QEMU
+        if: matrix.name == 'linux'
+        run: qemu-aarch64-static -L /usr/aarch64-linux-gnu ./buffer-crypto/build/bin/linuxArm64/debugTest/test.kexe
+
+  # ---------------------------------------------------------------------------
+  # The artifact producer, concurrent with the test legs.
+  #
+  # Unlike build-apple's publish job this one stays on the full `publishToMavenLocal`:
+  # validate-artifacts.yaml uses the LINUX repo as its base and merges Apple on top, so
+  # every jvm/js/wasmJs/android/linux publication has to come from here.
+  publish:
+    name: "Publish (all Linux-host targets)"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4
+
+      # Publishing :buffer's linuxArm64 publication cross-compiles simdutf (C++) with the
+      # aarch64 toolchain, so this job needs the cross-compiler even though it never runs
+      # an arm64 binary (no qemu / no runtime libs needed here). Same reasoning as the
+      # equivalent step in osv-scanner.yaml.
+      - name: Install ARM64 cross-compiler (for buffer simdutf arm64)
+        run: |
+          set -euo pipefail
+          sudo apt-get -o Acquire::Retries=5 update
+          sudo apt-get -o Acquire::Retries=5 install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
+      # This job is the single SAVER for both Linux caches (see the legs' restore-only
+      # note above), so it uses the full restore+save action rather than cache/restore.
+      - name: Cache Konan
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.konan
+          key: konan-linux-${{ hashFiles('gradle/libs.versions.toml') }}
+          restore-keys: konan-linux-
+
+      - name: Cache Gradle build outputs
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.gradle/caches
+          key: gradle-linux-${{ hashFiles('gradle/libs.versions.toml', '**/*.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-linux-
+
+      - name: Cache simdutf x64
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: buffer/build/simdutf/libs/linux-x64
+          key: simdutf-publish-linux-x64-${{ hashFiles('gradle/libs.versions.toml', 'buffer/src/nativeInterop/cinterop/simdutf_wrapper.cpp') }}
+
+      - name: Cache simdutf ARM64
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: buffer/build/simdutf/libs/linux-arm64
+          key: simdutf-publish-linux-arm64-${{ hashFiles('gradle/libs.versions.toml', 'buffer/src/nativeInterop/cinterop/simdutf_wrapper.cpp') }}
+
       # Prefer the version the caller computed once for the whole run. Falling back to a
       # local `nextVersion` query keeps this workflow usable standalone, but a caller that
       # also runs build-apple must pass one in — two independent queries straddling a
@@ -176,69 +351,6 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "ORG_GRADLE_PROJECT_version=$version" >> "$GITHUB_ENV"
 
-      - name: Run KSP processor tests
-        run: >-
-          ./gradlew :buffer-codec-processor:test
-          ${{ inputs.gradle-args }}
-
-      - name: Run JVM / JS / WASM / Android-host tests
-        # The host-JVM Android unit tasks run here so contributors can reproduce
-        # them on the desktop without an emulator — a convenience signal.
-        # Under AGP 9, a KMP androidTarget creates a unit-test task only for its
-        # testBuildType: compression/flow/codec default to "debug"
-        # (testDebugUnitTest), while :buffer pins testBuildType="benchmark"
-        # (testBenchmarkUnitTest). There is no testReleaseUnitTest.
-        # They are NOT authoritative for Android: the host JDK 21 differs
-        # from ART (its own Unsafe / libcore surface, the legacy
-        # java.nio.DirectByteBuffer `(long, int)` ctor, different
-        # `Unsafe.invokeCleaner` resolution). The dedicated "Android
-        # Emulator Integration Test" workflow runs the full suite on a
-        # real emulator (ART, API 19 + 29) and is the source of truth
-        # for Android behavior.
-        run: >-
-          ./gradlew ktlintCheck
-          jvmTest jsNodeTest jsBrowserTest wasmJsNodeTest wasmJsBrowserTest
-          testDebugUnitTest testBenchmarkUnitTest
-          ${{ inputs.gradle-args }}
-
-      # BoringSSL is provisioned by the com.ditchoom.boringssl.provision plugin (resolved from the
-      # Plugin Portal / Maven Central at the pinned version): it downloads the checksum-pinned
-      # linuxX64/linuxArm64 bundle from the boringssl-kmp GitHub Release and verifies it against its
-      # baked-in SHA-256 before use — no in-repo BoringSSL build, no TOFU.
-      - name: Run Linux x64 tests
-        # :buffer-crypto:linuxX64Test runs the full common crypto suite (KAT + Wycheproof +
-        # tamper/negative + capability) over the BoringSSL backend. BoringSSL's libcrypto.a is now
-        # provisioned by the com.ditchoom.boringssl.provision plugin (download + sha256-verify), not
-        # built in-repo — this is also the pin-downgrade (API42 -> API21) validation gate.
-        run: >-
-          ./gradlew :buffer:linuxX64Test :buffer-compression:linuxX64Test :buffer-flow:linuxX64Test
-          :buffer-codec:linuxX64Test :buffer-codec-test:linuxX64Test :buffer-crypto:linuxX64Test
-          ${{ inputs.gradle-args }}
-
-      - name: Build ARM64 test binaries
-        # buffer-crypto's arm64 BoringSSL is the prebuilt linuxArm64 tarball from the provision bundle
-        # (no in-repo cross-build); :buffer's simdutf is still cross-built with the aarch64 toolchain
-        # installed above. The linkDebugTestLinuxArm64 output is then QEMU-run below.
-        run: >-
-          ./gradlew :buffer:linkDebugTestLinuxArm64 :buffer-compression:linkDebugTestLinuxArm64 :buffer-flow:linkDebugTestLinuxArm64
-          :buffer-codec-test:linkDebugTestLinuxArm64 :buffer-crypto:linkDebugTestLinuxArm64
-          ${{ inputs.gradle-args }}
-
-      - name: Run buffer ARM64 tests via QEMU
-        run: qemu-aarch64-static -L /usr/aarch64-linux-gnu ./buffer/build/bin/linuxArm64/debugTest/test.kexe
-
-      - name: Run buffer-compression ARM64 tests via QEMU
-        run: qemu-aarch64-static -L /usr/aarch64-linux-gnu ./buffer-compression/build/bin/linuxArm64/debugTest/test.kexe
-
-      - name: Run buffer-flow ARM64 tests via QEMU
-        run: qemu-aarch64-static -L /usr/aarch64-linux-gnu ./buffer-flow/build/bin/linuxArm64/debugTest/test.kexe
-
-      - name: Run buffer-codec-test ARM64 tests via QEMU
-        run: qemu-aarch64-static -L /usr/aarch64-linux-gnu ./buffer-codec-test/build/bin/linuxArm64/debugTest/test.kexe
-
-      - name: Run buffer-crypto ARM64 tests via QEMU
-        run: qemu-aarch64-static -L /usr/aarch64-linux-gnu ./buffer-crypto/build/bin/linuxArm64/debugTest/test.kexe
-
       # The release/publish-to-Central path passes clean-publish: true to force a cold,
       # cache-free rebuild of the published artifacts. PR validation reuses the build cache.
       - name: Publish to Maven Local
@@ -250,3 +362,25 @@ jobs:
           name: maven-local-linux
           path: ~/.m2/repository/com/ditchoom
           retention-days: 3
+
+  # ---------------------------------------------------------------------------
+  # Branch-protection gate. `build-linux / Linux / JVM / JS / WASM / Android` is one of
+  # exactly three required status checks on main, and the context string is
+  # `<caller job id> / <this job's name>` — so this job MUST keep that exact name even
+  # though it no longer does the work itself. See the matching gate in build-apple.yaml
+  # for why this is `if: always()` with explicit result checks rather than a bare `needs:`.
+  linux:
+    name: "Linux / JVM / JS / WASM / Android"
+    needs: [test, publish]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Assert every Linux job succeeded
+        run: |
+          echo "test legs: ${{ needs.test.result }}"
+          echo "publish:   ${{ needs.publish.result }}"
+          # A matrix job's aggregate result is `success` only when every leg succeeded.
+          [ "${{ needs.test.result }}" = "success" ] || { echo "::error::Linux test legs did not all pass"; exit 1; }
+          [ "${{ needs.publish.result }}" = "success" ] || { echo "::error::Linux publish did not pass"; exit 1; }
+          echo "All Linux / JVM / JS / WASM / Android checks passed."

--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -96,8 +96,12 @@ jobs:
           echo "CHROME_BIN=$CHROME_BIN" >> "$GITHUB_ENV"
           echo "Using preinstalled browser: $CHROME_BIN ($("$CHROME_BIN" --version 2>/dev/null || echo version-unknown))"
 
+      # Deliberately NOT gated to the android leg. Gradle configures every project in
+      # every leg, and the Android modules need a resolvable SDK at CONFIGURATION time —
+      # so a leg that never builds an Android variant still fails without one. The
+      # original single job installed this unconditionally; keeping that is worth far
+      # more than the ~20s it costs on a leg that does not use it.
       - name: Setup Android SDK
-        if: matrix.name == 'android-ktlint'
         uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4
 
       # Restore-only in the test legs: five concurrent jobs racing to save one key is the

--- a/.github/workflows/merged.yaml
+++ b/.github/workflows/merged.yaml
@@ -119,9 +119,30 @@ jobs:
     with:
       gradle-args: ${{ needs.check-release.outputs.gradle-args }}
 
+  # `actions: write` is what makes this run's caches actually reachable by later PRs.
+  #
+  # Every merged.yaml run was silently failing EVERY cache save with
+  # `cache write denied: token has no writable scopes` — the workflow-level
+  # `permissions: contents: read` above leaves the token with no writable scope at all,
+  # and GitHub's cache service refuses writes outright in that state. Because merges are
+  # the only runs whose ref is `refs/heads/main`, and a PR can restore only from its own
+  # `refs/pull/N/merge` scope plus main's, main having no gradle-*/konan-* entry meant
+  # every PR's FIRST run restored nothing and paid a fully cold Kotlin/Native build:
+  # ~47 min for build-apple versus ~7 min once warm. A reusable workflow can only narrow
+  # what its caller grants, so this has to be set here as well as inside the callee.
+  #
+  # If a merged run still logs `cache write denied` after this, the denial is
+  # ref-driven rather than scope-driven (pull_request_target on a CLOSED pr resolves to
+  # `refs/pull/N/merge`, which is no longer writable once the PR is merged). The fallback
+  # is a small `push: branches: [main]` workflow that does nothing but run the build to
+  # populate the main-scoped caches. Check the "Post Cache ..." steps of the first merged
+  # run on this change before assuming it took.
   build-linux:
     needs: [check-release, version]
     if: needs.check-release.outputs.flow != 'skip'
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/build-linux.yaml
     with:
       gradle-args: ${{ needs.check-release.outputs.gradle-args }}
@@ -130,9 +151,13 @@ jobs:
       # of the published artifacts. Non-publishing flows (dry-run) reuse the build cache.
       clean-publish: ${{ needs.check-release.outputs.flow == 'release' || needs.check-release.outputs.flow == 'draft' }}
 
+  # See the build-linux job above for why `actions: write` is required here.
   build-apple:
     needs: [check-release, version]
     if: needs.check-release.outputs.flow != 'skip'
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/build-apple.yaml
     with:
       gradle-args: ${{ needs.check-release.outputs.gradle-args }}

--- a/.github/workflows/merged.yaml
+++ b/.github/workflows/merged.yaml
@@ -119,30 +119,18 @@ jobs:
     with:
       gradle-args: ${{ needs.check-release.outputs.gradle-args }}
 
-  # `actions: write` is what makes this run's caches actually reachable by later PRs.
+  # Note: this run CANNOT write Actions caches, and no `permissions:` grant changes that.
   #
-  # Every merged.yaml run was silently failing EVERY cache save with
-  # `cache write denied: token has no writable scopes` — the workflow-level
-  # `permissions: contents: read` above leaves the token with no writable scope at all,
-  # and GitHub's cache service refuses writes outright in that state. Because merges are
-  # the only runs whose ref is `refs/heads/main`, and a PR can restore only from its own
-  # `refs/pull/N/merge` scope plus main's, main having no gradle-*/konan-* entry meant
-  # every PR's FIRST run restored nothing and paid a fully cold Kotlin/Native build:
-  # ~47 min for build-apple versus ~7 min once warm. A reusable workflow can only narrow
-  # what its caller grants, so this has to be set here as well as inside the callee.
-  #
-  # If a merged run still logs `cache write denied` after this, the denial is
-  # ref-driven rather than scope-driven (pull_request_target on a CLOSED pr resolves to
-  # `refs/pull/N/merge`, which is no longer writable once the PR is merged). The fallback
-  # is a small `push: branches: [main]` workflow that does nothing but run the build to
-  # populate the main-scoped caches. Check the "Post Cache ..." steps of the first merged
-  # run on this change before assuming it took.
+  # `pull_request_target` on a CLOSED pr resolves to `refs/pull/N/merge`, which stops
+  # being a writable cache scope once the PR is merged, so every cache save in these
+  # builds fails with `cache write denied: token has no writable scopes` regardless of
+  # token scopes. This repo's logs show the same key saving fine from a `pull_request`
+  # run whose token was equally read-only, which is what rules out the scopes as the
+  # cause. See warm-cache.yaml — it runs on `push: branches: [main]`, where the ref is
+  # writable, and is what actually keeps main's caches populated for PRs to restore.
   build-linux:
     needs: [check-release, version]
     if: needs.check-release.outputs.flow != 'skip'
-    permissions:
-      contents: read
-      actions: write
     uses: ./.github/workflows/build-linux.yaml
     with:
       gradle-args: ${{ needs.check-release.outputs.gradle-args }}
@@ -151,13 +139,10 @@ jobs:
       # of the published artifacts. Non-publishing flows (dry-run) reuse the build cache.
       clean-publish: ${{ needs.check-release.outputs.flow == 'release' || needs.check-release.outputs.flow == 'draft' }}
 
-  # See the build-linux job above for why `actions: write` is required here.
+  # Same cache-write caveat as build-linux above.
   build-apple:
     needs: [check-release, version]
     if: needs.check-release.outputs.flow != 'skip'
-    permissions:
-      contents: read
-      actions: write
     uses: ./.github/workflows/build-apple.yaml
     with:
       gradle-args: ${{ needs.check-release.outputs.gradle-args }}

--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -91,24 +91,19 @@ jobs:
   version:
     uses: ./.github/workflows/compute-version.yaml
 
-  # `actions: write` is required by the callee so its cache steps can SAVE — a reusable
-  # workflow can only narrow the caller's permissions, never widen them, so omitting it
-  # here would leave the build unable to write its own PR-scoped cache. See the extended
-  # note in merged.yaml.
+  # These runs CAN write caches despite the read-only token — an open PR's
+  # `refs/pull/N/merge` is a writable cache scope, so no `permissions:` grant is needed
+  # (verified: `Cache saved with key: gradle-macos-…` from a job printing only
+  # `Contents: read, Metadata: read`). Those saves stay confined to this PR's scope
+  # though, which is why main has to be warmed separately — see warm-cache.yaml.
   build-linux:
     needs: version
-    permissions:
-      contents: read
-      actions: write
     uses: ./.github/workflows/build-linux.yaml
     with:
       version: ${{ needs.version.outputs.version }}
 
   build-apple:
     needs: version
-    permissions:
-      contents: read
-      actions: write
     uses: ./.github/workflows/build-apple.yaml
     with:
       version: ${{ needs.version.outputs.version }}

--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -11,6 +11,79 @@ permissions:
   contents: read
 
 jobs:
+  # Classify the diff once, so jobs that provably cannot be affected by it don't run.
+  #
+  # Deliberately NARROW. Only two consumers below are gated, and both are non-required
+  # checks, so a wrong answer here costs a missed signal rather than an unmergeable PR:
+  #   * docs     — the Dokka + Docusaurus validation job, which is a macOS runner
+  #   * android  — see android_integration.yaml, gated on the same reasoning
+  # build-linux / build-apple are NOT gated: their contexts are required status checks,
+  # and any `.github/**` change can alter the build itself, so the only safe skip for
+  # them is the pure-`**/*.md` case that `paths-ignore` above already handles (with
+  # review-docs-only.yaml supplying the stand-in contexts).
+  #
+  # Uses the paginated "list PR files" API rather than `gh pr diff`: the latter hits the
+  # .diff endpoint, which GitHub caps at 300 files and returns HTTP 406 for larger PRs.
+  # The PR-files API returns objects with a `filename` field, not `path`.
+  changes:
+    name: "Classify changed paths"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      docs: ${{ steps.filter.outputs.docs }}
+      android: ${{ steps.filter.outputs.android }}
+    steps:
+      - name: Classify
+        id: filter
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          files=$(gh api --paginate \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[].filename')
+
+          docs=false
+          android=false
+          while IFS= read -r f; do
+            [ -n "$f" ] || continue
+            case "$f" in
+              # Anything that changes the build itself, the version catalog, or this
+              # workflow can change any downstream job's behavior — take everything.
+              *.gradle.kts|gradle/*|gradle.properties|.github/workflows/*|settings.gradle.kts)
+                docs=true; android=true ;;
+              # Dokka reads every module's sources; the site build reads docs/.
+              docs/*|MODULE.md)
+                docs=true ;;
+              # Source under any module feeds Dokka. It only feeds the emulator when it
+              # can reach ART: common/jvm-shared/android source sets, never a foreign
+              # native/web-only actual.
+              #
+              # The foreign-source-set list below is written as ONE line of explicit
+              # names on purpose. A `\`-continued pattern list would fold the next line's
+              # indentation INTO the pattern (`*/src/nativeMain/*|      */src/jsMain/*`),
+              # so every glob after the first would silently never match; and a
+              # wildcard-in-the-middle form like `*/src/*osMain/*` can over-match, which
+              # fails in the dangerous direction — a false skip drops real Android coverage.
+              # Anything under src/ that is NOT recognised here falls through to
+              # android=true, so a source set added later errs toward running the tests.
+              */src/*)
+                docs=true
+                case "$f" in
+                  */src/appleMain/*|*/src/appleTest/*|*/src/appleLp64Main/*|*/src/macosMain/*|*/src/iosMain/*|*/src/tvosMain/*|*/src/watchosMain/*|*/src/linuxMain/*|*/src/linuxTest/*|*/src/nativeMain/*|*/src/nativeTest/*|*/src/nonJvmMain/*|*/src/jsMain/*|*/src/jsTest/*|*/src/wasmJsMain/*|*/src/wasmJsTest/*|*/src/webMain/*)
+                    ;;
+                  *) android=true ;;
+                esac ;;
+            esac
+          done <<< "$files"
+
+          echo "docs=$docs"    >> "$GITHUB_OUTPUT"
+          echo "android=$android" >> "$GITHUB_OUTPUT"
+          echo "docs=$docs android=$android"
+
   # One version for the whole run. The linux and apple builds run in parallel, so
   # letting each compute its own lets a release publishing to Central mid-run make
   # them disagree — and `validate` then looks up artifacts under a version only one
@@ -18,14 +91,24 @@ jobs:
   version:
     uses: ./.github/workflows/compute-version.yaml
 
+  # `actions: write` is required by the callee so its cache steps can SAVE — a reusable
+  # workflow can only narrow the caller's permissions, never widen them, so omitting it
+  # here would leave the build unable to write its own PR-scoped cache. See the extended
+  # note in merged.yaml.
   build-linux:
     needs: version
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/build-linux.yaml
     with:
       version: ${{ needs.version.outputs.version }}
 
   build-apple:
     needs: version
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/build-apple.yaml
     with:
       version: ${{ needs.version.outputs.version }}
@@ -36,8 +119,16 @@ jobs:
     with:
       version: ${{ needs.version.outputs.version }}
 
+  # Gated on `changes` because this is a macOS runner and build-apple's fan-out already
+  # uses up to 5 of them concurrently (4 test shards + publish). GitHub's per-plan cap on
+  # concurrent macOS jobs is 5 on Free/Team, so leaving this ungated would make a 6th
+  # macOS job queue behind the build on every PR — including the many that cannot change
+  # a single line of generated documentation. Not a required check, so skipping it
+  # reports no status and blocks nothing.
   docs:
     name: "Validate Docs Generation"
+    needs: changes
+    if: needs.changes.outputs.docs == 'true'
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -50,8 +141,8 @@ jobs:
       - name: Cache Konan
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ~/.konan
           key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
+          path: ~/.konan
           restore-keys: konan-${{ runner.os }}-
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/warm-cache.yaml
+++ b/.github/workflows/warm-cache.yaml
@@ -1,0 +1,223 @@
+name: "Warm main-scoped build caches"
+
+# Populates the `refs/heads/main` Actions-cache scope so that every PR's FIRST run
+# restores a warm Gradle/Konan cache instead of paying a cold Kotlin/Native build.
+#
+# WHY THIS EXISTS AS A SEPARATE WORKFLOW
+#
+# A PR run can restore caches from exactly two scopes: its own `refs/pull/N/merge`, and
+# the default branch's. buffer's post-merge build (merged.yaml) is triggered by
+# `pull_request_target` on a CLOSED pr, whose ref is `refs/pull/N/merge` — and once the PR
+# is merged that ref stops being a writable cache scope. Every cache save in every merged
+# run therefore fails with:
+#
+#     cache write denied: token has no writable scopes
+#
+# despite the message, this is NOT about the token's declared permissions. The same cache
+# key saved successfully from a `pull_request` run whose token printed the identical
+# `Contents: read, Metadata: read`; only the ref differed. So no `permissions:` grant on
+# merged.yaml can fix it, and none is applied there.
+#
+# The upshot was that `refs/heads/main` never held a `gradle-*`/`konan-*` entry, so every
+# PR's first run restored nothing: build-apple measured 46m53s cold against 6m40s warm,
+# with publishToMavenLocal alone accounting for 27m25s of the cold run. Subsequent pushes
+# to the same PR hit that PR's own scope and were fast, which is why the cost looked
+# intermittent rather than systematic.
+#
+# A `push: branches: [main]` run's ref genuinely IS `refs/heads/main` and is writable, so
+# this workflow can do what merged.yaml cannot. It duplicates build work that merged.yaml
+# is already doing, which is deliberate: nothing waits on this job, and the alternative
+# (moving the whole release flow off pull_request_target) would put the label-driven
+# version-bump logic at risk for no additional caching benefit.
+#
+# Self-reinforcing after the first run: this workflow restores the same keys it saves, so
+# only its very first execution is cold. PR runs restoring from main keep those entries
+# hot in the repo's LRU cache eviction order.
+
+on:
+  push:
+    branches: [main]
+    # No point re-warming for changes that cannot invalidate a compiled artifact.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+  workflow_dispatch:
+
+# Read-only is sufficient — see above, cache writability follows the ref, not the scopes.
+permissions:
+  contents: read
+
+# Only the newest main commit's cache is worth building. If merges land in quick
+# succession, cancel the older warm-up rather than queueing several full Apple builds.
+concurrency:
+  group: warm-cache
+  cancel-in-progress: true
+
+jobs:
+  macos:
+    name: "Warm macOS caches"
+    runs-on: macos-latest
+    # First run is a fully cold ~12-target Apple build; later runs restore their own
+    # output and finish in a fraction of that.
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # No `cache: gradle` — it would double-store ~/.gradle/caches against the 10 GB
+      # per-repo budget and race the explicit step below. Same reasoning as build-apple.yaml.
+      - name: Set up JDK 21
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+
+      # Keys MUST stay byte-identical to build-apple.yaml's, including the hashFiles
+      # inputs — a PR restores by exact key first and by the `gradle-macos-` /
+      # `konan-macos-` prefix second, so any drift here silently stops warming anything.
+      - name: Cache Konan
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.konan
+          key: konan-macos-${{ hashFiles('gradle/libs.versions.toml') }}
+          restore-keys: konan-macos-
+
+      - name: Cache Gradle build outputs
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.gradle/caches
+          key: gradle-macos-${{ hashFiles('gradle/libs.versions.toml', '**/*.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-macos-
+
+      # Pin a version so the module build scripts don't each query Maven Central for
+      # getNextVersion() at configuration time. The value is irrelevant — nothing here is
+      # published — but it must be set, and it must not perturb the cached task outputs
+      # that PRs will reuse, so it mirrors what a normal build would compute.
+      - name: Resolve version
+        run: |
+          set -euo pipefail
+          version="$(./gradlew -q nextVersion)"
+          echo "Warming caches for version $version"
+          echo "ORG_GRADLE_PROJECT_version=$version" >> "$GITHUB_ENV"
+
+      # Mirrors build-apple.yaml's publish job: the expensive, cacheable half is the
+      # shared prefix (KSP, commonizer, appleMain metadata) plus all 12 targets' main
+      # klibs, which is exactly what every PR shard needs back.
+      - name: Warm Apple publication outputs
+        run: >-
+          ./gradlew
+          publishKotlinMultiplatformPublicationToMavenLocal
+          publishMacosArm64PublicationToMavenLocal publishMacosX64PublicationToMavenLocal
+          publishIosArm64PublicationToMavenLocal publishIosSimulatorArm64PublicationToMavenLocal
+          publishIosX64PublicationToMavenLocal
+          publishTvosArm64PublicationToMavenLocal publishTvosSimulatorArm64PublicationToMavenLocal
+          publishTvosX64PublicationToMavenLocal
+          publishWatchosArm64PublicationToMavenLocal publishWatchosDeviceArm64PublicationToMavenLocal
+          publishWatchosSimulatorArm64PublicationToMavenLocal publishWatchosX64PublicationToMavenLocal
+
+      # Test-source compilation for the four shards. Link tasks themselves are not
+      # cacheable, but the compileTestKotlin* outputs they depend on are, and those are a
+      # large share of a shard's cold cost. `continue-on-error` because this workflow's
+      # job is to populate a cache, not to gate anything: merged.yaml already ran the real
+      # build for this commit, so a failure here must not page anyone.
+      - name: Warm Apple test-compilation outputs
+        continue-on-error: true
+        run: >-
+          ./gradlew
+          macosArm64Test iosSimulatorArm64Test tvosSimulatorArm64Test watchosSimulatorArm64Test
+          :buffer:linkDebugTestMacosX64 :buffer-codec:linkDebugTestMacosX64
+          :buffer-compression:linkDebugTestMacosX64 :buffer-flow:linkDebugTestMacosX64
+          :buffer-codec-test:linkDebugTestMacosX64 :buffer-crypto:linkDebugTestMacosX64
+          :buffer:linkDebugTestIosArm64 :buffer-codec:linkDebugTestIosArm64
+          :buffer-compression:linkDebugTestIosArm64 :buffer-flow:linkDebugTestIosArm64
+          :buffer-codec-test:linkDebugTestIosArm64 :buffer-crypto:linkDebugTestIosArm64
+          :buffer:linkDebugTestTvosArm64 :buffer-codec:linkDebugTestTvosArm64
+          :buffer-compression:linkDebugTestTvosArm64 :buffer-flow:linkDebugTestTvosArm64
+          :buffer-codec-test:linkDebugTestTvosArm64 :buffer-crypto:linkDebugTestTvosArm64
+          :buffer:linkDebugTestWatchosArm64 :buffer-codec:linkDebugTestWatchosArm64
+          :buffer-compression:linkDebugTestWatchosArm64 :buffer-flow:linkDebugTestWatchosArm64
+          :buffer-codec-test:linkDebugTestWatchosArm64
+          :buffer:linkDebugTestWatchosDeviceArm64 :buffer-codec:linkDebugTestWatchosDeviceArm64
+          :buffer-compression:linkDebugTestWatchosDeviceArm64 :buffer-flow:linkDebugTestWatchosDeviceArm64
+          :buffer-codec-test:linkDebugTestWatchosDeviceArm64 :buffer-crypto:linkDebugTestWatchosDeviceArm64
+
+  linux:
+    name: "Warm Linux caches"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+
+      # Gradle configures every project, and the Android modules need a resolvable SDK at
+      # configuration time — so this is required even though nothing here builds an
+      # Android variant deliberately.
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4
+
+      # publishToMavenLocal builds :buffer's linuxArm64 publication, which cross-compiles
+      # simdutf (C++) with the aarch64 toolchain. No qemu or arm64 runtime libs are needed:
+      # this job compiles arm64 artifacts but never executes them.
+      - name: Install ARM64 cross-compiler (for buffer simdutf arm64)
+        run: |
+          set -euo pipefail
+          sudo apt-get -o Acquire::Retries=5 update
+          sudo apt-get -o Acquire::Retries=5 install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
+      # Keys MUST stay byte-identical to build-linux.yaml's — see the macOS note above.
+      - name: Cache Konan
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.konan
+          key: konan-linux-${{ hashFiles('gradle/libs.versions.toml') }}
+          restore-keys: konan-linux-
+
+      - name: Cache Gradle build outputs
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.gradle/caches
+          key: gradle-linux-${{ hashFiles('gradle/libs.versions.toml', '**/*.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-linux-
+
+      # publishToMavenLocal below cross-builds simdutf for both Linux arches, so warm those
+      # too — same keys build-linux.yaml uses, where the `linux` test leg restores them
+      # read-only. Without this they would only ever exist in a per-PR scope.
+      - name: Cache simdutf x64
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: buffer/build/simdutf/libs/linux-x64
+          key: simdutf-linux-x64-${{ hashFiles('gradle/libs.versions.toml', 'buffer/src/nativeInterop/cinterop/simdutf_wrapper.cpp') }}
+
+      - name: Cache simdutf ARM64
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: buffer/build/simdutf/libs/linux-arm64
+          key: simdutf-linux-arm64-${{ hashFiles('gradle/libs.versions.toml', 'buffer/src/nativeInterop/cinterop/simdutf_wrapper.cpp') }}
+
+      - name: Resolve version
+        run: |
+          set -euo pipefail
+          version="$(./gradlew -q nextVersion)"
+          echo "Warming caches for version $version"
+          echo "ORG_GRADLE_PROJECT_version=$version" >> "$GITHUB_ENV"
+
+      - name: Warm publication outputs
+        run: ./gradlew publishToMavenLocal
+
+      # The test legs' compile outputs. No browser and no QEMU here: jsBrowserTest /
+      # wasmJsBrowserTest and the arm64 QEMU runs execute binaries rather than producing
+      # cacheable Gradle outputs, so they are left to the real PR legs. continue-on-error
+      # for the same reason as the macOS job — this gates nothing.
+      - name: Warm test-compilation outputs
+        continue-on-error: true
+        run: >-
+          ./gradlew :buffer-codec-processor:test jvmTest jsNodeTest wasmJsNodeTest
+          ktlintCheck testDebugUnitTest testBenchmarkUnitTest
+          :buffer:linuxX64Test :buffer-compression:linuxX64Test :buffer-flow:linuxX64Test
+          :buffer-codec:linuxX64Test :buffer-codec-test:linuxX64Test :buffer-crypto:linuxX64Test

--- a/.github/workflows/warm-cache.yaml
+++ b/.github/workflows/warm-cache.yaml
@@ -18,6 +18,18 @@ name: "Warm main-scoped build caches"
 # `Contents: read, Metadata: read`; only the ref differed. So no `permissions:` grant on
 # merged.yaml can fix it, and none is applied there.
 #
+# IF YOU RE-INVESTIGATE THIS, know that one obvious instrument gives a FALSE NEGATIVE.
+# `ReserveCacheError: Unable to reserve cache <key>, another job may be creating this
+# cache` looks like an ordinary reservation conflict and reads as "the write was
+# permitted, it just lost a race". It is not proof of that: setup-gradle logs
+# `Cache reservation failed: cache write denied: token has no writable scopes` and THEN
+# re-reports the identical denial as that generic ReserveCacheError (see any merged-run
+# `validate` job log). A denial and a genuine race are indistinguishable from that line
+# alone, and it fails in the direction that makes you stop looking.
+#
+# Only a POSITIVE result proves writability: a run that printed `Cache saved with key:
+# <key>` from a token with no writable declared scopes. That is the test that settled it.
+#
 # The upshot was that `refs/heads/main` never held a `gradle-*`/`konan-*` entry, so every
 # PR's first run restored nothing: build-apple measured 46m53s cold against 6m40s warm,
 # with publishToMavenLocal alone accounting for 27m25s of the cold run. Subsequent pushes


### PR DESCRIPTION
## The problem

`build-apple` took 40–47 minutes because **every cache lookup missed**, not because of job
shape. Same workflow, same commit: **cold 46m53s vs warm 6m40s**; `publishToMavenLocal`
alone was 27m25s cold vs 3m19s warm.

Every `merged.yaml` run failed *every* cache save, Apple and Linux alike:

```
cache write denied: token has no writable scopes
```

Merges are the only runs whose ref is `refs/heads/main`. A PR restores from its own
`refs/pull/N/merge` scope plus main's — so with main never holding a `gradle-*`/`konan-*`
entry, **every PR's first run was 100% cold**. Later pushes on the same PR hit that PR's
own scope and ran ~7 min, which is why the cost looked intermittent rather than structural.

Still reproducible on main today:

```
$ gh api "repos/DitchOoM/buffer/actions/caches?per_page=50&sort=size_in_bytes&direction=desc" \
    --jq '.actions_caches[] | "\(.size_in_bytes/1024/1024|floor)MB \(.ref) \(.key)"'
1300MB refs/pull/343/merge gradle-macos-…
1290MB refs/pull/343/merge gradle-linux-…
 605MB refs/pull/343/merge konan-macos-…
 565MB refs/heads/main     gradle-dependencies-v1-…
```

Zero main-scoped build caches.

## The denial is ref-driven, not scope-driven

An earlier attempt added `actions: write`. That grant is **provably inert** — proof from
this repo's own logs, same cache key, same printed token in both:

| trigger | token | result |
|---|---|---|
| `pull_request` | Contents: read, Metadata: read | `Cache saved with key: gradle-macos-1f607f18…` |
| `pull_request_target` | Contents: read, Metadata: read | `cache write denied: token has no writable scopes` |

A token with zero writable declared scopes saved that exact key on the PR run. A closed
PR's `refs/pull/N/merge` simply stops being a writable cache scope, and no `permissions:`
grant on `merged.yaml` can change that. The error text is misleading: "no writable scopes"
means no writable *ref* scope. The grants are removed rather than left in place — an inert
permission on `pull_request_target`, the most security-sensitive trigger type, would read
as load-bearing to the next person.

Corroborated externally: a sibling repo in this org with no `pull_request_target` workflow,
doing its post-merge work on `push: main`, holds 75 main-scoped caches.

## The fix

**`warm-cache.yaml` on `push: branches: [main]`**, where the ref genuinely is
`refs/heads/main` and is writable. It saves byte-identical keys to the ones
`build-apple`/`build-linux` restore, so a PR's first run restores a warm tree. Only its
first execution is cold — it restores the same keys it saves. Both warm jobs mark test
compilation `continue-on-error`: this workflow populates a cache, gates nothing, and
`merged.yaml` already ran the real build for that commit. A failure here must not page
anyone.

It deliberately duplicates build work `merged.yaml` does. Nothing waits on it, and moving
the release flow off `pull_request_target` would put the label-driven version-bump logic at
risk for no extra caching benefit.

Alongside that:

- **Dropped `setup-java`'s `cache: gradle`.** Same `~/.gradle/caches` path as the explicit
  cache step, stored twice (839MB macOS + 482MB Linux) against a 10 GB per-repo cap already
  at 8.9 GB — and the two raced.
- **The Apple runner now publishes only Apple publications.** 2,268 of 2,923 tasks (78%)
  were jvm/js/wasmJs/android work Linux also does and `validate-artifacts` discards. Graph
  2,908 → 1,660 tasks (−43%); JS bucket 324 → 23. Verified byte-identical output: 248 Apple
  leaf artifacts plus all 27 umbrella module/jar/pom files.
- **Fan-out.** `build-apple` → macos / ios / watchos / tvos shards + publish;
  `build-linux` → jvm / js+wasm / android+ktlint / linuxX64 + publish. Shards are
  restore-only; exactly one job saves each key.
- **Path classifier** gates the macOS docs job and both Android emulator legs.

## Required checks are preserved

The fan-out keeps the three required contexts alive with gate jobs — a final job whose
`name:` is the exact required context string, `needs:` all shards, `if: always()` plus
explicit `needs.X.result` assertions. A bare `needs:` is a trap: a job whose needs failed is
*skipped*, a skipped job reports no status, and the required check then waits forever
instead of going red.

- `build-apple / Apple Targets`
- `build-linux / Linux / JVM / JS / WASM / Android`

## Verification

**Artifact equality is not coverage equality.** Byte-comparing published artifacts proves
the artifacts match, not that the same compilation ran. Diffing `--dry-run` task *graphs*
— the old job's graph against the union of the new jobs' graphs — caught two silent
regressions that nothing would have failed on:

1. `:buffer-codec` was missing from every shard. The old graph compiled and linked its
   Apple test binaries for all 12 targets as a side effect of publishing. Added to all four
   shards.
2. `tvosSimulatorArm64Test` and `watchosSimulatorArm64Test` were *executing* in the old job,
   again as a `publishToMavenLocal` side effect — 10 test tasks across 5 modules. The shards
   only linked those binaries; both are now run explicitly. The x64 variants are
   deliberately not run (the old CI's own log shows them `SKIPPED` — an x64 simulator can't
   run on an arm64 runner); their link coverage is kept via explicit `linkDebugTest*X64`
   entries.

Shards keep registering all 12 Apple targets. Narrowing per shard would narrow
`compileAppleMainKotlinMetadata` and stop it catching the cross-target mismatches that
motivated #342.

## Expected rollout behavior

`warm-cache.yaml` only fires on push to main, so **this PR's own run will still be cold**
(~45 min). That is not the fix failing. The payoff appears on the first PR opened *after*
this merges.

On the merge commit itself, `warm-cache`'s macOS job runs alongside `merged.yaml`'s Apple
shards + publish — 6 concurrent macOS jobs against the 5-job limit. They queue rather than
fail, so the merge run will look stalled for a stretch.

## Notes for anyone re-opening this

Two instruments here fail toward "looks fine, stop looking":

1. `ReserveCacheError: Unable to reserve cache <key>, another job may be creating this
   cache` **does not prove the write was permitted.** setup-gradle logs the denial and then
   re-reports it as that generic error, so a denial and a real race are indistinguishable
   from that line alone. Only a positive `Cache saved with key:` from a read-only token
   proves writability — that is the test that settled the ref-vs-scope question above.
2. A green job does not prove the thing you care about ran. Task avoidance leaves stale
   `build/test-results/**/*.xml` showing PASSED while the task was `UP-TO-DATE`/`FROM-CACHE`.
   Check for the absence of that suffix on the `> Task :x:y` line in a real run's log.

CI-only change; no library code touched. Labeled `skip-release`.
