### PR TITLE
fix(codec-processor): reject framing that is not uniform across a dispatch family (#359)

### DIFF
--- a/buffer-codec-processor/config/detekt/baseline.xml
+++ b/buffer-codec-processor/config/detekt/baseline.xml
@@ -140,6 +140,7 @@
     <ID>ReturnCount:ProtocolMessageProcessor.kt:ProtocolMessageProcessor$private fun isBooleanReturningValProperty: Boolean</ID>
     <ID>ReturnCount:ProtocolMessageProcessor.kt:ProtocolMessageProcessor$private fun isIntReturningValProperty: Boolean</ID>
     <ID>ReturnCount:ProtocolMessageProcessor.kt:ProtocolMessageProcessor$private fun isListOfProtocolMessageDataClass: Boolean</ID>
+    <ID>ReturnCount:ProtocolMessageProcessor.kt:ProtocolMessageProcessor$private fun validateFramedBy</ID>
     <ID>ReturnCount:ProtocolMessageProcessor.kt:ProtocolMessageProcessor$private fun isNestedProtocolMessageType: Boolean</ID>
     <ID>ReturnCount:ProtocolMessageProcessor.kt:ProtocolMessageProcessor$private fun validateDispatchOnSealed</ID>
     <ID>ReturnCount:ProtocolMessageProcessor.kt:ProtocolMessageProcessor$private fun validateGenericPayloadVariantShape: Boolean</ID>

--- a/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/ProtocolMessageProcessor.kt
+++ b/buffer-codec-processor/src/main/kotlin/com/ditchoom/buffer/codec/processor/ProtocolMessageProcessor.kt
@@ -1838,6 +1838,54 @@ class ProtocolMessageProcessor(
 
         val isSealedParent = Modifier.SEALED in owner.modifiers && owner.classKind == ClassKind.INTERFACE
 
+        // E5 — framing must be uniform across a dispatch family.
+        //
+        // A dispatcher emits calls into its variant codecs, and a framed codec has a different
+        // encode signature from an unframed one (`encode(value, context, factory): ReadBuffer`
+        // versus `Codec.encode(buffer, value, context)`). The analyzer derives dispatcher-level
+        // framing only for `@DispatchOn` parents carrying `@FramedBy`, so the two ways to get a
+        // framed variant under an unframed dispatcher both emit a generated file that does not
+        // compile, with no diagnostic:
+        //
+        //   1. `@FramedBy` on a sealed parent dispatched by plain `@PacketType` — the variants
+        //      inherit framing, the dispatcher does not.
+        //   2. `@FramedBy` on an individual dispatch variant — that one variant is framed while
+        //      its dispatcher is not.
+        //
+        // Both are rejected here. See #359 for the alternative (deriving dispatcher framing for
+        // `@PacketType` too, which is a wire-layout decision rather than a cleanup).
+        if (isSealedParent && !owner.hasAnnotation(DISPATCH_ON_SHORT, DISPATCH_ON_QNAME)) {
+            logger.error(
+                "@FramedBy on $ownerName is a sealed dispatch parent without @DispatchOn. The " +
+                    "framing prefix has to follow a discriminator the wire format declares, and " +
+                    "under plain @PacketType the discriminator is a byte the dispatcher " +
+                    "synthesizes rather than a field — so the framing cannot be positioned " +
+                    "relative to it, and the emitted dispatcher would not compile. Give the " +
+                    "parent a value-class discriminator and dispatch on it: " +
+                    "`@DispatchOn(MyHeader::class)` with `@FramedBy(..., after = \"header\")`.",
+                owner,
+            )
+            return
+        }
+        val framedDispatchParent =
+            owner.dispatchParentOrNull()?.takeIf { parent ->
+                !parent.hasAnnotation(FRAMED_BY_SHORT, FRAMED_BY_QNAME)
+            }
+        if (framedDispatchParent != null) {
+            val parentName =
+                framedDispatchParent.qualifiedName?.asString() ?: framedDispatchParent.simpleName.asString()
+            logger.error(
+                "@FramedBy on $ownerName frames a single variant of the unframed dispatcher " +
+                    "$parentName. A dispatcher calls every variant codec through one encode " +
+                    "signature, and framing changes that signature, so the emitted $parentName " +
+                    "codec would not compile. Move @FramedBy onto $parentName (which requires " +
+                    "@DispatchOn there, so the framing prefix can follow the discriminator " +
+                    "field) — every variant then inherits it.",
+                owner,
+            )
+            return
+        }
+
         if (afterName.isEmpty()) {
             // E4 — @FramedBy with no `after` is incompatible with @PacketType dispatch.
             val variantsWithPacketType =
@@ -1934,6 +1982,21 @@ class ProtocolMessageProcessor(
                 )
             }
         }
+    }
+
+    /**
+     * The sealed `@ProtocolMessage` parent this class dispatches under, or null when it is not a
+     * dispatch variant. Only `@PacketType`-carrying subclasses participate in dispatch, so a
+     * sealed subclass without one (a plain nested type) is not a variant.
+     */
+    private fun KSClassDeclaration.dispatchParentOrNull(): KSClassDeclaration? {
+        if (!hasAnnotation(PACKET_TYPE_SHORT, PACKET_TYPE_QNAME)) return null
+        return superTypes
+            .mapNotNull { it.resolve().declaration as? KSClassDeclaration }
+            .firstOrNull { parent ->
+                Modifier.SEALED in parent.modifiers &&
+                    parent.hasAnnotation("ProtocolMessage", PROTOCOL_MESSAGE_QNAME)
+            }
     }
 
     private fun KSClassDeclaration.hasAnnotation(

--- a/buffer-codec-processor/src/test/kotlin/com/ditchoom/buffer/codec/processor/FramedByValidatorTest.kt
+++ b/buffer-codec-processor/src/test/kotlin/com/ditchoom/buffer/codec/processor/FramedByValidatorTest.kt
@@ -185,49 +185,242 @@ class FramedByValidatorTest {
     }
 
     @Test
-    fun rejectsAfterEmptyOnSealedParentWithPacketTypeVariants() {
-        // E4 — sealed parent with @PacketType variants requires after = "<headerField>" so the
-        // discriminator precedes the framing prefix on the wire.
+    fun rejectsAfterEmptyOnDispatchOnSealedParent() {
+        // E4 — a dispatching sealed parent requires after = "<headerField>" so the discriminator
+        // precedes the framing prefix on the wire. Stated on a @DispatchOn parent: without one,
+        // E5 rejects first and this would silently be testing that instead.
         val result =
             compile(
                 """
                 package test
 
-                import com.ditchoom.buffer.ReadBuffer
-                import com.ditchoom.buffer.WriteBuffer
-                import com.ditchoom.buffer.codec.BoundingLengthCodec
-                import com.ditchoom.buffer.codec.DecodeContext
-                import com.ditchoom.buffer.codec.EncodeContext
-                import com.ditchoom.buffer.codec.WireSize
-                import com.ditchoom.buffer.codec.annotations.FramedBy
-                import com.ditchoom.buffer.codec.annotations.PacketType
-                import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+                $VALIDATOR_IMPORTS
+                import com.ditchoom.buffer.codec.annotations.DispatchOn
+                import com.ditchoom.buffer.codec.annotations.DispatchValue
 
-                object MyCodec : BoundingLengthCodec<UInt> {
-                    override val maxWireSize: Int = 4
-                    override fun decode(buffer: ReadBuffer, context: DecodeContext): UInt = buffer.readInt().toUInt()
-                    override fun encode(buffer: WriteBuffer, value: UInt, context: EncodeContext) {
-                        buffer.writeInt(value.toInt())
-                    }
-                    override fun wireSize(value: UInt, context: EncodeContext): WireSize = WireSize.Exact(4)
-                    override fun applyBound(buffer: ReadBuffer, decodedValue: UInt) {
-                        buffer.setLimit(buffer.position() + decodedValue.toInt())
-                    }
+                $BOUNDING_CODEC
+
+                @JvmInline
+                @ProtocolMessage
+                value class Header(val raw: UByte) {
+                    @DispatchValue
+                    val kind: Int get() = raw.toUInt().shr(4).toInt()
                 }
 
+                @DispatchOn(Header::class)
                 @ProtocolMessage
                 @FramedBy(MyCodec::class)
                 sealed interface Bad {
-                    @ProtocolMessage @PacketType(1)
-                    data class Ping(val timestamp: Long) : Bad
+                    @ProtocolMessage @PacketType(value = 1, wire = 0x10)
+                    data class Ping(val header: Header, val timestamp: Long) : Bad
                 }
                 """.trimIndent(),
             )
         assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode, result.messages)
         assertTrue(
-            result.messages.contains("after = \"\"") || result.messages.contains("discriminator"),
-            "expected E4 (after-empty-with-PacketType) diagnostic, got:\n${result.messages}",
+            result.messages.contains("after = \"\""),
+            "expected E4 (after-empty) diagnostic, got:\n${result.messages}",
         )
+    }
+
+    /**
+     * **E5** — the shape from #359. Every `@FramedBy` check passed on this declaration and the
+     * emitted dispatcher then failed to compile, because the analyzer derives framing for the
+     * dispatcher only under `@DispatchOn`: the variants inherited framing while the dispatcher
+     * did not, so the unframed emit called framed variant codecs with the `Codec` signature.
+     *
+     * `after = "kind"` here is what E4's own message tells you to write, and `kind` is present
+     * with `Exact` wire width on every variant — so E1–E4 all pass. Without E5 the only signal
+     * is an argument-type mismatch inside generated source.
+     */
+    @Test
+    fun rejectsFramedByOnSealedParentWithoutDispatchOn() {
+        val result =
+            compile(
+                """
+                package test
+
+                $VALIDATOR_IMPORTS
+
+                $BOUNDING_CODEC
+
+                @ProtocolMessage
+                @FramedBy(MyCodec::class, after = "kind")
+                sealed interface Bad {
+                    @ProtocolMessage @PacketType(0x01)
+                    data class Ping(val kind: UByte, val timestamp: Long) : Bad
+
+                    @ProtocolMessage @PacketType(0x02)
+                    data class Pong(val kind: UByte) : Bad
+                }
+                """.trimIndent(),
+            )
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode, result.messages)
+        assertTrue(
+            result.messages.contains("@DispatchOn"),
+            "expected E5 (framed sealed parent needs @DispatchOn), got:\n${result.messages}",
+        )
+    }
+
+    /**
+     * The positive control for E5: the shipped shape must keep compiling. Without this, E5 could
+     * over-reject every framed dispatcher and the negative above would still pass.
+     */
+    @Test
+    fun acceptsFramedByOnDispatchOnSealedParent() {
+        val result =
+            compile(
+                """
+                package test
+
+                $VALIDATOR_IMPORTS
+                import com.ditchoom.buffer.codec.annotations.DispatchOn
+                import com.ditchoom.buffer.codec.annotations.DispatchValue
+
+                $BOUNDING_CODEC
+
+                @JvmInline
+                @ProtocolMessage
+                value class Header(val raw: UByte) {
+                    @DispatchValue
+                    val kind: Int get() = raw.toUInt().shr(4).toInt()
+                }
+
+                @DispatchOn(Header::class)
+                @ProtocolMessage
+                @FramedBy(MyCodec::class, after = "header")
+                sealed interface Good {
+                    @ProtocolMessage @PacketType(value = 1, wire = 0x10)
+                    data class Ping(val header: Header, val timestamp: Long) : Good
+
+                    @ProtocolMessage @PacketType(value = 2, wire = 0x20)
+                    data class Pong(val header: Header) : Good
+                }
+                """.trimIndent(),
+            )
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+    }
+
+    /**
+     * The second way into #359, found while writing this file as an *accept* case: framing one
+     * variant of an unframed dispatcher breaks the same way. The dispatcher calls every variant
+     * codec through one encode signature, and framing changes that signature, so `OuterCodec`
+     * failed to compile with the identical argument-shift mismatch.
+     */
+    @Test
+    fun rejectsFramedByOnASingleVariantOfAnUnframedDispatcher() {
+        val result =
+            compile(
+                """
+                package test
+
+                $VALIDATOR_IMPORTS
+
+                $BOUNDING_CODEC
+
+                @ProtocolMessage
+                sealed interface Outer {
+                    @ProtocolMessage
+                    @PacketType(0x01)
+                    @FramedBy(MyCodec::class, after = "kind")
+                    data class Ping(val kind: UByte, val timestamp: Long) : Outer
+
+                    @ProtocolMessage @PacketType(0x02)
+                    data class Pong(val kind: UByte) : Outer
+                }
+                """.trimIndent(),
+            )
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode, result.messages)
+        assertTrue(
+            result.messages.contains("single variant"),
+            "expected E5 (uniform framing across a dispatch family), got:\n${result.messages}",
+        )
+    }
+
+    /** A framed variant under a framed @DispatchOn parent is the shipped shape and must compile. */
+    @Test
+    fun acceptsAFramedVariantUnderAFramedDispatchOnParent() {
+        val result =
+            compile(
+                """
+                package test
+
+                $VALIDATOR_IMPORTS
+                import com.ditchoom.buffer.codec.annotations.DispatchOn
+                import com.ditchoom.buffer.codec.annotations.DispatchValue
+
+                $BOUNDING_CODEC
+
+                @JvmInline
+                @ProtocolMessage
+                value class Header(val raw: UByte) {
+                    @DispatchValue
+                    val kind: Int get() = raw.toUInt().shr(4).toInt()
+                }
+
+                @DispatchOn(Header::class)
+                @ProtocolMessage
+                @FramedBy(MyCodec::class, after = "header")
+                sealed interface Good {
+                    @ProtocolMessage
+                    @PacketType(value = 1, wire = 0x10)
+                    @FramedBy(MyCodec::class, after = "header")
+                    data class Ping(val header: Header, val timestamp: Long) : Good
+                }
+                """.trimIndent(),
+            )
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+    }
+
+    /** A standalone @FramedBy message that is not in any dispatch family is untouched by E5. */
+    @Test
+    fun acceptsFramedByOnANonDispatchNestedMessage() {
+        val result =
+            compile(
+                """
+                package test
+
+                $VALIDATOR_IMPORTS
+
+                $BOUNDING_CODEC
+
+                @ProtocolMessage
+                @FramedBy(MyCodec::class, after = "kind")
+                data class Standalone(val kind: UByte, val timestamp: Long)
+                """.trimIndent(),
+            )
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+    }
+
+    private companion object {
+        val VALIDATOR_IMPORTS =
+            """
+            import com.ditchoom.buffer.ReadBuffer
+            import com.ditchoom.buffer.WriteBuffer
+            import com.ditchoom.buffer.codec.BoundingLengthCodec
+            import com.ditchoom.buffer.codec.DecodeContext
+            import com.ditchoom.buffer.codec.EncodeContext
+            import com.ditchoom.buffer.codec.WireSize
+            import com.ditchoom.buffer.codec.annotations.FramedBy
+            import com.ditchoom.buffer.codec.annotations.PacketType
+            import com.ditchoom.buffer.codec.annotations.ProtocolMessage
+            """.trimIndent()
+
+        val BOUNDING_CODEC =
+            """
+            object MyCodec : BoundingLengthCodec<UInt> {
+                override val maxWireSize: Int = 4
+                override fun decode(buffer: ReadBuffer, context: DecodeContext): UInt =
+                    buffer.readInt().toUInt()
+                override fun encode(buffer: WriteBuffer, value: UInt, context: EncodeContext) {
+                    buffer.writeInt(value.toInt())
+                }
+                override fun wireSize(value: UInt, context: EncodeContext): WireSize = WireSize.Exact(4)
+                override fun applyBound(buffer: ReadBuffer, decodedValue: UInt) {
+                    buffer.setLimit(buffer.position() + decodedValue.toInt())
+                }
+            }
+            """.trimIndent()
     }
 
     private fun compile(


### PR DESCRIPTION
Closes #359.

## The problem

A dispatcher calls every variant codec through one encode signature, and framing changes that signature — `encode(value, context, factory): ReadBuffer` rather than `Codec.encode(buffer, value, context)`. Dispatcher-level framing is derived only for a `@DispatchOn` parent carrying `@FramedBy`, so both ways of ending up with a framed variant under an unframed dispatcher emitted a generated file that does not compile, with no diagnostic at the declaration:

1. `@FramedBy` on a sealed parent dispatched by plain `@PacketType` — the variants inherit framing, the dispatcher does not.
2. `@FramedBy` on a single variant of an unframed dispatcher.

The consumer's only signal was an argument-shift mismatch inside generated source:

```
e: FramedCodec.kt:41:33 Argument type mismatch: actual type is 'WriteBuffer', but 'Framed.Empty' was expected.
e: FramedCodec.kt:41:41 Argument type mismatch: actual type is 'Framed.Empty', but 'EncodeContext' was expected.
e: FramedCodec.kt:41:48 Argument type mismatch: actual type is 'EncodeContext', but 'BufferFactory' was expected.
```

Case 1 is worse than an unsupported combination — **validator E4 instructs you to write it.** Its message says to set `after = "<headerField>"`; doing so passes E1–E4 and then fails in generated code.

Case 2 turned up while writing this PR's tests. It was drafted as an *accept* case, on the assumption that variant-level framing stayed available, and failed identically.

## The change

One rule, E5: framing must be uniform across a dispatch family. A framed sealed parent must carry `@DispatchOn` (the only shape where the discriminator is a declared field the prefix can follow), and a dispatch variant may not declare `@FramedBy` unless its parent does.

Nothing is lost by rejecting — neither shape can compile today, so no working code depends on either. If the wire layout is wanted later, #359 records the alternative: derive dispatcher framing for `@PacketType` too, which needs a call on whether the discriminator byte sits inside or outside the framed region. E5 comes back out at that point.

E4's message is unchanged and still correct for the one case that reaches it (a `@DispatchOn` parent with `after = ""`).

## Note on an existing test

`rejectsAfterEmptyOnSealedParentWithPacketTypeVariants` was written on a shape E5 now rejects first, and its assertion (`"after = \"\"" || "discriminator"`) would have kept passing against E5's message while no longer testing E4 at all. Retargeted to a `@DispatchOn` parent so it exercises E4 for real.

## Verification

- `:buffer-codec-processor:test` (10 in `FramedByValidatorTest`), `:buffer-codec-test:jvmTest`, `ktlintCheck`, `detekt` — green.
- The codec-test run is the evidence E5 does not over-reject: every shipped protocol (MQTT v3/v5, HTTP/3 flow control, WebSocket, slice14b/14c) compiles unchanged.
- Positive controls alongside each negative: a framed `@DispatchOn` parent, the same with redundant framing on a variant, and a standalone framed message outside any dispatch family.