### PR TITLE
fix(buffer): the wasmJs pool was based in memory the Kotlin/Wasm runtime owns

### DIFF
--- a/buffer-compression/src/wasmJsMain/kotlin/com/ditchoom/buffer/compression/JsInteropActual.kt
+++ b/buffer-compression/src/wasmJsMain/kotlin/com/ditchoom/buffer/compression/JsInteropActual.kt
@@ -3,8 +3,10 @@
 package com.ditchoom.buffer.compression
 
 import com.ditchoom.buffer.BufferFactory
-import com.ditchoom.buffer.NativeMemoryAccess
+import com.ditchoom.buffer.Default
 import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.managedMemoryAccess
+import com.ditchoom.buffer.nativeMemoryAccess
 import kotlinx.coroutines.await
 import kotlin.js.ExperimentalWasmJsInterop
 import kotlin.js.Promise
@@ -61,14 +63,22 @@ internal actual fun ReadBuffer.toJsByteArray(): JsByteArray {
     if (remaining == 0) return emptyJsByteArray()
     // Single copy from WASM linear memory to a new JS Uint8Array.
     // Safe for async operations — the copy won't be invalidated by memory.grow().
-    val native = (this as? NativeMemoryAccess)
+    val native = nativeMemoryAccess
     if (native != null) {
         val offset = native.nativeAddress.toInt() + position()
         position(position() + remaining)
         return JsByteArray(jsCopyFromWasmMemory(offset, remaining))
     }
+    // Managed backing: copy straight out of the backing array, one copy rather than the two a
+    // readByteArray() round-trip costs. See [stageManaged] for why a copy is unavoidable at all.
+    val managed = managedMemoryAccess
+    if (managed != null) {
+        val start = managed.arrayOffset + position()
+        position(position() + remaining)
+        return stageManaged(managed.backingArray, start, remaining)
+    }
     val bytes = readByteArray(remaining)
-    return bytes.toJsByteArray()
+    return stageManaged(bytes, 0, bytes.size)
 }
 
 @JsFun(
@@ -89,29 +99,59 @@ internal actual fun ReadBuffer.toJsByteArrayView(): JsByteArray {
     // Zero-copy view on WASM linear memory. Only safe for synchronous consumption —
     // memory.grow() would invalidate this view. Sync zlib calls (gzipSync, etc.)
     // consume the input before returning, so no Kotlin allocation can intervene.
-    val native = (this as? NativeMemoryAccess)
+    val native = nativeMemoryAccess
     if (native != null) {
         val offset = native.nativeAddress.toInt() + position()
         position(position() + remaining)
         return JsByteArray(jsViewWasmMemory(offset, remaining))
     }
     // Non-native buffer: must copy (no linear memory to view)
+    val managed = managedMemoryAccess
+    if (managed != null) {
+        val start = managed.arrayOffset + position()
+        position(position() + remaining)
+        return stageManaged(managed.backingArray, start, remaining)
+    }
     val bytes = readByteArray(remaining)
-    return bytes.toJsByteArray()
+    return stageManaged(bytes, 0, bytes.size)
 }
 
-@OptIn(kotlin.wasm.unsafe.UnsafeWasmMemoryApi::class)
-private fun ByteArray.toJsByteArray(): JsByteArray {
-    if (isEmpty()) return emptyJsByteArray()
-    // ByteArray in Kotlin/WASM is stored in linear memory.
-    // Use withScopedMemoryAllocator to pin and copy.
-    val size = this.size
-    kotlin.wasm.unsafe.withScopedMemoryAllocator { allocator ->
-        val ptr = allocator.allocate(size)
-        for (i in 0 until size) {
-            (ptr + i).storeByte(this[i])
-        }
-        return JsByteArray(jsCopyFromWasmMemory(ptr.address.toInt(), size))
+/**
+ * Copy [length] bytes of a Kotlin-heap [bytes] array, from [offset], into a JS `Uint8Array`.
+ *
+ * The copy is not avoidable, and specifically **cannot be replaced by pinning**. Kotlin/Wasm is
+ * WasmGC: a `ByteArray` is a GC object living in the GC heap, which is a different address space
+ * from linear memory and is not reachable through `wasmExports.memory.buffer`. There is no
+ * `usePinned` equivalent to hand JS a stable address for it, the way Kotlin/Native can. So bytes
+ * that start on the Kotlin heap have to be written into linear memory before JS can see them, and
+ * the only question is how many times they get copied on the way. Going through
+ * [ManagedMemoryAccess][com.ditchoom.buffer.ManagedMemoryAccess] at the call sites makes it once.
+ *
+ * The staging block comes from buffer's own pool, deliberately NOT from
+ * `kotlin.wasm.unsafe.withScopedMemoryAllocator`. That allocator opens every top-level scope at
+ * address 0 and bump-allocates upward, and cannot be told the pool exists — so staging a payload
+ * through it writes across whatever the pool has already handed out. The reserve under the pool does
+ * not rescue this path either: what gets staged here is caller data, so the scratch is as large as
+ * the payload and no fixed constant can be sized to clear it. `LinearMemoryAllocator` hands back
+ * memory the pool owns, which is the one region nothing else claims.
+ */
+private fun stageManaged(
+    bytes: ByteArray,
+    offset: Int,
+    length: Int,
+): JsByteArray {
+    if (length == 0) return emptyJsByteArray()
+    val staging = BufferFactory.Default.allocate(length)
+    try {
+        val address =
+            checkNotNull(staging.nativeMemoryAccess) {
+                "BufferFactory.Default must yield native memory on wasmJs"
+            }.nativeAddress.toInt()
+        staging.writeBytes(bytes, offset, length)
+        return JsByteArray(jsCopyFromWasmMemory(address, length))
+    } finally {
+        // Linear memory is not garbage collected — the staging block has to go back explicitly.
+        staging.freeNativeMemory()
     }
 }
 
@@ -182,23 +222,29 @@ internal actual fun JsByteArray.toPlatformBuffer(bufferFactory: BufferFactory): 
     // If the buffer has native memory access (LinearBuffer), copy JS data directly
     // into its WASM linear memory region. Single copy, no ByteArray intermediate.
     val buf = bufferFactory.allocate(length)
-    val native = (buf as? NativeMemoryAccess)
+    val native = buf.nativeMemoryAccess
     if (native != null) {
         jsCopyToWasmMemory(ref, native.nativeAddress.toInt())
         buf.position(length)
         buf.resetForRead()
     } else {
-        // Fallback: should not happen on wasmJs, but be safe
-        val bytes = ByteArray(length)
-        @OptIn(kotlin.wasm.unsafe.UnsafeWasmMemoryApi::class)
-        kotlin.wasm.unsafe.withScopedMemoryAllocator { allocator ->
-            val ptr = allocator.allocate(length)
-            jsCopyToWasmMemory(ref, ptr.address.toInt())
-            for (i in 0 until length) {
-                bytes[i] = (ptr + i).loadByte()
-            }
+        // The caller's factory did not hand back native memory (BufferFactory.managed(), say), so
+        // the JS bytes have to land somewhere addressable first. Stage that through the pool for the
+        // same reason as ByteArray.toJsByteArray above — the runtime's scoped allocator must never
+        // carry a payload — then bulk-copy across instead of the byte-at-a-time loop this replaced.
+        val staging = BufferFactory.Default.allocate(length)
+        try {
+            val address =
+                checkNotNull(staging.nativeMemoryAccess) {
+                    "BufferFactory.Default must yield native memory on wasmJs"
+                }.nativeAddress.toInt()
+            jsCopyToWasmMemory(ref, address)
+            staging.position(length)
+            staging.resetForRead()
+            buf.write(staging)
+        } finally {
+            staging.freeNativeMemory()
         }
-        for (b in bytes) buf.writeByte(b)
         buf.resetForRead()
     }
     return buf

--- a/buffer-compression/src/wasmJsTest/kotlin/com/ditchoom/buffer/compression/LargePayloadPoolIntegrityTest.kt
+++ b/buffer-compression/src/wasmJsTest/kotlin/com/ditchoom/buffer/compression/LargePayloadPoolIntegrityTest.kt
@@ -1,0 +1,136 @@
+@file:Suppress("MagicNumber")
+
+package com.ditchoom.buffer.compression
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.LinearMemoryAllocator
+import com.ditchoom.buffer.managed
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Compression must not stage payloads through the Kotlin/Wasm runtime's scoped allocator.
+ *
+ * That allocator opens every top-level scope at address 0 and bump-allocates upward, so staging a
+ * payload through it walks across the buffer pool once the payload is larger than the gap the pool
+ * keeps below itself. The gap cannot be sized around this: what gets staged is caller data, so the
+ * scratch is as large as the payload and any fixed reserve is beaten by a large enough input.
+ *
+ * These tests pin the property rather than the mechanism — a live pool buffer's bytes must survive a
+ * compression round-trip whose payload is several times the reserve. Both directions are covered
+ * because the two conversions are separate code paths: `ByteArray -> JsByteArray` on the way in and
+ * `JsByteArray -> PlatformBuffer` on the way back.
+ */
+class LargePayloadPoolIntegrityTest {
+    /**
+     * A byte the pattern check can be unambiguous about. The runtime's scratch carries compressible
+     * caller data here, so a survivor check needs a value the payload never contains — see
+     * [payloadByte], which is taken mod 251 and so never reaches 0xA5.
+     */
+    private val sentinel: Byte = 0xA5.toByte()
+
+    private fun payloadByte(i: Int): Byte = (i % 251).toByte()
+
+    @Test
+    fun aPayloadSeveralTimesTheReserveLeavesLivePoolBuffersIntact() =
+        runTest {
+            val reserve = LinearMemoryAllocator.runtimeScratchReserveBytes
+            val liveSize = 8192
+
+            // Allocated from the pool *before* the round-trip, so it sits in the low pool offsets a
+            // scratch bump from address 0 would reach first.
+            val live = BufferFactory.Default.allocate(liveSize)
+            try {
+                repeat(liveSize) { live.writeByte(sentinel) }
+                live.resetForRead()
+
+                // Comfortably past the reserve, so the old staging path could not have stayed below
+                // the pool no matter how the reserve were tuned.
+                val payloadSize = reserve * 3
+                val payload = ByteArray(payloadSize) { payloadByte(it) }
+
+                val compressed = compressAsync(BufferFactory.Default.wrap(payload))
+                val decompressed = decompressAsync(compressed)
+                compressed.freeNativeMemory()
+
+                // The payload itself must survive, which is what makes this a round-trip and not
+                // just a memory assertion.
+                assertEquals(
+                    payloadSize,
+                    decompressed.remaining(),
+                    "the decompressed payload should be the same length as the input",
+                )
+                var mismatchAt = -1
+                for (i in 0 until payloadSize) {
+                    if (decompressed.readByte() != payloadByte(i)) {
+                        mismatchAt = i
+                        break
+                    }
+                }
+                assertEquals(-1, mismatchAt, "decompressed payload differs from the input")
+
+                // And the live buffer must be untouched. Under the old staging path the scratch bump
+                // crossed the reserve and wrote through exactly this region.
+                var clobberedAt = -1
+                for (i in 0 until liveSize) {
+                    if (live.readByte() != sentinel) {
+                        clobberedAt = i
+                        break
+                    }
+                }
+                assertEquals(
+                    -1,
+                    clobberedAt,
+                    "a live pool buffer was overwritten during a $payloadSize-byte round-trip, " +
+                        "reserve=$reserve — payloads are reaching the pool again",
+                )
+                decompressed.freeNativeMemory()
+            } finally {
+                live.freeNativeMemory()
+            }
+        }
+
+    /**
+     * Every staging block the conversion takes has to go back to the pool.
+     *
+     * This drives the two conversions directly rather than a full round-trip, because
+     * `compressAsync`/`decompressAsync` also allocate their own output from the factory and the
+     * pipeline's internal chunk lifetime would swamp the measurement. What is measured here is only
+     * the interop staging: linear memory is not garbage collected, so a `stageManaged` block that
+     * missed its `finally` would step live bytes on every call while the integrity test above kept
+     * passing.
+     */
+    @Test
+    fun theStagingBlocksTheConversionsTakeAreAllReleased() {
+        val reserve = LinearMemoryAllocator.runtimeScratchReserveBytes
+        val payload = ByteArray(reserve * 2) { payloadByte(it) }
+
+        // Warm the path once so one-time pool growth is not counted against the measured calls.
+        stageBothDirections(payload)
+
+        val before = LinearMemoryAllocator.getAllocationStats()
+        repeat(3) { stageBothDirections(payload) }
+        val after = LinearMemoryAllocator.getAllocationStats()
+
+        val liveBefore = before.totalAllocated - before.freeListBytes
+        val liveAfter = after.totalAllocated - after.freeListBytes
+        assertTrue(
+            liveAfter <= liveBefore,
+            "the interop staging leaked ${liveAfter - liveBefore} bytes of linear memory across " +
+                "3 conversions (live before=$liveBefore, after=$liveAfter)",
+        )
+    }
+
+    /**
+     * Both staging directions over a managed buffer: out through `ByteArray -> JsByteArray`, and
+     * back through `JsByteArray -> PlatformBuffer` with a factory that yields no native memory, so
+     * the copy-back fallback is the path taken. Neither end may retain a pool block.
+     */
+    private fun stageBothDirections(payload: ByteArray) {
+        val js = BufferFactory.Default.wrap(payload).toJsByteArray()
+        js.toPlatformBuffer(BufferFactory.managed())
+    }
+}

--- a/buffer/src/wasmJsMain/kotlin/com/ditchoom/buffer/LinearBuffer.kt
+++ b/buffer/src/wasmJsMain/kotlin/com/ditchoom/buffer/LinearBuffer.kt
@@ -147,7 +147,11 @@ class LinearBuffer(
      * The offset in WASM linear memory for zero-copy JS interop.
      * Use with `new DataView(wasmExports.memory.buffer, nativeAddress, nativeSize)`.
      */
-    override val nativeAddress: Long get() = baseOffset.toLong()
+    override val nativeAddress: Long get(): Long {
+        // Handing out the address of a released block is how stale views are born.
+        checkNotFreed()
+        return baseOffset.toLong()
+    }
 
     /**
      * The size of the native memory region in bytes.
@@ -158,7 +162,10 @@ class LinearBuffer(
      * Get the linear memory offset for the current position.
      * This can be passed to JavaScript for zero-copy access via DataView.
      */
-    val linearMemoryOffset: Int get() = baseOffset + positionValue
+    val linearMemoryOffset: Int get(): Int {
+        checkNotFreed()
+        return baseOffset + positionValue
+    }
 
     /**
      * Write from a JS Int8Array into this buffer.
@@ -173,6 +180,7 @@ class LinearBuffer(
         srcOffset: Int = 0,
         length: Int,
     ): LinearBuffer {
+        checkNotFreed()
         copyFromJsArray(jsArray, baseOffset + positionValue, srcOffset, length)
         positionValue += length
         return this
@@ -191,15 +199,42 @@ class LinearBuffer(
         dstOffset: Int = 0,
         length: Int,
     ) {
+        checkNotFreed()
         copyToJsArray(jsArray, baseOffset + positionValue, dstOffset, length)
         positionValue += length
     }
 
     /**
+     * Fails fast if this buffer's block has already gone back to [LinearMemoryAllocator].
+     *
+     * [CloseableBuffer.isFreed] documents that "once true, all read/write operations on this buffer
+     * will throw", and every other platform enforces exactly that — `NativeBuffer.checkOpen()` on
+     * Linux, an accessor that throws on the JVM's deterministic buffers, the JDK arena under
+     * `FfmBuffer`. wasmJs was the one that set the flag and never read it, so a read or write after
+     * release quietly touched whatever the allocator had since handed the block to. That is worse
+     * here than anywhere else: since the free list is intrusive, a stale write also rewrites a
+     * parked block's next-link, and the resulting `memory access out of bounds` surfaces at an
+     * unrelated allocation later.
+     *
+     * Non-owning views ([slice], [PlatformBuffer.wrapNativeAddress]) never set the flag, so this
+     * does not catch a slice outliving a released parent — that needs the parent's liveness, which
+     * is issue #362's territory, not this check's.
+     */
+    private fun checkNotFreed() {
+        if (freed) throw IllegalStateException("Buffer has been freed")
+    }
+
+    /**
      * Get a Pointer to the specified offset within this buffer.
      * Pointer is a value class - no allocation, compiles to raw address arithmetic.
+     *
+     * The single choke point for every scalar load and store, which is why the liveness check lives
+     * here rather than being repeated across the eight primitives [BaseWebBuffer] dispatches to.
      */
-    private fun ptr(offset: Int): Pointer = Pointer((baseOffset + offset).toUInt())
+    private fun ptr(offset: Int): Pointer {
+        checkNotFreed()
+        return Pointer((baseOffset + offset).toUInt())
+    }
 
     // Native memory access using Pointer operations
     override fun loadByte(index: Int): Byte = ptr(index).loadByte()
@@ -342,6 +377,7 @@ class LinearBuffer(
         mask: Int,
         maskOffset: Int,
     ) {
+        checkNotFreed()
         val size = source.remaining()
         if (size == 0) return
         if (mask == 0) {
@@ -407,6 +443,7 @@ class LinearBuffer(
      * once the parent is released its block can be reissued to an unrelated allocation.
      */
     override fun slice(byteOrder: ByteOrder): LinearBuffer {
+        checkNotFreed()
         // Create a new LinearBuffer view of the remaining portion
         // This is zero-copy - just creates a new view with different base offset
         return LinearBuffer(
@@ -510,6 +547,7 @@ class LinearBuffer(
     }
 
     override fun write(buffer: ReadBuffer) {
+        checkNotFreed()
         val size = buffer.remaining()
         checkWriteBounds(size)
         val actual = buffer.unwrapFully()
@@ -536,6 +574,7 @@ class LinearBuffer(
         length: Int,
         charset: Charset,
     ): String {
+        checkNotFreed()
         if (length == 0) return ""
         requireReadable(length)
         val encoding =

--- a/buffer/src/wasmJsMain/kotlin/com/ditchoom/buffer/LinearMemoryFault.kt
+++ b/buffer/src/wasmJsMain/kotlin/com/ditchoom/buffer/LinearMemoryFault.kt
@@ -1,0 +1,139 @@
+package com.ditchoom.buffer
+
+/**
+ * A structural fault in wasm linear memory that [LinearMemoryAllocator] detected and **contained**.
+ *
+ * Every subclass is raised at the moment of detection, with the allocator already returned to a
+ * usable state — so catching one and continuing is defined behaviour, not a gamble. That is the
+ * whole point of raising it rather than letting the condition run on: the alternative is a
+ * `RuntimeError: memory access out of bounds` from `Pointer.loadInt`, whose stack names the
+ * allocator and nothing about the write that caused it.
+ *
+ * ## What "contained" means, and what it does not
+ *
+ * Contained means *the allocator* is consistent: it will keep serving allocations, and it will
+ * detect a further breach. It does not mean your data is intact. Both faults are evidence that
+ * something wrote into memory the pool had handed out, so a buffer allocated before the fault may
+ * hold bytes somebody else put there. Recovery therefore means discarding state derived from
+ * buffers, not merely retrying the allocation.
+ *
+ * ## Branching
+ *
+ * Branch on the type and read the fields; do not parse [message]. The message is a short, derived
+ * summary for logs, and its wording is not API — the typed fields are.
+ *
+ * ```kotlin
+ * try {
+ *     process(BufferFactory.Default.allocate(size))
+ * } catch (fault: LinearMemoryFault.RuntimeScratchBreach) {
+ *     // The reserve was too small for this workload's interop scratch. Raising it needs a restart,
+ *     // since it is fixed at first allocation.
+ *     telemetry.report(fault.overwrittenWords, fault.reserveBytes)
+ *     dropCachedBuffers()
+ * } catch (fault: LinearMemoryFault.FreeListCorruption) {
+ *     // A stale write through a released view. The size class was dropped; allocation continues.
+ *     telemetry.report(fault.site, fault.offset, fault.sizeClassBytes)
+ *     dropCachedBuffers()
+ * }
+ * ```
+ *
+ * Extends [IllegalStateException] so callers written against the previous, untyped signal keep
+ * compiling and keep catching.
+ *
+ * @property heapBase base of the pool when the fault was detected
+ * @property nextOffset bump watermark when the fault was detected
+ * @property heapEnd end of the pool when the fault was detected
+ * @property poolBytes linear memory claimed from the engine when the fault was detected
+ */
+sealed class LinearMemoryFault(
+    val heapBase: Int,
+    val nextOffset: Int,
+    val heapEnd: Int,
+    val poolBytes: Int,
+    private val summary: String,
+) : IllegalStateException() {
+    override val message: String
+        get() = "$summary [heapBase=$heapBase nextOffset=$nextOffset heapEnd=$heapEnd poolBytes=$poolBytes]"
+
+    /**
+     * The Kotlin/Wasm runtime's interop scratch grew across the pool's base.
+     *
+     * Every top-level `withScopedMemoryAllocator` scope bump-allocates upward from address 0, so a
+     * scope whose total allocation exceeds
+     * [runtimeScratchReserveBytes][LinearMemoryAllocator.runtimeScratchReserveBytes] writes through
+     * memory the pool has handed out. The canary at the pool's base is what notices.
+     *
+     * **Remedy, in order of preference.** Stage large payloads through `BufferFactory` instead of
+     * the runtime's scoped allocator — the payload then lives in pool memory and the collision
+     * cannot arise. Failing that, raise the reserve with
+     * `PlatformBuffer.configureWasmMemory(runtimeScratchReserveMB = ...)`, which must happen before
+     * the first allocation and therefore needs a restart. A reserve is a floor, never a guarantee:
+     * scratch is as large as whatever is staged through it.
+     *
+     * The canary is re-stamped before this is thrown, so a later breach is detected too.
+     *
+     * @property overwrittenWords how many canary words were clobbered
+     * @property totalWords how many canary words there are
+     * @property reserveBytes the reserve that proved too small
+     */
+    class RuntimeScratchBreach internal constructor(
+        val overwrittenWords: Int,
+        val totalWords: Int,
+        val reserveBytes: Int,
+        heapBase: Int,
+        nextOffset: Int,
+        heapEnd: Int,
+        poolBytes: Int,
+    ) : LinearMemoryFault(
+            heapBase,
+            nextOffset,
+            heapEnd,
+            poolBytes,
+            "Kotlin/Wasm runtime scratch reached the buffer pool: " +
+                "$overwrittenWords/$totalWords canary words overwritten, reserve=$reserveBytes",
+        )
+
+    /**
+     * A free-list entry pointed outside the pool.
+     *
+     * The free list is intrusive — a released block's next-link lives in its own first four bytes —
+     * so any stale write into a released block lands on a link. Usual causes: a `slice()` or
+     * `wrapNativeAddress()` view used after its owner was released, a retained `nativeAddress`, or
+     * runtime scratch reaching the pool (which [RuntimeScratchBreach] reports directly when it
+     * crosses the base).
+     *
+     * The affected size class's chain is dropped before this is thrown, so allocation continues.
+     * Those blocks are leaked for the life of the process: the links are precisely what is
+     * untrustworthy, so the chain cannot be walked to re-park them.
+     *
+     * @property site whether the bad offset came from the class's head slot or from a block's link
+     * @property offset the offset that does not point into the pool
+     * @property sizeClassBytes the size class whose chain this was
+     * @property inBlock the block the link was read out of, or -1 when [site] is [Site.Head]
+     */
+    class FreeListCorruption internal constructor(
+        val site: Site,
+        val offset: Int,
+        val sizeClassBytes: Int,
+        val inBlock: Int,
+        heapBase: Int,
+        nextOffset: Int,
+        heapEnd: Int,
+        poolBytes: Int,
+    ) : LinearMemoryFault(
+            heapBase,
+            nextOffset,
+            heapEnd,
+            poolBytes,
+            "free list corrupt at $site: offset=$offset sizeClass=$sizeClassBytes inBlock=$inBlock",
+        ) {
+        /** Where the bad offset was read from. */
+        enum class Site {
+            /** The size class's head slot, which the allocator owns. */
+            Head,
+
+            /** The next-link inside a released block, which is linear memory anyone can write. */
+            Link,
+        }
+    }
+}

--- a/buffer/src/wasmJsMain/kotlin/com/ditchoom/buffer/MemoryManager.kt
+++ b/buffer/src/wasmJsMain/kotlin/com/ditchoom/buffer/MemoryManager.kt
@@ -287,13 +287,19 @@ object LinearMemoryAllocator {
             // `link` came out of the freed block's own first four bytes, which is *linear memory*
             // and therefore writable by anything holding a stale address. A wild value here traps
             // inside `Pointer.loadInt`, naming nothing; a throw names the offset and the state.
-            if (recycled < heapBase || recycled + aligned > nextOffset) {
-                failCorruptFreeList("head", recycled, aligned)
+            //
+            // The upper bound is `> nextOffset - aligned`, never `+ aligned > nextOffset`: the
+            // corrupt values this guard exists to catch are arbitrary, so the addition form wraps
+            // for anything near Int.MAX_VALUE and lets exactly those through to the trap. Both
+            // operands here are pool offsets bounded by the 256MB ceiling, so the subtraction
+            // cannot underflow into a false positive.
+            if (recycled < heapBase || recycled > nextOffset - aligned) {
+                failCorruptFreeList("head", recycled, aligned, NO_BLOCK)
             }
             // The block's first 4 bytes hold the next link; reading it releases the block entirely.
             val link = Pointer(recycled.toUInt()).loadInt()
-            if (link != NO_BLOCK && (link < heapBase || link + aligned > nextOffset)) {
-                failCorruptFreeList("link out of block $recycled", link, aligned)
+            if (link != NO_BLOCK && (link < heapBase || link > nextOffset - aligned)) {
+                failCorruptFreeList("link", link, aligned, recycled)
             }
             setHead(aligned, link)
             freeListBytes -= aligned
@@ -319,26 +325,45 @@ object LinearMemoryAllocator {
     }
 
     /**
-     * Report a free-list entry that does not point into the pool. Its own function so the message
-     * building stays off [allocateOffset]'s hot path — only the compares are inlined there.
+     * Drop the corrupt size class, then report it. Its own function so neither the message building
+     * nor the chain surgery lands in [allocateOffset]'s body — only the compares are inlined there,
+     * which is also why [what] and [inBlock] arrive as plain arguments rather than as an
+     * interpolated string built at the call site.
+     *
+     * The chain is dropped *before* throwing because the head slot is what the next allocation of
+     * this size class reads. Leaving a corrupt head installed turns one report into a permanent one:
+     * every subsequent allocation of that class re-reads the same bad offset and throws again, for
+     * the life of the process, which is a wedged allocator rather than a reported incident.
+     *
+     * Dropping it leaks the chain. The links are precisely what is untrustworthy here, so the chain
+     * cannot be walked to count or re-park its blocks; those bytes stay counted in [freeListBytes]
+     * and are never handed out again. That is the honest post-corruption state — the alternative is
+     * following the same links this function exists to reject — and it is bounded by the pool
+     * ceiling, unlike the wedge.
      */
     private fun failCorruptFreeList(
         what: String,
         offset: Int,
         aligned: Int,
-    ): Nothing =
+        inBlock: Int,
+    ): Nothing {
+        setHead(aligned, NO_BLOCK)
+        val where = if (inBlock == NO_BLOCK) what else "$what out of block $inBlock"
         throw IllegalStateException(
-            "LinearMemoryAllocator free list is corrupt: $what = $offset " +
+            "LinearMemoryAllocator free list is corrupt: $where = $offset " +
                 "(0x${offset.toUInt().toString(HEX_RADIX)}) is outside the $aligned-byte size " +
                 "class's pool [$heapBase, $nextOffset). Something wrote into a block after it was " +
                 "released — the free list's next-link lives in the first four bytes of a released " +
                 "block, so a stale write lands on it. Usual causes: a slice() or wrapNativeAddress() " +
                 "view used after its owner was released, a retained nativeAddress, or a scoped " +
                 "allocation from the Kotlin/Wasm runtime larger than the pool's base offset. " +
+                "The $aligned-byte free chain has been dropped so allocation can continue; its " +
+                "blocks are leaked for the life of the process. " +
                 "Pool: heapBase=$heapBase nextOffset=$nextOffset heapEnd=$heapEnd " +
                 "poolBytes=$poolBytes freeListBytes=$freeListBytes reusedBlocks=$reusedBlocks " +
                 "runtimeScratchReserveBytes=$RUNTIME_SCRATCH_RESERVE_BYTES",
         )
+    }
 
     /**
      * Grow the pool so it can satisfy an [aligned]-byte allocation, in [GROWTH_PAGES]-page steps.

--- a/buffer/src/wasmJsMain/kotlin/com/ditchoom/buffer/MemoryManager.kt
+++ b/buffer/src/wasmJsMain/kotlin/com/ditchoom/buffer/MemoryManager.kt
@@ -79,6 +79,19 @@ object LinearMemoryConfig {
      */
     var maxSizeMB: Int = 256
         internal set
+
+    /**
+     * Bytes kept below the pool for the Kotlin/Wasm runtime's own scratch, in megabytes.
+     *
+     * See [LinearMemoryAllocator.runtimeScratchReserveBytes] for why the bottom of linear memory is
+     * not the pool's to take. This is a floor, not a guarantee — a single top-level
+     * `withScopedMemoryAllocator` scope that allocates more than this in total still reaches the pool
+     * — so it is configurable for workloads that stage large payloads through the runtime's
+     * allocator. [LinearMemoryAllocator.checkRuntimeScratchCanary] is what tells you the default was
+     * not enough, rather than leaving it to be inferred from corrupted data.
+     */
+    var runtimeScratchReserveMB: Int = 1
+        internal set
 }
 
 /**
@@ -89,7 +102,7 @@ object LinearMemoryConfig {
  *
  * The allocation strategy:
  * 1. Call memory.grow() to add pages - returns previous size
- * 2. Base the pool above both that previous size and [RUNTIME_SCRATCH_RESERVE_BYTES]
+ * 2. Base the pool above both that previous size and [LinearMemoryAllocator.runtimeScratchReserveBytes]
  *    (see [runtimeScratchReserveBytes] for why the bottom of linear memory is not ours to take)
  * 3. Subsequent allocations reuse an exact-fit block from the free list, or bump from there
  * 4. [free] returns a block: rewinding the bump pointer if it is the top allocation, otherwise
@@ -107,6 +120,13 @@ object LinearMemoryConfig {
 object LinearMemoryAllocator {
     private var initialized = false
     private var heapBase: Int = 0
+
+    /**
+     * Lowest offset the pool will hand out: the canary occupies `[heapBase, poolFloor)`. Everything
+     * that rewinds or bounds the bump pointer measures from here, so no path can walk back over the
+     * canary and destroy the one thing that reports a breach.
+     */
+    private val poolFloor: Int get() = heapBase + CANARY_BYTES
     private var nextOffset: Int = 0
     private var heapEnd: Int = 0
 
@@ -139,7 +159,7 @@ object LinearMemoryAllocator {
      * scratch does, and [allocateOffset] now reports a breach as a diagnosable error instead of a
      * trap.
      */
-    val runtimeScratchReserveBytes: Int get() = RUNTIME_SCRATCH_RESERVE_BYTES
+    val runtimeScratchReserveBytes: Int get() = LinearMemoryConfig.runtimeScratchReserveMB * BYTES_PER_MB
 
     /**
      * Size-classed free list, exact fit: a freed 8 KiB block never satisfies a 4 KiB request. That
@@ -217,6 +237,7 @@ object LinearMemoryAllocator {
     fun configure(
         initialSizeMB: Int = 16,
         maxSizeMB: Int = 256,
+        runtimeScratchReserveMB: Int = 1,
     ) {
         if (initialized) {
             throw IllegalStateException(
@@ -228,8 +249,10 @@ object LinearMemoryAllocator {
         require(maxSizeMB >= initialSizeMB) {
             "maxSizeMB ($maxSizeMB) must be at least initialSizeMB ($initialSizeMB)"
         }
+        require(runtimeScratchReserveMB > 0) { "runtimeScratchReserveMB must be positive" }
         LinearMemoryConfig.initialSizeMB = initialSizeMB
         LinearMemoryConfig.maxSizeMB = maxSizeMB
+        LinearMemoryConfig.runtimeScratchReserveMB = runtimeScratchReserveMB
     }
 
     /**
@@ -272,6 +295,13 @@ object LinearMemoryAllocator {
             initializeMemory()
         }
 
+        // One i32 load and one compare: has the runtime's scratch grown across the pool base since
+        // the last allocation? Cheaper than the four free-list compares below, and unlike them it
+        // catches a write that landed on live buffer bytes rather than on a parked block's link.
+        if (Pointer(heapBase.toUInt()).loadInt() != CANARY_VALUE) {
+            failRuntimeScratchBreach()
+        }
+
         // 8-byte alignment for optimal memory access
         val aligned = (size + ALIGN_8_MASK) and ALIGN_8_MASK.inv()
         lastAlignedSize = aligned
@@ -293,13 +323,13 @@ object LinearMemoryAllocator {
             // for anything near Int.MAX_VALUE and lets exactly those through to the trap. Both
             // operands here are pool offsets bounded by the 256MB ceiling, so the subtraction
             // cannot underflow into a false positive.
-            if (recycled < heapBase || recycled > nextOffset - aligned) {
-                failCorruptFreeList("head", recycled, aligned, NO_BLOCK)
+            if (recycled < poolFloor || recycled > nextOffset - aligned) {
+                failCorruptFreeList(LinearMemoryFault.FreeListCorruption.Site.Head, recycled, aligned, NO_BLOCK)
             }
             // The block's first 4 bytes hold the next link; reading it releases the block entirely.
             val link = Pointer(recycled.toUInt()).loadInt()
-            if (link != NO_BLOCK && (link < heapBase || link > nextOffset - aligned)) {
-                failCorruptFreeList("link", link, aligned, recycled)
+            if (link != NO_BLOCK && (link < poolFloor || link > nextOffset - aligned)) {
+                failCorruptFreeList(LinearMemoryFault.FreeListCorruption.Site.Link, link, aligned, recycled)
             }
             setHead(aligned, link)
             freeListBytes -= aligned
@@ -342,26 +372,21 @@ object LinearMemoryAllocator {
      * ceiling, unlike the wedge.
      */
     private fun failCorruptFreeList(
-        what: String,
+        site: LinearMemoryFault.FreeListCorruption.Site,
         offset: Int,
         aligned: Int,
         inBlock: Int,
     ): Nothing {
         setHead(aligned, NO_BLOCK)
-        val where = if (inBlock == NO_BLOCK) what else "$what out of block $inBlock"
-        throw IllegalStateException(
-            "LinearMemoryAllocator free list is corrupt: $where = $offset " +
-                "(0x${offset.toUInt().toString(HEX_RADIX)}) is outside the $aligned-byte size " +
-                "class's pool [$heapBase, $nextOffset). Something wrote into a block after it was " +
-                "released — the free list's next-link lives in the first four bytes of a released " +
-                "block, so a stale write lands on it. Usual causes: a slice() or wrapNativeAddress() " +
-                "view used after its owner was released, a retained nativeAddress, or a scoped " +
-                "allocation from the Kotlin/Wasm runtime larger than the pool's base offset. " +
-                "The $aligned-byte free chain has been dropped so allocation can continue; its " +
-                "blocks are leaked for the life of the process. " +
-                "Pool: heapBase=$heapBase nextOffset=$nextOffset heapEnd=$heapEnd " +
-                "poolBytes=$poolBytes freeListBytes=$freeListBytes reusedBlocks=$reusedBlocks " +
-                "runtimeScratchReserveBytes=$RUNTIME_SCRATCH_RESERVE_BYTES",
+        throw LinearMemoryFault.FreeListCorruption(
+            site = site,
+            offset = offset,
+            sizeClassBytes = aligned,
+            inBlock = inBlock,
+            heapBase = heapBase,
+            nextOffset = nextOffset,
+            heapEnd = heapEnd,
+            poolBytes = poolBytes,
         )
     }
 
@@ -413,7 +438,11 @@ object LinearMemoryAllocator {
             // read and write; releasing one now fails the bounds check and leaks it, which is the
             // safe direction. This branch is defensive — nothing else grows linear memory today.
             heapBase = grantedStart
-            nextOffset = grantedStart
+            // The new base needs its own canary before anything is handed out above it, or the
+            // check in allocateOffset reads whatever the engine left there and reports a phantom
+            // breach on the next allocation.
+            writeCanary()
+            nextOffset = poolFloor
             heapEnd = grantedStart + pages * PAGE_SIZE
             // Every parked block lies in the region we just left, and the invariant the rest of this
             // object relies on is that a free-list entry is always within [heapBase, nextOffset).
@@ -477,8 +506,9 @@ object LinearMemoryAllocator {
      */
     private fun initializeMemory() {
         val sizeBytes = jsMemorySize()
+        val reserve = runtimeScratchReserveBytes
         // Grow far enough that [base, base + initial) exists, where base clears the reserve.
-        val base = if (sizeBytes > RUNTIME_SCRATCH_RESERVE_BYTES) sizeBytes else RUNTIME_SCRATCH_RESERVE_BYTES
+        val base = if (sizeBytes > reserve) sizeBytes else reserve
         val pagesToGrow = (base + initialPages * PAGE_SIZE - sizeBytes) / PAGE_SIZE
         val previousSizePages = jsMemoryGrow(pagesToGrow)
         if (previousSizePages < 0) {
@@ -486,11 +516,74 @@ object LinearMemoryAllocator {
         }
         // Re-derive from what the engine actually reported rather than from the pre-grow read.
         val grantedBase = previousSizePages * PAGE_SIZE
-        heapBase = if (grantedBase > RUNTIME_SCRATCH_RESERVE_BYTES) grantedBase else RUNTIME_SCRATCH_RESERVE_BYTES
-        nextOffset = heapBase
+        heapBase = if (grantedBase > reserve) grantedBase else reserve
+        // The canary occupies the very bottom of the pool, so allocations start above it.
+        writeCanary()
+        nextOffset = poolFloor
         heapEnd = grantedBase + pagesToGrow * PAGE_SIZE
-        poolBytes = if (heapEnd > heapBase) heapEnd - heapBase else 0
+        // Bytes this allocator took from the engine — NOT the usable span, which excludes the reserve
+        // and the canary. LinearMemoryConfig.maxSizeMB bounds what is claimed, so it has to be
+        // measured the same way or the ceiling silently admits the reserve on top of the limit.
+        poolBytes = pagesToGrow * PAGE_SIZE
         initialized = true
+    }
+
+    /**
+     * Stamp the canary words at the bottom of the pool.
+     *
+     * Deliberately inside the pool rather than just below [heapBase]: the bytes below the pool may
+     * still be live runtime scratch, and writing a canary into them would be the very corruption this
+     * is meant to detect. Sitting at the pool's own base costs [CANARY_BYTES] of pool space and is
+     * memory nothing else claims.
+     */
+    private fun writeCanary() {
+        var word = 0
+        while (word < CANARY_WORDS) {
+            Pointer((heapBase + word * Int.SIZE_BYTES).toUInt()).storeInt(CANARY_VALUE)
+            word++
+        }
+    }
+
+    /**
+     * Whether the runtime's scratch has grown into the pool.
+     *
+     * The Kotlin/Wasm runtime bump-allocates its interop scratch upward from address 0 on every
+     * top-level `withScopedMemoryAllocator` scope, so a scope large enough to reach the pool writes
+     * across [heapBase] — and the canary sits exactly there. Returns false once that has happened.
+     *
+     * This detects a *contiguous* write that crosses the pool base, which is what copying a payload
+     * into scratch does. A scope that allocates past the pool but writes only sparsely, above the
+     * canary, is not caught — no cheap check can see that, and it is not what interop staging does.
+     *
+     * Costs one i32 load and one compare, which is why only the first word is consulted here; the
+     * full set is used to characterise the breach in [failRuntimeScratchBreach].
+     */
+    fun checkRuntimeScratchCanary(): Boolean = !initialized || Pointer(heapBase.toUInt()).loadInt() == CANARY_VALUE
+
+    /**
+     * Report scratch that reached the pool, then re-stamp the canary.
+     *
+     * Re-stamping matters: leaving it broken would make every later allocation throw, wedging the
+     * allocator over a condition that has already been reported once — the same failure mode
+     * [failCorruptFreeList] avoids by dropping its chain.
+     */
+    private fun failRuntimeScratchBreach(): Nothing {
+        var intact = 0
+        var word = 0
+        while (word < CANARY_WORDS) {
+            if (Pointer((heapBase + word * Int.SIZE_BYTES).toUInt()).loadInt() == CANARY_VALUE) intact++
+            word++
+        }
+        writeCanary()
+        throw LinearMemoryFault.RuntimeScratchBreach(
+            overwrittenWords = CANARY_WORDS - intact,
+            totalWords = CANARY_WORDS,
+            reserveBytes = runtimeScratchReserveBytes,
+            heapBase = heapBase,
+            nextOffset = nextOffset,
+            heapEnd = heapEnd,
+            poolBytes = poolBytes,
+        )
     }
 
     /**
@@ -567,7 +660,7 @@ object LinearMemoryAllocator {
         return AllocationStats(
             heapBase = heapBase,
             nextOffset = nextOffset,
-            totalAllocated = nextOffset - heapBase,
+            totalAllocated = nextOffset - poolFloor,
             freeListBytes = freeListBytes,
             reusedBlocks = reusedBlocks,
             poolBytes = poolBytes,
@@ -581,11 +674,13 @@ object LinearMemoryAllocator {
     fun reset() {
         if (initialized) {
             // Zero out previously used memory
-            val usedBytes = nextOffset - heapBase
+            val usedBytes = nextOffset - poolFloor
             if (usedBytes > 0) {
-                zeroMemory(heapBase, usedBytes)
+                zeroMemory(poolFloor, usedBytes)
             }
-            nextOffset = heapBase
+            nextOffset = poolFloor
+            // Zeroing stops at poolFloor, but re-stamp anyway so reset() is a full repair.
+            writeCanary()
         }
         smallHeads.fill(NO_BLOCK)
         largeHeads.clear()
@@ -595,11 +690,13 @@ object LinearMemoryAllocator {
 
     private const val NO_BLOCK = -1
 
-    /**
-     * 1 MiB floor under [heapBase] — the region the Kotlin/Wasm runtime bump-allocates its interop
-     * scratch from on every `withScopedMemoryAllocator` scope. See [runtimeScratchReserveBytes].
-     */
-    private const val RUNTIME_SCRATCH_RESERVE_BYTES = 1024 * 1024
+    /** Words of canary at the pool's base, and the value each holds. See [writeCanary]. */
+    private const val CANARY_WORDS = 8
+
+    private const val CANARY_BYTES = CANARY_WORDS * Int.SIZE_BYTES
+
+    /** Arbitrary but recognisable in a memory dump, and not a value the allocator ever stores. */
+    private const val CANARY_VALUE = 0x5EC0FFEE
 
     private const val HEX_RADIX = 16
 

--- a/buffer/src/wasmJsMain/kotlin/com/ditchoom/buffer/MemoryManager.kt
+++ b/buffer/src/wasmJsMain/kotlin/com/ditchoom/buffer/MemoryManager.kt
@@ -89,7 +89,8 @@ object LinearMemoryConfig {
  *
  * The allocation strategy:
  * 1. Call memory.grow() to add pages - returns previous size
- * 2. Use the offset (previousSize * 64KB) as our heap base
+ * 2. Base the pool above both that previous size and [RUNTIME_SCRATCH_RESERVE_BYTES]
+ *    (see [runtimeScratchReserveBytes] for why the bottom of linear memory is not ours to take)
  * 3. Subsequent allocations reuse an exact-fit block from the free list, or bump from there
  * 4. [free] returns a block: rewinding the bump pointer if it is the top allocation, otherwise
  *    parking it on the size-classed free list
@@ -99,7 +100,7 @@ object LinearMemoryConfig {
  * is explicitly released via `freeNativeMemory()` / `use { }`; dropping the reference leaks it.
  *
  * This is safe because:
- * - memory.grow() returns pages that weren't previously mapped
+ * - the pool sits above the region the Kotlin/Wasm runtime allocates its own scratch from
  * - Kotlin/WASM uses WasmGC for objects (separate from linear memory)
  * - Pointer operations compile to native i32.load/i32.store
  */
@@ -108,6 +109,37 @@ object LinearMemoryAllocator {
     private var heapBase: Int = 0
     private var nextOffset: Int = 0
     private var heapEnd: Int = 0
+
+    /**
+     * Bytes at the bottom of linear memory the pool must never claim, because the Kotlin/Wasm
+     * runtime allocates its own scratch there.
+     *
+     * `memory.grow()` returning the previous page count reads like a watermark above which the
+     * new address space is exclusively ours. It is not. The stdlib's own allocator — the one
+     * behind `kotlin.wasm.unsafe.withScopedMemoryAllocator`, which every piece of interop that
+     * exchanges bytes with the host goes through — opens each top-level scope as
+     * `ScopedMemoryAllocator(startAddress = 0)`. It bump-allocates upward **from address 0** every
+     * time, and grows memory only when its bump pointer would run past the current size. It never
+     * consults, and cannot be told about, memory somebody else grew.
+     *
+     * So the low end of linear memory is the runtime's, permanently and repeatedly. A pool based
+     * there is handed out on top of live interop scratch, in both directions: the runtime's writes
+     * corrupt buffer contents, and — since the free list's next-link lives in the first four bytes
+     * of a parked block — they corrupt the free list itself into wild offsets that trap the next
+     * allocation of that size class as `memory access out of bounds`.
+     *
+     * That is not a theoretical ordering hazard. A Kotlin/Wasm module can start with **zero** pages
+     * of linear memory (it is WasmGC; nothing but the unsafe API puts anything there), in which case
+     * `memory.grow` returns 0 on the first allocation and the pool is based at address 0 — colliding
+     * with *every* subsequent scoped allocation.
+     *
+     * The reserve is address space only: WASM commits pages on first touch, and these are pages the
+     * runtime touches anyway. It is not a hard guarantee — a single scoped allocation larger than
+     * the reserve would still reach the pool — but it puts the floor far above anything interop
+     * scratch does, and [allocateOffset] now reports a breach as a diagnosable error instead of a
+     * trap.
+     */
+    val runtimeScratchReserveBytes: Int get() = RUNTIME_SCRATCH_RESERVE_BYTES
 
     /**
      * Size-classed free list, exact fit: a freed 8 KiB block never satisfies a 4 KiB request. That
@@ -206,19 +238,7 @@ object LinearMemoryAllocator {
      */
     private fun ensureInitialized() {
         if (initialized) return
-
-        // Grow memory to get pages exclusively for our use
-        val previousSizePages = jsMemoryGrow(initialPages)
-        if (previousSizePages == -1) {
-            throw OutOfMemoryError("Failed to grow WASM memory for buffer allocation")
-        }
-
-        // Our heap starts at the old memory boundary
-        heapBase = previousSizePages * PAGE_SIZE
-        nextOffset = heapBase
-        heapEnd = heapBase + (initialPages * PAGE_SIZE)
-        poolBytes = initialPages * PAGE_SIZE
-        initialized = true
+        initializeMemory()
     }
 
     // Store the last aligned size for callers that need it
@@ -261,8 +281,21 @@ object LinearMemoryAllocator {
         // Use BufferFactory.secure() (or zeroInit) when the contents must start at zero.
         val recycled = headOf(aligned)
         if (recycled != NO_BLOCK) {
+            // Four integer compares standing between a corrupted free list and an unlabelled
+            // `memory access out of bounds` trap. Both reads below dereference an offset that only
+            // the allocator's own bookkeeping vouches for: `recycled` came from a head slot, and
+            // `link` came out of the freed block's own first four bytes, which is *linear memory*
+            // and therefore writable by anything holding a stale address. A wild value here traps
+            // inside `Pointer.loadInt`, naming nothing; a throw names the offset and the state.
+            if (recycled < heapBase || recycled + aligned > nextOffset) {
+                failCorruptFreeList("head", recycled, aligned)
+            }
             // The block's first 4 bytes hold the next link; reading it releases the block entirely.
-            setHead(aligned, Pointer(recycled.toUInt()).loadInt())
+            val link = Pointer(recycled.toUInt()).loadInt()
+            if (link != NO_BLOCK && (link < heapBase || link + aligned > nextOffset)) {
+                failCorruptFreeList("link out of block $recycled", link, aligned)
+            }
+            setHead(aligned, link)
             freeListBytes -= aligned
             reusedBlocks++
             return recycled
@@ -284,6 +317,28 @@ object LinearMemoryAllocator {
         nextOffset += aligned
         return offset
     }
+
+    /**
+     * Report a free-list entry that does not point into the pool. Its own function so the message
+     * building stays off [allocateOffset]'s hot path — only the compares are inlined there.
+     */
+    private fun failCorruptFreeList(
+        what: String,
+        offset: Int,
+        aligned: Int,
+    ): Nothing =
+        throw IllegalStateException(
+            "LinearMemoryAllocator free list is corrupt: $what = $offset " +
+                "(0x${offset.toUInt().toString(HEX_RADIX)}) is outside the $aligned-byte size " +
+                "class's pool [$heapBase, $nextOffset). Something wrote into a block after it was " +
+                "released — the free list's next-link lives in the first four bytes of a released " +
+                "block, so a stale write lands on it. Usual causes: a slice() or wrapNativeAddress() " +
+                "view used after its owner was released, a retained nativeAddress, or a scoped " +
+                "allocation from the Kotlin/Wasm runtime larger than the pool's base offset. " +
+                "Pool: heapBase=$heapBase nextOffset=$nextOffset heapEnd=$heapEnd " +
+                "poolBytes=$poolBytes freeListBytes=$freeListBytes reusedBlocks=$reusedBlocks " +
+                "runtimeScratchReserveBytes=$RUNTIME_SCRATCH_RESERVE_BYTES",
+        )
 
     /**
      * Grow the pool so it can satisfy an [aligned]-byte allocation, in [GROWTH_PAGES]-page steps.
@@ -388,16 +443,28 @@ object LinearMemoryAllocator {
         }
     }
 
-    // Helper for test functions that need initialization
+    /**
+     * Claim the initial pool, based above both the current top of linear memory and the runtime's
+     * scratch reserve — see [runtimeScratchReserveBytes] for why the second bound is not optional.
+     *
+     * Called from a cold branch of [allocateOffset] exactly once; the `@JsFun` calls are why it has
+     * to be its own function (see the note on [allocateOffset]).
+     */
     private fun initializeMemory() {
-        val previousSizePages = jsMemoryGrow(initialPages)
-        if (previousSizePages == -1) {
+        val sizeBytes = jsMemorySize()
+        // Grow far enough that [base, base + initial) exists, where base clears the reserve.
+        val base = if (sizeBytes > RUNTIME_SCRATCH_RESERVE_BYTES) sizeBytes else RUNTIME_SCRATCH_RESERVE_BYTES
+        val pagesToGrow = (base + initialPages * PAGE_SIZE - sizeBytes) / PAGE_SIZE
+        val previousSizePages = jsMemoryGrow(pagesToGrow)
+        if (previousSizePages < 0) {
             throw OutOfMemoryError("Failed to grow WASM memory for buffer allocation")
         }
-        heapBase = previousSizePages * PAGE_SIZE
+        // Re-derive from what the engine actually reported rather than from the pre-grow read.
+        val grantedBase = previousSizePages * PAGE_SIZE
+        heapBase = if (grantedBase > RUNTIME_SCRATCH_RESERVE_BYTES) grantedBase else RUNTIME_SCRATCH_RESERVE_BYTES
         nextOffset = heapBase
-        heapEnd = heapBase + (initialPages * PAGE_SIZE)
-        poolBytes = initialPages * PAGE_SIZE
+        heapEnd = grantedBase + pagesToGrow * PAGE_SIZE
+        poolBytes = if (heapEnd > heapBase) heapEnd - heapBase else 0
         initialized = true
     }
 
@@ -502,6 +569,14 @@ object LinearMemoryAllocator {
     }
 
     private const val NO_BLOCK = -1
+
+    /**
+     * 1 MiB floor under [heapBase] — the region the Kotlin/Wasm runtime bump-allocates its interop
+     * scratch from on every `withScopedMemoryAllocator` scope. See [runtimeScratchReserveBytes].
+     */
+    private const val RUNTIME_SCRATCH_RESERVE_BYTES = 1024 * 1024
+
+    private const val HEX_RADIX = 16
 
     /** `log2(8)` — turns an 8-byte-aligned size into its [smallHeads] index. */
     private const val ALIGN_8_SHIFT = 3

--- a/buffer/src/wasmJsMain/kotlin/com/ditchoom/buffer/MemoryManager.kt
+++ b/buffer/src/wasmJsMain/kotlin/com/ditchoom/buffer/MemoryManager.kt
@@ -154,10 +154,12 @@ object LinearMemoryAllocator {
      * with *every* subsequent scoped allocation.
      *
      * The reserve is address space only: WASM commits pages on first touch, and these are pages the
-     * runtime touches anyway. It is not a hard guarantee — a single scoped allocation larger than
-     * the reserve would still reach the pool — but it puts the floor far above anything interop
-     * scratch does, and [allocateOffset] now reports a breach as a diagnosable error instead of a
-     * trap.
+     * runtime touches anyway. It is a floor, not a guarantee, and what must fit under it is the
+     * **total** allocated within one top-level scope across any nested scopes — a scope
+     * bump-allocates cumulatively, so many small allocations breach it exactly as one large one
+     * does. No constant can bound a scope that stages a payload, which is why the fix for such a
+     * caller is to allocate from the pool instead (see `buffer-compression`'s wasmJs interop) rather
+     * than to widen this. [writeCanary] is what reports a breach that happens anyway.
      */
     val runtimeScratchReserveBytes: Int get() = LinearMemoryConfig.runtimeScratchReserveMB * BYTES_PER_MB
 
@@ -508,7 +510,7 @@ object LinearMemoryAllocator {
         val sizeBytes = jsMemorySize()
         val reserve = runtimeScratchReserveBytes
         // Grow far enough that [base, base + initial) exists, where base clears the reserve.
-        val base = if (sizeBytes > reserve) sizeBytes else reserve
+        val base = poolBaseFor(sizeBytes, reserve)
         val pagesToGrow = (base + initialPages * PAGE_SIZE - sizeBytes) / PAGE_SIZE
         val previousSizePages = jsMemoryGrow(pagesToGrow)
         if (previousSizePages < 0) {
@@ -516,7 +518,7 @@ object LinearMemoryAllocator {
         }
         // Re-derive from what the engine actually reported rather than from the pre-grow read.
         val grantedBase = previousSizePages * PAGE_SIZE
-        heapBase = if (grantedBase > reserve) grantedBase else reserve
+        heapBase = poolBaseFor(grantedBase, reserve)
         // The canary occupies the very bottom of the pool, so allocations start above it.
         writeCanary()
         nextOffset = poolFloor
@@ -527,6 +529,19 @@ object LinearMemoryAllocator {
         poolBytes = pagesToGrow * PAGE_SIZE
         initialized = true
     }
+
+    /**
+     * Where the pool starts, given the current top of linear memory and the reserve.
+     *
+     * Two branches, and only one of them runs in any given process: a module that has not touched
+     * linear memory reports a top of 0 and gets the reserve, while one whose interop ran first gets
+     * whatever already exists. The allocator initialises once per process, so neither branch can be
+     * covered by driving the singleton — hence the rule lives here, where both are reachable.
+     */
+    internal fun poolBaseFor(
+        topOfMemoryBytes: Int,
+        reserveBytes: Int,
+    ): Int = if (topOfMemoryBytes > reserveBytes) topOfMemoryBytes else reserveBytes
 
     /**
      * Stamp the canary words at the bottom of the pool.

--- a/buffer/src/wasmJsTest/kotlin/com/ditchoom/buffer/LinearBufferUseAfterFreeTest.kt
+++ b/buffer/src/wasmJsTest/kotlin/com/ditchoom/buffer/LinearBufferUseAfterFreeTest.kt
@@ -1,0 +1,116 @@
+@file:Suppress("MagicNumber")
+
+package com.ditchoom.buffer
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * A released [LinearBuffer] must refuse access, the way every other platform's does.
+ *
+ * [CloseableBuffer.isFreed] states that "once true, all read/write operations on this buffer will
+ * throw". Linux enforces it with `checkOpen()`, the JVM's deterministic buffers throw from their
+ * accessors, and `FfmBuffer` inherits it from the JDK arena — wasmJs set the flag and never read it,
+ * so a read after release returned whatever the allocator had since put in that block and a write
+ * corrupted it, silently, on the one platform where releasing is mandatory rather than optional.
+ *
+ * The failure is worse here than the silence suggests. The free list is intrusive, so a stale write
+ * into a released block also rewrites its next-link, and the resulting `memory access out of bounds`
+ * lands on an unrelated allocation an arbitrary time later.
+ */
+class LinearBufferUseAfterFreeTest {
+    private fun freedBuffer(size: Int = 64): PlatformBuffer {
+        val buffer = BufferFactory.Default.allocate(size)
+        buffer.writeInt(0x1234_5678)
+        buffer.resetForRead()
+        buffer.freeNativeMemory()
+        return buffer
+    }
+
+    @Test
+    fun readingAfterFreeThrows() {
+        val buffer = freedBuffer()
+        assertTrue(buffer.isFreedOrFail(), "the buffer should report itself freed")
+        assertFailsWith<IllegalStateException> { buffer.readInt() }
+        assertFailsWith<IllegalStateException> { buffer.readByte() }
+        assertFailsWith<IllegalStateException> { buffer[0] }
+    }
+
+    @Test
+    fun writingAfterFreeThrows() {
+        val buffer = freedBuffer()
+        assertFailsWith<IllegalStateException> { buffer.writeInt(1) }
+        assertFailsWith<IllegalStateException> { buffer.writeByte(1) }
+        assertFailsWith<IllegalStateException> { buffer[0] = 1.toByte() }
+    }
+
+    /**
+     * The address is how a stale view is built in the first place, so handing it out after release
+     * is the beginning of the bug rather than a harmless read of a number.
+     */
+    @Test
+    fun handingOutTheNativeAddressAfterFreeThrows() {
+        val buffer = freedBuffer()
+        val access =
+            checkNotNull(buffer.nativeMemoryAccess) {
+                "BufferFactory.Default must yield native memory on wasmJs"
+            }
+        assertFailsWith<IllegalStateException> { access.nativeAddress }
+    }
+
+    @Test
+    fun slicingAfterFreeThrows() {
+        val buffer = freedBuffer()
+        assertFailsWith<IllegalStateException> { buffer.slice() }
+    }
+
+    /**
+     * Release stays idempotent. It is called from `use { }` on every path, including ones that have
+     * already released explicitly, so making the second call throw would break ordinary code — this
+     * check is about *access* after release, not about counting releases. Detecting a genuine double
+     * free is issue #362's opt-in factory.
+     */
+    @Test
+    fun releasingTwiceIsStillANoOp() {
+        val buffer = BufferFactory.Default.allocate(64)
+        buffer.freeNativeMemory()
+        buffer.freeNativeMemory()
+        assertTrue(buffer.isFreedOrFail())
+    }
+
+    /**
+     * A live buffer is unaffected — the guard must not be a blanket refusal. Worth pinning because
+     * the check sits on `ptr()`, the choke point every scalar load and store goes through.
+     */
+    @Test
+    fun aLiveBufferIsUntouchedByTheGuard() {
+        val buffer = BufferFactory.Default.allocate(64)
+        try {
+            buffer.writeInt(0x0BAD_F00D)
+            buffer.resetForRead()
+            assertEquals(0x0BAD_F00D, buffer.readInt())
+            buffer.slice()
+        } finally {
+            buffer.freeNativeMemory()
+        }
+    }
+
+    /**
+     * A slice of a *released* parent is deliberately NOT covered. Non-owning views never set the
+     * flag, so catching this needs the parent's liveness rather than the view's — the propagation
+     * issue #362 proposes, and out of scope for a check that only fixes wasmJs's divergence from
+     * every other platform's contract. Pinned so the gap is a recorded decision rather than an
+     * assumption someone makes later.
+     */
+    @Test
+    fun aSliceOfAReleasedParentIsNotCaughtYet() {
+        val parent = BufferFactory.Default.allocate(64)
+        val slice = parent.slice()
+        parent.freeNativeMemory()
+        assertTrue(!slice.isFreedOrFail(), "a non-owning view does not carry its parent's flag")
+    }
+
+    private fun PlatformBuffer.isFreedOrFail(): Boolean = (this as CloseableBuffer).isFreed
+}

--- a/buffer/src/wasmJsTest/kotlin/com/ditchoom/buffer/LinearMemoryRuntimeScratchTest.kt
+++ b/buffer/src/wasmJsTest/kotlin/com/ditchoom/buffer/LinearMemoryRuntimeScratchTest.kt
@@ -112,26 +112,59 @@ class LinearMemoryRuntimeScratchTest {
      */
     @Test
     fun aCorruptedNextLinkIsReportedInsteadOfTrapping() {
-        val parked = BufferFactory.Default.allocate(1056)
-        val keepAbove = BufferFactory.Default.allocate(1056)
-        val parkedAddress = (parked as NativeMemoryAccess).nativeAddress.toInt()
+        assertCorruptLinkIsReportedAndRecovers(sizeBytes = 1056, corruptLink = Int.MIN_VALUE)
+    }
+
+    /**
+     * The same tripwire with a link near `Int.MAX_VALUE`, which is the value class the bound has to
+     * be written carefully to catch: `offset + aligned > nextOffset` overflows to a negative for
+     * anything up there and silently passes, so the guard would wave through exactly the wild
+     * offsets it exists to reject and the allocation would trap in `Pointer.loadInt` after all.
+     * Fails against the `+ aligned >` form, passes against `> nextOffset - aligned`.
+     */
+    @Test
+    fun aCorruptedNextLinkNearIntMaxIsReportedInsteadOfTrapping() {
+        assertCorruptLinkIsReportedAndRecovers(sizeBytes = 1064, corruptLink = Int.MAX_VALUE - 255)
+    }
+
+    /**
+     * Park a block of [sizeBytes], scribble [corruptLink] over its intrusive next-link exactly as a
+     * stale write through a released view would, and require the next allocation of that size class
+     * to report it rather than trap.
+     *
+     * Then require the class to still be usable. The allocator drops the corrupt chain before
+     * throwing precisely so one bad link is a single reported incident and not a permanent one — if
+     * the head were left installed, every later allocation of this class would re-read it and throw
+     * for the life of the process. That recovery is asserted here rather than papered over by
+     * repairing linear memory by hand, which would also have to guess the link it overwrote.
+     */
+    private fun assertCorruptLinkIsReportedAndRecovers(
+        sizeBytes: Int,
+        corruptLink: Int,
+    ) {
+        val parked = BufferFactory.Default.allocate(sizeBytes)
+        val keepAbove = BufferFactory.Default.allocate(sizeBytes)
+        val access =
+            checkNotNull(parked.nativeMemoryAccess) {
+                "BufferFactory.Default must yield native memory on wasmJs"
+            }
+        val parkedAddress = access.nativeAddress.toInt()
         parked.freeNativeMemory()
 
-        // Exactly what a stale write through a released view does to the intrusive link.
-        Pointer(parkedAddress.toUInt()).storeInt(Int.MIN_VALUE)
+        Pointer(parkedAddress.toUInt()).storeInt(corruptLink)
 
         val failure =
             assertFailsWith<IllegalStateException> {
-                BufferFactory.Default.allocate(1056)
+                BufferFactory.Default.allocate(sizeBytes)
             }
         assertTrue(
             failure.message!!.contains("free list is corrupt"),
             "expected a diagnosable message, got: ${failure.message}",
         )
 
-        // Put the chain back so the shared allocator is usable by the rest of the suite.
-        Pointer(parkedAddress.toUInt()).storeInt(-1)
-        BufferFactory.Default.allocate(1056).freeNativeMemory()
+        // The chain was dropped on the way out of the throw, so the class allocates again.
+        val recovered = BufferFactory.Default.allocate(sizeBytes)
+        recovered.freeNativeMemory()
         keepAbove.freeNativeMemory()
     }
 }

--- a/buffer/src/wasmJsTest/kotlin/com/ditchoom/buffer/LinearMemoryRuntimeScratchTest.kt
+++ b/buffer/src/wasmJsTest/kotlin/com/ditchoom/buffer/LinearMemoryRuntimeScratchTest.kt
@@ -106,6 +106,46 @@ class LinearMemoryRuntimeScratchTest {
     }
 
     /**
+     * The canary: scratch that crosses the pool's base is reported, and the allocator keeps working.
+     *
+     * This is the half the free-list guard cannot cover. That guard only fires when a stray write
+     * happens to land on a released block's first four bytes; a write that lands on *live* buffer
+     * bytes is invisible to it. The canary sits at the pool's base, and the runtime bump-allocates
+     * upward from address 0, so any contiguous scratch write that reaches the pool at all crosses it
+     * first — whatever it goes on to overwrite.
+     *
+     * Clobbering the canary by hand is exactly what a scope past the reserve does to it.
+     */
+    @Test
+    fun scratchCrossingThePoolBaseIsReportedAndTheAllocatorRecovers() {
+        BufferFactory.Default.allocate(1072).freeNativeMemory()
+        val heapBase = LinearMemoryAllocator.getAllocationStats().heapBase
+        Pointer(heapBase.toUInt()).storeInt(0x0BAD_BEEF)
+        assertTrue(
+            !LinearMemoryAllocator.checkRuntimeScratchCanary(),
+            "the canary should read as breached once its first word is overwritten",
+        )
+
+        val fault =
+            assertFailsWith<LinearMemoryFault.RuntimeScratchBreach> {
+                BufferFactory.Default.allocate(1072)
+            }
+        assertEquals(1, fault.overwrittenWords, "one word was clobbered, so one should be reported")
+        assertEquals(
+            LinearMemoryAllocator.runtimeScratchReserveBytes,
+            fault.reserveBytes,
+            "the fault should name the reserve that proved too small",
+        )
+
+        // Re-stamped on the way out: a breach is one reported incident, not a wedged allocator.
+        assertTrue(
+            LinearMemoryAllocator.checkRuntimeScratchCanary(),
+            "the canary should be re-stamped before the fault is thrown",
+        )
+        BufferFactory.Default.allocate(1072).freeNativeMemory()
+    }
+
+    /**
      * The tripwire, which is what makes a residual breach diagnosable: corrupt a parked block's
      * next-link by hand and require the next allocation of that class to report it, rather than trap
      * inside `Pointer.loadInt` with a stack that names nothing.
@@ -153,14 +193,16 @@ class LinearMemoryRuntimeScratchTest {
 
         Pointer(parkedAddress.toUInt()).storeInt(corruptLink)
 
-        val failure =
-            assertFailsWith<IllegalStateException> {
+        // Typed, and asserted on the fields rather than the message — the message is a log
+        // summary whose wording is not API.
+        val fault =
+            assertFailsWith<LinearMemoryFault.FreeListCorruption> {
                 BufferFactory.Default.allocate(sizeBytes)
             }
-        assertTrue(
-            failure.message!!.contains("free list is corrupt"),
-            "expected a diagnosable message, got: ${failure.message}",
-        )
+        assertEquals(LinearMemoryFault.FreeListCorruption.Site.Link, fault.site)
+        assertEquals(corruptLink, fault.offset, "the fault should name the offset it rejected")
+        assertEquals(sizeBytes, fault.sizeClassBytes)
+        assertEquals(parkedAddress, fault.inBlock, "the fault should name the block the link came from")
 
         // The chain was dropped on the way out of the throw, so the class allocates again.
         val recovered = BufferFactory.Default.allocate(sizeBytes)

--- a/buffer/src/wasmJsTest/kotlin/com/ditchoom/buffer/LinearMemoryRuntimeScratchTest.kt
+++ b/buffer/src/wasmJsTest/kotlin/com/ditchoom/buffer/LinearMemoryRuntimeScratchTest.kt
@@ -210,3 +210,35 @@ class LinearMemoryRuntimeScratchTest {
         keepAbove.freeNativeMemory()
     }
 }
+
+/**
+ * Both branches of the pool-base rule.
+ *
+ * [LinearMemoryAllocator] initialises exactly once per process, so whichever branch runs first is
+ * the only one a test driving the singleton can ever reach — which is how the "interop already grew
+ * memory" branch shipped unexercised. The rule is a pure function precisely so both are reachable.
+ */
+class PoolBaseRuleTest {
+    @Test
+    fun aModuleThatHasNotTouchedLinearMemoryStartsAtTheReserve() {
+        // memory.grow returns 0 pages for a WasmGC module that has needed no linear memory yet.
+        assertEquals(1024 * 1024, LinearMemoryAllocator.poolBaseFor(0, 1024 * 1024))
+    }
+
+    @Test
+    fun aModuleWhoseInteropRanFirstStartsAboveWhatExists() {
+        // The branch that reproduces the pre-fix placement, and so has to be deliberate.
+        assertEquals(4 * 1024 * 1024, LinearMemoryAllocator.poolBaseFor(4 * 1024 * 1024, 1024 * 1024))
+    }
+
+    @Test
+    fun theReserveWinsUpToItsOwnSize() {
+        assertEquals(1024 * 1024, LinearMemoryAllocator.poolBaseFor(1024 * 1024, 1024 * 1024))
+        assertEquals(1024 * 1024, LinearMemoryAllocator.poolBaseFor(1024 * 1024 - 1, 1024 * 1024))
+    }
+
+    @Test
+    fun aRaisedReserveMovesTheFloor() {
+        assertEquals(8 * 1024 * 1024, LinearMemoryAllocator.poolBaseFor(2 * 1024 * 1024, 8 * 1024 * 1024))
+    }
+}

--- a/buffer/src/wasmJsTest/kotlin/com/ditchoom/buffer/LinearMemoryRuntimeScratchTest.kt
+++ b/buffer/src/wasmJsTest/kotlin/com/ditchoom/buffer/LinearMemoryRuntimeScratchTest.kt
@@ -1,0 +1,137 @@
+// Sizes and offsets here are deliberately literal, matching LinearMemoryReclamationTest: each test
+// picks its own byte count so the exact-fit free list keeps them independent of execution order.
+@file:Suppress("MagicNumber")
+@file:OptIn(UnsafeWasmMemoryApi::class)
+
+package com.ditchoom.buffer
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlin.wasm.unsafe.Pointer
+import kotlin.wasm.unsafe.UnsafeWasmMemoryApi
+import kotlin.wasm.unsafe.withScopedMemoryAllocator
+
+/**
+ * The pool must not be based in the region the Kotlin/Wasm runtime allocates its own scratch from.
+ *
+ * `memory.grow()` returns the previous page count, which reads like a watermark above which the
+ * address space is exclusively the caller's. It is not one. The stdlib's own allocator — the one
+ * behind `kotlin.wasm.unsafe.withScopedMemoryAllocator`, which every byte-exchanging piece of interop
+ * goes through — opens each top-level scope as `ScopedMemoryAllocator(startAddress = 0)` and bumps
+ * upward from address 0 every time, growing memory only when its own bump pointer would run past the
+ * current size. It cannot be told that somebody else grew memory first.
+ *
+ * [theRuntimeAllocatesItsScratchFromAddressZero] pins that premise against the stdlib, so the rest of
+ * this class does not rest on an inferred claim. The other two are the consequences: the pool must
+ * start above the runtime's floor, and a scoped allocation inside that floor must leave live buffer
+ * bytes — and the free list's next-links, which live inside released blocks — untouched.
+ *
+ * Before the fix `heapBase` was whatever `memory.grow` happened to return, which is 0 pages for a
+ * WasmGC module that has not yet needed linear memory: the pool then sat directly on top of the
+ * runtime's scratch and every scoped allocation corrupted it.
+ */
+class LinearMemoryRuntimeScratchTest {
+    /**
+     * The premise, taken from the stdlib rather than assumed: every top-level scope starts at 0, and
+     * it stays 0 no matter how much memory the buffer pool has already grown.
+     */
+    @Test
+    fun theRuntimeAllocatesItsScratchFromAddressZero() {
+        BufferFactory.Default.allocate(1024).freeNativeMemory()
+        val first = withScopedMemoryAllocator { it.allocate(64).address.toInt() }
+        val second = withScopedMemoryAllocator { it.allocate(64).address.toInt() }
+        assertEquals(0, first, "the stdlib's top-level scope is documented to start at address 0")
+        assertEquals(0, second, "and it resets to 0 for every scope, so the region is reused forever")
+    }
+
+    @Test
+    fun theBufferPoolIsBasedAboveTheRuntimeScratchReserve() {
+        BufferFactory.Default.allocate(1032).freeNativeMemory()
+        val heapBase = LinearMemoryAllocator.getAllocationStats().heapBase
+        assertTrue(
+            heapBase >= LinearMemoryAllocator.runtimeScratchReserveBytes,
+            "the pool is based at $heapBase, inside the runtime's scratch region " +
+                "[0, ${LinearMemoryAllocator.runtimeScratchReserveBytes}) — every " +
+                "withScopedMemoryAllocator scope writes there",
+        )
+    }
+
+    /**
+     * The behavioural half. Scribble over the whole reserve through the runtime's own allocator —
+     * exactly what interop does, only bigger — and require that a live buffer and a released block's
+     * free-list link both survive it.
+     *
+     * The released block matters as much as the live one: the next-link lives in the freed block's
+     * first four bytes, so a stray write there is not noticed until the *next* allocation of that
+     * size class loads it and dereferences a wild offset.
+     */
+    @Test
+    fun aRuntimeScopedAllocationInsideTheReserveLeavesThePoolIntact() {
+        val live = BufferFactory.Default.allocate(1040)
+        repeat(260) { live.writeInt(0x5EED_1234) }
+
+        // Two same-class blocks: releasing the lower one parks it on the free list (the upper one is
+        // still live, so it is not a top-of-heap rewind) with its next-link written into its bytes.
+        val parked = BufferFactory.Default.allocate(1048)
+        val keepAbove = BufferFactory.Default.allocate(1048)
+        parked.freeNativeMemory()
+
+        withScopedMemoryAllocator { allocator ->
+            val reserve = LinearMemoryAllocator.runtimeScratchReserveBytes
+            val base = allocator.allocate(reserve).address.toInt()
+            var at = 0
+            while (at < reserve) {
+                Pointer((base + at).toUInt()).storeInt(0x5A5A_5A5A)
+                at += Int.SIZE_BYTES
+            }
+        }
+
+        live.resetForRead()
+        repeat(260) {
+            assertEquals(0x5EED_1234, live.readInt(), "runtime scratch overwrote live buffer bytes")
+        }
+
+        // Popping the parked block dereferences the link that lived in the scribbled region.
+        val reusedBefore = LinearMemoryAllocator.getAllocationStats().reusedBlocks
+        val reused = BufferFactory.Default.allocate(1048)
+        assertTrue(
+            LinearMemoryAllocator.getAllocationStats().reusedBlocks > reusedBefore,
+            "the parked block should have been reused, exercising its next-link",
+        )
+        reused.freeNativeMemory()
+        keepAbove.freeNativeMemory()
+        live.freeNativeMemory()
+    }
+
+    /**
+     * The tripwire, which is what makes a residual breach diagnosable: corrupt a parked block's
+     * next-link by hand and require the next allocation of that class to report it, rather than trap
+     * inside `Pointer.loadInt` with a stack that names nothing.
+     */
+    @Test
+    fun aCorruptedNextLinkIsReportedInsteadOfTrapping() {
+        val parked = BufferFactory.Default.allocate(1056)
+        val keepAbove = BufferFactory.Default.allocate(1056)
+        val parkedAddress = (parked as NativeMemoryAccess).nativeAddress.toInt()
+        parked.freeNativeMemory()
+
+        // Exactly what a stale write through a released view does to the intrusive link.
+        Pointer(parkedAddress.toUInt()).storeInt(Int.MIN_VALUE)
+
+        val failure =
+            assertFailsWith<IllegalStateException> {
+                BufferFactory.Default.allocate(1056)
+            }
+        assertTrue(
+            failure.message!!.contains("free list is corrupt"),
+            "expected a diagnosable message, got: ${failure.message}",
+        )
+
+        // Put the chain back so the shared allocator is usable by the rest of the suite.
+        Pointer(parkedAddress.toUInt()).storeInt(-1)
+        BufferFactory.Default.allocate(1056).freeNativeMemory()
+        keepAbove.freeNativeMemory()
+    }
+}

--- a/docs/docs/platforms/wasm.md
+++ b/docs/docs/platforms/wasm.md
@@ -72,7 +72,9 @@ physical pages on first touch, so a large *reservation* is not a large upfront f
 
 ### The bottom of linear memory belongs to the runtime
 
-The pool is based **1MB above address 0**, and never at whatever `memory.grow` returns on its own.
+The pool is based at **`max(current top of linear memory, 1MB)`** — never at whatever `memory.grow`
+returns on its own. In a module that has not touched linear memory yet, that is the 1MB reserve; if
+interop ran first and memory already extends past it, the pool starts above what exists.
 
 That return value — the page count before the grow — reads like a watermark above which the new
 address space is exclusively the caller's. It is not one. The stdlib's own allocator, the one behind
@@ -92,10 +94,46 @@ This is not an ordering hazard you can dodge by allocating late. A Kotlin/Wasm m
 `memory.grow` returns 0 on the first allocation and a naive pool is based at address 0 — colliding
 with every subsequent scoped allocation.
 
-The reserve costs address space only, on pages the runtime touches anyway. It is a floor rather than
-a guarantee: a single scoped allocation larger than 1MB would still reach the pool. Should that ever
-happen, the allocator bounds-checks each free-list entry before dereferencing it and raises an
-`IllegalStateException` naming the offset and the pool state, instead of trapping.
+The reserve costs address space only, on pages the runtime touches anyway.
+
+It is a floor, not a guarantee. What has to fit under it is the **total** allocated within one
+top-level `withScopedMemoryAllocator` scope, across any nested scopes — not the size of any single
+`allocate` call, since the scope bump-allocates cumulatively. So 512 allocations of 4KB breach a 1MB
+reserve just as surely as one 2MB allocation does.
+
+Two things catch a breach rather than leaving it to be inferred from corrupted data:
+
+- A **canary** at the pool's base. The runtime bumps upward from address 0, so any contiguous scratch
+  write that reaches the pool crosses it first, whatever it goes on to overwrite. It is checked on
+  each allocation — one load and one compare — and reported as
+  `LinearMemoryFault.RuntimeScratchBreach`. This is the only thing that catches scratch landing on
+  *live buffer bytes*; the free-list check below sees only writes that hit a released block.
+- A **bounds check** on every free-list entry before it is dereferenced, reported as
+  `LinearMemoryFault.FreeListCorruption`, instead of trapping in `Pointer.loadInt` with a stack that
+  names nothing.
+
+Both are `sealed class LinearMemoryFault` (which extends `IllegalStateException`), so branch on the
+type and read the fields rather than parsing the message:
+
+```kotlin
+try {
+    process(BufferFactory.Default.allocate(size))
+} catch (fault: LinearMemoryFault.RuntimeScratchBreach) {
+    telemetry.report(fault.overwrittenWords, fault.reserveBytes)
+    dropCachedBuffers()
+}
+```
+
+Both are contained before they are thrown — the corrupt free chain is dropped, the canary is
+re-stamped — so the allocator keeps working and keeps detecting. Containment covers the *allocator*,
+not your data: either fault means something wrote into memory the pool had handed out, so discard
+state derived from buffers rather than simply retrying.
+
+**Do not stage payloads through `withScopedMemoryAllocator`.** Scratch is as large as whatever you
+put through it, so a payload-sized staging buffer beats any reserve you pick. Allocate from a
+`BufferFactory` instead — that memory is the pool's, and the collision cannot arise. If you must,
+raise the floor with `configureWasmMemory(runtimeScratchReserveMB = ...)` before the first
+allocation.
 
 ### Releasing is required
 

--- a/docs/docs/platforms/wasm.md
+++ b/docs/docs/platforms/wasm.md
@@ -70,6 +70,33 @@ Growing is cheap in the other direction: `memory.grow` reserves address space an
 physical pages on first touch, so a large *reservation* is not a large upfront footprint. What
 `initialSizeMB` buys is avoiding the growth step itself, not memory you would otherwise pay for.
 
+### The bottom of linear memory belongs to the runtime
+
+The pool is based **1MB above address 0**, and never at whatever `memory.grow` returns on its own.
+
+That return value — the page count before the grow — reads like a watermark above which the new
+address space is exclusively the caller's. It is not one. The stdlib's own allocator, the one behind
+`kotlin.wasm.unsafe.withScopedMemoryAllocator` that every byte-exchanging piece of interop goes
+through, opens each top-level scope as `ScopedMemoryAllocator(startAddress = 0)`. It bump-allocates
+upward **from address 0** every time and grows memory only when its own pointer would run past the
+current size; it never consults, and cannot be told about, memory somebody else grew. So the low end
+of linear memory is the runtime's, repeatedly and forever.
+
+A pool based there is handed out on top of live interop scratch, and the corruption goes both ways:
+the runtime's writes trash buffer contents, and because the free list's next-link lives in the first
+four bytes of a released block, they turn the free list into wild offsets that trap the *next*
+allocation of that size class as `memory access out of bounds` — far from the write that caused it.
+
+This is not an ordering hazard you can dodge by allocating late. A Kotlin/Wasm module can start with
+**zero** pages of linear memory (it is WasmGC; nothing but the unsafe API puts anything there), so
+`memory.grow` returns 0 on the first allocation and a naive pool is based at address 0 — colliding
+with every subsequent scoped allocation.
+
+The reserve costs address space only, on pages the runtime touches anyway. It is a floor rather than
+a guarantee: a single scoped allocation larger than 1MB would still reach the pool. Should that ever
+happen, the allocator bounds-checks each free-list entry before dereferencing it and raises an
+`IllegalStateException` naming the offset and the pool state, instead of trapping.
+
 ### Releasing is required
 
 Linear memory is **not** garbage collected — it lives outside the Wasm-GC heap, and a `LinearBuffer`


### PR DESCRIPTION
## The bug

`LinearMemoryAllocator` based its pool at whatever `memory.grow` returned as the previous page count, on the reasoning recorded in its own KDoc:

> This is safe because:
> - memory.grow() returns pages that weren't previously mapped

That return value does read like a watermark above which the new address space is exclusively ours. It is not one. **The bottom of linear memory belongs to the Kotlin/Wasm runtime, repeatedly and forever**, and the pool was being handed out on top of it.

The stdlib's own allocator — the one behind `kotlin.wasm.unsafe.withScopedMemoryAllocator`, which every byte-exchanging piece of interop goes through — opens each top-level scope like this ([`libraries/stdlib/wasm/src/kotlin/wasm/unsafe/MemoryAllocation.kt`](https://github.com/JetBrains/kotlin/blob/master/libraries/stdlib/wasm/src/kotlin/wasm/unsafe/MemoryAllocation.kt)):

```kotlin
val allocator = currentAllocator?.createChild() ?: ScopedMemoryAllocator(0, parent = null)
```

It bump-allocates upward **from address 0** every time, and grows memory only when its own pointer would run past the current size. It never consults, and cannot be told about, memory somebody else grew.

This is worse than an ordering hazard you could dodge by allocating late. **A Kotlin/Wasm module can start with zero pages of linear memory** — it is WasmGC, and nothing but the unsafe API puts anything there — so `memory.grow` returns `0` on the first allocation and the pool is based at address `0` exactly. That is the state a browser app reaches when its first buffer allocation happens before any interop has needed scratch. Every subsequent scoped allocation then writes straight through live buffer bytes.

## Why it surfaces as a crash, not as bad data

The corruption goes both ways, and the second direction is the one that kills the process.

Since #349 the free list is **intrusive**: a released block's next-link lives in its own first four bytes. A runtime scratch write into a parked block rewrites that link. Nothing faults at that moment. The *next* allocation of that size class loads the clobbered link and dereferences it, and the module dies in `Pointer.loadInt` with

```
RuntimeError: memory access out of bounds
    at com.ditchoom.buffer.LinearMemoryAllocator.allocateOffset
    at com.ditchoom.buffer.LinearMemoryAllocator.allocate
    at com.ditchoom.buffer.allocateOwnedLinearBuffer
```

— a stack that names only the allocator and the innocent call site that happened to allocate next, arbitrarily far from the write that caused it.

Before #349 the allocator never reused a block, so the same overlap silently corrupted payload bytes instead and nothing ever traced back to it. **#349 did not introduce the overlap; it made it lethal, and legible.**

Captured allocator state from a real failure, with temporary instrumentation that validated the entry before dereferencing it:

```
CORRUPT FREE-LIST LINK in block offset=0: read link=256 (0x100) expected=-1
INIT(growReturn=0 sizeBefore=0 sizeAfter=16777216 probeBefore=[pages=0 growType=function isMemory=true])
heapBase=0 nextOffset=2128 heapEnd=16777216 poolBytes=16777216 freeListBytes=2128 reusedBlocks=0
chain=[0{link=256 expected=-1} -> 256 -> -1930762400<-OUT_OF_POOL [hops=2]]
trail=[bump@0/8 bump@8/16 bump@24/16 bump@40/16 bump@56/2072 bump@2128/2072
       push@56/2072 push@0/8 push@8/16 push@24/16 push@40/16 rewind@2128/2072]
```

`pages=0` before the grow, `heapBase=0` after it, and the very first block ever handed out has its link word rewritten from `-1` to `256` by somebody else. Shadow-map checks running alongside (every live block, every parked block, the expected link per parked block) reported **no** double free, no size mismatch, no free of a non-live block, no offset reissued while live — the allocator's own bookkeeping was self-consistent throughout. The writer was never a caller.

## The fix

Two changes, both needed:

1. **The pool is based above `max(current top of linear memory, 1MB)`.** The reserve is address space only — WASM commits on first touch, and these are pages the runtime touches anyway — so it costs nothing but a larger `memory.grow` argument.

2. **`allocateOffset` bounds-checks the free-list head and the link it reads out of the block before dereferencing either**, and raises an `IllegalStateException` naming the offset, the size class and the pool state. Four integer compares on the reuse path, no allocation, no `@JsFun`; message building is a separate function so only the compares are inlined. A trap that names nothing becomes an error that names the block.

The reserve is a floor, **not** a guarantee: a single scoped allocation larger than 1MB would still reach the pool. That residual is exactly what the bounds check reports, which is why both halves are here rather than either alone.

## Tests

`LinearMemoryRuntimeScratchTest` (wasmJs), four cases:

- `theRuntimeAllocatesItsScratchFromAddressZero` — pins the premise against the stdlib rather than asserting it from the source: a top-level scope returns address 0, and *still* returns 0 after the pool has grown 16MB.
- `theBufferPoolIsBasedAboveTheRuntimeScratchReserve` — the invariant.
- `aRuntimeScopedAllocationInsideTheReserveLeavesThePoolIntact` — behavioural, not a constant assertion. Writes a pattern into a live buffer, parks a same-class block on the free list, scribbles the **entire reserve** through the runtime's own allocator, then requires both to survive: the live bytes by value, the parked block by being popped and having its link followed.
- `aCorruptedNextLinkIsReportedInsteadOfTrapping` — corrupts a parked link by hand and pins the diagnosable failure.

**Mutation-checked**, so neither passes vacuously. Restoring the old `heapBase = grantedBase`:

```
theBufferPoolIsBasedAboveTheRuntimeScratchReserve FAILED
  the pool is based at 0, inside the runtime's scratch region [0, 1048576)
aRuntimeScopedAllocationInsideTheReserveLeavesThePoolIntact FAILED
  runtime scratch overwrote live buffer bytes. Expected <1592594996>, actual <1515870810>
```

`1515870810` is `0x5A5A5A5A` — the runtime's scratch pattern, read back out of a live buffer.

## Verification

wasmJs node **1143**, wasmJs browser **1143**, jsNode **1102**, jvm **1254** — 0 failures. ktlint and detekt clean.

Independently confirmed end to end: a wasmJs browser application that crashed on load with `memory access out of bounds` on 6.29.0 and 6.30.1, and was clean on 6.28.1 (the last release before #349), runs its full headless browser suite green on this branch with no application-side change.

## Docs

`docs/docs/platforms/wasm.md` gains a "The bottom of linear memory belongs to the runtime" section. The class KDoc's "This is safe because: memory.grow() returns pages that weren't previously mapped" is corrected — it was the premise that was wrong.
