### PR TITLE
perf(ci): stop seven jobs from double-storing the Gradle cache

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -42,7 +42,16 @@ jobs:
         with:
           distribution: "zulu"
           java-version: "21"
-          cache: gradle
+
+      # Restore-only against build-linux's key rather than setup-java's `cache: gradle`,
+      # which stored a second copy of the same ~/.gradle/caches tree under its own key.
+      # Analysis jobs consume the build cache; only build-linux/warm-cache save it.
+      - name: Restore Gradle build outputs
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.gradle/caches
+          key: gradle-linux-${{ hashFiles('gradle/libs.versions.toml', '**/*.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: gradle-linux-
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6

--- a/.github/workflows/compute-version.yaml
+++ b/.github/workflows/compute-version.yaml
@@ -44,7 +44,18 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '21'
-          cache: gradle
+
+      # Restore-only, and deliberately NOT setup-java's `cache: gradle`. This job is on the
+      # critical path — every other job waits on its output — so it does want a warm
+      # ~/.gradle/caches for the configuration phase that `nextVersion` triggers. What it
+      # must not do is SAVE a second copy: `cache: gradle` wrote its own ~400 MB entry per
+      # ref of the same tree build-linux already caches under `gradle-linux-`.
+      - name: Restore Gradle build outputs
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.gradle/caches
+          key: gradle-linux-${{ hashFiles('gradle/libs.versions.toml', '**/*.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: gradle-linux-
 
       # Assigned before the redirect, not inlined into `echo`: a failure inside
       # `$(...)` on the echo line would be swallowed by echo's exit status and

--- a/.github/workflows/crypto-tpm-integration.yaml
+++ b/.github/workflows/crypto-tpm-integration.yaml
@@ -29,7 +29,16 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '21'
-          cache: gradle
+
+      # Restore-only against build-linux's key rather than setup-java's `cache: gradle`,
+      # which stored a second copy of the same ~/.gradle/caches tree under its own key.
+      # Integration jobs consume the build cache; only build-linux/warm-cache save it.
+      - name: Restore Gradle build outputs
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.gradle/caches
+          key: gradle-linux-${{ hashFiles('gradle/libs.versions.toml', '**/*.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: gradle-linux-
 
       - name: Install swtpm + tpm2-pkcs11 stack
         run: |
@@ -110,7 +119,16 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '21'
-          cache: gradle
+
+      # Restore-only against build-linux's key rather than setup-java's `cache: gradle`,
+      # which stored a second copy of the same ~/.gradle/caches tree under its own key.
+      # Integration jobs consume the build cache; only build-linux/warm-cache save it.
+      - name: Restore Gradle build outputs
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.gradle/caches
+          key: gradle-linux-${{ hashFiles('gradle/libs.versions.toml', '**/*.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: gradle-linux-
 
       - name: Install and initialize SoftHSM
         run: |

--- a/.github/workflows/detekt.yaml
+++ b/.github/workflows/detekt.yaml
@@ -49,7 +49,15 @@ jobs:
         with:
           distribution: "zulu"
           java-version: "21"
-          cache: gradle
+      # Restore-only against build-linux's key rather than setup-java's `cache: gradle`,
+      # which stored a second copy of the same ~/.gradle/caches tree under its own key.
+      # Analysis jobs consume the build cache; only build-linux/warm-cache save it.
+      - name: Restore Gradle build outputs
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.gradle/caches
+          key: gradle-linux-${{ hashFiles('gradle/libs.versions.toml', '**/*.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: gradle-linux-
       - name: Run detekt across all modules and source sets
         # detektAll fans out to every module's `detekt` task; each scans its KMP
         # src/<sourceSet>/kotlin dirs (configured in the root build.gradle.kts).

--- a/.github/workflows/nightly-dependency-update.yaml
+++ b/.github/workflows/nightly-dependency-update.yaml
@@ -37,14 +37,26 @@ jobs:
         with:
           distribution: "zulu"
           java-version: "21"
-          cache: gradle
 
-      - name: Cache Konan
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # Restore-only on both caches. This job deliberately builds with CHANGED dependency
+      # versions, so anything it produced would be keyed off a libs.versions.toml that does
+      # not exist on main — a copy nothing else can ever restore, occupying the shared
+      # 10 GB budget. warm-cache.yaml owns populating these keys.
+      - name: Restore Gradle build outputs
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.gradle/caches
+          key: gradle-linux-${{ hashFiles('gradle/libs.versions.toml', '**/*.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: gradle-linux-
+
+      # Literal `konan-linux-`, not `konan-${{ runner.os }}-`: runner.os is "Linux", which
+      # expanded to `konan-Linux-` and never matched build-linux's `konan-linux-`.
+      - name: Restore Konan
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.konan
-          key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
-          restore-keys: konan-${{ runner.os }}-
+          key: konan-linux-${{ hashFiles('gradle/libs.versions.toml') }}
+          restore-keys: konan-linux-
 
       - name: Claude — coordinated toolchain update
         uses: anthropics/claude-code-action@6b082c41935b4c8a3b8b0ef85ba4ba4d9eeb8975 # v1

--- a/.github/workflows/osv-scanner.yaml
+++ b/.github/workflows/osv-scanner.yaml
@@ -47,7 +47,16 @@ jobs:
         with:
           distribution: "zulu"
           java-version: "21"
-          cache: gradle
+
+      # Restore-only against build-linux's key rather than setup-java's `cache: gradle`,
+      # which stored a second copy of the same ~/.gradle/caches tree under its own key.
+      # Analysis jobs consume the build cache; only build-linux/warm-cache save it.
+      - name: Restore Gradle build outputs
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.gradle/caches
+          key: gradle-linux-${{ hashFiles('gradle/libs.versions.toml', '**/*.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: gradle-linux-
 
       # publishToMavenLocal builds :buffer's linuxArm64 publication, which cross-compiles simdutf (C++)
       # with the aarch64 toolchain. Without these the cmake step fails (exit 1) and the SBOM build dies

--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -132,13 +132,27 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '21'
-          cache: gradle
-      - name: Cache Konan
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # Restore-only against the keys build-apple already saves, instead of setup-java's
+      # `cache: gradle`. That option covers ~/.gradle/caches — the same tree build-apple
+      # caches explicitly — so it stored a SECOND full copy under its own key: 1.74 GB on
+      # a single PR's macOS run, against a 10 GB per-repo cap that warm-cache's
+      # main-scoped entries must also fit inside. This job only consumes; it saves nothing.
+      - name: Restore Gradle build outputs
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
+          path: ~/.gradle/caches
+          key: gradle-macos-${{ hashFiles('gradle/libs.versions.toml', '**/*.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: gradle-macos-
+      # Spelled literally, NOT as `konan-${{ runner.os }}-`: runner.os is "macOS", so that
+      # expanded to `konan-macOS-` — a distinct key from build-apple's `konan-macos-`.
+      # Both existed side by side as separate 439 MB and 605 MB entries, and this job
+      # restored the one nothing else populates.
+      - name: Restore Konan
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
           path: ~/.konan
-          restore-keys: konan-${{ runner.os }}-
+          key: konan-macos-${{ hashFiles('gradle/libs.versions.toml') }}
+          restore-keys: konan-macos-
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:


### PR DESCRIPTION
Follow-up to #345, which fixed the cache-reachability bug but only cleaned up
`cache: gradle` in the two build workflows. Seven other jobs still set it.

## The measurement

The repo is at **9.75 GB against a 10 GB per-repo cap**:

```
1740MB refs/pull/339/merge  setup-java-macOS-arm64-gradle-…
 706MB refs/pull/340/merge  setup-java-macOS-arm64-gradle-…
 482MB refs/heads/main      setup-java-Linux-x64-gradle-…
 349MB refs/heads/main      setup-java-Linux-x64-gradle-…
 303MB refs/heads/main      setup-java-Linux-x64-gradle-…
 275MB refs/pull/340/merge  setup-java-Linux-x64-gradle-…
 + wrapper variants
```

That is roughly **4.4 GB — 45% of the entire budget — in duplicate copies** of
`~/.gradle/caches`, a tree already cached under `gradle-macos-*` / `gradle-linux-*`.

## Why this is not just tidiness

GitHub evicts least-recently-used entries once a repo exceeds the cap. The eviction
candidates include the **main-scoped `gradle-macos` and `gradle-linux` entries that
`warm-cache.yaml` exists to maintain** — the entire point of #345. Losing them puts every
PR's first run back on a cold ~47-minute Kotlin/Native build.

Restores keep refreshing their access time, so they are not in immediate danger. But the
margin is 2.5%, and the failure is silent: a cold run looks like ordinary variance, which
is the same false-negative trap #345's investigation kept hitting.

## The change

Every one of these jobs *consumes* the build cache; none should *produce* it. They now
restore-only against the keys `build-linux`/`build-apple` already save, matching the
one-saver-per-key rule the fan-out established:

| Job | Restores |
|---|---|
| `codeql`, `detekt`, `osv-scanner` | `gradle-linux-*` |
| `crypto-tpm-integration` (both jobs) | `gradle-linux-*` |
| `nightly-dependency-update` | `gradle-linux-*`, `konan-linux-*` |
| `compute-version` | `gradle-linux-*` |
| `review.yaml` `docs` (macos-latest) | `gradle-macos-*`, `konan-macos-*` |

## Two Konan keys that never matched anything

`konan-${{ runner.os }}-` expands to `konan-macOS-` and `konan-Linux-` — **distinct keys**
from `build-apple`'s `konan-macos-` and `build-linux`'s `konan-linux-`. The macOS pair was
visibly coexisting as separate 439 MB and 605 MB entries, meaning the docs job was paying
to populate a cache no other job could ever restore, and restoring one nothing else
populates. Both are now spelled literally.

## Judgment calls

- **`compute-version` keeps a restore.** It is on the critical path — every other job waits
  on its output — and `nextVersion` triggers a full configuration phase. It just no longer
  writes a ~400 MB copy per ref.
- **`nightly-dependency-update` is restore-only on both caches.** It builds with
  deliberately *changed* dependency versions, so anything it saved would be keyed off a
  `libs.versions.toml` that does not exist on main — a copy nothing can ever restore,
  occupying the shared budget.

No change to what any job builds or asserts. All 18 workflow files verified to parse.
