### PR TITLE
fix(test): construct unpaired-surrogate fixtures at runtime — Kotlin/JS clean builds mangle the literals

### DIFF
--- a/buffer/src/commonTest/kotlin/com/ditchoom/buffer/TextEncodingTests.kt
+++ b/buffer/src/commonTest/kotlin/com/ditchoom/buffer/TextEncodingTests.kt
@@ -22,6 +22,14 @@ import kotlin.test.assertTrue
  * 4. wrappers stay transparent and fluent results identify the wrapper, not the inner buffer.
  */
 class TextEncodingTests {
+    // Unpaired-surrogate STRINGS must be constructed at runtime: the Kotlin/JS compiler's
+// clean-build codegen lossily rewrites unpaired surrogates in string LITERALS to '?'
+// (incremental builds emit them faithfully — the divergence was caught when a clean
+// rebuild flipped these tests). Char() is numeric and safe. Valid pairs are unaffected.
+    private val loneHigh = Char(0xD800).toString()
+    private val loneHighEnd = Char(0xDBFF).toString()
+    private val loneLow = Char(0xDC00).toString()
+    private val loneLowEnd = Char(0xDFFF).toString()
     private val wellFormed =
         listOf(
             "",
@@ -37,14 +45,14 @@ class TextEncodingTests {
 
     private val illFormed =
         listOf(
-            "\uD800" to 0,
-            "\uDC00" to 0,
-            "\uD800€" to 0,
-            "\uD800A" to 0,
-            "A\uD800" to 1,
-            "AB\uD800" to 2,
-            "\uDC00\uD800" to 0,
-            "😀\uD800" to 2,
+            loneHigh to 0,
+            loneLow to 0,
+            (loneHigh + "€") to 0,
+            (loneHigh + "A") to 0,
+            ("A" + loneHigh) to 1,
+            ("AB" + loneHigh) to 2,
+            (loneLow + loneHigh) to 0,
+            ("😀" + loneHigh) to 2,
         )
 
     private val factories = listOf("default" to BufferFactory.Default, "managed" to BufferFactory.managed())
@@ -82,14 +90,14 @@ class TextEncodingTests {
     @Test
     fun lenientSubstitutionBytesArePinned() {
         for ((name, factory) in factories) {
-            assertEquals(fffd, writtenBytes(factory, "\uD800"), "lone high [$name]")
-            assertEquals(fffd, writtenBytes(factory, "\uDC00"), "lone low [$name]")
+            assertEquals(fffd, writtenBytes(factory, loneHigh), "lone high [$name]")
+            assertEquals(fffd, writtenBytes(factory, loneLow), "lone low [$name]")
             assertEquals(
                 fffd + listOf(0xE2.toByte(), 0x82.toByte(), 0xAC.toByte()),
-                writtenBytes(factory, "\uD800€"),
+                writtenBytes(factory, (loneHigh + "€")),
                 "U+FFFD then € [$name]",
             )
-            assertEquals(listOf(0x41.toByte()) + fffd, writtenBytes(factory, "A\uD800"), "A then U+FFFD [$name]")
+            assertEquals(listOf(0x41.toByte()) + fffd, writtenBytes(factory, ("A" + loneHigh)), "A then U+FFFD [$name]")
             assertEquals(
                 listOf(0xF0.toByte(), 0x9F.toByte(), 0x98.toByte(), 0x80.toByte()),
                 writtenBytes(factory, "😀"),
@@ -143,7 +151,7 @@ class TextEncodingTests {
     @Test
     fun oneArgWriteTextIsLenient() {
         val buffer = BufferFactory.Default.allocate(16)
-        assertSame(buffer, buffer.writeText("\uD800"))
+        assertSame(buffer, buffer.writeText(loneHigh))
         assertEquals(3, buffer.position())
     }
 
@@ -159,7 +167,7 @@ class TextEncodingTests {
     fun writeTextThroughPooledBufferAndTrackedSliceStaysFluentAndTransparent() {
         withPool(defaultBufferSize = 256) { pool ->
             pool.withBuffer(128) { pooled ->
-                val returned = pooled.writeText("a\uD800€", Utf8.Lenient)
+                val returned = pooled.writeText(("a" + loneHigh + "€"), Utf8.Lenient)
                 assertSame(pooled, returned, "fluent result must be the wrapper, not the inner buffer")
                 assertEquals(7, pooled.position(), "1 + 3 (U+FFFD) + 3 (€)")
 
@@ -167,7 +175,7 @@ class TextEncodingTests {
                 val sliceReturned = slice.writeText("😀", Utf8.Lenient)
                 assertSame(slice, sliceReturned, "slice fluent result must be the tracked slice")
 
-                val strict = pooled.writeText("\uDC00", Utf8.Strict)
+                val strict = pooled.writeText(loneLow, Utf8.Strict)
                 assertIs<TextOutcome.Malformed>(strict)
                 assertEquals(7, pooled.position(), "strict rejection through wrapper must not move position")
             }
@@ -187,7 +195,7 @@ class TextEncodingTests {
 
     @Test
     fun toReadBufferSubstitutesIllFormedText() {
-        val readBuffer = "\uD800€".toReadBuffer(Utf8.Lenient, SizeHint.Exact)
+        val readBuffer = (loneHigh + "€").toReadBuffer(Utf8.Lenient, SizeHint.Exact)
         assertEquals(6, readBuffer.remaining())
         assertEquals(fffd + listOf(0xE2.toByte(), 0x82.toByte(), 0xAC.toByte()), readBuffer.readByteArray(6).toList())
     }

--- a/buffer/src/commonTest/kotlin/com/ditchoom/buffer/Utf8LengthTests.kt
+++ b/buffer/src/commonTest/kotlin/com/ditchoom/buffer/Utf8LengthTests.kt
@@ -21,6 +21,15 @@ import kotlin.test.assertEquals
  * prove nothing about the count.
  */
 class Utf8LengthTests {
+    // Unpaired-surrogate STRINGS must be constructed at runtime: the Kotlin/JS compiler's
+// clean-build codegen lossily rewrites unpaired surrogates in string LITERALS to '?'
+// (incremental builds emit them faithfully — the divergence was caught when a clean
+// rebuild flipped these tests). Char() is numeric and safe. Valid pairs are unaffected.
+    private val loneHigh = Char(0xD800).toString()
+    private val loneHighEnd = Char(0xDBFF).toString()
+    private val loneLow = Char(0xDC00).toString()
+    private val loneLowEnd = Char(0xDFFF).toString()
+
     private fun assertUtf8Length(
         expected: Int,
         text: String,
@@ -55,26 +64,26 @@ class Utf8LengthTests {
 
     @Test
     fun unpairedSurrogatesCountAsReplacementChar() {
-        assertUtf8Length(3, "\uD800", "lone high surrogate (range start)")
-        assertUtf8Length(3, "\uDBFF", "lone high surrogate (range end)")
-        assertUtf8Length(3, "\uDC00", "lone low surrogate (range start)")
-        assertUtf8Length(3, "\uDFFF", "lone low surrogate (range end)")
-        assertUtf8Length(6, "\uD800\uD800", "two consecutive lone high surrogates")
-        assertUtf8Length(6, "\uDC00\uD800", "reversed pair is two lone surrogates")
+        assertUtf8Length(3, loneHigh, "lone high surrogate (range start)")
+        assertUtf8Length(3, loneHighEnd, "lone high surrogate (range end)")
+        assertUtf8Length(3, loneLow, "lone low surrogate (range start)")
+        assertUtf8Length(3, loneLowEnd, "lone low surrogate (range end)")
+        assertUtf8Length(6, (loneHigh + loneHigh), "two consecutive lone high surrogates")
+        assertUtf8Length(6, (loneLow + loneHigh), "reversed pair is two lone surrogates")
     }
 
     @Test
     fun unpairedHighSurrogateMustNotSwallowTheNextChar() {
         // Regression: the pre-fix loop charged 4 for a high surrogate and skipped the
-        // following char unconditionally, under-counting "\uD800€" as 4 instead of 6.
-        assertUtf8Length(6, "\uD800€", "lone high then € (3 + 3)")
-        assertUtf8Length(4, "\uD800A", "lone high then ASCII (3 + 1)")
-        assertUtf8Length(7, "\uD800😀", "lone high then a valid pair (3 + 4)")
+        // following char unconditionally, under-counting (loneHigh + "€") as 4 instead of 6.
+        assertUtf8Length(6, (loneHigh + "€"), "lone high then € (3 + 3)")
+        assertUtf8Length(4, (loneHigh + "A"), "lone high then ASCII (3 + 1)")
+        assertUtf8Length(7, (loneHigh + "😀"), "lone high then a valid pair (3 + 4)")
     }
 
     @Test
     fun unpairedHighSurrogateAtEndOfString() {
-        assertUtf8Length(4, "A\uD800", "ASCII then lone high (1 + 3)")
-        assertUtf8Length(5, "AB\uD800", "two ASCII then lone high (2 + 3)")
+        assertUtf8Length(4, ("A" + loneHigh), "ASCII then lone high (1 + 3)")
+        assertUtf8Length(5, ("AB" + loneHigh), "two ASCII then lone high (2 + 3)")
     }
 }


### PR DESCRIPTION
Cherry-picked ahead of the TextPolicy batch so main's tests don't flip red on the first clean JS rebuild.

**What happens without this:** the Kotlin/JS compiler's clean-build codegen rewrites unpaired surrogates in string **literals** to `?` (incremental builds emit them faithfully — which is why every run so far has been green). Six merged tests (`TextEncodingTests`, pinning U+FFFD substitution) then fail with byte `0x3F` where `EF BF BD` is expected: the compiler performs the exact silent lossy substitution these tests exist to guard against, on the tests themselves.

Reproduce on main: `rm -rf buffer/build/compileSync/js && ./gradlew :buffer:cleanJsNodeTest :buffer:jsNodeTest` — compiled output contains `writtenBytes(this, factory, '?')` for source `writtenBytes(factory, "\uD800")`.

**Fix:** ill-formed fixture strings are constructed at runtime (`Char(0xD800)` — numeric, no string-literal emission). Valid surrogate pairs are unaffected and stay as literals. Test-only change; `skip-release`.

Verified: stable under clean JS rebuilds; suites green on jvm / jsNode / wasmJsNode / macosArm64 / linuxX64 (alien).