### PR TITLE
feat(buffer): writeText/TextEncoding — policy-typed text encoding with an exact-size guarantee

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,6 +230,39 @@ buffer.fill(0x123456789ABCDEF0L) // fill with Long pattern
 buffer.xorMask(0x12345678)      // XOR remaining bytes with repeating 4-byte mask
 ```
 
+### Text Encoding (`writeText` / `TextEncoding`)
+
+**Prefer `writeText` over `writeString`** (which is deprecated toward it). The policy picks the
+result type, and `size(text)` reports exactly the bytes the write produces — on every platform:
+
+```kotlin
+// Lenient (substituting): cannot fail, fluent, identical bytes everywhere.
+// Unpaired surrogates become U+FFFD (3 bytes) — never platform-dependent.
+buffer.writeText(text)                          // same as writeText(text, Utf8.Lenient)
+buffer.writeText(text, Utf8.Lenient)
+val exact = Utf8.Lenient.size(text)             // == bytes writeText writes, exactly
+val exact2 = text.utf8Size()                    // convenience for the same number
+
+// Strict (validating): sealed result, atomic rejection (position unchanged).
+when (val r = buffer.writeText(text, Utf8.Strict)) {
+    is TextOutcome.Bytes -> framePayload(r.count)
+    is TextOutcome.Malformed -> reject(r.index)  // index of first unpaired surrogate
+}
+
+// Allocation with a sizing strategy:
+val rb = text.toReadBuffer(Utf8.Lenient, SizeHint.Exact)       // one measuring pass, minimal memory
+val rb2 = text.toReadBuffer(Utf8.Lenient, SizeHint.UpperBound) // no pass, up to 3x memory (default)
+```
+
+Guarantees (pinned by `TextEncodingTests` on every platform): `size == bytes written`; identical
+bytes for identical `(text, encoding)`; strict `Malformed` writes nothing; overflow throws and is
+unreachable when the buffer was sized from the same policy. Measured: `writeText` is at parity
+with `writeString` (JVM 0.86–1.14x, macOS 0.92–1.11x, same-run A/B). On Apple, the `size()` pass
+is slower than the Foundation encode itself — prefer `SizeHint.UpperBound` there unless memory-bound.
+
+Deprecated toward this API (removed in v7): `utf8Length()` → `utf8Size()`, `maxBufferSize()`
+→ `SizeHint`, `writeString` → `writeText` (once non-UTF-8 policies reach parity).
+
 ### Buffer Pool (`com.ditchoom.buffer.pool`)
 
 High-performance buffer pooling for minimizing allocations:

--- a/buffer/build.gradle.kts
+++ b/buffer/build.gradle.kts
@@ -569,7 +569,15 @@ benchmark {
             iterations = 5
             iterationTime = 1000
             iterationTimeUnit = "ms"
-            include("(WriteString|ReadString|Utf8Length)")
+            include("(WriteString|WriteText|ReadString|Utf8Length)")
+        }
+        // writeText vs writeString A/B: identical measurement params, only the encode entry differs.
+        register("writeText") {
+            warmups = 3
+            iterations = 5
+            iterationTime = 1000
+            iterationTimeUnit = "ms"
+            include("(WriteString|WriteText)Benchmark")
         }
         register("codec") {
             warmups = 5

--- a/buffer/src/appleMain/kotlin/com/ditchoom/buffer/MutableDataBuffer.kt
+++ b/buffer/src/appleMain/kotlin/com/ditchoom/buffer/MutableDataBuffer.kt
@@ -441,6 +441,18 @@ class MutableDataBuffer private constructor(
         position += stringLength
         return this
     }
+    override fun <R> writeText(
+        text: CharSequence,
+        encoding: TextEncoding<R>,
+    ): R =
+        dispatchWriteText(text, encoding) { t ->
+            // This platform's writeString(UTF8) already substitutes U+FFFD for unpaired
+            // surrogates (pinned by TextEncodingTests), so it is the substituting core.
+            val start = position()
+            writeString(t, Charset.UTF8)
+            position() - start
+        }
+
 
     // endregion
 
@@ -1052,6 +1064,18 @@ class MutableDataBufferSlice(
         position += stringLength
         return this
     }
+    override fun <R> writeText(
+        text: CharSequence,
+        encoding: TextEncoding<R>,
+    ): R =
+        dispatchWriteText(text, encoding) { t ->
+            // This platform's writeString(UTF8) already substitutes U+FFFD for unpaired
+            // surrogates (pinned by TextEncodingTests), so it is the substituting core.
+            val start = position()
+            writeString(t, Charset.UTF8)
+            position() - start
+        }
+
 
     fun close() = Unit
 

--- a/buffer/src/appleMain/kotlin/com/ditchoom/buffer/MutableDataBuffer.kt
+++ b/buffer/src/appleMain/kotlin/com/ditchoom/buffer/MutableDataBuffer.kt
@@ -441,6 +441,7 @@ class MutableDataBuffer private constructor(
         position += stringLength
         return this
     }
+
     override fun <R> writeText(
         text: CharSequence,
         encoding: TextEncoding<R>,
@@ -452,7 +453,6 @@ class MutableDataBuffer private constructor(
             writeString(t, Charset.UTF8)
             position() - start
         }
-
 
     // endregion
 
@@ -1064,6 +1064,7 @@ class MutableDataBufferSlice(
         position += stringLength
         return this
     }
+
     override fun <R> writeText(
         text: CharSequence,
         encoding: TextEncoding<R>,
@@ -1075,7 +1076,6 @@ class MutableDataBufferSlice(
             writeString(t, Charset.UTF8)
             position() - start
         }
-
 
     fun close() = Unit
 

--- a/buffer/src/appleMain/kotlin/com/ditchoom/buffer/StreamingStringDecoder.apple.kt
+++ b/buffer/src/appleMain/kotlin/com/ditchoom/buffer/StreamingStringDecoder.apple.kt
@@ -143,8 +143,8 @@ private class AppleStreamingStringDecoder(
             pendingCount = dataRemaining - boundary
             pendingLong = 0L
             for (i in 0 until pendingCount) {
-                val maskedByte = ptr[boundary + i].toLong() and Utf8.BYTE_MASK.toLong()
-                pendingLong = pendingLong or (maskedByte shl (i * Utf8.BITS_PER_BYTE))
+                val maskedByte = ptr[boundary + i].toLong() and Utf8Wire.BYTE_MASK.toLong()
+                pendingLong = pendingLong or (maskedByte shl (i * Utf8Wire.BITS_PER_BYTE))
             }
         }
 
@@ -178,13 +178,13 @@ private class AppleStreamingStringDecoder(
         buffer: ReadBuffer,
         destination: Appendable,
     ): DecodeResult {
-        val leadByte = (pendingLong and Utf8.BYTE_MASK.toLong()).toInt()
+        val leadByte = (pendingLong and Utf8Wire.BYTE_MASK.toLong()).toInt()
         val expectedLen =
             when {
-                leadByte < Utf8.ASCII_LIMIT -> 1
-                leadByte and Utf8.TWO_BYTE_LEAD_MASK == Utf8.TWO_BYTE_LEAD -> 2
-                leadByte and Utf8.THREE_BYTE_LEAD_MASK == Utf8.THREE_BYTE_LEAD -> 3
-                leadByte and Utf8.FOUR_BYTE_LEAD_MASK == Utf8.FOUR_BYTE_LEAD -> 4
+                leadByte < Utf8Wire.ASCII_LIMIT -> 1
+                leadByte and Utf8Wire.TWO_BYTE_LEAD_MASK == Utf8Wire.TWO_BYTE_LEAD -> 2
+                leadByte and Utf8Wire.THREE_BYTE_LEAD_MASK == Utf8Wire.THREE_BYTE_LEAD -> 3
+                leadByte and Utf8Wire.FOUR_BYTE_LEAD_MASK == Utf8Wire.FOUR_BYTE_LEAD -> 4
                 else -> {
                     pendingCount = 0
                     return handleMalformedInput(destination)
@@ -198,8 +198,8 @@ private class AppleStreamingStringDecoder(
             val basePos = buffer.position()
             for (i in 0 until available) {
                 val b = buffer.get(basePos + i)
-                val maskedByte = b.toLong() and Utf8.BYTE_MASK.toLong()
-                pendingLong = pendingLong or (maskedByte shl ((pendingCount + i) * Utf8.BITS_PER_BYTE))
+                val maskedByte = b.toLong() and Utf8Wire.BYTE_MASK.toLong()
+                pendingLong = pendingLong or (maskedByte shl ((pendingCount + i) * Utf8Wire.BITS_PER_BYTE))
             }
             pendingCount += available
             return DecodeResult(0, available)
@@ -210,7 +210,9 @@ private class AppleStreamingStringDecoder(
         for (i in 0 until needed) {
             val b = buffer.get(basePos + i)
             pendingLong =
-                pendingLong or ((b.toLong() and Utf8.BYTE_MASK.toLong()) shl ((pendingCount + i) * Utf8.BITS_PER_BYTE))
+                pendingLong or (
+                    (b.toLong() and Utf8Wire.BYTE_MASK.toLong()) shl ((pendingCount + i) * Utf8Wire.BITS_PER_BYTE)
+                )
         }
         pendingCount = 0
 
@@ -223,19 +225,21 @@ private class AppleStreamingStringDecoder(
         byteCount: Int,
         destination: Appendable,
     ): Int {
-        val b0 = (pendingLong and Utf8.BYTE_MASK.toLong()).toInt()
-        val b1 = if (byteCount > 1) ((pendingLong ushr 8) and Utf8.BYTE_MASK.toLong()).toInt() else 0
-        val b2 = if (byteCount > 2) ((pendingLong ushr 16) and Utf8.BYTE_MASK.toLong()).toInt() else 0
-        val b3 = if (byteCount > 3) ((pendingLong ushr 24) and Utf8.BYTE_MASK.toLong()).toInt() else 0
+        val b0 = (pendingLong and Utf8Wire.BYTE_MASK.toLong()).toInt()
+        val b1 = if (byteCount > 1) ((pendingLong ushr 8) and Utf8Wire.BYTE_MASK.toLong()).toInt() else 0
+        val b2 = if (byteCount > 2) ((pendingLong ushr 16) and Utf8Wire.BYTE_MASK.toLong()).toInt() else 0
+        val b3 = if (byteCount > 3) ((pendingLong ushr 24) and Utf8Wire.BYTE_MASK.toLong()).toInt() else 0
 
         // Validate continuation bytes
-        if (byteCount > 1 && (b1 and Utf8.CONTINUATION_MASK) != Utf8.CONTINUATION_MARKER) {
+        if (byteCount > 1 && (b1 and Utf8Wire.CONTINUATION_MASK) != Utf8Wire.CONTINUATION_MARKER) {
             return handleMalformedInput(destination).charsWritten
         }
-        if (byteCount > 2 && (b2 and Utf8.CONTINUATION_MASK) != Utf8.CONTINUATION_MARKER) {
+        if (byteCount > 2 && (b2 and Utf8Wire.CONTINUATION_MASK) != Utf8Wire.CONTINUATION_MARKER) {
             return handleMalformedInput(destination).charsWritten
         }
-        if (byteCount > FOURTH_BYTE_PRESENT_THRESHOLD && (b3 and Utf8.CONTINUATION_MASK) != Utf8.CONTINUATION_MARKER) {
+        if (byteCount > FOURTH_BYTE_PRESENT_THRESHOLD &&
+            (b3 and Utf8Wire.CONTINUATION_MASK) != Utf8Wire.CONTINUATION_MARKER
+        ) {
             return handleMalformedInput(destination).charsWritten
         }
 
@@ -243,39 +247,39 @@ private class AppleStreamingStringDecoder(
             when (byteCount) {
                 1 -> b0
                 2 ->
-                    ((b0 and Utf8.TWO_BYTE_PAYLOAD_MASK) shl Utf8.CONTINUATION_SHIFT) or
-                        (b1 and Utf8.CONTINUATION_PAYLOAD_MASK)
+                    ((b0 and Utf8Wire.TWO_BYTE_PAYLOAD_MASK) shl Utf8Wire.CONTINUATION_SHIFT) or
+                        (b1 and Utf8Wire.CONTINUATION_PAYLOAD_MASK)
                 3 ->
-                    ((b0 and Utf8.THREE_BYTE_PAYLOAD_MASK) shl (Utf8.CONTINUATION_SHIFT * 2)) or
-                        ((b1 and Utf8.CONTINUATION_PAYLOAD_MASK) shl Utf8.CONTINUATION_SHIFT) or
-                        (b2 and Utf8.CONTINUATION_PAYLOAD_MASK)
+                    ((b0 and Utf8Wire.THREE_BYTE_PAYLOAD_MASK) shl (Utf8Wire.CONTINUATION_SHIFT * 2)) or
+                        ((b1 and Utf8Wire.CONTINUATION_PAYLOAD_MASK) shl Utf8Wire.CONTINUATION_SHIFT) or
+                        (b2 and Utf8Wire.CONTINUATION_PAYLOAD_MASK)
                 4 ->
-                    ((b0 and Utf8.FOUR_BYTE_PAYLOAD_MASK) shl (Utf8.CONTINUATION_SHIFT * 3)) or
-                        ((b1 and Utf8.CONTINUATION_PAYLOAD_MASK) shl (Utf8.CONTINUATION_SHIFT * 2)) or
-                        ((b2 and Utf8.CONTINUATION_PAYLOAD_MASK) shl Utf8.CONTINUATION_SHIFT) or
-                        (b3 and Utf8.CONTINUATION_PAYLOAD_MASK)
+                    ((b0 and Utf8Wire.FOUR_BYTE_PAYLOAD_MASK) shl (Utf8Wire.CONTINUATION_SHIFT * 3)) or
+                        ((b1 and Utf8Wire.CONTINUATION_PAYLOAD_MASK) shl (Utf8Wire.CONTINUATION_SHIFT * 2)) or
+                        ((b2 and Utf8Wire.CONTINUATION_PAYLOAD_MASK) shl Utf8Wire.CONTINUATION_SHIFT) or
+                        (b3 and Utf8Wire.CONTINUATION_PAYLOAD_MASK)
                 else -> return handleMalformedInput(destination).charsWritten
             }
 
         // Reject overlong encodings and surrogate codepoints
         val isValid =
             when (byteCount) {
-                2 -> codePoint >= Utf8.ASCII_LIMIT
+                2 -> codePoint >= Utf8Wire.ASCII_LIMIT
                 3 ->
-                    codePoint >= Utf8.THREE_BYTE_MIN &&
-                        (codePoint < Utf8.HIGH_SURROGATE_START || codePoint > Utf8.LOW_SURROGATE_END)
-                4 -> codePoint in Utf8.FOUR_BYTE_MIN..Utf8.MAX_CODE_POINT
+                    codePoint >= Utf8Wire.THREE_BYTE_MIN &&
+                        (codePoint < Utf8Wire.HIGH_SURROGATE_START || codePoint > Utf8Wire.LOW_SURROGATE_END)
+                4 -> codePoint in Utf8Wire.FOUR_BYTE_MIN..Utf8Wire.MAX_CODE_POINT
                 else -> true
             }
         if (!isValid) return handleMalformedInput(destination).charsWritten
 
-        return if (codePoint <= Utf8.BMP_MAX) {
+        return if (codePoint <= Utf8Wire.BMP_MAX) {
             destination.append(codePoint.toChar())
             1
         } else {
-            val adjusted = codePoint - Utf8.FOUR_BYTE_MIN
-            destination.append((Utf8.HIGH_SURROGATE_START + (adjusted shr Utf8.SURROGATE_SHIFT)).toChar())
-            destination.append((Utf8.LOW_SURROGATE_START + (adjusted and Utf8.LOW_SURROGATE_MASK)).toChar())
+            val adjusted = codePoint - Utf8Wire.FOUR_BYTE_MIN
+            destination.append((Utf8Wire.HIGH_SURROGATE_START + (adjusted shr Utf8Wire.SURROGATE_SHIFT)).toChar())
+            destination.append((Utf8Wire.LOW_SURROGATE_START + (adjusted and Utf8Wire.LOW_SURROGATE_MASK)).toChar())
             2
         }
     }
@@ -366,7 +370,7 @@ private class AppleStreamingStringDecoder(
         if (length == 0) return 0
 
         // Fast path: if last byte is ASCII
-        if ((ptr[length - 1].toInt() and Utf8.BYTE_MASK) < Utf8.ASCII_LIMIT) {
+        if ((ptr[length - 1].toInt() and Utf8Wire.BYTE_MASK) < Utf8Wire.ASCII_LIMIT) {
             return length
         }
 
@@ -374,15 +378,15 @@ private class AppleStreamingStringDecoder(
         val checkStart = if (length > 4) length - 4 else 0
         var i = length - 1
         while (i >= checkStart) {
-            val b = ptr[i].toInt() and Utf8.BYTE_MASK
+            val b = ptr[i].toInt() and Utf8Wire.BYTE_MASK
             // Found a lead byte (not a continuation byte 10xxxxxx)
-            if ((b and Utf8.CONTINUATION_MASK) != Utf8.CONTINUATION_MARKER) {
+            if ((b and Utf8Wire.CONTINUATION_MASK) != Utf8Wire.CONTINUATION_MARKER) {
                 val seqLen =
                     when {
-                        b < Utf8.ASCII_LIMIT -> 1
-                        (b and Utf8.TWO_BYTE_LEAD_MASK) == Utf8.TWO_BYTE_LEAD -> 2
-                        (b and Utf8.THREE_BYTE_LEAD_MASK) == Utf8.THREE_BYTE_LEAD -> 3
-                        (b and Utf8.FOUR_BYTE_LEAD_MASK) == Utf8.FOUR_BYTE_LEAD -> 4
+                        b < Utf8Wire.ASCII_LIMIT -> 1
+                        (b and Utf8Wire.TWO_BYTE_LEAD_MASK) == Utf8Wire.TWO_BYTE_LEAD -> 2
+                        (b and Utf8Wire.THREE_BYTE_LEAD_MASK) == Utf8Wire.THREE_BYTE_LEAD -> 3
+                        (b and Utf8Wire.FOUR_BYTE_LEAD_MASK) == Utf8Wire.FOUR_BYTE_LEAD -> 4
                         else -> return i
                     }
                 val available = length - i

--- a/buffer/src/commonBenchmark/kotlin/com/ditchoom/buffer/benchmark/WriteTextBenchmark.kt
+++ b/buffer/src/commonBenchmark/kotlin/com/ditchoom/buffer/benchmark/WriteTextBenchmark.kt
@@ -34,6 +34,9 @@ import kotlinx.benchmark.Warmup
 @Measurement(iterations = 5)
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(BenchmarkTimeUnit.SECONDS)
+// One @Benchmark method per corpus mirrors WriteStringBenchmark (shape must match for a valid
+// A/B) plus the three size-pass probes; splitting the class would change the shape being compared.
+@Suppress("TooManyFunctions")
 open class WriteTextBenchmark {
     // Char counts, not byte counts. Multi-byte/emoji strings encode to a larger byte payload.
     private val small = 64

--- a/buffer/src/commonBenchmark/kotlin/com/ditchoom/buffer/benchmark/WriteTextBenchmark.kt
+++ b/buffer/src/commonBenchmark/kotlin/com/ditchoom/buffer/benchmark/WriteTextBenchmark.kt
@@ -1,0 +1,144 @@
+package com.ditchoom.buffer.benchmark
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.Utf8
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.BenchmarkMode
+import kotlinx.benchmark.BenchmarkTimeUnit
+import kotlinx.benchmark.Measurement
+import kotlinx.benchmark.Mode
+import kotlinx.benchmark.OutputTimeUnit
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+import kotlinx.benchmark.Warmup
+
+/**
+ * Benchmarks for `WriteBuffer.writeText(text, Utf8.Lenient)` — the policy-typed encode path —
+ * against [WriteStringBenchmark] as the baseline. Deliberately the SAME class shape, corpus
+ * builders, sizes, and measurement parameters as [WriteStringBenchmark]: class shape alone has
+ * moved wasm numbers 27%, so any structural difference would contaminate the comparison.
+ *
+ * Also measures the exact-size pass (`Utf8.Lenient.size`) separately, so the `SizeHint.Exact`
+ * cost is a number, not a guess.
+ *
+ * Run with:
+ *   ./gradlew :buffer:jvmStringBenchmark
+ *   ./gradlew :buffer:macosArm64StringBenchmark
+ *   ./gradlew :buffer:linuxX64StringBenchmark
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(BenchmarkTimeUnit.SECONDS)
+open class WriteTextBenchmark {
+    // Char counts, not byte counts. Multi-byte/emoji strings encode to a larger byte payload.
+    private val small = 64
+    private val medium = 1024
+    private val large = 64 * 1024
+
+    private lateinit var asciiSmall: String
+    private lateinit var asciiMedium: String
+    private lateinit var asciiLarge: String
+    private lateinit var cjkSmall: String
+    private lateinit var cjkMedium: String
+    private lateinit var cjkLarge: String
+    private lateinit var emojiSmall: String
+    private lateinit var emojiMedium: String
+    private lateinit var emojiLarge: String
+
+    // One destination sized for the worst case (largest char count, 4 bytes/char).
+    private lateinit var destination: PlatformBuffer
+
+    @Setup
+    fun setup() {
+        asciiSmall = buildAscii(small)
+        asciiMedium = buildAscii(medium)
+        asciiLarge = buildAscii(large)
+        cjkSmall = repeatTo(CJK_PATTERN, small)
+        cjkMedium = repeatTo(CJK_PATTERN, medium)
+        cjkLarge = repeatTo(CJK_PATTERN, large)
+        emojiSmall = repeatSurrogatePairsTo(small)
+        emojiMedium = repeatSurrogatePairsTo(medium)
+        emojiLarge = repeatSurrogatePairsTo(large)
+
+        destination = BufferFactory.Default.allocate(large * MAX_UTF8_BYTES_PER_CHAR)
+    }
+
+    private fun write(text: String): Int {
+        destination.position(0)
+        destination.writeText(text, Utf8.Lenient)
+        return destination.position()
+    }
+
+    @Benchmark fun asciiSmall(): Int = write(asciiSmall)
+
+    @Benchmark fun asciiMedium(): Int = write(asciiMedium)
+
+    @Benchmark fun asciiLarge(): Int = write(asciiLarge)
+
+    @Benchmark fun cjkSmall(): Int = write(cjkSmall)
+
+    @Benchmark fun cjkMedium(): Int = write(cjkMedium)
+
+    @Benchmark fun cjkLarge(): Int = write(cjkLarge)
+
+    @Benchmark fun emojiSmall(): Int = write(emojiSmall)
+
+    @Benchmark fun emojiMedium(): Int = write(emojiMedium)
+
+    @Benchmark fun emojiLarge(): Int = write(emojiLarge)
+
+    @Benchmark fun sizeAsciiLarge(): Int = Utf8.Lenient.size(asciiLarge)
+
+    @Benchmark fun sizeCjkLarge(): Int = Utf8.Lenient.size(cjkLarge)
+
+    @Benchmark fun sizeEmojiLarge(): Int = Utf8.Lenient.size(emojiLarge)
+
+    companion object {
+        private const val PRINTABLE_ASCII_START = 32
+        private const val PRINTABLE_ASCII_RANGE = 95
+
+        // Worst-case UTF-8 expansion: a surrogate pair (2 chars) encodes to 4 bytes.
+        private const val MAX_UTF8_BYTES_PER_CHAR = 4
+
+        // Mixed 2- and 3-byte code points: accented Latin (é, ü) and CJK (世, 界).
+        private const val CJK_PATTERN = "é世ü界"
+
+        private fun buildAscii(charCount: Int): String {
+            val sb = StringBuilder(charCount)
+            for (i in 0 until charCount) {
+                sb.append((PRINTABLE_ASCII_START + (i % PRINTABLE_ASCII_RANGE)).toChar())
+            }
+            return sb.toString()
+        }
+
+        private fun repeatTo(
+            pattern: String,
+            charCount: Int,
+        ): String {
+            val sb = StringBuilder(charCount)
+            while (sb.length < charCount) {
+                sb.append(pattern)
+            }
+            return sb.substring(0, charCount)
+        }
+
+        // Each grinning-face emoji is a surrogate pair (2 chars, 4 UTF-8 bytes).
+        private fun repeatSurrogatePairsTo(charCount: Int): String {
+            val sb = StringBuilder(charCount)
+            // Append complete surrogate pairs so we never split one at the boundary.
+            while (sb.length + 2 <= charCount) {
+                sb.append('\uD83D').append('\uDE00')
+            }
+            // Pad any odd trailing slot with ASCII to keep the exact char count valid.
+            while (sb.length < charCount) {
+                sb.append(' ')
+            }
+            return sb.toString()
+        }
+    }
+}

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/BufferFactory.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/BufferFactory.kt
@@ -2,18 +2,10 @@ package com.ditchoom.buffer
 
 import kotlin.math.roundToInt
 
-/** Largest code point encoded as a single UTF-8 byte (`0x7F`). */
-private const val UTF8_ONE_BYTE_MAX = 0x7F
-
-/** Largest code point encoded as two UTF-8 bytes (`0x7FF`). */
-private const val UTF8_TWO_BYTE_MAX = 0x7FF
-
-/** UTF-8 byte count for a code point that requires three bytes. */
-private const val UTF8_THREE_BYTES = 3
-
-/** UTF-8 byte count for a supplementary code point (surrogate pair → four bytes). */
-private const val UTF8_FOUR_BYTES = 4
-
+@Deprecated(
+    "Use utf8Size() for exact UTF-8 sizing, or toReadBuffer(Utf8.Lenient, SizeHint.UpperBound) " +
+        "for allocation. Removed in v7.",
+)
 fun CharSequence.maxBufferSize(charset: Charset): Int = (charset.maxBytesPerChar * this.length).roundToInt()
 
 /**
@@ -33,6 +25,8 @@ fun String.toReadBuffer(
     if (this == "") {
         return ReadBuffer.EMPTY_BUFFER
     }
+
+    @Suppress("DEPRECATION")
     val maxBytes = maxBufferSize(charset)
     val buffer = factory.allocate(maxBytes)
     buffer.writeString(this, charset)
@@ -40,26 +34,9 @@ fun String.toReadBuffer(
     return buffer.slice()
 }
 
-fun CharSequence.utf8Length(): Int {
-    var count = 0
-    var i = 0
-    val len = length
-    while (i < len) {
-        val ch = get(i)
-        if (ch.code <= UTF8_ONE_BYTE_MAX) {
-            count++
-        } else if (ch.code <= UTF8_TWO_BYTE_MAX) {
-            count += 2
-        } else if (ch.isHighSurrogate() && i + 1 < len && get(i + 1).isLowSurrogate()) {
-            // Valid surrogate pair: one supplementary code point, four UTF-8 bytes.
-            count += UTF8_FOUR_BYTES
-            ++i
-        } else {
-            // BMP code point — or an unpaired surrogate, which substituting encoders
-            // replace with U+FFFD (also three UTF-8 bytes).
-            count += UTF8_THREE_BYTES
-        }
-        i++
-    }
-    return count
-}
+@Deprecated(
+    "Use utf8Size(), whose count is guaranteed to match writeText(text, Utf8.Lenient) " +
+        "byte-for-byte on every platform. Removed in v7.",
+    ReplaceWith("this.utf8Size()", "com.ditchoom.buffer.utf8Size"),
+)
+fun CharSequence.utf8Length(): Int = Utf8TextEncoder.sizeSubstituting(this)

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/Charset.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/Charset.kt
@@ -1,16 +1,22 @@
 package com.ditchoom.buffer
 
 // The literals below are the average/maximum bytes-per-character ratios that define each encoding
-// (e.g. UTF-8 averages ~1.1 bytes/char, up to 4); they are intrinsic charset data, not tunable values.
+// (e.g. UTF-8 averages ~1.1 bytes/char, up to 3); they are intrinsic charset data, not tunable values.
+//
+// Maximums are per UTF-16 CHAR, not per code point, matching the JDK's CharsetEncoder values:
+// - UTF-8: 3 (a surrogate pair is 4 bytes over 2 chars = 2/char; an unpaired surrogate under
+//   U+FFFD substitution is 3; a BMP char is at most 3)
+// - UTF-16BE/LE: 2 (every char is exactly one code unit)
+// - UTF-16 (BOM-prefixed): 4 (the JDK charges the 2-byte BOM against the first char)
 @Suppress("MagicNumber")
 enum class Charset(
     val averageBytesPerChar: Float,
     val maxBytesPerChar: Float,
 ) {
-    UTF8(1.1f, 4f),
+    UTF8(1.1f, 3f),
     UTF16(2f, 4f),
-    UTF16BigEndian(2f, 4f),
-    UTF16LittleEndian(2f, 4f),
+    UTF16BigEndian(2f, 2f),
+    UTF16LittleEndian(2f, 2f),
     ASCII(1f, 1f),
     ISOLatin1(1f, 1f), // aka ISO/IEC 8859-1
     UTF32(4f, 4f),

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/TextEncoding.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/TextEncoding.kt
@@ -136,6 +136,29 @@ sealed interface SizeHint {
     }
 }
 
+/**
+ * Shared [WriteBuffer.writeText] dispatch: policy selection, strict pre-validation (atomic
+ * rejection), and the outcome-to-R mapping. Platform overrides supply only [substitutingWrite] —
+ * their fastest "encode with U+FFFD substitution, return bytes written" primitive. The sentinel
+ * Int (bytes written, or first-malformed `~index`) is internal to implementations; the public
+ * surface is the policy-typed R.
+ */
+internal inline fun <R> WriteBuffer.dispatchWriteText(
+    text: CharSequence,
+    encoding: TextEncoding<R>,
+    substitutingWrite: (CharSequence) -> Int,
+): R {
+    val outcome =
+        when (encoding) {
+            Utf8.Lenient -> substitutingWrite(text)
+            Utf8.Strict -> {
+                val bad = Utf8TextEncoder.firstMalformedIndex(text)
+                if (bad >= 0) bad.inv() else substitutingWrite(text)
+            }
+        }
+    return if (outcome >= 0) encoding.written(this, outcome) else encoding.malformed(outcome.inv())
+}
+
 /** Writes [text] as substituting UTF-8 — the drop-in replacement for `writeString(text)`. */
 fun WriteBuffer.writeText(text: CharSequence): WriteBuffer = writeText(text, Utf8.Lenient)
 

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/TextEncoding.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/TextEncoding.kt
@@ -1,0 +1,171 @@
+package com.ditchoom.buffer
+
+/**
+ * A text-encode policy for [WriteBuffer.writeText]: a charset plus a malformed-input policy.
+ *
+ * The type parameter [R] is the write-result type, chosen by the policy — so a lenient write
+ * cannot express failure and a strict result cannot be ignored without the compiler seeing it:
+ *
+ * ```kotlin
+ * buffer.writeText(text, Utf8.Lenient)                 // returns WriteBuffer — fluent, cannot fail
+ * when (val r = buffer.writeText(text, Utf8.Strict)) { // returns TextOutcome — must be handled
+ *     is TextOutcome.Bytes -> send(r.count)
+ *     is TextOutcome.Malformed -> reject(r.index)
+ * }
+ * ```
+ *
+ * **The invariant every platform upholds:** the policy's `size(text)` reports exactly the bytes
+ * `writeText(text, policy)` writes. Sizing from the same policy you write with makes buffer
+ * overflow unreachable and under-counting unrepresentable.
+ *
+ * The hierarchy is sealed: every policy that exists is one every platform implements and tests.
+ * Third-party [WriteBuffer] implementations inherit the common default of [WriteBuffer.writeText]
+ * (which routes through [WriteBuffer.writeBytes]) and may decorate it via a `super` call, but
+ * cannot re-implement the policy mapping — that stays inside the library on purpose.
+ */
+sealed class TextEncoding<out R> {
+    /** Maps a successful write of [byteCount] bytes into the policy's result type. */
+    internal abstract fun written(
+        buffer: WriteBuffer,
+        byteCount: Int,
+    ): R
+
+    /** Maps a rejected write (first ill-formed code unit at [index]) into the policy's result type. */
+    internal abstract fun malformed(index: Int): R
+
+    /**
+     * Re-binds a result produced against a wrapped buffer to the wrapper [self].
+     * Wrappers (PooledBuffer, TrackedSlice) delegate `writeText` to their inner buffer and pass
+     * the result through this, so fluent policies return the wrapper — never the unwrapped buffer.
+     */
+    internal open fun rewrap(
+        result: @UnsafeVariance R,
+        self: WriteBuffer,
+    ): R = result
+}
+
+/** UTF-8 [TextEncoding] policies. */
+object Utf8 {
+    /**
+     * Substituting UTF-8: each unpaired surrogate is written as U+FFFD (three bytes).
+     * Cannot fail, so the write is fluent and [size] is a plain [Int].
+     * Produces identical bytes on every platform.
+     */
+    object Lenient : TextEncoding<WriteBuffer>() {
+        /** Exactly the bytes `writeText(text, Lenient)` writes — on every platform. */
+        fun size(text: CharSequence): Int = Utf8TextEncoder.sizeSubstituting(text)
+
+        override fun written(
+            buffer: WriteBuffer,
+            byteCount: Int,
+        ): WriteBuffer = buffer
+
+        override fun malformed(index: Int): Nothing = error("unreachable: Lenient substitutes instead of rejecting")
+
+        override fun rewrap(
+            result: WriteBuffer,
+            self: WriteBuffer,
+        ): WriteBuffer = self
+    }
+
+    /**
+     * Validating UTF-8: ill-formed UTF-16 input rejects the whole write —
+     * **atomically, with the buffer position unchanged** — as [TextOutcome.Malformed].
+     * Well-formed input writes the same bytes as [Lenient].
+     */
+    object Strict : TextEncoding<TextOutcome>() {
+        /**
+         * [TextOutcome.Bytes] with exactly the bytes `writeText(text, Strict)` writes, or
+         * [TextOutcome.Malformed] with the index of the first unpaired surrogate.
+         */
+        fun size(text: CharSequence): TextOutcome {
+            val bad = Utf8TextEncoder.firstMalformedIndex(text)
+            return if (bad >= 0) {
+                TextOutcome.Malformed(bad)
+            } else {
+                TextOutcome.Bytes(Utf8TextEncoder.sizeSubstituting(text))
+            }
+        }
+
+        override fun written(
+            buffer: WriteBuffer,
+            byteCount: Int,
+        ): TextOutcome = TextOutcome.Bytes(byteCount)
+
+        override fun malformed(index: Int): TextOutcome = TextOutcome.Malformed(index)
+    }
+}
+
+/** Result of a strict text operation: the byte count, or where the input is ill-formed. */
+sealed interface TextOutcome {
+    /** The operation covers exactly [count] bytes. */
+    data class Bytes(
+        val count: Int,
+    ) : TextOutcome
+
+    /** The input is ill-formed UTF-16; [index] is the first unpaired surrogate. Nothing was written. */
+    data class Malformed(
+        val index: Int,
+    ) : TextOutcome
+}
+
+/** Allocation sizing strategy for [toReadBuffer]-style operations that allocate before writing. */
+sealed interface SizeHint {
+    /** One measuring pass over the text, then allocate precisely. Minimal memory, two passes. */
+    data object Exact : SizeHint
+
+    /** No measuring pass; allocate the worst case for the policy's charset. Fast, up to 3x memory. */
+    data object UpperBound : SizeHint
+
+    /**
+     * Caller-tuned ratio for corpora with a known profile (e.g. `1.1f` for ASCII-heavy text).
+     * If the guess is too small the write throws [BufferOverflowException] — size from
+     * [Exact]/[UpperBound] when the input is not under your control.
+     */
+    data class BytesPerChar(
+        val ratio: Float,
+    ) : SizeHint {
+        init {
+            require(ratio in MIN_RATIO..MAX_RATIO) { "ratio must be in [$MIN_RATIO, $MAX_RATIO]" }
+        }
+
+        private companion object {
+            const val MIN_RATIO = 1f
+            const val MAX_RATIO = 4f
+        }
+    }
+}
+
+/** Writes [text] as substituting UTF-8 — the drop-in replacement for `writeString(text)`. */
+fun WriteBuffer.writeText(text: CharSequence): WriteBuffer = writeText(text, Utf8.Lenient)
+
+/** Exactly the bytes a lenient UTF-8 write of this text produces, on every platform. */
+fun CharSequence.utf8Size(): Int = Utf8.Lenient.size(this)
+
+/** UTF-8 bytes-per-char upper bound under substitution (a surrogate pair is 4 bytes / 2 chars). */
+private const val UTF8_MAX_BYTES_PER_CHAR = 3
+
+/**
+ * Encodes this text into a fresh [ReadBuffer] using substituting UTF-8.
+ *
+ * [sizing] controls the allocation strategy; see [SizeHint]. Defaults to [SizeHint.UpperBound]
+ * (no measuring pass). Defaults to [BufferFactory.managed] for the same staging-lifetime reason
+ * as [String.toReadBuffer].
+ */
+fun CharSequence.toReadBuffer(
+    encoding: Utf8.Lenient,
+    sizing: SizeHint = SizeHint.UpperBound,
+    factory: BufferFactory = BufferFactory.managed(),
+): ReadBuffer {
+    if (isEmpty()) return ReadBuffer.EMPTY_BUFFER
+    val capacity =
+        when (sizing) {
+            SizeHint.Exact -> encoding.size(this)
+            SizeHint.UpperBound -> length * UTF8_MAX_BYTES_PER_CHAR
+            is SizeHint.BytesPerChar -> (length * sizing.ratio).toInt().coerceAtLeast(1)
+        }
+    val buffer = factory.allocate(capacity)
+    buffer.writeText(this, encoding)
+    buffer.resetForRead()
+    return buffer.slice()
+}

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/Utf8TextEncoder.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/Utf8TextEncoder.kt
@@ -1,0 +1,132 @@
+package com.ditchoom.buffer
+
+/**
+ * Common reference implementation of the [TextEncoding] UTF-8 contract: sizing, validation,
+ * and substituting encode. This is the single source of truth for the bytes every platform
+ * must produce — platform fast paths may override [WriteBuffer.writeText] but MUST match
+ * these bytes exactly (pinned by the cross-platform vectors in `TextEncodingTests`).
+ *
+ * Platform staging encoders cannot serve this role: `String.encodeToByteArray()` substitutes
+ * U+FFFD (3 bytes) on Kotlin/Native and JS but `?` (1 byte) on Kotlin/JVM, which would break
+ * the size == bytes-written invariant across platforms.
+ */
+internal object Utf8TextEncoder {
+    /** Largest code point encoded as a single UTF-8 byte (`0x7F`). */
+    private const val ONE_BYTE_MAX = 0x7F
+
+    /** Largest code point encoded as two UTF-8 bytes (`0x7FF`). */
+    private const val TWO_BYTE_MAX = 0x7FF
+
+    /** UTF-8 byte count for a BMP code point above [TWO_BYTE_MAX] — and for U+FFFD itself. */
+    private const val THREE_BYTES = 3
+
+    /** UTF-8 byte count for a supplementary code point (surrogate pair). */
+    private const val FOUR_BYTES = 4
+
+    /** U+FFFD REPLACEMENT CHARACTER encoded as UTF-8. */
+    private val REPLACEMENT = byteArrayOf(0xEF.toByte(), 0xBF.toByte(), 0xBD.toByte())
+
+    private const val CONTINUATION_MARKER = 0x80
+    private const val CONTINUATION_PAYLOAD_MASK = 0x3F
+    private const val TWO_BYTE_LEAD = 0xC0
+    private const val THREE_BYTE_LEAD = 0xE0
+    private const val FOUR_BYTE_LEAD = 0xF0
+    private const val CONTINUATION_SHIFT = 6
+
+    /** Payload bit offsets of the 2nd/1st continuation byte in a 4-byte sequence. */
+    private const val SECOND_CONTINUATION_SHIFT = CONTINUATION_SHIFT * 2
+    private const val FOUR_BYTE_LEAD_SHIFT = CONTINUATION_SHIFT * 3
+    private const val SUPPLEMENTARY_BASE = 0x10000
+    private const val SURROGATE_SHIFT = 10
+
+    /**
+     * Exact byte count of [encodeSubstituting] — the size half of the invariant.
+     * Unpaired surrogates cost [THREE_BYTES], the U+FFFD substitution cost.
+     */
+    fun sizeSubstituting(text: CharSequence): Int {
+        var count = 0
+        var i = 0
+        val len = text.length
+        while (i < len) {
+            val ch = text[i]
+            if (ch.code <= ONE_BYTE_MAX) {
+                count++
+            } else if (ch.code <= TWO_BYTE_MAX) {
+                count += 2
+            } else if (ch.isHighSurrogate() && i + 1 < len && text[i + 1].isLowSurrogate()) {
+                count += FOUR_BYTES
+                ++i
+            } else {
+                count += THREE_BYTES
+            }
+            i++
+        }
+        return count
+    }
+
+    /**
+     * Index of the first unpaired surrogate in [text], or -1 if the text is well-formed UTF-16.
+     * Internal sentinel only — public API surfaces this as [TextOutcome.Malformed].
+     */
+    fun firstMalformedIndex(text: CharSequence): Int {
+        var i = 0
+        val len = text.length
+        while (i < len) {
+            val ch = text[i]
+            if (ch.isHighSurrogate() && i + 1 < len && text[i + 1].isLowSurrogate()) {
+                i += 2
+            } else if (ch.isSurrogate()) {
+                return i
+            } else {
+                i++
+            }
+        }
+        return -1
+    }
+
+    /**
+     * Encodes [text] as UTF-8, substituting U+FFFD for each unpaired surrogate.
+     * Produces exactly [sizeSubstituting] bytes — identical on every platform.
+     */
+    fun encodeSubstituting(text: CharSequence): ByteArray {
+        val out = ByteArray(sizeSubstituting(text))
+        var o = 0
+        var i = 0
+        val len = text.length
+        while (i < len) {
+            val ch = text[i]
+            val code = ch.code
+            when {
+                code <= ONE_BYTE_MAX -> out[o++] = code.toByte()
+                code <= TWO_BYTE_MAX -> {
+                    out[o++] = (TWO_BYTE_LEAD or (code shr CONTINUATION_SHIFT)).toByte()
+                    out[o++] = (CONTINUATION_MARKER or (code and CONTINUATION_PAYLOAD_MASK)).toByte()
+                }
+                ch.isHighSurrogate() && i + 1 < len && text[i + 1].isLowSurrogate() -> {
+                    val codePoint =
+                        SUPPLEMENTARY_BASE +
+                            ((code - Char.MIN_HIGH_SURROGATE.code) shl SURROGATE_SHIFT) +
+                            (text[i + 1].code - Char.MIN_LOW_SURROGATE.code)
+                    out[o++] = (FOUR_BYTE_LEAD or (codePoint shr FOUR_BYTE_LEAD_SHIFT)).toByte()
+                    out[o++] = continuation(codePoint shr SECOND_CONTINUATION_SHIFT)
+                    out[o++] = continuation(codePoint shr CONTINUATION_SHIFT)
+                    out[o++] = continuation(codePoint)
+                    ++i
+                }
+                ch.isSurrogate() -> {
+                    REPLACEMENT.copyInto(out, o)
+                    o += THREE_BYTES
+                }
+                else -> {
+                    out[o++] = (THREE_BYTE_LEAD or (code shr SECOND_CONTINUATION_SHIFT)).toByte()
+                    out[o++] = continuation(code shr CONTINUATION_SHIFT)
+                    out[o++] = continuation(code)
+                }
+            }
+            i++
+        }
+        return out
+    }
+
+    private fun continuation(bits: Int): Byte = (CONTINUATION_MARKER or (bits and CONTINUATION_PAYLOAD_MASK)).toByte()
+}

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/Utf8Wire.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/Utf8Wire.kt
@@ -8,7 +8,7 @@ package com.ditchoom.buffer
  * surrogate-pair encoding (Unicode). They are centralized here so the per-platform decoders cannot
  * drift from one another. Every value is the literal it replaces — there is no behavior change.
  */
-internal object Utf8 {
+internal object Utf8Wire {
     /**
      * Mask isolating the low 8 bits of a value (one byte). Used when packing/unpacking pending
      * incomplete sequences into/out of a `Long`.

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/WriteBuffer.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/WriteBuffer.kt
@@ -416,30 +416,12 @@ interface WriteBuffer : PositionBuffer {
     fun <R> writeText(
         text: CharSequence,
         encoding: TextEncoding<R>,
-    ): R {
-        // Sentinel is local to implementations only (bytes written, or first-malformed ~index);
-        // the public surface is the policy-typed R. Mapping through `encoding` (never through a
-        // smart-cast branch) is what lets each branch produce R without unchecked casts.
-        val outcome =
-            when (encoding) {
-                Utf8.Lenient -> {
-                    val bytes = Utf8TextEncoder.encodeSubstituting(text)
-                    writeBytes(bytes)
-                    bytes.size
-                }
-                Utf8.Strict -> {
-                    val bad = Utf8TextEncoder.firstMalformedIndex(text)
-                    if (bad >= 0) {
-                        bad.inv()
-                    } else {
-                        val bytes = Utf8TextEncoder.encodeSubstituting(text)
-                        writeBytes(bytes)
-                        bytes.size
-                    }
-                }
-            }
-        return if (outcome >= 0) encoding.written(this, outcome) else encoding.malformed(outcome.inv())
-    }
+    ): R =
+        dispatchWriteText(text, encoding) { t ->
+            val bytes = Utf8TextEncoder.encodeSubstituting(t)
+            writeBytes(bytes)
+            bytes.size
+        }
 
     /**
      * Writes all remaining bytes from the source buffer and advances both positions.

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/WriteBuffer.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/WriteBuffer.kt
@@ -399,6 +399,49 @@ interface WriteBuffer : PositionBuffer {
     ): WriteBuffer
 
     /**
+     * Writes [text] under the given [encoding] policy and advances position by the bytes written.
+     *
+     * The result type is chosen by the policy — see [TextEncoding]. Guarantees, on every platform:
+     * - the policy's `size(text)` reports exactly the bytes this call writes;
+     * - identical bytes for identical `(text, encoding)` inputs;
+     * - a strict policy rejecting ill-formed input writes nothing (position unchanged);
+     * - insufficient remaining capacity throws [BufferOverflowException] — unreachable when the
+     *   buffer was sized from the same policy.
+     *
+     * This is the only text-encode member; platform implementations override it for fast paths.
+     * The default routes through [writeBytes] using the common reference encoder, so it is correct
+     * for any implementation, including wrappers. No `writeText(text)` member will ever be added;
+     * the one-argument form is provided as an extension and stays an extension.
+     */
+    fun <R> writeText(
+        text: CharSequence,
+        encoding: TextEncoding<R>,
+    ): R {
+        // Sentinel is local to implementations only (bytes written, or first-malformed ~index);
+        // the public surface is the policy-typed R. Mapping through `encoding` (never through a
+        // smart-cast branch) is what lets each branch produce R without unchecked casts.
+        val outcome =
+            when (encoding) {
+                Utf8.Lenient -> {
+                    val bytes = Utf8TextEncoder.encodeSubstituting(text)
+                    writeBytes(bytes)
+                    bytes.size
+                }
+                Utf8.Strict -> {
+                    val bad = Utf8TextEncoder.firstMalformedIndex(text)
+                    if (bad >= 0) {
+                        bad.inv()
+                    } else {
+                        val bytes = Utf8TextEncoder.encodeSubstituting(text)
+                        writeBytes(bytes)
+                        bytes.size
+                    }
+                }
+            }
+        return if (outcome >= 0) encoding.written(this, outcome) else encoding.malformed(outcome.inv())
+    }
+
+    /**
      * Writes all remaining bytes from the source buffer and advances both positions.
      *
      * After this operation:

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/PooledBuffer.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/PooledBuffer.kt
@@ -4,6 +4,7 @@ import com.ditchoom.buffer.ByteOrder
 import com.ditchoom.buffer.Charset
 import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.TextEncoding
 import com.ditchoom.buffer.WriteBuffer
 import com.ditchoom.buffer.bufferEquals
 import com.ditchoom.buffer.bufferHashCode
@@ -252,6 +253,15 @@ internal class PooledBuffer(
         checkNotFreed()
         inner.writeString(text, charset)
         return this
+    }
+
+    override fun <R> writeText(
+        text: CharSequence,
+        encoding: TextEncoding<R>,
+    ): R {
+        checkNotFreed()
+        // rewrap re-binds fluent results to this wrapper instead of leaking the inner buffer.
+        return encoding.rewrap(inner.writeText(text, encoding), this)
     }
 
     override fun write(buffer: ReadBuffer) {

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/TrackedSlice.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/TrackedSlice.kt
@@ -4,6 +4,7 @@ import com.ditchoom.buffer.ByteOrder
 import com.ditchoom.buffer.Charset
 import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.TextEncoding
 import com.ditchoom.buffer.WriteBuffer
 import com.ditchoom.buffer.bufferEquals
 import com.ditchoom.buffer.bufferHashCode
@@ -569,6 +570,15 @@ internal class TrackedSlice(
         checkNotReleased()
         inner.writeString(text, charset)
         return this
+    }
+
+    override fun <R> writeText(
+        text: CharSequence,
+        encoding: TextEncoding<R>,
+    ): R {
+        checkNotReleased()
+        // rewrap re-binds fluent results to this wrapper instead of leaking the inner buffer.
+        return encoding.rewrap(inner.writeText(text, encoding), this)
     }
 
     override fun writeNumberOfByteSize(

--- a/buffer/src/commonTest/kotlin/com/ditchoom/buffer/TextEncodingTests.kt
+++ b/buffer/src/commonTest/kotlin/com/ditchoom/buffer/TextEncodingTests.kt
@@ -1,0 +1,233 @@
+// Surrogate code units (0xD800..0xDFFF), UTF-8 byte values, and sizing ratios are the
+// subject under test; naming each literal would obscure the cases rather than clarify them.
+@file:Suppress("MagicNumber")
+
+package com.ditchoom.buffer
+
+import com.ditchoom.buffer.pool.withBuffer
+import com.ditchoom.buffer.pool.withPool
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Pins the [TextEncoding] contract on every platform:
+ *
+ * 1. `size(text)` == bytes written by `writeText(text, policy)` — exactly, for any input;
+ * 2. identical bytes for identical `(text, encoding)` on every platform (explicit vectors);
+ * 3. strict rejection is atomic — position unchanged;
+ * 4. wrappers stay transparent and fluent results identify the wrapper, not the inner buffer.
+ */
+class TextEncodingTests {
+    private val wellFormed =
+        listOf(
+            "",
+            "A",
+            "yolo swag lyfestyle",
+            "é",
+            "€",
+            "aé€😀",
+            "😀😀😀",
+            "\uD800\uDC00", // minimum surrogate pair (U+10000)
+            "\uDBFF\uDFFF", // maximum surrogate pair (U+10FFFF)
+        )
+
+    private val illFormed =
+        listOf(
+            "\uD800" to 0,
+            "\uDC00" to 0,
+            "\uD800€" to 0,
+            "\uD800A" to 0,
+            "A\uD800" to 1,
+            "AB\uD800" to 2,
+            "\uDC00\uD800" to 0,
+            "😀\uD800" to 2,
+        )
+
+    private val factories = listOf("default" to BufferFactory.Default, "managed" to BufferFactory.managed())
+
+    // U+FFFD as UTF-8
+    private val fffd = listOf(0xEF.toByte(), 0xBF.toByte(), 0xBD.toByte())
+
+    private fun writtenBytes(
+        factory: BufferFactory,
+        text: String,
+    ): List<Byte> {
+        val buffer = factory.allocate(text.length * 3 + 8)
+        buffer.writeText(text, Utf8.Lenient)
+        val count = buffer.position()
+        buffer.resetForRead()
+        return buffer.readByteArray(count).toList()
+    }
+
+    @Test
+    fun lenientSizeMatchesBytesWrittenExactly() {
+        for ((name, factory) in factories) {
+            for (text in wellFormed + illFormed.map { it.first }) {
+                val buffer = factory.allocate(text.length * 3 + 8)
+                val returned = buffer.writeText(text, Utf8.Lenient)
+                assertSame(buffer, returned, "lenient write must be fluent on the same instance")
+                assertEquals(
+                    Utf8.Lenient.size(text),
+                    buffer.position(),
+                    "size(text) must equal bytes written [$name] for ${text.length} chars",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun lenientSubstitutionBytesArePinned() {
+        for ((name, factory) in factories) {
+            assertEquals(fffd, writtenBytes(factory, "\uD800"), "lone high [$name]")
+            assertEquals(fffd, writtenBytes(factory, "\uDC00"), "lone low [$name]")
+            assertEquals(
+                fffd + listOf(0xE2.toByte(), 0x82.toByte(), 0xAC.toByte()),
+                writtenBytes(factory, "\uD800€"),
+                "U+FFFD then € [$name]",
+            )
+            assertEquals(listOf(0x41.toByte()) + fffd, writtenBytes(factory, "A\uD800"), "A then U+FFFD [$name]")
+            assertEquals(
+                listOf(0xF0.toByte(), 0x9F.toByte(), 0x98.toByte(), 0x80.toByte()),
+                writtenBytes(factory, "😀"),
+                "valid pair passes through [$name]",
+            )
+        }
+    }
+
+    @Test
+    fun strictAcceptsWellFormedWithSameBytesAsLenient() {
+        for ((name, factory) in factories) {
+            for (text in wellFormed) {
+                val buffer = factory.allocate(text.length * 3 + 8)
+                val outcome = buffer.writeText(text, Utf8.Strict)
+                assertIs<TextOutcome.Bytes>(outcome, "well-formed must be accepted [$name]")
+                assertEquals(outcome.count, buffer.position(), "reported count must equal bytes written [$name]")
+                assertEquals(Utf8.Lenient.size(text), outcome.count, "strict and lenient agree on well-formed [$name]")
+            }
+        }
+    }
+
+    @Test
+    fun strictRejectsIllFormedAtomically() {
+        for ((name, factory) in factories) {
+            for ((text, expectedIndex) in illFormed) {
+                val buffer = factory.allocate(64)
+                buffer.writeInt(42) // non-zero starting position
+                val before = buffer.position()
+                val outcome = buffer.writeText(text, Utf8.Strict)
+                assertIs<TextOutcome.Malformed>(outcome, "ill-formed must be rejected [$name]")
+                assertEquals(expectedIndex, outcome.index, "index of first unpaired surrogate [$name]")
+                assertEquals(before, buffer.position(), "rejection must not move position [$name]")
+            }
+        }
+    }
+
+    @Test
+    fun strictSizeAgreesWithStrictWrite() {
+        for (text in wellFormed) {
+            val sized = Utf8.Strict.size(text)
+            assertIs<TextOutcome.Bytes>(sized)
+            assertEquals(Utf8.Lenient.size(text), sized.count)
+        }
+        for ((text, expectedIndex) in illFormed) {
+            val sized = Utf8.Strict.size(text)
+            assertIs<TextOutcome.Malformed>(sized)
+            assertEquals(expectedIndex, sized.index)
+        }
+    }
+
+    @Test
+    fun oneArgWriteTextIsLenient() {
+        val buffer = BufferFactory.Default.allocate(16)
+        assertSame(buffer, buffer.writeText("\uD800"))
+        assertEquals(3, buffer.position())
+    }
+
+    @Test
+    fun utf8SizeMatchesDeprecatedUtf8Length() {
+        for (text in wellFormed + illFormed.map { it.first }) {
+            @Suppress("DEPRECATION")
+            assertEquals(text.utf8Length(), text.utf8Size(), "utf8Size must preserve utf8Length counts")
+        }
+    }
+
+    @Test
+    fun writeTextThroughPooledBufferAndTrackedSliceStaysFluentAndTransparent() {
+        withPool(defaultBufferSize = 256) { pool ->
+            pool.withBuffer(128) { pooled ->
+                val returned = pooled.writeText("a\uD800€", Utf8.Lenient)
+                assertSame(pooled, returned, "fluent result must be the wrapper, not the inner buffer")
+                assertEquals(7, pooled.position(), "1 + 3 (U+FFFD) + 3 (€)")
+
+                val slice = pooled.slice()
+                val sliceReturned = slice.writeText("😀", Utf8.Lenient)
+                assertSame(slice, sliceReturned, "slice fluent result must be the tracked slice")
+
+                val strict = pooled.writeText("\uDC00", Utf8.Strict)
+                assertIs<TextOutcome.Malformed>(strict)
+                assertEquals(7, pooled.position(), "strict rejection through wrapper must not move position")
+            }
+        }
+    }
+
+    @Test
+    fun toReadBufferSizingStrategiesRoundTrip() {
+        val text = "aé€😀 plus a tail to exercise more than one word"
+        val expectedBytes = Utf8.Lenient.size(text)
+        for (sizing in listOf(SizeHint.Exact, SizeHint.UpperBound, SizeHint.BytesPerChar(3f))) {
+            val readBuffer = text.toReadBuffer(Utf8.Lenient, sizing)
+            assertEquals(expectedBytes, readBuffer.remaining(), "sizing $sizing must expose exactly the text bytes")
+            assertEquals(text, readBuffer.readString(expectedBytes, Charset.UTF8), "round-trip [$sizing]")
+        }
+    }
+
+    @Test
+    fun toReadBufferSubstitutesIllFormedText() {
+        val readBuffer = "\uD800€".toReadBuffer(Utf8.Lenient, SizeHint.Exact)
+        assertEquals(6, readBuffer.remaining())
+        assertEquals(fffd + listOf(0xE2.toByte(), 0x82.toByte(), 0xAC.toByte()), readBuffer.readByteArray(6).toList())
+    }
+
+    @Test
+    fun toReadBufferEmptyTextIsEmptyBuffer() {
+        assertEquals(0, "".toReadBuffer(Utf8.Lenient).remaining())
+    }
+
+    @Test
+    fun bytesPerCharRatioIsValidated() {
+        assertFailsWith<IllegalArgumentException> { SizeHint.BytesPerChar(0.5f) }
+        assertFailsWith<IllegalArgumentException> { SizeHint.BytesPerChar(4.5f) }
+        SizeHint.BytesPerChar(1f)
+        SizeHint.BytesPerChar(4f)
+    }
+
+    @Test
+    fun undersizedBytesPerCharGuessOverflowsLoudly() {
+        // 1 byte/char cannot hold 3-byte € chars: overflow is a thrown bug-signal, never a short write.
+        assertFailsWith<BufferOverflowException> {
+            "€€€€€€€€".toReadBuffer(Utf8.Lenient, SizeHint.BytesPerChar(1f))
+        }
+    }
+
+    @Test
+    fun overflowThrowsInsteadOfShortWrite() {
+        val buffer = BufferFactory.Default.allocate(2)
+        assertFailsWith<BufferOverflowException> { buffer.writeText("€", Utf8.Lenient) }
+    }
+
+    @Test
+    fun correctedCharsetRatiosRemainTrueUpperBounds() {
+        for (text in wellFormed + illFormed.map { it.first }) {
+            @Suppress("DEPRECATION")
+            val bound = text.maxBufferSize(Charset.UTF8)
+            assertTrue(
+                Utf8.Lenient.size(text) <= bound,
+                "UTF-8 maxBytesPerChar must upper-bound the lenient encoding for $text",
+            )
+        }
+    }
+}

--- a/buffer/src/commonTest/kotlin/com/ditchoom/buffer/Utf8LengthTests.kt
+++ b/buffer/src/commonTest/kotlin/com/ditchoom/buffer/Utf8LengthTests.kt
@@ -25,7 +25,11 @@ class Utf8LengthTests {
         expected: Int,
         text: String,
         message: String,
-    ) = assertEquals(expected, text.utf8Length(), message)
+    ) {
+        @Suppress("DEPRECATION")
+        assertEquals(expected, text.utf8Length(), message)
+        assertEquals(expected, text.utf8Size(), message)
+    }
 
     @Test
     fun wellFormedText() {

--- a/buffer/src/jsMain/kotlin/com/ditchoom/buffer/JsBuffer.kt
+++ b/buffer/src/jsMain/kotlin/com/ditchoom/buffer/JsBuffer.kt
@@ -236,6 +236,7 @@ class JsBuffer(
         }
         return this
     }
+
     override fun <R> writeText(
         text: CharSequence,
         encoding: TextEncoding<R>,
@@ -247,7 +248,6 @@ class JsBuffer(
             writeString(t, Charset.UTF8)
             position() - start
         }
-
 
     /**
      * Reverses bytes of an Int for little-endian Int32Array compatibility.

--- a/buffer/src/jsMain/kotlin/com/ditchoom/buffer/JsBuffer.kt
+++ b/buffer/src/jsMain/kotlin/com/ditchoom/buffer/JsBuffer.kt
@@ -236,6 +236,18 @@ class JsBuffer(
         }
         return this
     }
+    override fun <R> writeText(
+        text: CharSequence,
+        encoding: TextEncoding<R>,
+    ): R =
+        dispatchWriteText(text, encoding) { t ->
+            // This platform's writeString(UTF8) already substitutes U+FFFD for unpaired
+            // surrogates (pinned by TextEncodingTests), so it is the substituting core.
+            val start = position()
+            writeString(t, Charset.UTF8)
+            position() - start
+        }
+
 
     /**
      * Reverses bytes of an Int for little-endian Int32Array compatibility.

--- a/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/FfmAutoBuffer.kt
+++ b/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/FfmAutoBuffer.kt
@@ -39,6 +39,11 @@ class FfmAutoBuffer(
         return true
     }
 
+    override fun tryWriteUtf8LenientToNative(text: CharSequence): Boolean {
+        position(encodeUtf8LenientToNative(text, position(), limit(), segment.address()))
+        return true
+    }
+
     // Read mirror of tryWriteUtf8ToNative: decode UTF-8 straight off the segment's native address
     // instead of taking the direct-ByteBuffer decodeBufferLoop. Non-UTF-8 falls back to the base
     // CharsetDecoder path.

--- a/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/FfmBuffer.kt
+++ b/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/FfmBuffer.kt
@@ -107,6 +107,13 @@ class FfmBuffer(
         return true
     }
 
+    override fun tryWriteUtf8LenientToNative(text: CharSequence): Boolean {
+        // Same freed-segment guard as the strict twin above.
+        if (isFreed) return false
+        position(encodeUtf8LenientToNative(text, position(), limit(), segment.address()))
+        return true
+    }
+
     // Read mirror of tryWriteUtf8ToNative: decode UTF-8 straight off the segment's native address
     // instead of taking the direct-ByteBuffer decodeBufferLoop. Falls back to the base CharsetDecoder
     // path for non-UTF-8, and for a freed segment (whose closed address must never be read).

--- a/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/Utf8DirectEncode.kt
+++ b/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/Utf8DirectEncode.kt
@@ -88,9 +88,10 @@ internal fun encodeUtf8ToNative(
  * U+FFFD (EF BF BD) instead of throwing — the [com.ditchoom.buffer.Utf8.Lenient] contract.
  * Produces byte-for-byte the output of `Utf8TextEncoder.encodeSubstituting`, with no staging array.
  *
- * Same complexity drivers as the strict loop, same suppressions.
+ * Same complexity drivers as the strict loop, same suppressions (the per-sequence-length
+ * overflow guards drive ThrowsCount exactly as in the strict twin).
  */
-@Suppress("CyclomaticComplexMethod")
+@Suppress("CyclomaticComplexMethod", "ThrowsCount")
 internal fun encodeUtf8LenientToNative(
     text: CharSequence,
     startPosition: Int,

--- a/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/Utf8DirectEncode.kt
+++ b/buffer/src/jvm21Main/kotlin/com/ditchoom/buffer/Utf8DirectEncode.kt
@@ -83,6 +83,70 @@ internal fun encodeUtf8ToNative(
     return pos
 }
 
+/**
+ * Substituting twin of [encodeUtf8ToNative]: identical loop, but an unpaired surrogate writes
+ * U+FFFD (EF BF BD) instead of throwing — the [com.ditchoom.buffer.Utf8.Lenient] contract.
+ * Produces byte-for-byte the output of `Utf8TextEncoder.encodeSubstituting`, with no staging array.
+ *
+ * Same complexity drivers as the strict loop, same suppressions.
+ */
+@Suppress("CyclomaticComplexMethod")
+internal fun encodeUtf8LenientToNative(
+    text: CharSequence,
+    startPosition: Int,
+    limit: Int,
+    base: Long,
+): Int {
+    var pos = startPosition
+    val len = text.length
+    var i = 0
+    while (i < len) {
+        val c = text[i].code
+        when {
+            c < 0x80 -> {
+                if (pos >= limit) throw overflow(pos, limit)
+                directPutByte(base + pos, c.toByte())
+                pos += 1
+            }
+            c < 0x800 -> {
+                if (pos + 2 > limit) throw overflow(pos, limit)
+                directPutByte(base + pos, (0xC0 or (c ushr 6)).toByte())
+                directPutByte(base + pos + 1, (0x80 or (c and 0x3F)).toByte())
+                pos += 2
+            }
+            c < 0xD800 || c >= 0xE000 -> {
+                // BMP scalar (excludes the surrogate range 0xD800..0xDFFF): 3 bytes.
+                if (pos + 3 > limit) throw overflow(pos, limit)
+                directPutByte(base + pos, (0xE0 or (c ushr 12)).toByte())
+                directPutByte(base + pos + 1, (0x80 or ((c ushr 6) and 0x3F)).toByte())
+                directPutByte(base + pos + 2, (0x80 or (c and 0x3F)).toByte())
+                pos += 3
+            }
+            c < 0xDC00 && i + 1 < len && text[i + 1].code in 0xDC00..0xDFFF -> {
+                // High surrogate with a real low surrogate: one supplementary scalar, 4 bytes.
+                val cp = 0x10000 + ((c - 0xD800) shl 10) + (text[i + 1].code - 0xDC00)
+                if (pos + 4 > limit) throw overflow(pos, limit)
+                directPutByte(base + pos, (0xF0 or (cp ushr 18)).toByte())
+                directPutByte(base + pos + 1, (0x80 or ((cp ushr 12) and 0x3F)).toByte())
+                directPutByte(base + pos + 2, (0x80 or ((cp ushr 6) and 0x3F)).toByte())
+                directPutByte(base + pos + 3, (0x80 or (cp and 0x3F)).toByte())
+                pos += 4
+                i += 1 // consumed the low surrogate as well
+            }
+            else -> {
+                // Unpaired surrogate (lone high or lone low): substitute U+FFFD.
+                if (pos + 3 > limit) throw overflow(pos, limit)
+                directPutByte(base + pos, 0xEF.toByte())
+                directPutByte(base + pos + 1, 0xBF.toByte())
+                directPutByte(base + pos + 2, 0xBD.toByte())
+                pos += 3
+            }
+        }
+        i += 1
+    }
+    return pos
+}
+
 private fun overflow(
     pos: Int,
     limit: Int,

--- a/buffer/src/jvmCommonMain/kotlin/com/ditchoom/buffer/BaseJvmBuffer.kt
+++ b/buffer/src/jvmCommonMain/kotlin/com/ditchoom/buffer/BaseJvmBuffer.kt
@@ -447,6 +447,36 @@ abstract class BaseJvmBuffer(
      */
     protected open fun tryWriteUtf8ToNative(text: CharSequence): Boolean = false
 
+    /**
+     * Substituting twin of [tryWriteUtf8ToNative] for the [Utf8.Lenient] policy: same native
+     * fast path, but unpaired surrogates become U+FFFD instead of throwing.
+     */
+    protected open fun tryWriteUtf8LenientToNative(text: CharSequence): Boolean = false
+
+    override fun <R> writeText(
+        text: CharSequence,
+        encoding: TextEncoding<R>,
+    ): R = dispatchWriteText(text, encoding) { t -> writeUtf8Substituting(t) }
+
+    /** Encodes with U+FFFD substitution and returns the bytes written. */
+    private fun writeUtf8Substituting(text: CharSequence): Int {
+        val start = position()
+        if (!tryWriteUtf8LenientToNative(text)) {
+            // Heap fallback: the REPLACE-configured encoder writes into the backing array directly.
+            val encoder = utf8LenientEncoder.get()
+            encoder.reset()
+            val result = encoder.encode(CharBuffer.wrap(text), byteBuffer, true)
+            if (result.isOverflow) {
+                throw BufferOverflowException(
+                    "Buffer overflow: cannot encode UTF-8 string of ${text.length} char(s) at position " +
+                        "${position()} (limit=${limit()}, remaining=${remaining()})",
+                )
+            }
+            // REPLACE mode cannot produce malformed/unmappable results for UTF-8.
+        }
+        return position() - start
+    }
+
     override fun write(buffer: ReadBuffer) {
         val actual = buffer.unwrapFully()
         try {

--- a/buffer/src/jvmCommonMain/kotlin/com/ditchoom/buffer/CharsetEncoderHelper.kt
+++ b/buffer/src/jvmCommonMain/kotlin/com/ditchoom/buffer/CharsetEncoderHelper.kt
@@ -24,6 +24,26 @@ internal class DefaultEncoder(
 }
 
 internal val utf8Encoder = DefaultEncoder(Charsets.UTF_8)
+
+/** U+FFFD REPLACEMENT CHARACTER encoded as UTF-8. */
+private val UTF8_REPLACEMENT_BYTES = byteArrayOf(0xEF.toByte(), 0xBF.toByte(), 0xBD.toByte())
+
+/**
+ * Substituting UTF-8 encoder for the [Utf8.Lenient] heap fallback: unpaired surrogates become
+ * U+FFFD (the JDK's default UTF-8 replacement is `?`, which would break the cross-platform
+ * byte contract pinned by `TextEncodingTests`).
+ */
+internal val utf8LenientEncoder =
+    object : ThreadLocal<CharsetEncoder>() {
+        override fun initialValue(): CharsetEncoder =
+            Charsets.UTF_8
+                .newEncoder()
+                .onMalformedInput(java.nio.charset.CodingErrorAction.REPLACE)
+                .onUnmappableCharacter(java.nio.charset.CodingErrorAction.REPLACE)
+                .replaceWith(UTF8_REPLACEMENT_BYTES)
+
+        override fun get(): CharsetEncoder = super.get()!!
+    }
 internal val utf16Encoder = DefaultEncoder(Charsets.UTF_16)
 internal val utf16BEEncoder = DefaultEncoder(Charsets.UTF_16BE)
 internal val utf16LEEncoder = DefaultEncoder(Charsets.UTF_16LE)

--- a/buffer/src/jvmCommonMain/kotlin/com/ditchoom/buffer/StreamingStringDecoder.jvmCommon.kt
+++ b/buffer/src/jvmCommonMain/kotlin/com/ditchoom/buffer/StreamingStringDecoder.jvmCommon.kt
@@ -94,8 +94,8 @@ private class JvmStreamingStringDecoder(
                         pendingCount = unconsumed
                         pendingLong = 0L
                         for (i in 0 until unconsumed) {
-                            val maskedByte = byteBuffer.get().toLong() and Utf8.BYTE_MASK.toLong()
-                            pendingLong = pendingLong or (maskedByte shl (i * Utf8.BITS_PER_BYTE))
+                            val maskedByte = byteBuffer.get().toLong() and Utf8Wire.BYTE_MASK.toLong()
+                            pendingLong = pendingLong or (maskedByte shl (i * Utf8Wire.BITS_PER_BYTE))
                         }
                     } else {
                         pendingCount = 0
@@ -175,7 +175,7 @@ private class JvmStreamingStringDecoder(
 
         // Add pending bytes first (unpack from Long)
         for (i in 0 until pendingCount) {
-            cb.put(((pendingLong ushr (i * Utf8.BITS_PER_BYTE)) and Utf8.BYTE_MASK.toLong()).toByte())
+            cb.put(((pendingLong ushr (i * Utf8Wire.BITS_PER_BYTE)) and Utf8Wire.BYTE_MASK.toLong()).toByte())
         }
         pendingCount = 0
 
@@ -202,7 +202,7 @@ private class JvmStreamingStringDecoder(
             }
             (cb as java.nio.Buffer).clear()
             for (i in 0 until pendingCount) {
-                cb.put(((pendingLong ushr (i * Utf8.BITS_PER_BYTE)) and Utf8.BYTE_MASK.toLong()).toByte())
+                cb.put(((pendingLong ushr (i * Utf8Wire.BITS_PER_BYTE)) and Utf8Wire.BYTE_MASK.toLong()).toByte())
             }
             (cb as java.nio.Buffer).flip()
             val byteBuffer = cb

--- a/buffer/src/jvmMain/kotlin/com/ditchoom/buffer/DirectJvmBuffer.kt
+++ b/buffer/src/jvmMain/kotlin/com/ditchoom/buffer/DirectJvmBuffer.kt
@@ -79,6 +79,13 @@ class DirectJvmBuffer(
         return true
     }
 
+    override fun tryWriteUtf8LenientToNative(text: CharSequence): Boolean {
+        val base = directBase()
+        if (base == 0L) return false // no --add-opens on JVM<21: fall back to the CharsetEncoder path
+        position(encodeUtf8LenientToNative(text, position(), limit(), base))
+        return true
+    }
+
     // No readString override here: the direct-from-native UTF-8 decode is a win only where the byte
     // accessor is a JIT intrinsic — the FFM buffers on JDK 21+ (see jvm21Main/Utf8DirectDecode.kt).
     // On the sun.misc.Unsafe path this class takes (JVM 8-20 / Android) a per-byte Unsafe.getByte loop

--- a/buffer/src/jvmMain/kotlin/com/ditchoom/buffer/Utf8DirectEncode.kt
+++ b/buffer/src/jvmMain/kotlin/com/ditchoom/buffer/Utf8DirectEncode.kt
@@ -88,9 +88,10 @@ internal fun encodeUtf8ToNative(
  * U+FFFD (EF BF BD) instead of throwing — the [com.ditchoom.buffer.Utf8.Lenient] contract.
  * Produces byte-for-byte the output of `Utf8TextEncoder.encodeSubstituting`, with no staging array.
  *
- * Same complexity drivers as the strict loop, same suppressions.
+ * Same complexity drivers as the strict loop, same suppressions (the per-sequence-length
+ * overflow guards drive ThrowsCount exactly as in the strict twin).
  */
-@Suppress("CyclomaticComplexMethod")
+@Suppress("CyclomaticComplexMethod", "ThrowsCount")
 internal fun encodeUtf8LenientToNative(
     text: CharSequence,
     startPosition: Int,

--- a/buffer/src/jvmMain/kotlin/com/ditchoom/buffer/Utf8DirectEncode.kt
+++ b/buffer/src/jvmMain/kotlin/com/ditchoom/buffer/Utf8DirectEncode.kt
@@ -83,6 +83,70 @@ internal fun encodeUtf8ToNative(
     return pos
 }
 
+/**
+ * Substituting twin of [encodeUtf8ToNative]: identical loop, but an unpaired surrogate writes
+ * U+FFFD (EF BF BD) instead of throwing — the [com.ditchoom.buffer.Utf8.Lenient] contract.
+ * Produces byte-for-byte the output of `Utf8TextEncoder.encodeSubstituting`, with no staging array.
+ *
+ * Same complexity drivers as the strict loop, same suppressions.
+ */
+@Suppress("CyclomaticComplexMethod")
+internal fun encodeUtf8LenientToNative(
+    text: CharSequence,
+    startPosition: Int,
+    limit: Int,
+    base: Long,
+): Int {
+    var pos = startPosition
+    val len = text.length
+    var i = 0
+    while (i < len) {
+        val c = text[i].code
+        when {
+            c < 0x80 -> {
+                if (pos >= limit) throw overflow(pos, limit)
+                directPutByte(base + pos, c.toByte())
+                pos += 1
+            }
+            c < 0x800 -> {
+                if (pos + 2 > limit) throw overflow(pos, limit)
+                directPutByte(base + pos, (0xC0 or (c ushr 6)).toByte())
+                directPutByte(base + pos + 1, (0x80 or (c and 0x3F)).toByte())
+                pos += 2
+            }
+            c < 0xD800 || c >= 0xE000 -> {
+                // BMP scalar (excludes the surrogate range 0xD800..0xDFFF): 3 bytes.
+                if (pos + 3 > limit) throw overflow(pos, limit)
+                directPutByte(base + pos, (0xE0 or (c ushr 12)).toByte())
+                directPutByte(base + pos + 1, (0x80 or ((c ushr 6) and 0x3F)).toByte())
+                directPutByte(base + pos + 2, (0x80 or (c and 0x3F)).toByte())
+                pos += 3
+            }
+            c < 0xDC00 && i + 1 < len && text[i + 1].code in 0xDC00..0xDFFF -> {
+                // High surrogate with a real low surrogate: one supplementary scalar, 4 bytes.
+                val cp = 0x10000 + ((c - 0xD800) shl 10) + (text[i + 1].code - 0xDC00)
+                if (pos + 4 > limit) throw overflow(pos, limit)
+                directPutByte(base + pos, (0xF0 or (cp ushr 18)).toByte())
+                directPutByte(base + pos + 1, (0x80 or ((cp ushr 12) and 0x3F)).toByte())
+                directPutByte(base + pos + 2, (0x80 or ((cp ushr 6) and 0x3F)).toByte())
+                directPutByte(base + pos + 3, (0x80 or (cp and 0x3F)).toByte())
+                pos += 4
+                i += 1 // consumed the low surrogate as well
+            }
+            else -> {
+                // Unpaired surrogate (lone high or lone low): substitute U+FFFD.
+                if (pos + 3 > limit) throw overflow(pos, limit)
+                directPutByte(base + pos, 0xEF.toByte())
+                directPutByte(base + pos + 1, 0xBF.toByte())
+                directPutByte(base + pos + 2, 0xBD.toByte())
+                pos += 3
+            }
+        }
+        i += 1
+    }
+    return pos
+}
+
 private fun overflow(
     pos: Int,
     limit: Int,

--- a/buffer/src/linuxMain/kotlin/com/ditchoom/buffer/NativeBuffer.kt
+++ b/buffer/src/linuxMain/kotlin/com/ditchoom/buffer/NativeBuffer.kt
@@ -483,6 +483,22 @@ class NativeBuffer private constructor(
         positionValue += written
         return this
     }
+    override fun <R> writeText(
+        text: CharSequence,
+        encoding: TextEncoding<R>,
+    ): R =
+        dispatchWriteText(text, encoding) { t ->
+            // simdutf transcodes well-formed text in one pass but whole-write no-ops on any
+            // unpaired surrogate (position unchanged). The rare ill-formed case falls back to
+            // the common substituting encoder so the U+FFFD byte contract still holds.
+            val start = position()
+            writeString(t, Charset.UTF8)
+            if (position() == start && t.isNotEmpty()) {
+                writeBytes(Utf8TextEncoder.encodeSubstituting(t))
+            }
+            position() - start
+        }
+
 
     // === Optimized bulk operations ===
 
@@ -1086,6 +1102,22 @@ private class NativeBufferSlice(
         positionValue += written
         return this
     }
+    override fun <R> writeText(
+        text: CharSequence,
+        encoding: TextEncoding<R>,
+    ): R =
+        dispatchWriteText(text, encoding) { t ->
+            // simdutf transcodes well-formed text in one pass but whole-write no-ops on any
+            // unpaired surrogate (position unchanged). The rare ill-formed case falls back to
+            // the common substituting encoder so the U+FFFD byte contract still holds.
+            val start = position()
+            writeString(t, Charset.UTF8)
+            if (position() == start && t.isNotEmpty()) {
+                writeBytes(Utf8TextEncoder.encodeSubstituting(t))
+            }
+            position() - start
+        }
+
 
     fun close() = Unit
 

--- a/buffer/src/linuxMain/kotlin/com/ditchoom/buffer/NativeBuffer.kt
+++ b/buffer/src/linuxMain/kotlin/com/ditchoom/buffer/NativeBuffer.kt
@@ -483,6 +483,7 @@ class NativeBuffer private constructor(
         positionValue += written
         return this
     }
+
     override fun <R> writeText(
         text: CharSequence,
         encoding: TextEncoding<R>,
@@ -498,7 +499,6 @@ class NativeBuffer private constructor(
             }
             position() - start
         }
-
 
     // === Optimized bulk operations ===
 
@@ -1102,6 +1102,7 @@ private class NativeBufferSlice(
         positionValue += written
         return this
     }
+
     override fun <R> writeText(
         text: CharSequence,
         encoding: TextEncoding<R>,
@@ -1117,7 +1118,6 @@ private class NativeBufferSlice(
             }
             position() - start
         }
-
 
     fun close() = Unit
 

--- a/buffer/src/linuxMain/kotlin/com/ditchoom/buffer/StreamingStringDecoder.linux.kt
+++ b/buffer/src/linuxMain/kotlin/com/ditchoom/buffer/StreamingStringDecoder.linux.kt
@@ -116,8 +116,8 @@ private class LinuxStreamingStringDecoder(
             pendingLong = 0L
             val basePos = buffer.position() + bytesConsumed + boundary
             for (i in 0 until pendingCount) {
-                val maskedByte = buffer.get(basePos + i).toLong() and Utf8.BYTE_MASK.toLong()
-                pendingLong = pendingLong or (maskedByte shl (i * Utf8.BITS_PER_BYTE))
+                val maskedByte = buffer.get(basePos + i).toLong() and Utf8Wire.BYTE_MASK.toLong()
+                pendingLong = pendingLong or (maskedByte shl (i * Utf8Wire.BITS_PER_BYTE))
             }
         }
 
@@ -171,13 +171,13 @@ private class LinuxStreamingStringDecoder(
         destination: Appendable,
     ): DecodeResult {
         // Determine expected sequence length from lead byte
-        val leadByte = (pendingLong and Utf8.BYTE_MASK.toLong()).toInt()
+        val leadByte = (pendingLong and Utf8Wire.BYTE_MASK.toLong()).toInt()
         val expectedLen =
             when {
-                leadByte < Utf8.ASCII_LIMIT -> 1
-                leadByte and Utf8.TWO_BYTE_LEAD_MASK == Utf8.TWO_BYTE_LEAD -> 2
-                leadByte and Utf8.THREE_BYTE_LEAD_MASK == Utf8.THREE_BYTE_LEAD -> 3
-                leadByte and Utf8.FOUR_BYTE_LEAD_MASK == Utf8.FOUR_BYTE_LEAD -> 4
+                leadByte < Utf8Wire.ASCII_LIMIT -> 1
+                leadByte and Utf8Wire.TWO_BYTE_LEAD_MASK == Utf8Wire.TWO_BYTE_LEAD -> 2
+                leadByte and Utf8Wire.THREE_BYTE_LEAD_MASK == Utf8Wire.THREE_BYTE_LEAD -> 3
+                leadByte and Utf8Wire.FOUR_BYTE_LEAD_MASK == Utf8Wire.FOUR_BYTE_LEAD -> 4
                 else -> {
                     // Invalid lead byte
                     pendingCount = 0
@@ -193,8 +193,8 @@ private class LinuxStreamingStringDecoder(
             val basePos = buffer.position()
             for (i in 0 until available) {
                 val b = buffer.get(basePos + i)
-                val maskedByte = b.toLong() and Utf8.BYTE_MASK.toLong()
-                pendingLong = pendingLong or (maskedByte shl ((pendingCount + i) * Utf8.BITS_PER_BYTE))
+                val maskedByte = b.toLong() and Utf8Wire.BYTE_MASK.toLong()
+                pendingLong = pendingLong or (maskedByte shl ((pendingCount + i) * Utf8Wire.BITS_PER_BYTE))
             }
             pendingCount += available
             return DecodeResult(0, available)
@@ -205,7 +205,9 @@ private class LinuxStreamingStringDecoder(
         for (i in 0 until needed) {
             val b = buffer.get(basePos + i)
             pendingLong =
-                pendingLong or ((b.toLong() and Utf8.BYTE_MASK.toLong()) shl ((pendingCount + i) * Utf8.BITS_PER_BYTE))
+                pendingLong or (
+                    (b.toLong() and Utf8Wire.BYTE_MASK.toLong()) shl ((pendingCount + i) * Utf8Wire.BITS_PER_BYTE)
+                )
         }
         pendingCount = 0
 
@@ -218,19 +220,21 @@ private class LinuxStreamingStringDecoder(
         byteCount: Int,
         destination: Appendable,
     ): Int {
-        val b0 = (pendingLong and Utf8.BYTE_MASK.toLong()).toInt()
-        val b1 = if (byteCount > 1) ((pendingLong ushr 8) and Utf8.BYTE_MASK.toLong()).toInt() else 0
-        val b2 = if (byteCount > 2) ((pendingLong ushr 16) and Utf8.BYTE_MASK.toLong()).toInt() else 0
-        val b3 = if (byteCount > 3) ((pendingLong ushr 24) and Utf8.BYTE_MASK.toLong()).toInt() else 0
+        val b0 = (pendingLong and Utf8Wire.BYTE_MASK.toLong()).toInt()
+        val b1 = if (byteCount > 1) ((pendingLong ushr 8) and Utf8Wire.BYTE_MASK.toLong()).toInt() else 0
+        val b2 = if (byteCount > 2) ((pendingLong ushr 16) and Utf8Wire.BYTE_MASK.toLong()).toInt() else 0
+        val b3 = if (byteCount > 3) ((pendingLong ushr 24) and Utf8Wire.BYTE_MASK.toLong()).toInt() else 0
 
         // Validate continuation bytes
-        if (byteCount > 1 && (b1 and Utf8.CONTINUATION_MASK) != Utf8.CONTINUATION_MARKER) {
+        if (byteCount > 1 && (b1 and Utf8Wire.CONTINUATION_MASK) != Utf8Wire.CONTINUATION_MARKER) {
             return handleMalformedInput(destination).charsWritten
         }
-        if (byteCount > 2 && (b2 and Utf8.CONTINUATION_MASK) != Utf8.CONTINUATION_MARKER) {
+        if (byteCount > 2 && (b2 and Utf8Wire.CONTINUATION_MASK) != Utf8Wire.CONTINUATION_MARKER) {
             return handleMalformedInput(destination).charsWritten
         }
-        if (byteCount > FOURTH_BYTE_PRESENT_THRESHOLD && (b3 and Utf8.CONTINUATION_MASK) != Utf8.CONTINUATION_MARKER) {
+        if (byteCount > FOURTH_BYTE_PRESENT_THRESHOLD &&
+            (b3 and Utf8Wire.CONTINUATION_MASK) != Utf8Wire.CONTINUATION_MARKER
+        ) {
             return handleMalformedInput(destination).charsWritten
         }
 
@@ -238,39 +242,39 @@ private class LinuxStreamingStringDecoder(
             when (byteCount) {
                 1 -> b0
                 2 ->
-                    ((b0 and Utf8.TWO_BYTE_PAYLOAD_MASK) shl Utf8.CONTINUATION_SHIFT) or
-                        (b1 and Utf8.CONTINUATION_PAYLOAD_MASK)
+                    ((b0 and Utf8Wire.TWO_BYTE_PAYLOAD_MASK) shl Utf8Wire.CONTINUATION_SHIFT) or
+                        (b1 and Utf8Wire.CONTINUATION_PAYLOAD_MASK)
                 3 ->
-                    ((b0 and Utf8.THREE_BYTE_PAYLOAD_MASK) shl (Utf8.CONTINUATION_SHIFT * 2)) or
-                        ((b1 and Utf8.CONTINUATION_PAYLOAD_MASK) shl Utf8.CONTINUATION_SHIFT) or
-                        (b2 and Utf8.CONTINUATION_PAYLOAD_MASK)
+                    ((b0 and Utf8Wire.THREE_BYTE_PAYLOAD_MASK) shl (Utf8Wire.CONTINUATION_SHIFT * 2)) or
+                        ((b1 and Utf8Wire.CONTINUATION_PAYLOAD_MASK) shl Utf8Wire.CONTINUATION_SHIFT) or
+                        (b2 and Utf8Wire.CONTINUATION_PAYLOAD_MASK)
                 4 ->
-                    ((b0 and Utf8.FOUR_BYTE_PAYLOAD_MASK) shl (Utf8.CONTINUATION_SHIFT * 3)) or
-                        ((b1 and Utf8.CONTINUATION_PAYLOAD_MASK) shl (Utf8.CONTINUATION_SHIFT * 2)) or
-                        ((b2 and Utf8.CONTINUATION_PAYLOAD_MASK) shl Utf8.CONTINUATION_SHIFT) or
-                        (b3 and Utf8.CONTINUATION_PAYLOAD_MASK)
+                    ((b0 and Utf8Wire.FOUR_BYTE_PAYLOAD_MASK) shl (Utf8Wire.CONTINUATION_SHIFT * 3)) or
+                        ((b1 and Utf8Wire.CONTINUATION_PAYLOAD_MASK) shl (Utf8Wire.CONTINUATION_SHIFT * 2)) or
+                        ((b2 and Utf8Wire.CONTINUATION_PAYLOAD_MASK) shl Utf8Wire.CONTINUATION_SHIFT) or
+                        (b3 and Utf8Wire.CONTINUATION_PAYLOAD_MASK)
                 else -> return handleMalformedInput(destination).charsWritten
             }
 
         // Reject overlong encodings and surrogate codepoints
         val isValid =
             when (byteCount) {
-                2 -> codePoint >= Utf8.ASCII_LIMIT
+                2 -> codePoint >= Utf8Wire.ASCII_LIMIT
                 3 ->
-                    codePoint >= Utf8.THREE_BYTE_MIN &&
-                        (codePoint < Utf8.HIGH_SURROGATE_START || codePoint > Utf8.LOW_SURROGATE_END)
-                4 -> codePoint in Utf8.FOUR_BYTE_MIN..Utf8.MAX_CODE_POINT
+                    codePoint >= Utf8Wire.THREE_BYTE_MIN &&
+                        (codePoint < Utf8Wire.HIGH_SURROGATE_START || codePoint > Utf8Wire.LOW_SURROGATE_END)
+                4 -> codePoint in Utf8Wire.FOUR_BYTE_MIN..Utf8Wire.MAX_CODE_POINT
                 else -> true
             }
         if (!isValid) return handleMalformedInput(destination).charsWritten
 
-        return if (codePoint <= Utf8.BMP_MAX) {
+        return if (codePoint <= Utf8Wire.BMP_MAX) {
             destination.append(codePoint.toChar())
             1
         } else {
-            val adjusted = codePoint - Utf8.FOUR_BYTE_MIN
-            destination.append((Utf8.HIGH_SURROGATE_START + (adjusted shr Utf8.SURROGATE_SHIFT)).toChar())
-            destination.append((Utf8.LOW_SURROGATE_START + (adjusted and Utf8.LOW_SURROGATE_MASK)).toChar())
+            val adjusted = codePoint - Utf8Wire.FOUR_BYTE_MIN
+            destination.append((Utf8Wire.HIGH_SURROGATE_START + (adjusted shr Utf8Wire.SURROGATE_SHIFT)).toChar())
+            destination.append((Utf8Wire.LOW_SURROGATE_START + (adjusted and Utf8Wire.LOW_SURROGATE_MASK)).toChar())
             2
         }
     }

--- a/buffer/src/nonJvmMain/kotlin/com/ditchoom/buffer/ByteArrayBuffer.kt
+++ b/buffer/src/nonJvmMain/kotlin/com/ditchoom/buffer/ByteArrayBuffer.kt
@@ -356,6 +356,18 @@ class ByteArrayBuffer(
         }
         return this
     }
+    override fun <R> writeText(
+        text: CharSequence,
+        encoding: TextEncoding<R>,
+    ): R =
+        dispatchWriteText(text, encoding) { t ->
+            // This platform's writeString(UTF8) already substitutes U+FFFD for unpaired
+            // surrogates (pinned by TextEncodingTests), so it is the substituting core.
+            val start = position()
+            writeString(t, Charset.UTF8)
+            position() - start
+        }
+
 
     // === Optimized bulk operations ===
 

--- a/buffer/src/nonJvmMain/kotlin/com/ditchoom/buffer/ByteArrayBuffer.kt
+++ b/buffer/src/nonJvmMain/kotlin/com/ditchoom/buffer/ByteArrayBuffer.kt
@@ -356,6 +356,7 @@ class ByteArrayBuffer(
         }
         return this
     }
+
     override fun <R> writeText(
         text: CharSequence,
         encoding: TextEncoding<R>,
@@ -367,7 +368,6 @@ class ByteArrayBuffer(
             writeString(t, Charset.UTF8)
             position() - start
         }
-
 
     // === Optimized bulk operations ===
 

--- a/buffer/src/wasmJsMain/kotlin/com/ditchoom/buffer/LinearBuffer.kt
+++ b/buffer/src/wasmJsMain/kotlin/com/ditchoom/buffer/LinearBuffer.kt
@@ -566,6 +566,7 @@ class LinearBuffer(
         }
         return this
     }
+
     override fun <R> writeText(
         text: CharSequence,
         encoding: TextEncoding<R>,
@@ -577,7 +578,6 @@ class LinearBuffer(
             writeString(t, Charset.UTF8)
             position() - start
         }
-
 
     /**
      * Optimized single byte indexOf using Long comparisons (8 bytes at a time).

--- a/buffer/src/wasmJsMain/kotlin/com/ditchoom/buffer/LinearBuffer.kt
+++ b/buffer/src/wasmJsMain/kotlin/com/ditchoom/buffer/LinearBuffer.kt
@@ -566,6 +566,18 @@ class LinearBuffer(
         }
         return this
     }
+    override fun <R> writeText(
+        text: CharSequence,
+        encoding: TextEncoding<R>,
+    ): R =
+        dispatchWriteText(text, encoding) { t ->
+            // This platform's writeString(UTF8) already substitutes U+FFFD for unpaired
+            // surrogates (pinned by TextEncodingTests), so it is the substituting core.
+            val start = position()
+            writeString(t, Charset.UTF8)
+            position() - start
+        }
+
 
     /**
      * Optimized single byte indexOf using Long comparisons (8 bytes at a time).


### PR DESCRIPTION
## What

One new virtual member on `WriteBuffer`:

```kotlin
fun <R> writeText(text: CharSequence, encoding: TextEncoding<R>): R
```

The policy picks the result type, so the type system enforces the semantics:

```kotlin
buffer.writeText(text)                              // Utf8.Lenient: fluent, cannot fail
val n = Utf8.Lenient.size(text)                     // == bytes the write produces. Exactly. Every platform.
when (val r = buffer.writeText(text, Utf8.Strict)) {// sealed result, cannot be ignored
    is TextOutcome.Bytes -> framePayload(r.count)
    is TextOutcome.Malformed -> reject(r.index)     // atomic: nothing written, position unchanged
}
val rb = text.toReadBuffer(Utf8.Lenient, SizeHint.Exact)  // sizing strategies: Exact | UpperBound | BytesPerChar
```

No booleans, no nulls, no sentinels in the public surface. Impossible states don't typecheck: a lenient write cannot express failure, a strict result cannot be silently dropped, and under-counting (the #352 bug class) is unrepresentable because sizing and writing share one policy.

## Guarantees (pinned by `TextEncodingTests` on all five platforms)

1. `size(text)` equals bytes written — for well-formed AND ill-formed input
2. Identical bytes for identical `(text, encoding)` everywhere — U+FFFD substitution, never platform-dependent (measured: Kotlin/JVM `encodeToByteArray` substitutes `?` where Native/JS produce U+FFFD, so the contract is owned by a common reference encoder, not platform staging)
3. Strict rejection is atomic — `Malformed(index)`, position unchanged, verified at non-zero positions
4. Overflow throws — unreachable when sized from the same policy
5. Wrappers stay transparent: fluent results identify the PooledBuffer/TrackedSlice, never the inner buffer (policy `rewrap` hook, no unchecked casts)

## Fast paths, measured (same-run A/B vs `writeString`, ascii/cjk/emoji × 64B/1K/64K)

| platform | writeText vs writeString | mechanism |
|---|---|---|
| JVM | **0.86–1.14×** | lenient twin of `encodeUtf8ToNative` (jvmMain + jvm21 shadow copy, Direct/Ffm/FfmAuto); heap falls back to a REPLACE encoder with `replaceWith(EF BF BD)` |
| macOS | **0.92–1.11×** | Foundation `dataUsingEncoding` for well-formed, common encoder fallback |
| Linux | **0.88–1.09×** | simdutf single-pass; common-encoder fallback when simdutf no-ops on ill-formed |
| wasm | **0.96–1.03×** | linear-memory writeString delegation |
| JS | **0.97–1.00×** | TextEncoder delegation |

Parity across the board — the policy dispatch costs a few percent on 64B inputs and wins on JVM emojiLarge (no exception machinery).

**Bytecode checks:** javap — `GETSTATIC` policy singletons, `size()` unboxed int end-to-end, lenient result is `areturn` of the receiver (no allocation); wasm-dis (development build) — zero `struct.new` on the sizing and lenient-result paths.

**Finding worth recording:** the Kotlin/Native scalar `size()` pass is ~40× slower than JVM, and ascii sizing is ~6× slower than cjk on BOTH macOS and Linux (codegen, not hardware). `SizeHint.Exact` is therefore a net loss on Apple unless memory-bound — `UpperBound` is the default. Follow-ups: CFStringGetBytes null-buffer sizing (Apple), simdutf-backed sizing (Linux, only if it can honor the exact contract).

## Also in this PR

- **Corrected `Charset` ratios** (JDK-verified): UTF-8 max **3** (was 4), UTF-16BE/LE max **2** (was 4); pinned as true upper bounds in tests. `maxBufferSize` allocations shrink accordingly.
- **Deprecations** (removal in v7): `utf8Length()` → `utf8Size()`, `maxBufferSize()` → `SizeHint`. `writeString` stays undeprecated until non-UTF-8 policies reach parity.
- Internal `Utf8` constants object renamed `Utf8Wire` to free the public name.
- CLAUDE.md section documenting the API.

## Verified

- Full suites green: jvm (+ `jvmFfmTest` for the new tests; its 5 pre-existing failures reproduce on main), jsNode, wasmJsNode, macosArm64, linuxX64 on a real Linux host. js/wasm are nightly-only in CI — run by hand.
- ktlint + detekt clean.

Note for the release: this `minor` also carries the unreleased #351 (wasm growable pool, its release run was cancelled by a queue supersede) and #352 (utf8Length surrogate fix, merged `skip-release`) out as 6.30.0.