### PR TITLE
fix(buffer): a wasmJs view of a released buffer refuses access instead of reading reissued memory

### DIFF
--- a/buffer/src/wasmJsMain/kotlin/com/ditchoom/buffer/LinearBuffer.kt
+++ b/buffer/src/wasmJsMain/kotlin/com/ditchoom/buffer/LinearBuffer.kt
@@ -131,6 +131,10 @@ private external fun copyToJsArray(
  * @param owned whether releasing this buffer returns its block to [LinearMemoryAllocator]. Defaults
  *   to `false` so that a construction site that has not thought about ownership fails safe by
  *   leaking rather than by double-freeing.
+ * @param owner the buffer whose block this one aliases, for non-owning views taken with [slice]. A
+ *   view has no release of its own, so its liveness IS its owner's; see [checkNotFreed]. Null for an
+ *   owning buffer and for [PlatformBuffer.wrapNativeAddress], whose memory belongs to somebody
+ *   outside this allocator entirely and whose lifetime this class cannot speak for.
  */
 @Suppress("TooManyFunctions")
 class LinearBuffer(
@@ -138,6 +142,7 @@ class LinearBuffer(
     capacity: Int,
     byteOrder: ByteOrder,
     private val owned: Boolean = false,
+    private val owner: LinearBuffer? = null,
 ) : BaseWebBuffer(capacity, byteOrder),
     NativeMemoryAccess,
     CloseableBuffer {
@@ -216,12 +221,20 @@ class LinearBuffer(
      * parked block's next-link, and the resulting `memory access out of bounds` surfaces at an
      * unrelated allocation later.
      *
-     * Non-owning views ([slice], [PlatformBuffer.wrapNativeAddress]) never set the flag, so this
-     * does not catch a slice outliving a released parent — that needs the parent's liveness, which
-     * is issue #362's territory, not this check's.
+     * A non-owning view never sets its own flag — releasing one is a no-op — so its liveness is its
+     * [owner]'s, and the check follows the link. [slice] points every view straight at the owning
+     * buffer rather than at the buffer it was taken from, so this is one field read and one branch
+     * however many times a slice has been sliced, and never a chain walk.
+     *
+     * [PlatformBuffer.wrapNativeAddress] has no owner to consult: that memory belongs to something
+     * outside this allocator, and guessing at its lifetime would be worse than declining to.
      */
     private fun checkNotFreed() {
         if (freed) throw IllegalStateException("Buffer has been freed")
+        val owningBuffer = owner
+        if (owningBuffer != null && owningBuffer.freed) {
+            throw IllegalStateException("Buffer has been freed: this is a view of a buffer that was released")
+        }
     }
 
     /**
@@ -439,8 +452,14 @@ class LinearBuffer(
     /**
      * A zero-copy view of the remaining bytes, sharing this buffer's linear memory.
      *
-     * The slice is non-owning: releasing it does nothing, and it must not outlive this buffer —
-     * once the parent is released its block can be reissued to an unrelated allocation.
+     * The slice is non-owning: releasing it does nothing, and it must not outlive this buffer — once
+     * the owner is released its block can be reissued to an unrelated allocation, and a write through
+     * a stale view then lands on somebody else's bytes, or on a parked block's next-link. The view
+     * carries a link to the owning buffer so that using it after that point throws instead.
+     *
+     * The link points at the *owner*, not at the buffer `slice()` was called on: a view of a view
+     * aliases the same block and the same lifetime, so flattening keeps [checkNotFreed] to a single
+     * branch regardless of depth.
      */
     override fun slice(byteOrder: ByteOrder): LinearBuffer {
         checkNotFreed()
@@ -451,6 +470,7 @@ class LinearBuffer(
             limitValue - positionValue,
             byteOrder,
             owned = false,
+            owner = if (owned) this else owner,
         )
     }
 

--- a/buffer/src/wasmJsMain/kotlin/com/ditchoom/buffer/NativeDataConversions.wasmJs.kt
+++ b/buffer/src/wasmJsMain/kotlin/com/ditchoom/buffer/NativeDataConversions.wasmJs.kt
@@ -81,13 +81,11 @@ actual fun PlatformBuffer.toMutableNativeData(): MutableNativeData {
     return MutableNativeData(
         when (unwrapped) {
             is LinearBuffer -> {
-                // Create a new non-owning LinearBuffer view sharing the same memory
-                LinearBuffer(
-                    unwrapped.baseOffset + unwrapped.position(),
-                    unwrapped.remaining(),
-                    unwrapped.byteOrder,
-                    owned = false,
-                )
+                // A non-owning view over the same memory. Taken via slice() rather than built by
+                // hand — the two produce the same window, but slice() links the view to the owning
+                // buffer, so using this handle after that buffer is released throws instead of
+                // reading whatever the allocator has since reissued the block to.
+                unwrapped.slice(unwrapped.byteOrder)
             }
             else -> {
                 val bytes = toByteArray()

--- a/buffer/src/wasmJsTest/kotlin/com/ditchoom/buffer/LinearBufferUseAfterFreeTest.kt
+++ b/buffer/src/wasmJsTest/kotlin/com/ditchoom/buffer/LinearBufferUseAfterFreeTest.kt
@@ -98,18 +98,59 @@ class LinearBufferUseAfterFreeTest {
     }
 
     /**
-     * A slice of a *released* parent is deliberately NOT covered. Non-owning views never set the
-     * flag, so catching this needs the parent's liveness rather than the view's — the propagation
-     * issue #362 proposes, and out of scope for a check that only fixes wasmJs's divergence from
-     * every other platform's contract. Pinned so the gap is a recorded decision rather than an
-     * assumption someone makes later.
+     * A view of a released buffer refuses access, which is the case that actually corrupts memory:
+     * the owner's block goes back to the allocator and is reissued, so a write through the stale
+     * view lands on an unrelated buffer — or on a parked block's next-link, which is not noticed
+     * until some later allocation of that size class dereferences it.
+     *
+     * The view's own flag stays false, because releasing a non-owning view is a no-op and that
+     * remains true. Liveness is the owner's, and the view consults it.
      */
     @Test
-    fun aSliceOfAReleasedParentIsNotCaughtYet() {
+    fun aViewOfAReleasedBufferRefusesAccess() {
         val parent = BufferFactory.Default.allocate(64)
-        val slice = parent.slice()
+        parent.writeInt(0x1234_5678)
+        parent.resetForRead()
+        val view = parent.slice()
+        assertEquals(0x1234_5678, view.readInt(), "the view reads fine while its owner is live")
+        view.resetForRead()
+
         parent.freeNativeMemory()
-        assertTrue(!slice.isFreedOrFail(), "a non-owning view does not carry its parent's flag")
+
+        assertTrue(!view.isFreedOrFail(), "releasing a non-owning view is still a no-op")
+        assertFailsWith<IllegalStateException> { view.readInt() }
+        assertFailsWith<IllegalStateException> { view.writeInt(1) }
+        assertFailsWith<IllegalStateException> { view.slice() }
+    }
+
+    /**
+     * A view of a view is linked to the owner, not to the buffer it was taken from — so the check
+     * stays one branch however deep the slicing goes, and a released owner is still caught.
+     */
+    @Test
+    fun aViewOfAViewIsLinkedToTheOwner() {
+        val parent = BufferFactory.Default.allocate(64)
+        val view = parent.slice().slice().slice()
+        parent.freeNativeMemory()
+        assertFailsWith<IllegalStateException> { view.readByte() }
+    }
+
+    /**
+     * Releasing the *view* must not disturb the owner: a view has no block of its own to give back,
+     * so this is the direction that would break ordinary `use { }` code if it were symmetric.
+     */
+    @Test
+    fun releasingAViewLeavesItsOwnerUsable() {
+        val parent = BufferFactory.Default.allocate(64)
+        try {
+            val view = parent.slice()
+            view.freeNativeMemory()
+            parent.writeInt(0x0BAD_F00D)
+            parent.resetForRead()
+            assertEquals(0x0BAD_F00D, parent.readInt())
+        } finally {
+            parent.freeNativeMemory()
+        }
     }
 
     private fun PlatformBuffer.isFreedOrFail(): Boolean = (this as CloseableBuffer).isFreed


### PR DESCRIPTION
## The gap

#364 gave `LinearBuffer` the liveness check every other platform already had. It deliberately scoped out the case that actually corrupts memory: **a view outliving the buffer it aliases.**

`slice()` produces a non-owning `LinearBuffer`. Releasing one is a no-op, and it held no reference to the buffer that owned the block — so once the owner was released and the allocator reissued that block, a read through the view returned somebody else's bytes and a write overwrote them. Silently, and on the one platform where releasing is mandatory rather than optional.

The allocator's own free-list diagnostic already names this as a usual cause: *"a slice() or wrapNativeAddress() view used after its owner was released"*. It just had no way to catch it.

## Why by default here, when #362 proposes it as opt-in

#362 scopes slice liveness into an opt-in `checked()` factory, reasoning that guarding the surface means overriding ~130 methods and Kotlin **silently delegates** any that are missed. That is correct for a general wrapper — `TrackedSlice` needed 128 explicit overrides for exactly that reason.

It does not apply to `LinearBuffer`. It extends `BaseWebBuffer`, which dispatches every scalar load and store through eight primitives, and all eight go through `ptr()` — where #364 put the liveness check. Slice liveness is one more branch in a function already on that path, not a new guard surface. The cost argument that motivated "opt-in" isn't there, so this is on by default.

## What it does

- A view carries a link to the owning buffer; `checkNotFreed()` consults it.
- The link points at the **owner**, not at the buffer `slice()` was called on. A view of a view aliases the same block and the same lifetime, so flattening keeps the check to a single branch regardless of slicing depth rather than walking a chain per access.
- `wrapNativeAddress` gets no link — that memory belongs to something outside this allocator, and guessing at its lifetime would be worse than declining to.
- `toMutableNativeData` built its view by hand rather than calling `slice()`. Same window, but it would have been the one view without a link; it goes through `slice()` now.

Deliberately unchanged, and pinned by tests:

- A view's own `isFreed` stays **false** — releasing a non-owning view remains a no-op.
- Releasing a view must not disturb its owner. The symmetric version would break ordinary `use { }` code.

## What it does not do

#362 keeps its scope. This does not detect a genuine double free (release is idempotent by design, since `use { }` calls it on paths that may have released already), does not poison released blocks, and does not touch any platform but wasmJs. It closes the one case whose consequence is silent memory corruption rather than a logic error.

## Verification

Mutation-checked: dropping the owner consultation reddens exactly the two new cases (`aViewOfAReleasedBufferRefusesAccess`, `aViewOfAViewIsLinkedToTheOwner`) and nothing else.

buffer wasmJs node 1158, buffer-compression wasmJs node 179, buffer jsNode green — 0 failures. ktlint and detekt clean.

Related: #362 (opt-in `checked()` factory), #364 (the direct case, shipped in #363), #365 (typing these exceptions across platforms).
