### PR TITLE
fix(buffer): reclaim wasmJs linear memory on release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,8 +169,14 @@ parameter: on JVM 21+ it selects `Arena.ofConfined()` instead of the default
 | JVM 8 / Android | `DeterministicUnsafeJvmBuffer` | `Unsafe.allocateMemory`/`freeMemory` |
 | Apple    | `MutableDataBuffer` | ARC-managed (already deterministic) |
 | Linux    | `NativeBuffer` | malloc/free |
-| WASM     | `LinearBuffer` | Linear memory (already deterministic) |
+| WASM     | `LinearBuffer` | Linear memory, released back to `LinearMemoryAllocator` |
 | JS       | `JsBuffer` | GC-managed (no deterministic alternative) |
+
+**WASM is the one platform where releasing is not optional.** Linear memory sits outside the
+Wasm-GC heap and there is no finalization hook, so dropping the last reference to a `LinearBuffer`
+leaks its bytes out of a fixed 256 MB pool — `BufferFactory.Default` included, not just
+`deterministic()`. Always pair a WASM allocation with `use { }` / `freeNativeMemory()`, or use
+`BufferFactory.managed()` for high-frequency short-lived buffers.
 
 **When to use `BufferFactory.deterministic()` vs `BufferFactory.Default`/pooling:**
 - Use `deterministic()` for: FFI/JNI interop, zero-copy I/O, and any path where you need
@@ -598,7 +604,7 @@ When optimizing buffer operations, follow these principles:
 1. **LinearBuffer (Direct)** - Uses native WASM Pointer ops, 25% faster than ByteArrayBuffer
 2. **ByteArrayBuffer (Heap)** - Use for high-frequency allocations (no memory limit)
 3. **Bulk operations are 2x faster** than single operations on LinearBuffer
