### PR TITLE
fix(ci): hold the deploy slot until Central can be read correctly again

### DIFF
--- a/.github/workflows/merged.yaml
+++ b/.github/workflows/merged.yaml
@@ -294,3 +294,57 @@ jobs:
           version="${{ needs.version.outputs.version }}"
           gh release upload "v${version}" /tmp/buffer-sbom.cdx.json \
             --repo="$GITHUB_REPOSITORY" --clobber
+
+      # ---- Hold the `deploy` slot until Central can be read correctly again ----
+      #
+      # compute-version.yaml derives the next version from a LIVE read of Central's
+      # maven-metadata.xml <latest> (see getNextVersion in gradle/setup.gradle.kts).
+      # Central serves the artifacts well before that file reflects them, so a release
+      # cut inside the lag window reads a stale <latest> and computes a version <= the
+      # one just shipped.
+      #
+      # This is not hypothetical. v6.28.0 was tagged 2026-08-10T23:43:34Z; the next
+      # merged run computed 6.27.1 — content-wise a SUPERSET of 6.28.0 (its commit is a
+      # descendant), published BENEATH it. Central's <release> pointer stayed at 6.28.0,
+      # so nobody tracking latest ever received that fix, and every job in both runs
+      # reported success. Measured lag on the follow-up release: tagged 06:40:30Z,
+      # metadata lastUpdated 06:53:29Z — about 13 minutes. The 30-minute ceiling below
+      # is roughly 2.3x that.
+      #
+      # The `concurrency: deploy` group at the top of this file already serializes RUNS.
+      # The gap it cannot close is that a run FINISHES before Central catches up — which
+      # is why switching compute-version to read git tags instead would NOT have helped
+      # either: when 6.27.1 was computed, the v6.28.0 tag did not exist yet. Holding this
+      # job open is what closes it, because the next merged run queues behind this one and
+      # is then guaranteed a fresh read.
+      #
+      # Fails rather than warns on timeout, deliberately. The release itself has already
+      # succeeded by this point — tag, GitHub release, attestations and SBOM are all done
+      # above, and nothing here can undo any of it. A red X here means "the invariant the
+      # NEXT release depends on is not established yet", which is worth a loud false
+      # alarm; the alternative is the silent regression described above, which surfaces
+      # weeks later as "why is Central serving an older version than our newest tag".
+      - name: Wait for Central to index this release
+        if: needs.check-release.outputs.flow == 'release' && needs.publish.result == 'success'
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          set -uo pipefail
+          url="https://repo1.maven.org/maven2/com/ditchoom/buffer/maven-metadata.xml"
+          latest=""
+          for i in $(seq 1 60); do
+            # `|| true` so a transient network blip is just another poll, not a job failure.
+            latest="$(curl -sf --max-time 30 "$url" \
+                      | sed -n 's:.*<latest>\(.*\)</latest>.*:\1:p' || true)"
+            if [ "$latest" = "$VERSION" ]; then
+              echo "Central <latest> reports $latest after ~$((i * 30))s. Next release will read a current value."
+              exit 0
+            fi
+            echo "poll $i/60: <latest>=${latest:-unreadable}, waiting for $VERSION"
+            sleep 30
+          done
+          echo "::error::Central still reports <latest>=${latest:-unreadable} after 30m, not $VERSION. \
+          The release SUCCEEDED — v$VERSION is tagged, released and uploaded, and nothing needs undoing. \
+          This gate protects the NEXT release, which reads <latest> to pick its version and would \
+          compute a stale one. Before releasing again, confirm $url shows $VERSION."
+          exit 1


### PR DESCRIPTION
Fixes the bug that let **v6.27.1 publish after v6.28.0**.

## What happened

`compute-version.yaml` derives the next version from a **live read** of Central's
`maven-metadata.xml` `<latest>` (`getNextVersion`, `gradle/setup.gradle.kts`). Central
serves artifacts well before that file reflects them, so a release cut inside the lag
window reads a stale `<latest>` and computes a version **≤ the one just shipped**.

```
22:54:54  #342 (minor) merge run starts
23:06:13  #343 (patch) merge run starts   → queued behind #342 by `concurrency: deploy`
23:43:34  #342 publishes, tags v6.28.0
00:41:27  #343 publishes, tags v6.27.1    ← lower than 6.28.0
```

`89182ac6` (#343) is a **descendant** of `31ee095c` (#342), so `6.27.1` is content-wise a
*superset* of `6.28.0` — published beneath it. Central's `<release>` pointer stayed at
`6.28.0`, so nobody tracking latest ever received the Android X25519 fix that release
carried. **Every job in both runs reported `success`.** It took comparing tag order against
commit order to see it at all.

## Why serialization has to extend past the publish

Two fixes look plausible and only one works.

**Reading git tags instead of Central does not help.** When `6.27.1` was computed at
~23:44, the `v6.28.0` tag did not exist either — the previous run did not reach its tagging
step until 23:43:34, and Central's metadata was not updated until later still. No source of
truth held the value at the moment it was needed.

**The `concurrency: deploy` group is already correct and already serializes runs** — #343
did queue behind #342. The gap it cannot close is that a run *finishes* before Central
catches up.

So the fix is to keep the deploy slot held until the world is readable again: `finalize`
now polls `maven-metadata.xml` until `<latest>` equals the version it just published. The
next merged run queues behind it and is guaranteed a fresh read.

## Numbers

Measured on the `6.28.1` release: tagged **06:40:30Z**, metadata `lastUpdated`
**06:53:29Z** — about **13 minutes**. The 30-minute ceiling here is ~2.3× that.

## Two deliberate choices

**Placement.** This is the *last* step of `finalize`, after the tag, the GitHub release,
the attestations and the SBOM upload. A timeout therefore cannot prevent any part of the
release from completing.

**It fails rather than warns on timeout.** The release has already succeeded by the time
this runs and nothing here can undo it, so a red X means only *"the invariant the next
release depends on is not established yet"*. That is worth a loud false alarm; the
alternative is the silent regression above, which surfaces weeks later as "why is Central
serving an older version than our newest tag". The error text states explicitly that the
release succeeded and that nothing needs undoing, so it cannot be misread as a failed
publish.

Only the `release` flow is gated — a `draft` publish goes to the staging repository and
never moves `<latest>`.

## Verification

`merged.yaml` parses. The extraction expression was run against live Central metadata and
returns `6.28.1`. The polling path itself cannot be exercised until the next real release —
the first release after this merges is the test.
