### PR TITLE
fix(buffer-flow): a partial write silently truncated the message

### DIFF
--- a/buffer-flow/api/android/buffer-flow.api
+++ b/buffer-flow/api/android/buffer-flow.api
@@ -27,6 +27,12 @@ public final class com/ditchoom/buffer/flow/ByteSink$DefaultImpls {
 	public static fun writeGathered-egxuoLU (Lcom/ditchoom/buffer/flow/ByteSink;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class com/ditchoom/buffer/flow/ByteSinkStalledException : java/lang/IllegalStateException {
+	public fun <init> (II)V
+	public final fun getAccepted ()I
+	public final fun getPending ()I
+}
+
 public abstract interface class com/ditchoom/buffer/flow/ByteSource {
 	public abstract fun getReadPolicy ()Lcom/ditchoom/buffer/flow/ReadPolicy;
 	public abstract fun isOpen ()Z
@@ -196,6 +202,11 @@ public final class com/ditchoom/buffer/flow/TypedKt {
 	public static synthetic fun typed$default (Lcom/ditchoom/buffer/flow/ByteSink;Lcom/ditchoom/buffer/codec/Codec;Lcom/ditchoom/buffer/BufferFactory;Lcom/ditchoom/buffer/codec/EncodeContext;ILjava/lang/Object;)Lcom/ditchoom/buffer/flow/Sender;
 	public static synthetic fun typed$default (Lcom/ditchoom/buffer/flow/ByteSource;Lcom/ditchoom/buffer/codec/Codec;Lcom/ditchoom/buffer/codec/DecodeContext;Lcom/ditchoom/buffer/ByteOrder;ILjava/lang/Object;)Lcom/ditchoom/buffer/flow/Receiver;
 	public static synthetic fun typed$default (Lcom/ditchoom/buffer/flow/ByteStream;Lcom/ditchoom/buffer/codec/Codec;Lcom/ditchoom/buffer/BufferFactory;Lcom/ditchoom/buffer/codec/DecodeContext;Lcom/ditchoom/buffer/codec/EncodeContext;Lcom/ditchoom/buffer/ByteOrder;ILjava/lang/Object;)Lcom/ditchoom/buffer/flow/Connection;
+}
+
+public final class com/ditchoom/buffer/flow/WriteFullyKt {
+	public static final fun writeFully (Lcom/ditchoom/buffer/flow/ByteSink;Lcom/ditchoom/buffer/ReadBuffer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun writeFully-exY8QGI (Lcom/ditchoom/buffer/flow/ByteSink;Lcom/ditchoom/buffer/ReadBuffer;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class com/ditchoom/buffer/flow/WritePolicy {

--- a/buffer-flow/api/jvm/buffer-flow.api
+++ b/buffer-flow/api/jvm/buffer-flow.api
@@ -27,6 +27,12 @@ public final class com/ditchoom/buffer/flow/ByteSink$DefaultImpls {
 	public static fun writeGathered-egxuoLU (Lcom/ditchoom/buffer/flow/ByteSink;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class com/ditchoom/buffer/flow/ByteSinkStalledException : java/lang/IllegalStateException {
+	public fun <init> (II)V
+	public final fun getAccepted ()I
+	public final fun getPending ()I
+}
+
 public abstract interface class com/ditchoom/buffer/flow/ByteSource {
 	public abstract fun getReadPolicy ()Lcom/ditchoom/buffer/flow/ReadPolicy;
 	public abstract fun isOpen ()Z
@@ -196,6 +202,11 @@ public final class com/ditchoom/buffer/flow/TypedKt {
 	public static synthetic fun typed$default (Lcom/ditchoom/buffer/flow/ByteSink;Lcom/ditchoom/buffer/codec/Codec;Lcom/ditchoom/buffer/BufferFactory;Lcom/ditchoom/buffer/codec/EncodeContext;ILjava/lang/Object;)Lcom/ditchoom/buffer/flow/Sender;
 	public static synthetic fun typed$default (Lcom/ditchoom/buffer/flow/ByteSource;Lcom/ditchoom/buffer/codec/Codec;Lcom/ditchoom/buffer/codec/DecodeContext;Lcom/ditchoom/buffer/ByteOrder;ILjava/lang/Object;)Lcom/ditchoom/buffer/flow/Receiver;
 	public static synthetic fun typed$default (Lcom/ditchoom/buffer/flow/ByteStream;Lcom/ditchoom/buffer/codec/Codec;Lcom/ditchoom/buffer/BufferFactory;Lcom/ditchoom/buffer/codec/DecodeContext;Lcom/ditchoom/buffer/codec/EncodeContext;Lcom/ditchoom/buffer/ByteOrder;ILjava/lang/Object;)Lcom/ditchoom/buffer/flow/Connection;
+}
+
+public final class com/ditchoom/buffer/flow/WriteFullyKt {
+	public static final fun writeFully (Lcom/ditchoom/buffer/flow/ByteSink;Lcom/ditchoom/buffer/ReadBuffer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun writeFully-exY8QGI (Lcom/ditchoom/buffer/flow/ByteSink;Lcom/ditchoom/buffer/ReadBuffer;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class com/ditchoom/buffer/flow/WritePolicy {

--- a/buffer-flow/build.gradle.kts
+++ b/buffer-flow/build.gradle.kts
@@ -356,3 +356,12 @@ dokka {
         reportUndocumented.set(false)
     }
 }
+
+// `check` mode: the return-value checker only inspects declarations explicitly marked
+// @MustUseReturnValues (here, ByteSink — see ByteStream.kt). It has to be non-disabled on the
+// DECLARING module for the marker to be emitted at all; consumers then opt in on their own side by
+// compiling with the same flag. Deliberately `check` rather than `full`, so this adds no diagnostics
+// beyond the one contract it is meant to protect: a discarded write count is a truncated message.
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask<*>>().configureEach {
+    compilerOptions.freeCompilerArgs.add("-Xreturn-value-checker=check")
+}

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/ByteStream.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/ByteStream.kt
@@ -37,6 +37,7 @@ interface ByteSource {
  * Mirrors [ByteSource]: the deadline policy is the [writePolicy] **val**, the explicit-deadline
  * overloads are abstract, and the no-arg overloads consult [writePolicy].
  */
+@MustUseReturnValues
 interface ByteSink {
     val isOpen: Boolean
 
@@ -68,14 +69,28 @@ interface ByteSink {
 
     /**
      * Writes multiple buffers in a single operation (gather write), waiting at most [deadline].
-     * Default implementation writes each buffer sequentially.
+     * Default implementation writes each buffer sequentially, **completing each one before moving to
+     * the next** ([writeFully]).
+     *
+     * That completion is the whole contract of a gather write, and the reason this default cannot
+     * simply sum [write] results: [write] may accept a buffer only in PART, so summing-and-advancing
+     * would emit the first buffer's prefix immediately followed by the SECOND buffer's bytes, dropping
+     * the remainder from the middle of the stream. Callers gather precisely because the pieces are
+     * adjacent — a header and its payload — so a hole at that seam splices payload bytes into the
+     * region the header just declared.
+     *
+     * @throws ByteSinkStalledException if the sink stops making progress with bytes still pending.
      */
     suspend fun writeGathered(
         buffers: List<ReadBuffer>,
         deadline: Duration,
     ): BytesWritten {
         var total = 0
-        for (buf in buffers) total += write(buf, deadline).count
+        for (buf in buffers) {
+            // Count before writing: writeFully drains the buffer, so remaining() is 0 afterwards.
+            total += buf.remaining()
+            writeFully(buf, deadline)
+        }
         return BytesWritten(total)
     }
 

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/Typed.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/Typed.kt
@@ -113,7 +113,10 @@ private class CodecSink<T>(
     override suspend fun send(message: T) {
         val buffer = codec.encodeToPlatformBuffer(message, factory, context)
         try {
-            sink.write(buffer)
+            // writeFully, never a bare write: a sink may accept only PART of the buffer, and for a
+            // self-framing codec the dropped tail is corruption rather than loss — the peer reads on
+            // to the length this message already declared and swallows whatever follows.
+            sink.writeFully(buffer)
         } finally {
             buffer.freeNativeMemory()
         }

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/WriteFully.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/WriteFully.kt
@@ -1,0 +1,78 @@
+package com.ditchoom.buffer.flow
+
+import com.ditchoom.buffer.ReadBuffer
+import kotlin.time.Duration
+
+/**
+ * Write **every** byte of [buffer] to this sink, resuming until it is drained.
+ *
+ * [ByteSink.write] returns [BytesWritten] because a write may be PARTIAL — the contract calls the
+ * post-write position "the resume point for a partial write's residue". A caller that issues one
+ * `write` and discards the count therefore has a latent truncation bug: it looks correct against every
+ * sink that happens to accept everything, and silently loses the tail against one that does not.
+ *
+ * Plenty of sinks never expose it — one that copies into memory, or that loops internally until the
+ * buffer is gone, always reports the whole thing. A QUIC stream does expose it: it can buffer only as
+ * many bytes as its flow-control credit currently allows and reports that count (a fully blocked
+ * stream blocks; a PARTIALLY open one returns early by design, which is the normal state at a window
+ * boundary).
+ *
+ * **For a length-prefixed protocol a short write is corruption, not loss.** The length header the peer
+ * has already read still declares the full size, so the peer keeps reading and consumes whatever
+ * FOLLOWS as this message's tail: the truncated message arrives at exactly the right length with a
+ * neighbour's bytes inside it, the swallowed messages never arrive, and the stream never re-aligns.
+ * Any framed writer over a byte stream wants this, which is why it lives here beside [ByteSink] rather
+ * than being re-implemented per protocol.
+ *
+ * Resumption is driven by the reported COUNT rather than by the cursor, so both sink shapes work: the
+ * position is re-derived after every call, which neither double-advances a contract-compliant sink nor
+ * strands one that leaves the cursor alone.
+ *
+ * Returns [Unit] deliberately — there is no residue left to reason about and no count to accidentally
+ * ignore. Call [ByteSink.write] directly only when implementing a sink that must report a partial
+ * count faithfully to ITS caller.
+ *
+ * @throws ByteSinkStalledException if the sink reports no progress while bytes are still pending.
+ */
+public suspend fun ByteSink.writeFully(
+    buffer: ReadBuffer,
+    deadline: Duration,
+) {
+    while (buffer.remaining() > 0) {
+        val before = buffer.position()
+        val written = write(buffer, deadline).count
+        if (written <= 0) {
+            throw ByteSinkStalledException(accepted = written, pending = buffer.remaining())
+        }
+        val resumeAt = before + written
+        if (buffer.position() != resumeAt) buffer.position(resumeAt)
+    }
+}
+
+/**
+ * [writeFully] using the sink's injected [ByteSink.writePolicy] — the adapter rule ("propagate, don't
+ * clobber"): the leaf owns the deadline policy for its direction. The policy bounds each underlying
+ * call, as it always has, not the loop as a whole.
+ */
+public suspend fun ByteSink.writeFully(buffer: ReadBuffer): Unit = writeFully(buffer, writePolicy.toDeadline())
+
+/**
+ * A [ByteSink] reported **no progress** while bytes were still pending, so a write that must complete
+ * in full cannot make headway.
+ *
+ * This is a sink CONTRACT violation, not back-pressure: back-pressure is expected to block inside
+ * `write` and then report at least one byte. A sink that instead returns zero forever leaves a caller
+ * looping with nothing to do — and returning early instead would silently truncate the message, which
+ * for a framed protocol is corruption rather than loss.
+ *
+ * Carries the counts as typed fields so a caller can discriminate and report without parsing text.
+ */
+public class ByteSinkStalledException(
+    /** Bytes the sink accepted on the call that made no progress (zero, or a defensive negative). */
+    public val accepted: Int,
+    /** Bytes still waiting to be written when the sink stalled. */
+    public val pending: Int,
+) : IllegalStateException(
+        "byte sink accepted $accepted bytes with $pending still pending; cannot complete the write " +
+            "without truncating the message",
+    )

--- a/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/WriteFullyTests.kt
+++ b/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/WriteFullyTests.kt
@@ -1,0 +1,146 @@
+package com.ditchoom.buffer.flow
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.ReadBuffer
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * [ByteSink.write] may accept a buffer only in PART — its contract calls the post-write position "the
+ * resume point for a partial write's residue". A caller that issues one `write` and discards the count
+ * silently drops the tail, and for a length-prefixed protocol that is corruption rather than loss: the
+ * peer reads on to the already-declared length and swallows whatever follows.
+ *
+ * [writeFully] is the resumption primitive; these tests pin it, and pin the two defaults that were
+ * getting it wrong ([ByteSink.writeGathered] and the typed [CodecSink]).
+ */
+class WriteFullyTests {
+    /**
+     * Accepts at most [acceptPerWrite] bytes per call and reports the count. [advanceCursor] selects
+     * which real sink shape to imitate: contract-compliant (cursor consumed by what was taken) or the
+     * zero-copy kind that hands a native address to the platform and leaves the cursor alone.
+     */
+    private class PartialAcceptSink(
+        private val acceptPerWrite: Int,
+        private val advanceCursor: Boolean = true,
+    ) : ByteSink {
+        val wire = ArrayList<Byte>()
+        var writeCalls = 0
+            private set
+
+        override val isOpen: Boolean get() = true
+        override val writePolicy: WritePolicy = WritePolicy.Bounded(1.seconds)
+
+        override suspend fun write(
+            buffer: ReadBuffer,
+            deadline: Duration,
+        ): BytesWritten {
+            writeCalls++
+            val start = buffer.position()
+            val take = minOf(acceptPerWrite, buffer.remaining())
+            for (i in 0 until take) wire += buffer.readByte()
+            if (!advanceCursor) buffer.position(start)
+            return BytesWritten(take)
+        }
+
+        override suspend fun close() = Unit
+    }
+
+    /** Reports zero progress forever — a broken sink, not back-pressure. */
+    private class StalledSink : ByteSink {
+        override val isOpen: Boolean get() = true
+        override val writePolicy: WritePolicy = WritePolicy.Bounded(1.seconds)
+
+        override suspend fun write(
+            buffer: ReadBuffer,
+            deadline: Duration,
+        ): BytesWritten = BytesWritten(0)
+
+        override suspend fun close() = Unit
+    }
+
+    private fun bufferOf(bytes: ByteArray) =
+        BufferFactory.Default.allocate(bytes.size).apply {
+            writeBytes(bytes)
+            resetForRead()
+        }
+
+    private fun pattern(n: Int) = ByteArray(n) { ((it * 31 + it / 251) % 256).toByte() }
+
+    @Test
+    fun writeFullyResumesUntilTheBufferIsDrained() =
+        runTest {
+            val payload = pattern(10_000)
+            val sink = PartialAcceptSink(acceptPerWrite = 1_400)
+
+            sink.writeFully(bufferOf(payload), 1.seconds)
+
+            assertEquals(payload.toList(), sink.wire.toList())
+            assertTrue(sink.writeCalls > 1, "the sink was never asked to resume — the test proves nothing")
+        }
+
+    /** A zero-copy sink that never moves the cursor must still be resumed byte-exactly. */
+    @Test
+    fun writeFullyResumesASinkThatLeavesTheCursorAlone() =
+        runTest {
+            val payload = pattern(8_000)
+            val sink = PartialAcceptSink(acceptPerWrite = 900, advanceCursor = false)
+
+            sink.writeFully(bufferOf(payload), 1.seconds)
+
+            assertEquals(payload.toList(), sink.wire.toList())
+        }
+
+    @Test
+    fun writeFullyFailsLoudlyWhenTheSinkNeverMakesProgress() =
+        runTest {
+            val failure =
+                assertFailsWith<ByteSinkStalledException> {
+                    StalledSink().writeFully(bufferOf(pattern(64)), 1.seconds)
+                }
+            assertEquals(0, failure.accepted)
+            assertEquals(64, failure.pending)
+        }
+
+    /**
+     * The gather-write defect: summing partial counts and advancing to the next buffer emits the first
+     * buffer's prefix immediately followed by the SECOND buffer's bytes, dropping the remainder from
+     * the middle of the stream. Callers gather because the pieces are adjacent (a header and its
+     * payload), so that hole splices payload bytes into the header's declared region.
+     */
+    @Test
+    fun writeGatheredCompletesEachBufferBeforeStartingTheNext() =
+        runTest {
+            val header = pattern(300)
+            val payload = pattern(9_000)
+            val sink = PartialAcceptSink(acceptPerWrite = 128)
+
+            val written = sink.writeGathered(listOf(bufferOf(header), bufferOf(payload)), 1.seconds)
+
+            assertEquals(header.size + payload.size, written.count, "the reported total must cover every byte")
+            assertEquals(
+                (header + payload).toList(),
+                sink.wire.toList(),
+                "gathered buffers must arrive contiguously — a partial write must be resumed, not skipped",
+            )
+        }
+
+    @Test
+    fun writeGatheredReportsEveryByteEvenWhenAcceptedOneAtATime() =
+        runTest {
+            val a = pattern(50)
+            val b = pattern(70)
+            val sink = PartialAcceptSink(acceptPerWrite = 1)
+
+            val written = sink.writeGathered(listOf(bufferOf(a), bufferOf(b)), 1.seconds)
+
+            assertEquals(a.size + b.size, written.count)
+            assertEquals((a + b).toList(), sink.wire.toList())
+        }
+}


### PR DESCRIPTION
## The bug

`ByteSink.write` returns `BytesWritten` because a write may be **partial** — this module's own contract calls the post-write position *"the resume point for a partial write's residue"*. Two defaults here issued a single `write` and discarded the count, so whatever the sink did not accept was dropped while the caller returned as though the whole message had gone out.

## Why it stayed hidden

Plenty of sinks never expose a partial write: one that copies into memory, or that loops internally until the buffer is gone, always reports the whole thing. A QUIC stream does — it buffers only as many bytes as its flow-control credit allows at that instant and reports that count. A *fully* blocked stream blocks; a **partially open** one returns early by design, which is the normal state at a window boundary and most reliable on a fresh stream before the peer has extended credit.

## Why it is corruption, not loss

For a length-prefixed protocol a short write desynchronizes the stream permanently. The header the peer already read still declares the full size, so the peer keeps reading and consumes whatever **follows** as this message's tail:

- the truncated message arrives at exactly the right length, with a neighbour's bytes inside it;
- the swallowed messages never arrive;
- every subsequent boundary is wrong.

## The fix

**`ByteSink.writeFully(buffer)`** resumes until the buffer is drained, off the reported **count** rather than off the cursor — correct both for a contract-compliant sink and for a zero-copy one that hands a native address to the platform and never moves the cursor. It returns `Unit` deliberately: no residue to reason about, and no count left to accidentally ignore.

Two callers fixed:

- **`ByteSink.writeGathered`'s default** summed partial counts and advanced to the next buffer — worse than truncation. It emits the first buffer's prefix immediately followed by the *second* buffer's bytes, dropping the remainder from the middle of the stream. Callers gather precisely because the pieces are adjacent (a header and its payload), so the hole splices payload bytes into the region the header just declared.
- **`CodecSink.send`** (the typed `ByteSink.typed(codec)` sender) encoded a message and wrote it once, discarding the count — the same defect one level up.

A stalled sink (no progress, bytes still pending) is a contract violation rather than back-pressure, which blocks *inside* `write`. It now raises the typed `ByteSinkStalledException` carrying `accepted`/`pending` as fields, instead of spinning forever — and instead of returning early, since returning early **is** the truncation.

## Making it enforceable

`ByteSink` is marked **`@MustUseReturnValues`**, so a consumer compiling with `-Xreturn-value-checker` gets a diagnostic for every discarded write count instead of relying on review to catch it.

The marker can only be emitted by a module that itself compiles with the checker, so `buffer-flow` enables `check` mode — deliberately `check` and not `full`, so this adds no diagnostics beyond the one contract it is meant to protect.

It earned its keep immediately: `CodecSink.send` above was found by the checker, not by reading.

## Tests

`WriteFullyTests` — resumption across many partial writes, byte-exactness over a sink that leaves the cursor alone, the stalled-sink failure (asserting `accepted`/`pending`), and both gather cases. The two gather tests fail against the old default.

`:buffer-flow:jvmTest`, repo-wide `jvmTest`, `apiCheck` and `ktlintCheck` are green. The API dump is **additive only**.