-4. **256MB pre-allocated** - LinearBuffer uses bump allocator due to optimizer bug workaround
+4. **256MB pre-allocated** - fixed pool; the allocator cannot grow it after init (`@JsFun` calls on the allocation path trip a Kotlin/WASM optimizer bug). Released blocks are recycled: the bump pointer rewinds for the top allocation, otherwise the block goes on a size-classed free list
 5. **Use Direct for JS interop** - Zero-copy sharing with JavaScript via `wasmMemory.buffer`
 
 See `PERFORMANCE.md` for detailed benchmark results.

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -115,7 +115,7 @@ BufferFactory.deterministic().allocate(1024).use { buffer ->
 | Android | Unsafe.allocateMemory/freeMemory |
 | Apple | MutableDataBuffer (ARC, already deterministic) |
 | Linux | NativeBuffer (malloc/free, already deterministic) |
-| WASM | LinearBuffer (already deterministic) |
+| WASM | LinearBuffer (linear memory, released back to `LinearMemoryAllocator`) |
 | JS | JsBuffer (GC-managed, no alternative) |
 
 ## Secure Buffers (`buffer-crypto`)

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/ByteStream.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/ByteStream.kt
@@ -46,6 +46,16 @@ interface ByteSink {
     /**
      * Writes [buffer], waiting at most [deadline].
      *
+     * **Ownership is not transferred**: the sink borrows [buffer] for the duration of the call and
+     * never frees it — the caller frees it, or returns it to its pool, once the call returns. The
+     * same rule the datagram send half states (see the payload contract on
+     * [DatagramSink][com.ditchoom.buffer.flow.DatagramSink]), and the reason a caller may encode into
+     * a pooled or deterministic buffer and release it immediately after writing. A borrowing sink
+     * must therefore take no lasting reference on [buffer]: a sink that queues rather than transmits
+     * before returning has to copy, because the queued chunk outlives the borrow. Unlike a datagram
+     * send, a stream write *does* consume the cursor — the post-write position is the resume point
+     * for a partial write's residue.
+     *
      * @return number of bytes written
      */
     suspend fun write(

--- a/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/BufferedByteSourceTest.kt
+++ b/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/BufferedByteSourceTest.kt
@@ -186,11 +186,13 @@ class BufferedByteSourceTest {
     fun classifyingAnAcceptedStreamCopiesNothing() =
         runTest {
             val mux = MemoryByteStreamMux()
-            val sender = mux.openUnidirectional()
+            // Deliver as-is rather than through a ByteSink: identity has to survive to the reader
+            // for the assertSame below, and a sink borrows (so copies) what it writes.
+            val wire = mux.openUnidirectionalDelivering()
             val payloadSize = 4096
             val original = prefixedPayload(payloadSize)
-            sender.write(original)
-            sender.close()
+            wire.send(original)
+            wire.close()
 
             val counting = BufferFactory.Default.counting()
             val accepted = BufferedByteSource(mux.acceptUnidirectional(), counting)

--- a/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/MemoryByteStream.kt
+++ b/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/MemoryByteStream.kt
@@ -1,7 +1,10 @@
 package com.ditchoom.buffer.flow
 
+import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.managed
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.withTimeout
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -31,7 +34,16 @@ internal class ChannelByteSource(
     }
 }
 
-/** In-memory [ByteSink] over a channel of buffers. [close] closes the channel (a FIN). */
+/**
+ * In-memory [ByteSink] over a channel of buffers. [close] closes the channel (a FIN).
+ *
+ * Queues a **copy**: [ByteSink.write] only borrows its buffer, and the caller is free to release it
+ * the moment the call returns (`CodecSink.send` does exactly that), so a sink that hands the buffer
+ * onward instead of transmitting it before returning would be queuing freed memory. Real transports
+ * hand the bytes to the kernel/stack within the call; this one has to copy to stand in for that.
+ * A managed copy keeps the queued chunk off wasm linear memory, so a chunk the reader never
+ * consumes costs nothing from the pool.
+ */
 internal class ChannelByteSink(
     private val outbound: Channel<ReadBuffer>,
 ) : ByteSink {
@@ -44,7 +56,10 @@ internal class ChannelByteSink(
         deadline: Duration,
     ): BytesWritten {
         val size = buffer.remaining()
-        outbound.send(buffer)
+        val queued = BufferFactory.managed().allocate(size)
+        queued.write(buffer)
+        queued.resetForRead()
+        outbound.send(queued)
         return BytesWritten(size)
     }
 
@@ -101,6 +116,19 @@ internal class MemoryByteStreamMux : ByteStreamMux {
         val channel = Channel<ReadBuffer>(Channel.UNLIMITED)
         uniQueue.send(ChannelByteSource(channel))
         return ChannelByteSink(channel)
+    }
+
+    /**
+     * Opens a unidirectional stream and hands back its raw inbound channel, so buffers sent here
+     * reach the acceptor **as-is** — the read path's contract, where ownership transfers *out* of
+     * the transport to the reader. Use this over [openUnidirectional] to assert buffer identity
+     * across an accepted stream: a [ChannelByteSink] copies, because a sink only borrows what it
+     * writes and may not retain it.
+     */
+    suspend fun openUnidirectionalDelivering(): SendChannel<ReadBuffer> {
+        val channel = Channel<ReadBuffer>(Channel.UNLIMITED)
+        uniQueue.send(ChannelByteSource(channel))
+        return channel
     }
 
     override suspend fun acceptBidirectional(): ByteStream = bidiQueue.receive()

--- a/buffer/build.gradle.kts
+++ b/buffer/build.gradle.kts
@@ -578,6 +578,14 @@ benchmark {
             iterationTimeUnit = "ms"
             include("HexBenchmark\\.(to|from)HexString.*")
         }
+        // wasmJs allocate/release cost: bump-pointer rewind vs free-list reuse vs bump-only.
+        register("wasmAllocator") {
+            warmups = 3
+            iterations = 5
+            iterationTime = 500
+            iterationTimeUnit = "ms"
+            include("WasmAllocatorBenchmark")
+        }
         // Fast configuration for WASM - runs only key benchmarks to avoid long run times
         register("wasmFast") {
             warmups = 2

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/BufferFactoryInterface.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/BufferFactoryInterface.kt
@@ -126,16 +126,20 @@ interface BufferFactory {
 // =============================================================================
 
 /**
- * Safe, GC-managed, no-leak-risk factory.
+ * The general-purpose factory: platform-optimal memory, GC-managed on every platform but WASM.
  *
- * Returns buffers that are garbage-collected on all platforms — no explicit cleanup required:
+ * Returns buffers that are garbage-collected — no explicit cleanup required:
  * - **JVM 21+**: FfmAutoBuffer (Arena.ofAuto(), GC-collected)
  * - **JVM < 21**: DirectJvmBuffer (GC via Cleaner)
  * - **Android**: DirectJvmBuffer (GC via Cleaner)
  * - **Apple**: MutableDataBuffer (NSMutableData, ARC-managed)
  * - **JS**: JsBuffer (Int8Array, GC-managed)
- * - **WASM**: LinearBuffer (WASM linear memory)
  * - **Linux**: ByteArrayBuffer (GC-managed)
+ *
+ * **WASM is the exception**: LinearBuffer draws from a fixed pool of WASM linear memory, which lives
+ * outside the Wasm-GC heap and has no finalization hook — dropping the last reference to one leaks
+ * it. On WASM these buffers must be released with `use { }` / [PlatformBuffer.freeNativeMemory], or
+ * allocated from [managedBufferFactory] instead.
  */
 internal expect val defaultBufferFactory: BufferFactory
 

--- a/buffer/src/commonTest/kotlin/com/ditchoom/buffer/SustainedAllocationChurnTest.kt
+++ b/buffer/src/commonTest/kotlin/com/ditchoom/buffer/SustainedAllocationChurnTest.kt
@@ -1,0 +1,86 @@
+package com.ditchoom.buffer
+
+import kotlin.test.Test
+import kotlin.test.fail
+
+/**
+ * Isolation harness for the wasmJs out-of-memory failure first seen via PR #324's `toHexString`.
+ *
+ * The question this answers is whether that failure is a property of the hex conversion or of the
+ * allocator underneath it. Every test here does the same thing — allocate a buffer per iteration,
+ * write to it, release it — and varies **only which factory** the buffer comes from. No hex, no
+ * codecs, no strings.
+ *
+ * [CHURN_BYTES] x [ITERATIONS] is 287 MB, deliberately above the 256 MB that wasmJs pre-allocates for
+ * linear memory, and unremarkable for a GC on every other platform.
+ *
+ * Runs on all targets on purpose: the pass/fail split across platforms is the result. Originally
+ * every row was print-only, because on wasmJs each of these died at exactly 65,536 allocations —
+ * `LinearMemoryAllocator` had no deallocation entry point at all, so releasing a buffer reclaimed
+ * nothing. They now assert, and are the cross-platform regression gate for that fix.
+ *
+ * Every row here releases each buffer, which is the contract on a platform without a collector for
+ * native memory. The complementary case — allocating without ever releasing, which no collector can
+ * rescue on wasmJs — is `LinearMemoryExhaustionTest` in wasmJsTest, where the leak can be cleaned up
+ * afterwards instead of poisoning the rest of the suite. Mechanism-level assertions live in
+ * `LinearMemoryReclamationTest`.
+ */
+class SustainedAllocationChurnTest {
+    // `allocate` is last so it can be passed as a trailing lambda.
+    private fun churn(
+        label: String,
+        release: (PlatformBuffer) -> Unit = {},
+        allocate: (Int) -> PlatformBuffer,
+    ) {
+        var completed = 0
+        var failure: Throwable? = null
+        val outcome =
+            try {
+                while (completed < ITERATIONS) {
+                    val buffer = allocate(CHURN_BYTES)
+                    buffer.writeByte(1)
+                    release(buffer)
+                    completed++
+                }
+                "GREEN survived all $ITERATIONS"
+            } catch (
+                @Suppress("TooGenericExceptionCaught") t: Throwable,
+            ) {
+                failure = t
+                "RED died after $completed allocations (${(completed.toLong() * CHURN_BYTES) / MIB} MiB): " +
+                    (t::class.simpleName ?: "Throwable")
+            }
+        println("churn[$label] $outcome")
+        if (failure != null) fail("churn[$label] $outcome")
+    }
+
+    /**
+     * The documented explicit-cleanup path. CLAUDE.md promises the memory is "freed immediately when
+     * the block exits, no GC needed", so this is the one case that must not depend on a collector.
+     * `release` here is exactly what `use { }` runs on scope exit.
+     */
+    @Test
+    fun deterministicFactoryWithUse() =
+        churn(
+            "BufferFactory.deterministic() + use",
+            release = { it.freeNativeMemory() },
+        ) { BufferFactory.deterministic().allocate(it) }
+
+    /** Same loop, but explicitly freeing rather than relying on scope exit. */
+    @Test
+    fun defaultFactoryWithExplicitFree() =
+        churn(
+            "BufferFactory.Default + freeNativeMemory",
+            release = { it.freeNativeMemory() },
+        ) { BufferFactory.Default.allocate(it) }
+
+    /** The GC-managed heap alternative. */
+    @Test
+    fun managedFactory() = churn("BufferFactory.managed()") { BufferFactory.managed().allocate(it) }
+
+    private companion object {
+        private const val CHURN_BYTES = 4096
+        private const val ITERATIONS = 70_000
+        private const val MIB = 1024 * 1024
+    }
+}

--- a/buffer/src/wasmJsBenchmark/kotlin/com/ditchoom/buffer/benchmark/WasmAllocatorBenchmark.kt
+++ b/buffer/src/wasmJsBenchmark/kotlin/com/ditchoom/buffer/benchmark/WasmAllocatorBenchmark.kt
@@ -1,0 +1,110 @@
+package com.ditchoom.buffer.benchmark
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ByteArrayBuffer
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.LinearBuffer
+import com.ditchoom.buffer.LinearMemoryAllocator
+import com.ditchoom.buffer.PlatformBuffer
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.BenchmarkMode
+import kotlinx.benchmark.BenchmarkTimeUnit
+import kotlinx.benchmark.Measurement
+import kotlinx.benchmark.Mode
+import kotlinx.benchmark.OutputTimeUnit
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+import kotlinx.benchmark.Warmup
+
+/**
+ * Cost of the wasmJs allocate/release cycle.
+ *
+ * [LinearMemoryAllocator] reclaims released blocks, which puts work on the allocation path that a
+ * pure bump allocator did not have. These benchmarks measure both reclamation routes plus the
+ * read/write hot path, which must be unaffected:
+ *
+ * - [allocateAndReleaseLifo] — the `use { }` shape. The block is the top allocation when released,
+ *   so the bump pointer rewinds and the next allocation bumps straight back into it.
+ * - [allocateAndReleaseViaFreeList] — a released block that is *not* at the top of the heap, so it
+ *   goes onto the size-classed free list and is popped by the next same-size request.
+ * - [allocateWithoutRelease] — the old bump-only path, for reference. Leaks, so it is bounded by
+ *   [LEAK_BUDGET] and resets the allocator rather than running the pool dry.
+ * - [linearBufferReadWrite] / [byteArrayBufferAllocate] — unchanged-hot-path and managed-heap
+ *   reference points.
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(BenchmarkTimeUnit.SECONDS)
+open class WasmAllocatorBenchmark {
+    private lateinit var linearBuffer: LinearBuffer
+    private var leaked = 0
+
+    @Setup
+    fun setup() {
+        val (offset, _) = LinearMemoryAllocator.allocate(BUFFER_SIZE)
+        linearBuffer = LinearBuffer(offset, BUFFER_SIZE, ByteOrder.BIG_ENDIAN)
+    }
+
+    /** Allocate, touch, release — the shape `use { }` produces. Release rewinds the bump pointer. */
+    @Benchmark
+    fun allocateAndReleaseLifo(): Int {
+        val buffer = BufferFactory.Default.allocate(BUFFER_SIZE)
+        buffer.writeInt(SENTINEL_VALUE)
+        buffer.freeNativeMemory()
+        return buffer.capacity
+    }
+
+    /**
+     * Two live buffers, released oldest-first, so the first release cannot rewind and has to go
+     * through the free list. The next iteration's first allocation pops it back off.
+     */
+    @Benchmark
+    fun allocateAndReleaseViaFreeList(): Int {
+        val first = BufferFactory.Default.allocate(BUFFER_SIZE)
+        val second = BufferFactory.Default.allocate(BUFFER_SIZE)
+        first.writeInt(SENTINEL_VALUE)
+        second.writeInt(SENTINEL_VALUE)
+        first.freeNativeMemory() // pinned below `second` — parked on the free list
+        second.freeNativeMemory() // top of heap — rewinds
+        return first.capacity + second.capacity
+    }
+
+    /** Pure bump allocation, never released — the pre-reclamation cost baseline. */
+    @Benchmark
+    fun allocateWithoutRelease(): Int {
+        if (leaked >= LEAK_BUDGET) {
+            LinearMemoryAllocator.reset()
+            leaked = 0
+            setup()
+        }
+        leaked++
+        val buffer: PlatformBuffer = BufferFactory.Default.allocate(BUFFER_SIZE)
+        buffer.writeInt(SENTINEL_VALUE)
+        return buffer.capacity
+    }
+
+    /** The read/write hot path — must not have moved. */
+    @Benchmark
+    fun linearBufferReadWrite(): Int {
+        linearBuffer.resetForWrite()
+        linearBuffer.writeInt(SENTINEL_VALUE)
+        linearBuffer.resetForRead()
+        return linearBuffer.readInt()
+    }
+
+    /** Managed-heap reference point: allocation served by the Wasm-GC heap instead. */
+    @Benchmark
+    fun byteArrayBufferAllocate(): ByteArrayBuffer = ByteArrayBuffer(ByteArray(BUFFER_SIZE), ByteOrder.BIG_ENDIAN)
+
+    private companion object {
+        private const val BUFFER_SIZE = 1024
+        private const val SENTINEL_VALUE = 0x12345678
+
+        /** 32 MB of leaked 1 KiB blocks, well inside the 256 MB pool, then reset. */
+        private const val LEAK_BUDGET = 32 * 1024
+    }
+}

--- a/buffer/src/wasmJsMain/kotlin/com/ditchoom/buffer/BufferFactory.wasmJs.kt
+++ b/buffer/src/wasmJsMain/kotlin/com/ditchoom/buffer/BufferFactory.wasmJs.kt
@@ -4,16 +4,27 @@ package com.ditchoom.buffer
 // v2 BufferFactory implementations
 // =============================================================================
 
+/**
+ * Allocates an owning [LinearBuffer] out of WASM linear memory.
+ *
+ * Linear memory is not garbage collected, so every buffer this returns must be released with
+ * `freeNativeMemory()` / `use { }`; see [LinearBuffer] for the ownership rules.
+ */
+private fun allocateOwnedLinearBuffer(
+    size: Int,
+    byteOrder: ByteOrder,
+): PlatformBuffer {
+    require(size >= 0) { "Buffer size must be non-negative, got $size" }
+    val (offset, _) = LinearMemoryAllocator.allocate(size)
+    return LinearBuffer(offset, size, byteOrder, owned = true)
+}
+
 internal actual val defaultBufferFactory: BufferFactory =
     object : BufferFactory {
         override fun allocate(
             size: Int,
             byteOrder: ByteOrder,
-        ): PlatformBuffer {
-            require(size >= 0) { "Buffer size must be non-negative, got $size" }
-            val (offset, _) = LinearMemoryAllocator.allocate(size)
-            return LinearBuffer(offset, size, byteOrder)
-        }
+        ): PlatformBuffer = allocateOwnedLinearBuffer(size, byteOrder)
 
         override fun wrap(
             array: ByteArray,
@@ -34,10 +45,47 @@ internal actual val managedBufferFactory: BufferFactory =
         ): PlatformBuffer = ByteArrayBuffer(array, byteOrder)
     }
 
-internal actual val sharedBufferFactory: BufferFactory = defaultBufferFactory
+/**
+ * WASM has no cross-process shared memory, so this falls back to Direct linear memory — same as the
+ * JVM, Apple and Linux fallbacks. Bytes are visible to JavaScript in the same process (zero-copy via
+ * `wasmExports.memory.buffer`), but not to another worker or process.
+ */
+internal actual val sharedBufferFactory: BufferFactory =
+    object : BufferFactory {
+        override fun allocate(
+            size: Int,
+            byteOrder: ByteOrder,
+        ): PlatformBuffer = allocateOwnedLinearBuffer(size, byteOrder)
 
-// WASM LinearBuffer uses linear memory — already deterministic
-private val deterministicFactoryInstance: BufferFactory = defaultBufferFactory
+        override fun wrap(
+            array: ByteArray,
+            byteOrder: ByteOrder,
+        ): PlatformBuffer = ByteArrayBuffer(array, byteOrder)
+    }
+
+/**
+ * Deterministic cleanup on WASM is [LinearBuffer] itself: it implements [CloseableBuffer], and
+ * `freeNativeMemory()` returns the block to [LinearMemoryAllocator] for reuse.
+ *
+ * This is the same buffer type the default factory hands out — WASM has no GC-backed alternative
+ * for linear memory, so on this platform the *default* allocation also has to be released. The
+ * distinction the other platforms draw (`Arena.ofAuto` vs `Arena.ofShared`, GC vs malloc/free) does
+ * not exist here; what `deterministic()` adds is the documented guarantee, which now holds.
+ *
+ * [threadConfined] is ignored: WASM linear memory is single-threaded.
+ */
+private val deterministicFactoryInstance: BufferFactory =
+    object : BufferFactory {
+        override fun allocate(
+            size: Int,
+            byteOrder: ByteOrder,
+        ): PlatformBuffer = allocateOwnedLinearBuffer(size, byteOrder)
+
+        override fun wrap(
+            array: ByteArray,
+            byteOrder: ByteOrder,
+        ): PlatformBuffer = ByteArrayBuffer(array, byteOrder)
+    }
 
 internal actual fun deterministicBufferFactory(threadConfined: Boolean): BufferFactory = deterministicFactoryInstance
 
@@ -48,10 +96,7 @@ internal actual fun deterministicBufferFactory(threadConfined: Boolean): BufferF
 actual fun PlatformBuffer.Companion.allocateNative(
     size: Int,
     byteOrder: ByteOrder,
-): PlatformBuffer {
-    val (offset, _) = LinearMemoryAllocator.allocate(size)
-    return LinearBuffer(offset, size, byteOrder)
-}
+): PlatformBuffer = allocateOwnedLinearBuffer(size, byteOrder)
 
 /**
  * Allocates a buffer with shared memory support.
@@ -70,5 +115,7 @@ actual fun PlatformBuffer.Companion.wrapNativeAddress(
     require(address >= 0 && address <= Int.MAX_VALUE) {
         "WASM linear memory address must fit in Int range, got $address"
     }
-    return LinearBuffer(address.toInt(), size, byteOrder)
+    // Non-owning: the caller owns this address, so freeNativeMemory() must not hand it to the
+    // allocator's free list.
+    return LinearBuffer(address.toInt(), size, byteOrder, owned = false)
 }

--- a/buffer/src/wasmJsMain/kotlin/com/ditchoom/buffer/LinearBuffer.kt
+++ b/buffer/src/wasmJsMain/kotlin/com/ditchoom/buffer/LinearBuffer.kt
@@ -108,13 +108,41 @@ private external fun copyToJsArray(
  * JS (via DataView on the same memory) can access the same underlying bytes.
  *
  * All read/write operations compile to native WASM i32.load/i32.store instructions.
+ *
+ * ## Memory ownership
+ *
+ * Linear memory is outside the Wasm-GC heap, so dropping the last reference to a LinearBuffer does
+ * **not** reclaim its bytes. An *owning* buffer — one produced by a [BufferFactory] or by
+ * [PlatformBuffer.allocateNative] — must be released with [freeNativeMemory] (directly or via
+ * `use { }`), which returns the block to [LinearMemoryAllocator].
+ *
+ * [owned] is `false` for views that alias memory somebody else is responsible for: [slice], and
+ * [PlatformBuffer.wrapNativeAddress] over an externally-owned address. Releasing those is a no-op.
+ *
+ * Because a released block is handed straight back out to the next allocation of the same size,
+ * reading or writing through a buffer (or a live [slice] of one) after it has been released reads
+ * or corrupts unrelated data. As documented on [slice], a view must not outlive its parent.
+ *
+ * `@Suppress("TooManyFunctions")`: the count is set by the PlatformBuffer surface this class must
+ * implement (the read/write primitives plus the NativeMemoryAccess and CloseableBuffer members),
+ * not by anything decomposable. Splitting it would put the buffer's own accessors behind a delegate
+ * on the hot path. Same reasoning as LockFreeBufferPool.
+ *
+ * @param owned whether releasing this buffer returns its block to [LinearMemoryAllocator]. Defaults
+ *   to `false` so that a construction site that has not thought about ownership fails safe by
+ *   leaking rather than by double-freeing.
  */
+@Suppress("TooManyFunctions")
 class LinearBuffer(
     internal val baseOffset: Int,
     capacity: Int,
     byteOrder: ByteOrder,
+    private val owned: Boolean = false,
 ) : BaseWebBuffer(capacity, byteOrder),
-    NativeMemoryAccess {
+    NativeMemoryAccess,
+    CloseableBuffer {
+    private var freed: Boolean = false
+
     /**
      * The offset in WASM linear memory for zero-copy JS interop.
      * Use with `new DataView(wasmExports.memory.buffer, nativeAddress, nativeSize)`.
@@ -372,6 +400,12 @@ class LinearBuffer(
         }
     }
 
+    /**
+     * A zero-copy view of the remaining bytes, sharing this buffer's linear memory.
+     *
+     * The slice is non-owning: releasing it does nothing, and it must not outlive this buffer —
+     * once the parent is released its block can be reissued to an unrelated allocation.
+     */
     override fun slice(byteOrder: ByteOrder): LinearBuffer {
         // Create a new LinearBuffer view of the remaining portion
         // This is zero-copy - just creates a new view with different base offset
@@ -379,7 +413,22 @@ class LinearBuffer(
             baseOffset + positionValue,
             limitValue - positionValue,
             byteOrder,
+            owned = false,
         )
+    }
+
+    override val isFreed: Boolean get() = freed
+
+    /**
+     * Returns this buffer's block to [LinearMemoryAllocator], if this buffer owns it.
+     *
+     * Idempotent, and a no-op for non-owning views ([slice], wrapped external addresses) — so it is
+     * always safe to call, including through `use { }`.
+     */
+    override fun freeNativeMemory() {
+        if (freed || !owned) return
+        freed = true
+        LinearMemoryAllocator.free(baseOffset, capacity)
     }
 
     override fun readByteArray(size: Int): ByteArray = copyToByteArray(size)

--- a/buffer/src/wasmJsMain/kotlin/com/ditchoom/buffer/MemoryManager.kt
+++ b/buffer/src/wasmJsMain/kotlin/com/ditchoom/buffer/MemoryManager.kt
@@ -3,6 +3,7 @@
 package com.ditchoom.buffer
 
 import kotlin.js.ExperimentalWasmJsInterop
+import kotlin.wasm.unsafe.Pointer
 import kotlin.wasm.unsafe.UnsafeWasmMemoryApi
 
 private const val PAGE_SIZE = 65536 // 64KB per WASM page
@@ -12,11 +13,17 @@ private const val ALIGN_8_MASK = 7
 
 /**
  * Allocation statistics for debugging and monitoring.
+ *
+ * [totalAllocated] is the bump watermark (`nextOffset - heapBase`), i.e. the high-water mark of linear
+ * memory handed out and not yet rewound. [freeListBytes] is the portion of that watermark currently
+ * parked on the free list and available for reuse, so live bytes are `totalAllocated - freeListBytes`.
  */
 data class AllocationStats(
     val heapBase: Int,
     val nextOffset: Int,
     val totalAllocated: Int,
+    val freeListBytes: Int = 0,
+    val reusedBlocks: Int = 0,
 )
 
 /**
@@ -68,7 +75,12 @@ object LinearMemoryConfig {
  * The allocation strategy:
  * 1. Call memory.grow() to add pages - returns previous size
  * 2. Use the offset (previousSize * 64KB) as our heap base
- * 3. All subsequent allocations bump from there
+ * 3. Subsequent allocations reuse an exact-fit block from the free list, or bump from there
+ * 4. [free] returns a block: rewinding the bump pointer if it is the top allocation, otherwise
+ *    parking it on the size-classed free list
+ *
+ * Linear memory is not garbage collected. A block is only reclaimed when its owning [LinearBuffer]
+ * is explicitly released via `freeNativeMemory()` / `use { }`; dropping the reference leaks it.
  *
  * This is safe because:
  * - memory.grow() returns pages that weren't previously mapped
@@ -80,6 +92,61 @@ object LinearMemoryAllocator {
     private var heapBase: Int = 0
     private var nextOffset: Int = 0
     private var heapEnd: Int = 0
+
+    /**
+     * Size-classed free list, exact fit: a freed 8 KiB block never satisfies a 4 KiB request. That
+     * keeps both hot paths to an array index and one i32 load/store, with no splitting or coalescing
+     * bookkeeping.
+     *
+     * The list is *intrusive* — the "next" link lives in the first 4 bytes of the freed block itself
+     * (which is dead memory, and always at least 8 bytes since sizes are 8-byte aligned), reached
+     * with a raw [Pointer]. So push and pop allocate nothing: no boxed `Int` key, no list node, no
+     * hash lookup, nothing for the Wasm-GC collector to trace. That matters because allocation is
+     * the hot path this whole object exists to serve: a `HashMap<Int, MutableList<Int>>` version of
+     * the same free list measured 9.3M vs 14.8M ops/sec on `WasmAllocatorBenchmark`'s reuse route,
+     * because every allocation boxed the size key (`struct.new $kotlin.Int` in the emitted wasm).
+     *
+     * [smallHeads] holds the head offset per size class (`aligned ushr 3`) up to [SMALL_MAX_SIZE],
+     * covering every buffer size worth optimising. Larger blocks are rare and their allocation cost
+     * is dominated by their size, so they fall back to [largeHeads], which is the same intrusive
+     * chain behind a boxed lookup.
+     *
+     * Deliberately plain Kotlin integer and pointer code: the Kotlin/WASM optimizer bug documented
+     * on [allocateOffset] means neither the allocation nor the deallocation path may contain a
+     * `@JsFun` call. [Pointer] compiles to native i32.load/i32.store, so it does not.
+     */
+    private val smallHeads = IntArray(SMALL_CLASS_COUNT) { NO_BLOCK }
+    private val largeHeads = HashMap<Int, Int>()
+    private var freeListBytes: Int = 0
+    private var reusedBlocks: Int = 0
+
+    /**
+     * Head of the free chain for [aligned], or [NO_BLOCK].
+     *
+     * The small path compiles to a compare, a shift and an array load. The large path has to box the
+     * key for the map lookup (`struct.new $kotlin.Int` in the emitted wasm), so it is guarded on
+     * [largeHeads] being non-empty — a caller that never frees a >= 64 KiB block never pays for it.
+     */
+    private fun headOf(aligned: Int): Int =
+        when {
+            aligned < SMALL_MAX_SIZE -> smallHeads[aligned ushr ALIGN_8_SHIFT]
+            largeHeads.isEmpty() -> NO_BLOCK
+            else -> largeHeads[aligned] ?: NO_BLOCK
+        }
+
+    private fun setHead(
+        aligned: Int,
+        offset: Int,
+    ) {
+        if (aligned < SMALL_MAX_SIZE) {
+            smallHeads[aligned ushr ALIGN_8_SHIFT] = offset
+        } else if (offset == NO_BLOCK) {
+            // Drop the drained chain rather than parking a -1, so headOf's isEmpty() guard stays live.
+            largeHeads.remove(aligned)
+        } else {
+            largeHeads[aligned] = offset
+        }
+    }
 
     // Computed from config - 1MB = 16 pages (16 * 64KB)
     private val initialPages: Int get() = LinearMemoryConfig.initialSizeMB * 16
@@ -158,6 +225,18 @@ object LinearMemoryAllocator {
         val aligned = (size + ALIGN_8_MASK) and ALIGN_8_MASK.inv()
         lastAlignedSize = aligned
 
+        // Reuse a previously freed block of exactly this size before growing the watermark.
+        // Recycled memory is NOT zeroed — same contract as malloc, and as Linux `NativeBuffer`.
+        // Use BufferFactory.secure() (or zeroInit) when the contents must start at zero.
+        val recycled = headOf(aligned)
+        if (recycled != NO_BLOCK) {
+            // The block's first 4 bytes hold the next link; reading it releases the block entirely.
+            setHead(aligned, Pointer(recycled.toUInt()).loadInt())
+            freeListBytes -= aligned
+            reusedBlocks++
+            return recycled
+        }
+
         // Check bounds but don't try to grow (would require @JsFun call)
         if (nextOffset + aligned > heapEnd) {
             throw OutOfMemoryError(
@@ -170,6 +249,55 @@ object LinearMemoryAllocator {
         val offset = nextOffset
         nextOffset += aligned
         return offset
+    }
+
+    /**
+     * Return a block previously handed out by [allocate] / [allocateOffset] so it can satisfy a later
+     * request of the same size.
+     *
+     * Called by [LinearBuffer.freeNativeMemory], which guards against double-free and against freeing
+     * a non-owning view (a `slice()`), so this function trusts its arguments beyond the cheap sanity
+     * bounds check below.
+     *
+     * Two reclamation strategies, both pure integer math:
+     * - If the block sits at the top of the heap, rewind the bump pointer. This is what an
+     *   allocate/use/free loop does, so the steady-state watermark stays flat.
+     * - Otherwise park the block on the size-classed free list for an exact-fit reuse.
+     *
+     * `@Suppress("ReturnCount")`: the returns are four independent rejections of a block this
+     * allocator must not touch (uninitialized, degenerate size, foreign address, top-of-heap
+     * rewind). Folding them into nested conditions would bury the ownership checks that keep a
+     * double-free or a wrapped external address from corrupting the free list.
+     *
+     * @param offset the block's base offset, as returned by [allocateOffset]
+     * @param size the block's requested (unaligned) size — the same value passed to [allocate]
+     */
+    @Suppress("ReturnCount")
+    fun free(
+        offset: Int,
+        size: Int,
+    ) {
+        if (!initialized) return
+        val aligned = (size + ALIGN_8_MASK) and ALIGN_8_MASK.inv()
+        if (aligned <= 0) return
+        // Reject anything that was never handed out by this allocator (e.g. a wrapped external
+        // address). Blocks are always fully below the watermark at the time they are freed.
+        if (offset < heapBase || offset + aligned > nextOffset) return
+
+        if (offset + aligned == nextOffset) {
+            // Top of heap: give the bytes back outright.
+            //
+            // This can never strand a free-list entry above the new watermark. Allocations do not
+            // overlap, so any parked block X satisfies either X + sizeX <= offset (stays below the
+            // rewound watermark) or X >= nextOffset (impossible — X was handed out below it).
+            nextOffset = offset
+            return
+        }
+
+        // Push onto the intrusive chain: the old head goes into the block's first 4 bytes.
+        Pointer(offset.toUInt()).storeInt(headOf(aligned))
+        setHead(aligned, offset)
+        freeListBytes += aligned
     }
 
     // Helper for test functions that need initialization
@@ -259,6 +387,8 @@ object LinearMemoryAllocator {
             heapBase = heapBase,
             nextOffset = nextOffset,
             totalAllocated = nextOffset - heapBase,
+            freeListBytes = freeListBytes,
+            reusedBlocks = reusedBlocks,
         )
     }
 
@@ -275,5 +405,19 @@ object LinearMemoryAllocator {
             }
             nextOffset = heapBase
         }
+        smallHeads.fill(NO_BLOCK)
+        largeHeads.clear()
+        freeListBytes = 0
+        reusedBlocks = 0
     }
+
+    private const val NO_BLOCK = -1
+
+    /** `log2(8)` — turns an 8-byte-aligned size into its [smallHeads] index. */
+    private const val ALIGN_8_SHIFT = 3
+
+    /** Free-list size classes are tracked in an array up to this size; above it, in a hash map. */
+    private const val SMALL_MAX_SIZE = 64 * 1024
+
+    private const val SMALL_CLASS_COUNT = SMALL_MAX_SIZE ushr ALIGN_8_SHIFT
 }

--- a/buffer/src/wasmJsMain/kotlin/com/ditchoom/buffer/NativeDataConversions.wasmJs.kt
+++ b/buffer/src/wasmJsMain/kotlin/com/ditchoom/buffer/NativeDataConversions.wasmJs.kt
@@ -47,7 +47,9 @@ actual fun ReadBuffer.toNativeData(): NativeData {
             else -> {
                 val bytes = toByteArray()
                 val (offset, _) = LinearMemoryAllocator.allocate(bytes.size)
-                val linearBuffer = LinearBuffer(offset, bytes.size, byteOrder)
+                // Freshly allocated, so the returned wrapper owns it: releasing the LinearBuffer
+                // returns the copy to the allocator.
+                val linearBuffer = LinearBuffer(offset, bytes.size, byteOrder, owned = true)
                 linearBuffer.writeBytes(bytes)
                 linearBuffer.resetForRead()
                 linearBuffer
@@ -79,13 +81,20 @@ actual fun PlatformBuffer.toMutableNativeData(): MutableNativeData {
     return MutableNativeData(
         when (unwrapped) {
             is LinearBuffer -> {
-                // Create a new LinearBuffer view sharing the same memory
-                LinearBuffer(unwrapped.baseOffset + unwrapped.position(), unwrapped.remaining(), unwrapped.byteOrder)
+                // Create a new non-owning LinearBuffer view sharing the same memory
+                LinearBuffer(
+                    unwrapped.baseOffset + unwrapped.position(),
+                    unwrapped.remaining(),
+                    unwrapped.byteOrder,
+                    owned = false,
+                )
             }
             else -> {
                 val bytes = toByteArray()
                 val (offset, _) = LinearMemoryAllocator.allocate(bytes.size)
-                val linearBuffer = LinearBuffer(offset, bytes.size, byteOrder)
+                // Freshly allocated, so the returned wrapper owns it: releasing the LinearBuffer
+                // returns the copy to the allocator.
+                val linearBuffer = LinearBuffer(offset, bytes.size, byteOrder, owned = true)
                 linearBuffer.writeBytes(bytes)
                 linearBuffer.resetForRead()
                 linearBuffer

--- a/buffer/src/wasmJsTest/kotlin/com/ditchoom/buffer/LinearMemoryExhaustionTest.kt
+++ b/buffer/src/wasmJsTest/kotlin/com/ditchoom/buffer/LinearMemoryExhaustionTest.kt
@@ -1,0 +1,78 @@
+package com.ditchoom.buffer
+
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * The wasmJs half of `SustainedAllocationChurnTest`: what happens when buffers are allocated and
+ * never released.
+ *
+ * This is the one behaviour reclamation cannot fix. Linear memory sits outside the Wasm-GC heap and
+ * there is no finalization hook to attach to a [LinearBuffer], so dropping the last reference to one
+ * cannot return its bytes — unlike every other target, where a collector eventually does. The pool
+ * is a fixed [LinearMemoryConfig.initialSizeMB], so a caller who never releases will exhaust it.
+ * Releasing is the caller's job; `SustainedAllocationChurnTest` covers that side.
+ *
+ * The test keeps every buffer it allocates and releases them in a `finally`, so it exercises the
+ * exhaustion without leaving the shared allocator poisoned for the rest of the suite — and, in
+ * doing so, proves 256 MiB of leaked blocks are fully recoverable once they are released.
+ */
+class LinearMemoryExhaustionTest {
+    @Test
+    fun unreleasedBuffersExhaustThePoolAndAreRecoverableOnRelease() {
+        val baseline = LinearMemoryAllocator.getAllocationStats().totalAllocated
+        val leaked = mutableListOf<PlatformBuffer>()
+        try {
+            assertFailsWith<OutOfMemoryError>("a fixed pool must run out when nothing is ever released") {
+                repeat(ITERATIONS) {
+                    leaked.add(BufferFactory.Default.allocate(CHURN_BYTES).also { buffer -> buffer.writeByte(1) })
+                }
+            }
+            assertTrue(
+                leaked.size > MIN_EXPECTED_ALLOCATIONS,
+                "expected the pool to absorb most of ${LinearMemoryConfig.initialSizeMB} MB first, " +
+                    "got ${leaked.size} allocations",
+            )
+        } finally {
+            // Release in reverse: each buffer is then the top allocation, so the bump pointer rewinds
+            // the whole way instead of parking 65k blocks on the free list.
+            for (i in leaked.indices.reversed()) {
+                leaked[i].freeNativeMemory()
+            }
+        }
+        // `<=` rather than `==`: if an earlier test left a block of this size parked on the free
+        // list, the first allocation reused it and the final rewind can legitimately go past the
+        // starting watermark. What must not happen is retaining any of the 256 MiB.
+        val after = LinearMemoryAllocator.getAllocationStats().totalAllocated
+        assertTrue(after <= baseline, "every leaked block must be recoverable once released, got $after > $baseline")
+
+        // The assertion above reads the allocator's own bookkeeping, so on its own it cannot
+        // distinguish "the bytes are reusable" from "the counters say the bytes are reusable".
+        // Refilling the pool a second time settles that without consulting any counter: if
+        // `free()` updated its arithmetic but did not actually make the blocks available again,
+        // this pass runs out of memory exactly where the first one did.
+        val reused = mutableListOf<PlatformBuffer>()
+        try {
+            repeat(MIN_EXPECTED_ALLOCATIONS) {
+                reused.add(BufferFactory.Default.allocate(CHURN_BYTES).also { buffer -> buffer.writeByte(1) })
+            }
+        } catch (_: OutOfMemoryError) {
+            fail(
+                "released bytes were not genuinely reusable: the second pass exhausted the pool after " +
+                    "${reused.size} of $MIN_EXPECTED_ALLOCATIONS allocations",
+            )
+        } finally {
+            for (i in reused.indices.reversed()) {
+                reused[i].freeNativeMemory()
+            }
+        }
+    }
+
+    private companion object {
+        private const val CHURN_BYTES = 4096
+        private const val ITERATIONS = 70_000
+        private const val MIN_EXPECTED_ALLOCATIONS = 60_000
+    }
+}

--- a/buffer/src/wasmJsTest/kotlin/com/ditchoom/buffer/LinearMemoryReclamationTest.kt
+++ b/buffer/src/wasmJsTest/kotlin/com/ditchoom/buffer/LinearMemoryReclamationTest.kt
@@ -1,0 +1,282 @@
+// Sizes and offsets here are deliberately literal: each test picks its own byte count so the
+// exact-fit free list keeps them independent of execution order, and naming those would obscure
+// the one property that matters about them — that they differ. Matches the convention in
+// ReadStringDirectUtf8Test and WriteStringLoneSurrogateTest.
+@file:Suppress("MagicNumber")
+
+package com.ditchoom.buffer
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * Mechanism-level regression gate for wasmJs linear-memory reclamation, read straight off the
+ * allocator's own counters rather than inferred from an OutOfMemoryError.
+ *
+ * These assertions used to run the other way round: they pinned the broken behaviour, where
+ * [LinearMemoryAllocator] was a pure bump allocator with no deallocation entry point and
+ * [LinearBuffer] inherited the empty `freeNativeMemory` default, so releasing a buffer reclaimed
+ * nothing and `deterministic().use { }` leaked. They now assert that releasing a buffer gives its
+ * block back.
+ *
+ * Every test uses its own [SIZE_CLASS] value. Reuse is exact-fit, and wasm tests share one process
+ * with one global allocator, so distinct sizes keep the tests independent of execution order.
+ *
+ * `@Suppress("TooManyFunctions")`: one test per reclamation path, so the count is set by the number
+ * of paths rather than by anything extractable.
+ */
+@Suppress("TooManyFunctions")
+class LinearMemoryReclamationTest {
+    private fun watermark(): Int = LinearMemoryAllocator.getAllocationStats().totalAllocated
+
+    private fun freeListBytes(): Int = LinearMemoryAllocator.getAllocationStats().freeListBytes
+
+    private fun reusedBlocks(): Int = LinearMemoryAllocator.getAllocationStats().reusedBlocks
+
+    @Test
+    fun allocationAdvancesTheWatermark() {
+        val size = sizeClass(0)
+        val before = watermark()
+        BufferFactory.Default.allocate(size)
+        assertTrue(watermark() >= before + size, "expected the bump pointer to advance by at least $size")
+    }
+
+    /**
+     * The core defect, inverted. `freeNativeMemory()` is the documented way to hand native memory
+     * back; on a LinearBuffer it used to change nothing.
+     */
+    @Test
+    fun freeNativeMemoryReclaimsTheBlock() {
+        val before = watermark()
+        val buffer = BufferFactory.Default.allocate(sizeClass(1))
+        assertTrue(watermark() > before, "allocation should have consumed linear memory")
+        buffer.freeNativeMemory()
+        assertEquals(before, watermark(), "freeNativeMemory() must return the block to the allocator")
+    }
+
+    /** Same for the scope-exit form, which is what `use { }` calls underneath. */
+    @Test
+    fun deterministicUseBlockReclaimsImmediately() {
+        val before = watermark()
+        BufferFactory.deterministic().allocate(sizeClass(2)).use { it.writeByte(1) }
+        assertEquals(
+            before,
+            watermark(),
+            "deterministic().use { } is documented to free immediately, with no GC involved",
+        )
+    }
+
+    /** An allocate/use/release loop must reach a flat steady state, not a rising watermark. */
+    @Test
+    fun repeatedAllocateAndReleaseDoesNotGrowTheWatermark() {
+        val size = sizeClass(3)
+        BufferFactory.Default.allocate(size).use { it.writeByte(1) }
+        val afterFirst = watermark()
+        repeat(ITERATIONS) { BufferFactory.Default.allocate(size).use { buffer -> buffer.writeByte(1) } }
+        assertEquals(afterFirst, watermark(), "$ITERATIONS allocate/release cycles must not accumulate")
+    }
+
+    /**
+     * A block freed from the middle of the heap (not the top, so the bump pointer cannot simply
+     * rewind) is parked on the size-classed free list and handed back out to the next request of the
+     * same size — exactly once.
+     */
+    @Test
+    fun freedBlockIsHandedBackOutExactlyOnce() {
+        val size = sizeClass(4)
+        val first = BufferFactory.Default.allocate(size) as LinearBuffer
+        val pinnedAbove = BufferFactory.Default.allocate(size) as LinearBuffer
+
+        val reusedBefore = reusedBlocks()
+        first.freeNativeMemory()
+        assertTrue(freeListBytes() > 0, "a non-top-of-heap block should be parked on the free list")
+
+        val recycled = BufferFactory.Default.allocate(size) as LinearBuffer
+        assertEquals(first.baseOffset, recycled.baseOffset, "the freed block should satisfy the next request")
+        assertEquals(reusedBefore + 1, reusedBlocks(), "reuse should be counted")
+
+        // The block must not still be on the free list after being handed out.
+        val fresh = BufferFactory.Default.allocate(size) as LinearBuffer
+        assertNotEquals(first.baseOffset, fresh.baseOffset, "a freed block must not be issued twice")
+        assertNotEquals(pinnedAbove.baseOffset, fresh.baseOffset, "a live block must not be reissued")
+    }
+
+    /** Releasing twice must reclaim once — a double free would corrupt the free list. */
+    @Test
+    fun doubleFreeReclaimsOnce() {
+        val size = sizeClass(5)
+        val buffer = BufferFactory.Default.allocate(size)
+        BufferFactory.Default.allocate(size) // pins `buffer` below the top of the heap
+
+        buffer.freeNativeMemory()
+        val afterFirstFree = freeListBytes()
+        buffer.freeNativeMemory()
+        assertEquals(afterFirstFree, freeListBytes(), "the second release must be a no-op")
+
+        val recycled = BufferFactory.Default.allocate(size) as LinearBuffer
+        val fresh = BufferFactory.Default.allocate(size) as LinearBuffer
+        assertNotEquals(recycled.baseOffset, fresh.baseOffset, "the block must not be on the free list twice")
+    }
+
+    @Test
+    fun isFreedTracksTheRelease() {
+        val buffer = BufferFactory.Default.allocate(sizeClass(6))
+        val closeable = buffer as CloseableBuffer
+        assertFalse(closeable.isFreed, "a fresh buffer is not freed")
+        buffer.freeNativeMemory()
+        assertTrue(closeable.isFreed, "isFreed must reflect the release")
+    }
+
+    // ============================================================================
+    // Slice lifetime — slices alias the parent's memory and must never free it
+    // ============================================================================
+
+    /**
+     * The main hazard the free list introduces. A slice shares the parent's `baseOffset`; if it were
+     * treated as an owner, releasing it would hand a live block back to the allocator, which would
+     * then reissue memory the parent is still writing to.
+     */
+    @Test
+    fun releasingASliceDoesNotReclaimTheParentBlock() {
+        val size = sizeClass(7)
+        val parent = BufferFactory.Default.allocate(size)
+        val afterAllocate = watermark()
+        val freeListBefore = freeListBytes()
+
+        val slice = parent.slice()
+        slice.freeNativeMemory()
+
+        assertEquals(afterAllocate, watermark(), "a slice must not return its parent's block")
+        assertEquals(freeListBefore, freeListBytes(), "a slice must not reach the free list")
+        assertFalse((slice as CloseableBuffer).isFreed, "a non-owning view is never 'freed'")
+
+        // The parent is still usable, and still the owner.
+        parent.writeByte(7)
+        parent.freeNativeMemory()
+        assertEquals(afterAllocate - alignUp(size), watermark(), "the parent still owns the block")
+    }
+
+    /** A slice stays a valid view of the parent for as long as the parent is alive. */
+    @Test
+    fun sliceReadsThroughToTheParentWhileTheParentIsAlive() {
+        val parent = BufferFactory.Default.allocate(sizeClass(8))
+        parent.writeInt(0x0BADF00D)
+        parent.resetForRead()
+
+        val slice = parent.slice()
+        slice.use { assertEquals(0x0BADF00D, it.readInt()) }
+
+        parent.position(0)
+        assertEquals(0x0BADF00D, parent.readInt(), "using the slice must not disturb the parent")
+        parent.freeNativeMemory()
+    }
+
+    /**
+     * `wrapNativeAddress` hands back a view of memory the caller owns. Releasing it must not push
+     * somebody else's address onto the free list.
+     */
+    @Test
+    fun wrappedExternalAddressIsNeverReclaimed() {
+        val size = sizeClass(9)
+        val owner = BufferFactory.Default.allocate(size) as LinearBuffer
+        val afterAllocate = watermark()
+        val freeListBefore = freeListBytes()
+
+        val wrapped = PlatformBuffer.wrapNativeAddress(owner.nativeAddress, size)
+        wrapped.freeNativeMemory()
+
+        assertEquals(afterAllocate, watermark(), "wrapping must not take ownership")
+        assertEquals(freeListBefore, freeListBytes(), "an externally-owned address must not be parked")
+        owner.freeNativeMemory()
+    }
+
+    /**
+     * Blocks at or above the free list's array-backed size classes take the map-backed path. Same
+     * contract, different bookkeeping, so it gets its own round trip.
+     */
+    @Test
+    fun largeBlocksAreReclaimedAndReused() {
+        val size = LARGE_SIZE
+        val first = BufferFactory.Default.allocate(size) as LinearBuffer
+        BufferFactory.Default.allocate(size) // pins `first` below the top of the heap
+
+        first.freeNativeMemory()
+        val recycled = BufferFactory.Default.allocate(size) as LinearBuffer
+        assertEquals(first.baseOffset, recycled.baseOffset, "a large freed block should be reused")
+
+        val fresh = BufferFactory.Default.allocate(size) as LinearBuffer
+        assertNotEquals(first.baseOffset, fresh.baseOffset, "a large block must not be issued twice")
+    }
+
+    // ============================================================================
+    // Allocator boundaries
+    // ============================================================================
+
+    /** The escape hatch: a managed buffer never touches linear memory, so the watermark is untouched. */
+    @Test
+    fun managedFactoryDoesNotConsumeLinearMemory() {
+        val before = watermark()
+        repeat(REPEATS) { BufferFactory.managed().allocate(sizeClass(10)).writeByte(1) }
+        assertEquals(before, watermark(), "managed() must not draw from linear memory")
+    }
+
+    /**
+     * WASM has no GC-backed alternative for linear memory, so `deterministic()` draws from the same
+     * allocator as `Default` and costs the same. What it documents — release is immediate and does
+     * not wait on a collector — is now true of both.
+     */
+    @Test
+    fun deterministicMatchesDefaultAndBothAreCloseable() {
+        val size = sizeClass(11)
+        val before = watermark()
+        val deterministic = BufferFactory.deterministic().allocate(size)
+        val deterministicCost = watermark() - before
+
+        val beforeDefault = watermark()
+        val default = BufferFactory.Default.allocate(size)
+        val defaultCost = watermark() - beforeDefault
+
+        assertEquals(defaultCost, deterministicCost, "deterministic() draws from the same allocator as Default")
+        assertTrue(deterministic is CloseableBuffer && default is CloseableBuffer)
+        default.freeNativeMemory()
+        deterministic.freeNativeMemory()
+        assertEquals(before, watermark(), "both must reclaim on release")
+    }
+
+    /** Reuse via a pool: the pool holds one buffer and hands it back out without new linear memory. */
+    @Test
+    fun poolingReusesInsteadOfReclaiming() {
+        val size = sizeClass(12)
+        val pool =
+            com.ditchoom.buffer.pool
+                .BufferPool(defaultBufferSize = size)
+        val factory = BufferFactory.Default.withPooling(pool)
+        repeat(WARMUP) { factory.allocate(size).also { it.writeByte(1) }.freeNativeMemory() }
+        val afterWarm = watermark()
+        repeat(REPEATS) { factory.allocate(size).also { it.writeByte(1) }.freeNativeMemory() }
+        assertEquals(
+            afterWarm,
+            watermark(),
+            "a warmed pool must satisfy further requests without new linear memory",
+        )
+    }
+
+    private fun alignUp(size: Int): Int = (size + ALIGN - 1) and (ALIGN - 1).inv()
+
+    /** A distinct exact-fit size class per test, so tests cannot recycle each other's blocks. */
+    private fun sizeClass(index: Int): Int = BASE_SIZE + index * ALIGN
+
+    private companion object {
+        private const val BASE_SIZE = 4096
+        private const val ALIGN = 8
+
+        /** Above the free list's array-backed size classes, so it exercises the map-backed path. */
+        private const val LARGE_SIZE = 128 * 1024
+        private const val ITERATIONS = 1000
+        private const val REPEATS = 64
+        private const val WARMUP = 8
+    }
+}

--- a/docs/docs/core-concepts/allocation-zones.md
+++ b/docs/docs/core-concepts/allocation-zones.md
@@ -116,7 +116,7 @@ BufferFactory.deterministic().allocate(1024).use { buffer ->
 | JVM 21+ | `FfmBuffer` (FFM Arena-backed) |
 | Apple | `MutableDataBuffer` (ARC-managed, already deterministic) |
 | Linux | `NativeBuffer` (malloc/free, already deterministic) |
-| WASM | `LinearBuffer` (linear memory, already deterministic) |
+| WASM | `LinearBuffer` (linear memory, released back to `LinearMemoryAllocator`) |
 | JS | `JsBuffer` (GC-managed, no deterministic alternative) |
 
 ## Composable Decorators

--- a/docs/docs/platforms/wasm.md
+++ b/docs/docs/platforms/wasm.md
@@ -53,13 +53,39 @@ Benchmark results (WASM Node.js):
 
 ## Memory Management
 
-LinearBuffer uses a bump allocator with pre-allocated memory:
+LinearBuffer draws from a fixed, pre-allocated region of WASM linear memory:
 
 - **256MB** allocated by default at first allocation
 - Configurable via `LinearMemoryAllocator.configure()`
-- Memory is not freed (bump allocator)
-- Best for buffers with longer lifetimes (interop scenarios)
+- The pool cannot grow after initialization — growing needs a `@JsFun` call, which trips a
+  Kotlin/WASM optimizer bug if it appears on the allocation path
 - Use `BufferFactory.managed()` for high-frequency, short-lived allocations
+
+### Releasing is required
+
+Linear memory is **not** garbage collected — it lives outside the Wasm-GC heap, and a `LinearBuffer`
+has no finalizer that could return its bytes. Dropping the last reference to one leaks it out of the
+fixed pool. This applies to `BufferFactory.Default` just as much as to `BufferFactory.deterministic()`;
+WASM is the only target where the default allocation must be released.
+
+```kotlin
+// CORRECT — the block is returned to the allocator on scope exit
+BufferFactory.Default.allocate(4096).use { buffer ->
+    buffer.writeInt(42)
+}
+
+// LEAKS on WASM — nothing reclaims this, and the pool is finite
+val buffer = BufferFactory.Default.allocate(4096)
+buffer.writeInt(42)
+```
+
+Releasing a buffer calls `LinearMemoryAllocator.free()`, which either rewinds the bump pointer (when
+the block is the most recent allocation, so an allocate/use/release loop stays flat) or parks the
+block on a size-classed free list for the next request of the same size.
+
+`slice()` and `PlatformBuffer.wrapNativeAddress()` return **non-owning** views: releasing one is a
+no-op, because the memory belongs to someone else. A view must not outlive its owner — once the
+owner is released its block can be handed out to an unrelated allocation.
 
 ### Configuring Memory Size
 


### PR DESCRIPTION
## First, what "release" means here

WASM linear memory can only **grow** (`memory.grow`) — there is no shrink, and bytes are never
returned to the host. This PR does not claim otherwise, and the total wasm footprint is unchanged
by it.

`initializeMemory()` grows memory **once**, claiming a fixed 256 MB pool that is held forever.
Everything this PR adds is bookkeeping *inside* that fixed region, so a released block can satisfy
a later allocation. Same model as `malloc`/`free` over a heap that only ever `sbrk`s upward.

## The bug

`LinearMemoryAllocator` was a pure bump allocator with **no deallocation entry point**, and
`LinearBuffer` declared no `freeNativeMemory` override, so it inherited the empty default from
`PlatformBuffer`. Releasing a wasmJs buffer reclaimed nothing.

Every buffer from `Default` / `deterministic()` / `shared()` permanently consumed part of the
256 MB pool. In particular `deterministic().allocate(n).use { }` — documented in CLAUDE.md as
"freed immediately when the block exits, no GC needed" — **leaked on wasm**. An allocate/release
loop died at exactly 65,536 allocations, with correct `use { }` discipline throughout.

## The fix

- `LinearBuffer` takes `owned: Boolean = false` and implements `CloseableBuffer`.
  `freeNativeMemory()` returns the block when owned and not already freed. The default is `false`
  so a construction site that has not considered ownership fails safe by **leaking rather than
  double-freeing**; `slice()` and `wrapNativeAddress()` are explicitly non-owning views.
- `LinearMemoryAllocator.free()` rewinds the bump pointer when the block is the top allocation, so
  an allocate/use/release loop reaches a flat steady state. Otherwise the block goes on a
  size-classed exact-fit free list.
- The free list is **intrusive**: the next link lives in the freed block itself, reached with a raw
  `Pointer`, indexed by an `IntArray` of size-class heads. Push and pop allocate nothing and hash
  nothing.
- `deterministic()` and `shared()` are no longer aliases of the default factory, and no longer
  claim linear memory is "already deterministic".

### Why not a map

A `HashMap<Int, MutableList<Int>>` version of the same free list measured **9.3M vs 14.8M ops/sec**
on the reuse route, because every allocation boxed the size key (`struct.new $kotlin.Int` in the
emitted wasm). `androidx.collection`'s primitive-keyed maps would fix the boxing but still hash and
still allocate backing storage — and they cannot be a dependency of `:buffer` regardless:
`androidx.collection:collection:1.6.0` publishes no `macos_x64` variant (see `build-apple.yaml`,
which documents this as why an unqualified `linkDebugTestMacosX64` fails on `:buffer-1brc`).
Storing the link in memory that is already free costs nothing and needs no dependency.

## What reclamation costs

`WasmAllocatorBenchmark`, added here. 1 KiB buffers, Production wasm on node, 3 warmup + 5
measurement iterations at 500 ms (`./gradlew :buffer:wasmJsBenchmarkWasmAllocatorBenchmark`):

| Benchmark | ops/sec | alloc+release pairs/sec |
|---|---:|---:|
| `allocateWithoutRelease` — bump only, leaks | 35.4M ± 0.4M | — (never releases) |
| `allocateAndReleaseLifo` — rewind route | 29.4M ± 0.1M | 29.4M |
| `allocateAndReleaseViaFreeList` — free-list route | 14.2M ± 0.2M | 28.5M |
| `byteArrayBufferAllocate` — managed-heap reference | 34.7M ± 0.4M | — |
| `linearBufferReadWrite` — read/write hot path | 92.7M ± 0.2M | — |

**Release costs about 17% of the allocation path** — 29.4M alloc/release pairs per second against
35.4M for the old leak-forever bump allocator. That is the price of the pool no longer filling up.

**The free-list route is not the slow path it looks like.**
`allocateAndReleaseViaFreeList` performs *two* allocations and *two* releases per operation, so its
14.2M ops/sec is 28.5M alloc/release pairs per second — within 3% of the 29.4M the rewind route
manages. Reusing a released block costs the same whether it was on top of the heap or parked on a
size class, so there is no allocation pattern that needs steering away from the free list.

## Hot path

Measured, not inferred from the disassembly.

A two-benchmark copy of the class — `linearBufferReadWrite`, plus `byteArrayBufferAllocate` as a
control — was compiled against `origin/main` and against this branch in separate worktrees from
**byte-identical benchmark source**, then run **interleaved** (main, branch, main, branch, …)
directly through node, with no Gradle daemon sharing the machine with the measurement. 8 paired
rounds, 5 warmup + 10 measurement iterations at 500 ms:

| Benchmark | `origin/main` | this branch | branch / main |
|---|---:|---:|---:|
| `linearBufferReadWrite` | 69.6M | 74.0M | 1.066 |
| `byteArrayBufferAllocate` — control | 36.8M | 36.8M | 1.004 |

Medians of the 8 rounds. The control is the calibration: this PR does not touch its source, and it
lands at 1.004, so the harness is not systematically favouring either side.

**The hot path does not regress.** It measures ~6% *faster* on this branch, in 7 of 8 rounds. That
is not being claimed as a speedup: nothing in this change touches `loadInt`/`storeInt`, which still
emit the same `i32.load`/`i32.store` via `ptr()` with no freed-flag branch, and the two added `i8`
fields sit after every existing field in the struct layout. Wasm module layout shifting V8's code
placement is the likelier explanation. What the numbers establish is the absence of a regression —
and per-round control ratios spanned 0.95–1.07, so it is the medians and the consistency across
rounds carrying that, not any single round.

Two things about the method that cost a re-run to discover, recorded so the next person does not
repeat them:

- **Benchmark class shape moves the number more than the change does.** The committed five-method
  class reports ~94M for `linearBufferReadWrite`; the two-method A/B class reports ~70M on
  identical library code — a ~27% difference from nothing but which other benchmarks share the
  module. Only same-shape comparisons mean anything, which is why both A/B sides run the trimmed
  class and why its absolute figures do not match the table above.
- **The A/B cannot simply run the committed five-method class on both sides.** `main` has no
  deallocation entry point, so its three allocate/release benchmarks would leak the pool dry there
  rather than measure anything.

## How reclamation is validated — and the limits of it

There is no valgrind/ASAN/LeakSanitizer equivalent for Kotlin/Wasm linear memory, and heap
snapshots cannot help: linear memory is a single `ArrayBuffer` behind `WebAssembly.Memory`, so a V8
snapshot sees **one 256 MB object** with the allocator's sub-blocks as opaque bytes. Snapshots taken
before and after releasing 60,000 buffers are byte-identical. The same goes for
`process.memoryUsage().arrayBuffers` and the module's own `jsMemorySize()` — the pool is pre-grown
once, so that number is constant by construction.

Validating an allocator is therefore behavioural, and the tests are layered accordingly:

- `LinearMemoryReclamationTest` (14 cases) reads the allocator's own counters — slice lifetime,
  double free, external addresses, large blocks. Precise about *mechanism*, but self-referential.
- `LinearMemoryExhaustionTest` does not depend on those counters. It allocates until
  `OutOfMemoryError` — which is raised by the `heapEnd` bounds check, not by the stats — releases
  everything, and then **refills the pool a second time**. If `free()` updated its arithmetic but
  did not actually make the blocks available again, the second pass dies exactly where the first
  one did. This is the assertion that makes the recovery claim non-circular.
- `SustainedAllocationChurnTest` (commonTest) asserts the release-based rows green on every
  platform, not just wasm.

## Docs

CLAUDE.md, PERFORMANCE.md, and the wasm and allocation-zones pages previously stated the opposite —
that linear memory was "already deterministic" and needed no release. They now state that **WASM is
the one platform where releasing is not optional**, since linear memory sits outside the Wasm-GC
heap with no finalization hook.

## Verification

Re-run on this rebase (the branch was 13 commits behind main, including the Gradle 9.7.0 bump):

| Suite | Tests | Failures |
|---|---|---|
| wasmJsNodeTest | 1089 | 0 |
| jvmTest | 1209 | 0 |
| jsNodeTest | 1057 | 0 |

`ktlintCheck` and `detektAll` clean, including the eight post-baseline detekt findings this change
originally introduced.
