### PR TITLE
feat: connection-owned send — SendMode + OutboundWriter + encode-once fan-out (socket#382, buffer half)

### DIFF
--- a/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/ContextFreeCodec.kt
+++ b/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/ContextFreeCodec.kt
@@ -1,0 +1,58 @@
+package com.ditchoom.buffer.codec
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.ExperimentalFanoutApi
+import com.ditchoom.buffer.pool.SharedBytes
+
+/**
+ * A [Codec] whose encoding is **connection-independent**: [encode] and [wireSize] must produce
+ * identical bytes for identical values regardless of the [EncodeContext] they are given.
+ *
+ * This is a *capability declaration*, and it is what makes cross-connection encode sharing safe.
+ * Encoding is not context-free in general — a codec carrying per-connection state (a QPACK-style
+ * dynamic table, per-connection packet ids) encodes the same value to *different* bytes on
+ * different connections, and sharing those bytes across connections is silent stream corruption.
+ * By scoping [encodeShared] to this marker, sharing through a stateful codec is unrepresentable
+ * rather than merely discouraged.
+ *
+ * Implementors: only declare this when the contract genuinely holds for every value of [T].
+ * Generated codecs qualify whenever their schema reads no context keys in the encode direction.
+ */
+interface ContextFreeCodec<T> : Codec<T>
+
+/**
+ * One message encoded once, shareable across many connections.
+ *
+ * Pairs the encoded [bytes] with the [origin] message so loss reporting can hand back the
+ * *message* (never a buffer someone must remember to free). Created by [encodeShared]; the frame
+ * holds the creator's reference to [bytes] until [close].
+ *
+ * Reference flow for a fan-out loop: create once → each per-connection send **retains** and
+ * transfers a reference into that connection's outbound path (released there exactly once,
+ * write-complete or not-sent) → the creator calls [close] after the loop. N connections =
+ * N + 1 references; the last release frees the storage.
+ */
+@ExperimentalFanoutApi
+class SharedFrame<T>(
+    /** The message these bytes encode — the value loss reporting hands back. */
+    val origin: T,
+    /** The encoded bytes; refcounted, read through per-consumer [SharedBytes.view] cursors. */
+    val bytes: SharedBytes,
+) {
+    /** Releases the creator's reference. Call exactly once, after distributing the frame. */
+    fun close(): Unit = bytes.release()
+}
+
+/**
+ * Encodes [message] exactly once into a [SharedFrame] for fan-out to multiple connections.
+ *
+ * Only available on [ContextFreeCodec] — see the marker's contract for why. The encode allocates
+ * from [factory] ([BufferFactory.Default] unless the caller needs a specific allocation strategy)
+ * and the returned frame owns the buffer via its [SharedBytes] refcount.
+ */
+@ExperimentalFanoutApi
+fun <T> ContextFreeCodec<T>.encodeShared(
+    message: T,
+    factory: BufferFactory = BufferFactory.Default,
+): SharedFrame<T> = TODO("implemented by the shared-send work")

--- a/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/ContextFreeCodec.kt
+++ b/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/ContextFreeCodec.kt
@@ -40,7 +40,14 @@ class SharedFrame<T>(
     /** The encoded bytes; refcounted, read through per-consumer [SharedBytes.view] cursors. */
     val bytes: SharedBytes,
 ) {
-    /** Releases the creator's reference. Call exactly once, after distributing the frame. */
+    /**
+     * Releases the creator's reference. Call **exactly once**, after distributing the frame.
+     *
+     * Deliberately NOT idempotent: a second close throws, because silently absorbing it would
+     * mask the same accounting bug that silently absorbing an over-release would — the refcount
+     * is strict everywhere or trustworthy nowhere. Don't pair with `use`-style helpers that may
+     * close twice.
+     */
     fun close(): Unit = bytes.release()
 }
 

--- a/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/ContextFreeCodec.kt
+++ b/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/ContextFreeCodec.kt
@@ -4,6 +4,8 @@ import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.Default
 import com.ditchoom.buffer.ExperimentalFanoutApi
 import com.ditchoom.buffer.pool.SharedBytes
+import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
 /**
  * A [Codec] whose encoding is **connection-independent**: [encode] and [wireSize] must produce
@@ -19,6 +21,7 @@ import com.ditchoom.buffer.pool.SharedBytes
  * Implementors: only declare this when the contract genuinely holds for every value of [T].
  * Generated codecs qualify whenever their schema reads no context keys in the encode direction.
  */
+@ExperimentalFanoutApi
 interface ContextFreeCodec<T> : Codec<T>
 
 /**
@@ -34,6 +37,7 @@ interface ContextFreeCodec<T> : Codec<T>
  * N + 1 references; the last release frees the storage.
  */
 @ExperimentalFanoutApi
+@OptIn(ExperimentalAtomicApi::class)
 class SharedFrame<T>(
     /** The message these bytes encode — the value loss reporting hands back. */
     val origin: T,
@@ -41,14 +45,33 @@ class SharedFrame<T>(
     val bytes: SharedBytes,
 ) {
     /**
+     * Whether the creator's reference has already been dropped. Atomic because a frame is
+     * distributed across connections on unrelated threads, and the whole point of the flag is to
+     * make the second close a *diagnosis* rather than a race.
+     */
+    private val closed = AtomicBoolean(false)
+
+    /**
      * Releases the creator's reference. Call **exactly once**, after distributing the frame.
      *
      * Deliberately NOT idempotent: a second close throws, because silently absorbing it would
      * mask the same accounting bug that silently absorbing an over-release would — the refcount
      * is strict everywhere or trustworthy nowhere. Don't pair with `use`-style helpers that may
      * close twice.
+     *
+     * The flag is what makes that promise true. Delegating straight to [SharedBytes.release]
+     * would only throw when the count is already at zero — with consumer references still
+     * outstanding, a double close would instead *steal one of theirs*, freeing the storage an
+     * entire reference early and surfacing as another connection's bytes on the wire, far from
+     * the buggy call.
      */
-    fun close(): Unit = bytes.release()
+    fun close() {
+        check(closed.compareAndSet(expectedValue = false, newValue = true)) {
+            "SharedFrame.close() called more than once: the creator holds exactly one reference, " +
+                "and a second close would consume a consumer's reference instead of its own."
+        }
+        bytes.release()
+    }
 }
 
 /**

--- a/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/ContextFreeCodec.kt
+++ b/buffer-codec/src/commonMain/kotlin/com/ditchoom/buffer/codec/ContextFreeCodec.kt
@@ -55,4 +55,14 @@ class SharedFrame<T>(
 fun <T> ContextFreeCodec<T>.encodeShared(
     message: T,
     factory: BufferFactory = BufferFactory.Default,
-): SharedFrame<T> = TODO("implemented by the shared-send work")
+): SharedFrame<T> {
+    // EncodeContext.Empty is the honest argument: a ContextFreeCodec encodes identically for every
+    // context by contract, so threading a caller's context would only imply an influence that is
+    // declared not to exist.
+    //
+    // encodeToPlatformBuffer already hands back a buffer positioned for reading (position = 0,
+    // limit = encoded size) and frees it on any encode failure. Do NOT resetForRead() again —
+    // a second reset flips limit to the current position (0) and would adopt an empty frame.
+    val encoded = encodeToPlatformBuffer(message, factory, EncodeContext.Empty)
+    return SharedFrame(message, SharedBytes.adopt(encoded))
+}

--- a/buffer-codec/src/commonTest/kotlin/com/ditchoom/buffer/codec/ContextFreeCodecTests.kt
+++ b/buffer-codec/src/commonTest/kotlin/com/ditchoom/buffer/codec/ContextFreeCodecTests.kt
@@ -1,0 +1,235 @@
+package com.ditchoom.buffer.codec
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.ExperimentalFanoutApi
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.Utf8
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.buffer.pool.ThreadingMode
+import com.ditchoom.buffer.unwrapFully
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/** A value with one fixed-width and one variable-width field, so both encode paths are exercised. */
+private data class Greeting(
+    val id: Int,
+    val text: String,
+)
+
+/**
+ * Context-free by construction: neither [encode] nor [wireSize] reads a single context key, so the
+ * same [Greeting] produces the same bytes on every connection — the precondition [ContextFreeCodec]
+ * declares and [encodeShared] relies on.
+ */
+private object GreetingCodec : ContextFreeCodec<Greeting> {
+    override fun encode(
+        buffer: WriteBuffer,
+        value: Greeting,
+        context: EncodeContext,
+    ) {
+        buffer.writeInt(value.id)
+        buffer.writeInt(Utf8.Strict.size(value.text))
+        buffer.writeText(value.text, Utf8.Strict)
+    }
+
+    override fun wireSize(
+        value: Greeting,
+        context: EncodeContext,
+    ): WireSize = WireSize.Exact(Int.SIZE_BYTES * 2 + Utf8.Strict.size(value.text))
+
+    override fun decode(
+        buffer: ReadBuffer,
+        context: DecodeContext,
+    ): Greeting {
+        val id = buffer.readInt()
+        val length = buffer.readInt()
+        return Greeting(id, buffer.readText(length, Utf8.Strict))
+    }
+}
+
+/**
+ * Same wire format as [GreetingCodec] but reports [WireSize.BackPatch] with a deliberately tiny
+ * [sizeHint], so `encodeToPlatformBuffer`'s grow-and-retry loop runs (and frees its discarded
+ * attempts) underneath [encodeShared].
+ */
+private object GrowingGreetingCodec : ContextFreeCodec<Greeting> {
+    override fun encode(
+        buffer: WriteBuffer,
+        value: Greeting,
+        context: EncodeContext,
+    ) = GreetingCodec.encode(buffer, value, context)
+
+    override fun sizeHint(
+        value: Greeting,
+        context: EncodeContext,
+    ): Int = 1
+
+    override fun decode(
+        buffer: ReadBuffer,
+        context: DecodeContext,
+    ): Greeting = GreetingCodec.decode(buffer, context)
+}
+
+/**
+ * [encodeShared] — encode once, fan out to many consumers.
+ *
+ * What must hold: the shared bytes are indistinguishable from a plain encode (otherwise sharing
+ * silently corrupts one of the connections), every consumer reads the full frame through its own
+ * cursor, and the storage is released exactly once when the creator's [SharedFrame.close] follows
+ * the last consumer's release — including when the bytes came from a pool.
+ */
+@OptIn(ExperimentalFanoutApi::class)
+class ContextFreeCodecTests {
+    private val message = Greeting(0x0BADCAFE, "fan-out consumers")
+
+    // ========================================================================
+    // 6. Byte-identical to a plain encode
+    // ========================================================================
+
+    @Test
+    fun sharedBytesAreIdenticalToAPlainEncodeOfTheSameMessage() {
+        val plain = GreetingCodec.encodeToPlatformBuffer(message)
+        val frame = GreetingCodec.encodeShared(message)
+        try {
+            assertEquals(plain.remaining(), frame.bytes.size, "shared frame length must match a plain encode")
+            assertTrue(plain.contentEquals(frame.bytes.view()), "shared frame bytes must match a plain encode")
+
+            // contentEquals is non-consuming, so compare the raw bytes independently too.
+            val expected = plain.copyToByteArray(plain.remaining())
+            val actual = frame.bytes.view().copyToByteArray(frame.bytes.size)
+            assertContentEquals(expected, actual)
+
+            assertEquals(message, GreetingCodec.decode(frame.bytes.view(), DecodeContext.Empty))
+        } finally {
+            plain.freeNativeMemory()
+            frame.close()
+        }
+    }
+
+    @Test
+    fun backPatchSizedEncodeSharesTheSameBytesAfterGrowAndRetry() {
+        val plain = GrowingGreetingCodec.encodeToPlatformBuffer(message)
+        val frame = GrowingGreetingCodec.encodeShared(message)
+        try {
+            assertEquals(plain.remaining(), frame.bytes.size)
+            assertTrue(plain.contentEquals(frame.bytes.view()))
+            assertEquals(message, GrowingGreetingCodec.decode(frame.bytes.view(), DecodeContext.Empty))
+        } finally {
+            plain.freeNativeMemory()
+            frame.close()
+        }
+    }
+
+    // ========================================================================
+    // 7. Full frame lifecycle: 3 fan-out consumers
+    // ========================================================================
+
+    @Test
+    fun threeConsumersEachReadTheWholeFrameAndTheStorageIsFreedOnce() {
+        val pool = newPool()
+        val frame = GreetingCodec.encodeShared(message, pool)
+        assertSame(message, frame.origin, "loss reporting hands back the message, never a buffer")
+
+        val perConsumerBytes = mutableListOf<ByteArray>()
+        repeat(CONSUMERS) { consumer ->
+            // Fan-out reference protocol: retain on transfer, read through an own cursor, release
+            // exactly once when that connection is done with the bytes.
+            val shared = frame.bytes.retain()
+            perConsumerBytes += shared.view().copyToByteArray(shared.size)
+            assertEquals(
+                message,
+                GreetingCodec.decode(shared.view(), DecodeContext.Empty),
+                "consumer $consumer decoded a different value",
+            )
+            shared.release()
+            assertEquals(
+                0,
+                pool.stats().currentPoolSize,
+                "the creator still holds a reference — consumer $consumer's release must not free",
+            )
+        }
+
+        for (consumer in 1 until CONSUMERS) {
+            assertContentEquals(
+                perConsumerBytes[0],
+                perConsumerBytes[consumer],
+                "consumer $consumer saw different bytes than consumer 0",
+            )
+        }
+
+        frame.close()
+        assertEquals(1, pool.stats().currentPoolSize, "close() drops the creator's reference and frees the storage")
+
+        assertFailsWith<IllegalStateException>("a second close is an over-release") { frame.close() }
+        assertEquals(1, pool.stats().currentPoolSize, "over-release must not re-pool the storage")
+        pool.clear()
+    }
+
+    // ========================================================================
+    // 8. Pooled factory
+    // ========================================================================
+
+    @Test
+    fun encodeSharedWithAPooledFactoryRoundTripsAndReturnsTheBufferToThePool() {
+        val pool = newPool()
+        val frame = GreetingCodec.encodeShared(message, pool)
+
+        assertEquals(0, pool.stats().currentPoolSize, "the encoded chunk is checked out of the pool")
+        assertEquals(
+            WireSize.Exact(frame.bytes.size),
+            GreetingCodec.wireSize(message, EncodeContext.Empty),
+            "the frame holds exactly the encoded bytes, not the pooled chunk's capacity",
+        )
+        assertEquals(message, GreetingCodec.decode(frame.bytes.view(), DecodeContext.Empty), "round-trip")
+
+        frame.close()
+        assertEquals(1, pool.stats().currentPoolSize, "close() must return the pooled chunk to its pool")
+
+        val reacquired = pool.acquire(frame.bytes.size) as PlatformBuffer
+        assertTrue(pool.stats().poolHits >= 1, "the returned chunk must be genuinely reusable")
+        reacquired.freeNativeMemory()
+        pool.clear()
+    }
+
+    @Test
+    fun aPooledFrameSurvivesRepeatedFanOutCyclesWithoutLeakingChunks() {
+        val pool = newPool()
+        var storage: ReadBuffer? = null
+
+        repeat(CYCLES) {
+            val frame = GreetingCodec.encodeShared(message, pool)
+            val shared = frame.bytes.retain()
+            assertEquals(message, GreetingCodec.decode(shared.view(), DecodeContext.Empty))
+            shared.release()
+            frame.close()
+
+            // Every cycle must recycle the very same chunk — otherwise a reference is being leaked.
+            val chunk = pool.acquire(POOL_BUFFER_SIZE) as PlatformBuffer
+            val raw = chunk.unwrapFully()
+            if (storage == null) storage = raw else assertSame(storage, raw, "a chunk leaked out of the pool")
+            chunk.freeNativeMemory()
+        }
+        pool.clear()
+    }
+
+    private fun newPool(): BufferPool =
+        BufferPool(
+            threadingMode = ThreadingMode.MultiThreaded,
+            maxPoolSize = 4,
+            defaultBufferSize = POOL_BUFFER_SIZE,
+            factory = BufferFactory.Default,
+        )
+
+    private companion object {
+        const val CONSUMERS = 3
+        const val CYCLES = 8
+        const val POOL_BUFFER_SIZE = 256
+    }
+}

--- a/buffer-codec/src/commonTest/kotlin/com/ditchoom/buffer/codec/SharedFrameLifetimeTests.kt
+++ b/buffer-codec/src/commonTest/kotlin/com/ditchoom/buffer/codec/SharedFrameLifetimeTests.kt
@@ -1,0 +1,62 @@
+package com.ditchoom.buffer.codec
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.ExperimentalFanoutApi
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.pool.SharedBytes
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * [SharedFrame.close] is documented as exactly-once and deliberately non-idempotent. Delegating
+ * straight to [SharedBytes.release] did not make that true: `release` only throws once the count
+ * is already at *zero*, so with consumer references still outstanding a double close silently
+ * consumed **someone else's** reference instead — freeing the storage one release early and
+ * surfacing as another connection's bytes on the wire, far from the buggy call site.
+ */
+@OptIn(ExperimentalFanoutApi::class)
+class SharedFrameLifetimeTests {
+    private fun payload(): PlatformBuffer =
+        BufferFactory.Default.allocate(PAYLOAD_SIZE).apply {
+            repeat(PAYLOAD_SIZE) { writeByte(it.toByte()) }
+            resetForRead()
+        }
+
+    @Test
+    fun aSecondCloseThrowsInsteadOfStealingAConsumersReference() {
+        val bytes = SharedBytes.adopt(payload())
+        val frame = SharedFrame("message", bytes)
+
+        // One connection has taken the frame: creator + consumer = 2 references.
+        bytes.retain()
+
+        frame.close() // the creator's, leaving the consumer's alone
+
+        assertFailsWith<IllegalStateException>("the second close must be diagnosed, not absorbed") {
+            frame.close()
+        }
+
+        // The consumer's reference is intact and is the one that frees the storage.
+        bytes.release()
+        assertFailsWith<IllegalStateException>("storage should now be at zero") { bytes.release() }
+    }
+
+    @Test
+    fun theCreatorsCloseStillReleasesExactlyOneReference() {
+        val bytes = SharedBytes.adopt(payload())
+        val frame = SharedFrame("message", bytes)
+        assertEquals("message", frame.origin)
+
+        frame.close()
+
+        assertFailsWith<IllegalStateException>("close must have consumed the creator's reference") {
+            bytes.release()
+        }
+    }
+
+    private companion object {
+        const val PAYLOAD_SIZE = 16
+    }
+}

--- a/buffer-flow/api/android/buffer-flow.api
+++ b/buffer-flow/api/android/buffer-flow.api
@@ -80,9 +80,6 @@ public final class com/ditchoom/buffer/flow/BytesWritten {
 	public final synthetic fun unbox-impl ()I
 }
 
-public abstract interface class com/ditchoom/buffer/flow/CloseCause {
-}
-
 public final class com/ditchoom/buffer/flow/CloseCause$Aborted : com/ditchoom/buffer/flow/CloseCause {
 	public static final field INSTANCE Lcom/ditchoom/buffer/flow/CloseCause$Aborted;
 	public fun equals (Ljava/lang/Object;)Z
@@ -116,9 +113,6 @@ public abstract interface class com/ditchoom/buffer/flow/Connection : com/ditcho
 
 public final class com/ditchoom/buffer/flow/Connection$DefaultImpls {
 	public static fun abort (Lcom/ditchoom/buffer/flow/Connection;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public abstract interface class com/ditchoom/buffer/flow/ConnectionPhase {
 }
 
 public final class com/ditchoom/buffer/flow/ConnectionPhase$Closed : com/ditchoom/buffer/flow/ConnectionPhase {

--- a/buffer-flow/api/android/buffer-flow.api
+++ b/buffer-flow/api/android/buffer-flow.api
@@ -80,9 +80,70 @@ public final class com/ditchoom/buffer/flow/BytesWritten {
 	public final synthetic fun unbox-impl ()I
 }
 
+public abstract interface class com/ditchoom/buffer/flow/CloseCause {
+}
+
+public final class com/ditchoom/buffer/flow/CloseCause$Aborted : com/ditchoom/buffer/flow/CloseCause {
+	public static final field INSTANCE Lcom/ditchoom/buffer/flow/CloseCause$Aborted;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/flow/CloseCause$Failed : com/ditchoom/buffer/flow/CloseCause {
+	public fun <init> (Ljava/lang/Throwable;)V
+	public final fun component1 ()Ljava/lang/Throwable;
+	public final fun copy (Ljava/lang/Throwable;)Lcom/ditchoom/buffer/flow/CloseCause$Failed;
+	public static synthetic fun copy$default (Lcom/ditchoom/buffer/flow/CloseCause$Failed;Ljava/lang/Throwable;ILjava/lang/Object;)Lcom/ditchoom/buffer/flow/CloseCause$Failed;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCause ()Ljava/lang/Throwable;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/flow/CloseCause$Graceful : com/ditchoom/buffer/flow/CloseCause {
+	public static final field INSTANCE Lcom/ditchoom/buffer/flow/CloseCause$Graceful;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface class com/ditchoom/buffer/flow/Connection : com/ditchoom/buffer/flow/Receiver, com/ditchoom/buffer/flow/Sender {
+	public fun abort (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getId ()J
+}
+
+public final class com/ditchoom/buffer/flow/Connection$DefaultImpls {
+	public static fun abort (Lcom/ditchoom/buffer/flow/Connection;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/ditchoom/buffer/flow/ConnectionPhase {
+}
+
+public final class com/ditchoom/buffer/flow/ConnectionPhase$Closed : com/ditchoom/buffer/flow/ConnectionPhase {
+	public fun <init> (Lcom/ditchoom/buffer/flow/CloseCause;)V
+	public final fun component1 ()Lcom/ditchoom/buffer/flow/CloseCause;
+	public final fun copy (Lcom/ditchoom/buffer/flow/CloseCause;)Lcom/ditchoom/buffer/flow/ConnectionPhase$Closed;
+	public static synthetic fun copy$default (Lcom/ditchoom/buffer/flow/ConnectionPhase$Closed;Lcom/ditchoom/buffer/flow/CloseCause;ILjava/lang/Object;)Lcom/ditchoom/buffer/flow/ConnectionPhase$Closed;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCause ()Lcom/ditchoom/buffer/flow/CloseCause;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/flow/ConnectionPhase$Draining : com/ditchoom/buffer/flow/ConnectionPhase {
+	public static final field INSTANCE Lcom/ditchoom/buffer/flow/ConnectionPhase$Draining;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/flow/ConnectionPhase$Open : com/ditchoom/buffer/flow/ConnectionPhase {
+	public static final field INSTANCE Lcom/ditchoom/buffer/flow/ConnectionPhase$Open;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface annotation class com/ditchoom/buffer/flow/ExperimentalDatagramApi : java/lang/annotation/Annotation {
@@ -175,6 +236,16 @@ public abstract interface class com/ditchoom/buffer/flow/Receiver {
 
 public abstract interface class com/ditchoom/buffer/flow/Resettable {
 	public abstract fun reset (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/ditchoom/buffer/flow/SendMode {
+}
+
+public final class com/ditchoom/buffer/flow/SendMode$AwaitWritten : com/ditchoom/buffer/flow/SendMode {
+	public static final field INSTANCE Lcom/ditchoom/buffer/flow/SendMode$AwaitWritten;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class com/ditchoom/buffer/flow/Sender {

--- a/buffer-flow/api/jvm/buffer-flow.api
+++ b/buffer-flow/api/jvm/buffer-flow.api
@@ -80,9 +80,6 @@ public final class com/ditchoom/buffer/flow/BytesWritten {
 	public final synthetic fun unbox-impl ()I
 }
 
-public abstract interface class com/ditchoom/buffer/flow/CloseCause {
-}
-
 public final class com/ditchoom/buffer/flow/CloseCause$Aborted : com/ditchoom/buffer/flow/CloseCause {
 	public static final field INSTANCE Lcom/ditchoom/buffer/flow/CloseCause$Aborted;
 	public fun equals (Ljava/lang/Object;)Z
@@ -116,9 +113,6 @@ public abstract interface class com/ditchoom/buffer/flow/Connection : com/ditcho
 
 public final class com/ditchoom/buffer/flow/Connection$DefaultImpls {
 	public static fun abort (Lcom/ditchoom/buffer/flow/Connection;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public abstract interface class com/ditchoom/buffer/flow/ConnectionPhase {
 }
 
 public final class com/ditchoom/buffer/flow/ConnectionPhase$Closed : com/ditchoom/buffer/flow/ConnectionPhase {

--- a/buffer-flow/api/jvm/buffer-flow.api
+++ b/buffer-flow/api/jvm/buffer-flow.api
@@ -80,9 +80,70 @@ public final class com/ditchoom/buffer/flow/BytesWritten {
 	public final synthetic fun unbox-impl ()I
 }
 
+public abstract interface class com/ditchoom/buffer/flow/CloseCause {
+}
+
+public final class com/ditchoom/buffer/flow/CloseCause$Aborted : com/ditchoom/buffer/flow/CloseCause {
+	public static final field INSTANCE Lcom/ditchoom/buffer/flow/CloseCause$Aborted;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/flow/CloseCause$Failed : com/ditchoom/buffer/flow/CloseCause {
+	public fun <init> (Ljava/lang/Throwable;)V
+	public final fun component1 ()Ljava/lang/Throwable;
+	public final fun copy (Ljava/lang/Throwable;)Lcom/ditchoom/buffer/flow/CloseCause$Failed;
+	public static synthetic fun copy$default (Lcom/ditchoom/buffer/flow/CloseCause$Failed;Ljava/lang/Throwable;ILjava/lang/Object;)Lcom/ditchoom/buffer/flow/CloseCause$Failed;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCause ()Ljava/lang/Throwable;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/flow/CloseCause$Graceful : com/ditchoom/buffer/flow/CloseCause {
+	public static final field INSTANCE Lcom/ditchoom/buffer/flow/CloseCause$Graceful;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface class com/ditchoom/buffer/flow/Connection : com/ditchoom/buffer/flow/Receiver, com/ditchoom/buffer/flow/Sender {
+	public fun abort (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getId ()J
+}
+
+public final class com/ditchoom/buffer/flow/Connection$DefaultImpls {
+	public static fun abort (Lcom/ditchoom/buffer/flow/Connection;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/ditchoom/buffer/flow/ConnectionPhase {
+}
+
+public final class com/ditchoom/buffer/flow/ConnectionPhase$Closed : com/ditchoom/buffer/flow/ConnectionPhase {
+	public fun <init> (Lcom/ditchoom/buffer/flow/CloseCause;)V
+	public final fun component1 ()Lcom/ditchoom/buffer/flow/CloseCause;
+	public final fun copy (Lcom/ditchoom/buffer/flow/CloseCause;)Lcom/ditchoom/buffer/flow/ConnectionPhase$Closed;
+	public static synthetic fun copy$default (Lcom/ditchoom/buffer/flow/ConnectionPhase$Closed;Lcom/ditchoom/buffer/flow/CloseCause;ILjava/lang/Object;)Lcom/ditchoom/buffer/flow/ConnectionPhase$Closed;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCause ()Lcom/ditchoom/buffer/flow/CloseCause;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/flow/ConnectionPhase$Draining : com/ditchoom/buffer/flow/ConnectionPhase {
+	public static final field INSTANCE Lcom/ditchoom/buffer/flow/ConnectionPhase$Draining;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ditchoom/buffer/flow/ConnectionPhase$Open : com/ditchoom/buffer/flow/ConnectionPhase {
+	public static final field INSTANCE Lcom/ditchoom/buffer/flow/ConnectionPhase$Open;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface annotation class com/ditchoom/buffer/flow/ExperimentalDatagramApi : java/lang/annotation/Annotation {
@@ -175,6 +236,16 @@ public abstract interface class com/ditchoom/buffer/flow/Receiver {
 
 public abstract interface class com/ditchoom/buffer/flow/Resettable {
 	public abstract fun reset (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/ditchoom/buffer/flow/SendMode {
+}
+
+public final class com/ditchoom/buffer/flow/SendMode$AwaitWritten : com/ditchoom/buffer/flow/SendMode {
+	public static final field INSTANCE Lcom/ditchoom/buffer/flow/SendMode$AwaitWritten;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class com/ditchoom/buffer/flow/Sender {

--- a/buffer-flow/build.gradle.kts
+++ b/buffer-flow/build.gradle.kts
@@ -28,6 +28,10 @@ apiValidation {
     // breaking change (RFC §11.2). The marker is dropped — and the surface enters the dump — only
     // once conformance is green across every witness and platform.
     nonPublicMarkers.add("com.ditchoom.buffer.flow.ExperimentalDatagramApi")
+    // The fan-out/shared-send surface (SendMode.Handoff and its policy types, sendShared) is
+    // incubating under the same rule: gated out of the locked ABI until its sealed hierarchies
+    // are finalized (buffer#370), then stabilized into the dump.
+    nonPublicMarkers.add("com.ditchoom.buffer.ExperimentalFanoutApi")
     klib {
         enabled = false
     }

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/Connection.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/Connection.kt
@@ -3,9 +3,19 @@ package com.ditchoom.buffer.flow
 /**
  * A typed, bidirectional message connection with a stable identity.
  *
- * **Thread safety:** Implementations are NOT assumed to be thread-safe. Concurrent
- * calls to [send] or concurrent collectors of [receive] require external synchronization.
- * In coroutine code, confine send/receive to their respective coroutines or use a `Mutex`.
+ * **Send contract (staged toward v7):** a *conforming* implementation guarantees, with no
+ * external synchronization from callers, that
+ *
+ * 1. [send] is **atomic** — a message reaches the peer whole or not at all; cancelling a sender
+ *    can never leave a partial frame on the wire; and
+ * 2. [send] is **serialized** — concurrent `send`s on one connection never interleave their
+ *    bytes.
+ *
+ * Every implementation in this ecosystem conforms (they own their writer — see `OutboundWriter`
+ * for the reusable component). Third-party implementations written against the pre-6.x contract
+ * ("not assumed thread-safe, bring your own Mutex") remain *callable* but are not conforming;
+ * v7 makes the guarantee mandatory for all implementors. Callers should already treat the two
+ * properties above as the contract and stop wrapping sends in external locks.
  *
  * Combines [Sender] and [Receiver] with lifecycle management. This is the primary
  * interface that protocol libraries code against -- they don't need to know whether
@@ -35,4 +45,18 @@ interface Connection<T> :
 
     /** Close the whole connection (re-abstracts [Sender.close], which is send-side-only). */
     override suspend fun close()
+
+    /**
+     * Close the whole connection **immediately**, without draining queued sends — the RST-like
+     * counterpart to the graceful [close], mirroring the byte layer's [Resettable] against
+     * [ByteStream.close]'s FIN. Queued-but-unwritten messages are equivalent to messages lost by
+     * the network; implementations report them through their loss path where one exists.
+     *
+     * Defaults to [close] so existing implementations remain source- and behavior-compatible;
+     * implementations with a real abort (a transport reset, an owned writer to cancel) override.
+     * Idempotent.
+     */
+    suspend fun abort() {
+        close()
+    }
 }

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/Connection.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/Connection.kt
@@ -11,11 +11,19 @@ package com.ditchoom.buffer.flow
  * 2. [send] is **serialized** — concurrent `send`s on one connection never interleave their
  *    bytes.
  *
- * Every implementation in this ecosystem conforms (they own their writer — see `OutboundWriter`
- * for the reusable component). Third-party implementations written against the pre-6.x contract
- * ("not assumed thread-safe, bring your own Mutex") remain *callable* but are not conforming;
- * v7 makes the guarantee mandatory for all implementors. Callers should already treat the two
- * properties above as the contract and stop wrapping sends in external locks.
+ * `OutboundWriter` is the reusable component that provides both, and the socket library's
+ * `CodecConnection`/`CodecSender` are built on it.
+ *
+ * **Not every implementation conforms yet, and the exceptions matter.** In this module,
+ * [ByteSink.typed] and [ByteStream.typed] encode and `writeFully` on the *caller's* coroutine with
+ * no serialization: two concurrent sends can interleave partial writes, and for a self-framing
+ * codec the peer then reads a length prefix across the splice point — a silent, permanent stream
+ * desync. **Keep your external `Mutex` around sends through those two**, and do not read the
+ * guarantee above as already true of them. Third-party implementations written against the pre-6.x
+ * contract ("not assumed thread-safe, bring your own Mutex") are in the same position.
+ *
+ * v7 makes the guarantee mandatory for all implementors; retrofitting this module's typed views
+ * onto `OutboundWriter` is tracked as part of that milestone.
  *
  * Combines [Sender] and [Receiver] with lifecycle management. This is the primary
  * interface that protocol libraries code against -- they don't need to know whether

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/ConnectionPhase.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/ConnectionPhase.kt
@@ -1,5 +1,7 @@
 package com.ditchoom.buffer.flow
 
+import com.ditchoom.buffer.ExperimentalFanoutApi
+
 /**
  * The send/close lifecycle of a connection that owns its writer, exposed reactively as a
  * `StateFlow<ConnectionPhase>`.
@@ -12,7 +14,13 @@ package com.ditchoom.buffer.flow
  * (Initialized/Connecting/Connected/Disconnected in socket implementations): that vocabulary
  * describes reaching the peer; this one describes the writer-owning connection's send/close
  * ladder. The coexistence is intent, not drift.
+ *
+ * Experimental alongside every producer and consumer of it ([OutboundWriter.phase],
+ * [OutboundClosedException], [NotSentReason.ConnectionClosed]). Freezing an exhaustively-`when`-able
+ * hierarchy on day one is what makes a later discovery — a needed arm, a renamed cause — a major
+ * version instead of an experimental-round correction. It costs zero stable consumers today.
  */
+@ExperimentalFanoutApi
 sealed interface ConnectionPhase {
     /** Accepting sends; the writer is live. */
     data object Open : ConnectionPhase
@@ -26,7 +34,8 @@ sealed interface ConnectionPhase {
     ) : ConnectionPhase
 }
 
-/** Why a connection reached [ConnectionPhase.Closed]. */
+/** Why a connection reached [ConnectionPhase.Closed]. Experimental for the same reason. */
+@ExperimentalFanoutApi
 sealed interface CloseCause {
     /** Graceful close completed: every accepted frame reached the wire. */
     data object Graceful : CloseCause

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/ConnectionPhase.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/ConnectionPhase.kt
@@ -1,0 +1,45 @@
+package com.ditchoom.buffer.flow
+
+/**
+ * The send/close lifecycle of a connection that owns its writer, exposed reactively as a
+ * `StateFlow<ConnectionPhase>`.
+ *
+ * A sealed phase instead of boolean flags: `Closed` cannot exist without a [CloseCause], so
+ * "the connection is dead but nobody knows why" is unrepresentable, and the drain window is an
+ * explicit state instead of an inferred flag combination.
+ *
+ * This deliberately coexists with the *transport* layer's establishment lifecycle
+ * (Initialized/Connecting/Connected/Disconnected in socket implementations): that vocabulary
+ * describes reaching the peer; this one describes the writer-owning connection's send/close
+ * ladder. The coexistence is intent, not drift.
+ */
+sealed interface ConnectionPhase {
+    /** Accepting sends; the writer is live. */
+    data object Open : ConnectionPhase
+
+    /** Graceful close in progress: no new sends; queued frames are flushing. */
+    data object Draining : ConnectionPhase
+
+    /** Terminal. The cause is always present. */
+    data class Closed(
+        val cause: CloseCause,
+    ) : ConnectionPhase
+}
+
+/** Why a connection reached [ConnectionPhase.Closed]. */
+sealed interface CloseCause {
+    /** Graceful close completed: every accepted frame reached the wire. */
+    data object Graceful : CloseCause
+
+    /** Abort — explicit `abort()`, or a graceful close whose linger expired. */
+    data object Aborted : CloseCause
+
+    /**
+     * The writer or transport failed. At this layer the cause is the transport [Throwable];
+     * richer sealed classification belongs to the transport library's exception family
+     * (the dependency points from there to here, not the reverse).
+     */
+    data class Failed(
+        val cause: Throwable,
+    ) : CloseCause
+}

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/Map.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/Map.kt
@@ -35,4 +35,10 @@ fun <A, B> Connection<A>.mapNotNull(
         override fun receive(): Flow<B> = this@mapNotNull.receive().mapNotNull { decode(it) }
 
         override suspend fun close() = this@mapNotNull.close()
+
+        // Any decorator that overrides close() MUST override abort(). Without this, abort() on the
+        // wrapper resolves to Connection's default — which is close() — silently turning the
+        // escape hatch for a stalled peer back into the graceful drain it exists to break out of,
+        // even when the wrapped connection has a real abort.
+        override suspend fun abort() = this@mapNotNull.abort()
     }

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/OutboundWriter.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/OutboundWriter.kt
@@ -285,7 +285,10 @@ class OutboundWriter<T> internal constructor(
     }
 
     /** Terminal-phase cause, for reporting. Callers settle first, so the fallback is unreachable. */
-    private fun terminalCause(): CloseCause = (currentPhase.value as? ConnectionPhase.Closed)?.cause ?: CloseCause.Aborted
+    private fun terminalCause(): CloseCause {
+        val settled = currentPhase.value as? ConnectionPhase.Closed
+        return settled?.cause ?: CloseCause.Aborted
+    }
 
     /**
      * The cause a refused sender sees. `Draining` is closed to senders and its eventual cause is

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/OutboundWriter.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/OutboundWriter.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.channels.ClosedSendChannelException
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -222,14 +223,24 @@ class OutboundWriter<T>(
         origin: T,
     ): Unit = strategy.send(SharedSend(bytes, origin))
 
-    /** Graceful close: drain per mode, join the writer, settle at [ConnectionPhase.Closed]. */
+    /**
+     * Graceful close: drain per mode, join the writer, settle at [ConnectionPhase.Closed].
+     *
+     * Cancellation-safe by construction. The canonical teardown is `finally { close() }` from a
+     * scope that is *already* cancelled, so every step that must happen — leaving [Open],
+     * refusing senders, and escalating to [abort] when the drain cannot be waited on — runs under
+     * [NonCancellable]. Only the *waiting* is cancellable, and losing the wait escalates rather
+     * than abandoning the ladder half-climbed.
+     */
     suspend fun close() {
-        lock.withLock {
-            if (currentPhase.value === ConnectionPhase.Open) {
-                // One atomic step: the phase leaves Open and the strategy stops accepting in the
-                // same critical section, so no send can slip into a queue that is already draining.
-                currentPhase.value = ConnectionPhase.Draining
-                strategy.refuseSends()
+        withContext(NonCancellable) {
+            lock.withLock {
+                if (currentPhase.value === ConnectionPhase.Open) {
+                    // One atomic step: the phase leaves Open and the strategy stops accepting in
+                    // the same critical section, so no send can slip into a draining queue.
+                    currentPhase.value = ConnectionPhase.Draining
+                    strategy.refuseSends()
+                }
             }
         }
         if (insideWriter()) {
@@ -237,36 +248,57 @@ class OutboundWriter<T>(
             // coroutine, so opening the window is the whole job. Joining here would join ourselves.
             return
         }
-        when (val bound = linger) {
-            Linger.UntilDrained -> writerJob.join()
-            is Linger.Bounded ->
-                if (withTimeoutOrNull(bound.timeout) { writerJob.join() } == null) {
-                    // Linger expired with the queue unflushed: the ladder's last rung.
-                    abort()
-                    return
-                }
+        var lingerExpired = false
+        try {
+            when (val bound = linger) {
+                Linger.UntilDrained -> writerJob.join()
+                is Linger.Bounded ->
+                    lingerExpired = withTimeoutOrNull(bound.timeout) { writerJob.join() } == null
+            }
+        } catch (cancellation: CancellationException) {
+            // The *caller* was cancelled mid-drain (`finally { close() }` from a dead scope). The
+            // drain can no longer be waited on, but the queue's exactly-once obligations are not
+            // the caller's to drop: escalate to the ladder's last rung, then unwind as asked.
+            abort()
+            throw cancellation
+        }
+        if (lingerExpired) {
+            // Linger expired with the queue unflushed: the ladder's last rung.
+            abort()
+            return
         }
         settle(CloseCause.Graceful)
         scope.cancel()
     }
 
-    /** Immediate close: cancel the writer, report the queue not-sent, settle at [ConnectionPhase.Closed]. */
+    /**
+     * Immediate close: cancel the writer, report the queue not-sent, settle at
+     * [ConnectionPhase.Closed].
+     *
+     * The **entire** body is [NonCancellable]. Everything inside is bounded, and this is the API's
+     * escape hatch: a caller reaching for it is usually already being cancelled (a watchdog, a
+     * `finally`), and an abort that silently no-ops because its caller was cancelled first is
+     * worse than no escape hatch at all.
+     */
     suspend fun abort() {
-        lock.withLock {
-            if (currentPhase.value !is ConnectionPhase.Closed) {
-                currentPhase.value = ConnectionPhase.Closed(CloseCause.Aborted)
-            }
-            strategy.refuseSends()
-        }
-        val cause = terminalCause()
+        // Whether we are the writer's own lineage decides only whether we may *join* — see
+        // [insideWriter]. Read it outside NonCancellable so it reflects the caller's context.
         val reentrant = insideWriter()
-        // The discard must complete even if the caller is itself being cancelled — a dropped
-        // discard is a lost report, which is exactly what exactly-once forbids.
         withContext(NonCancellable) {
-            if (!reentrant) {
-                writerJob.cancel()
-                writerJob.join()
+            lock.withLock {
+                if (currentPhase.value !is ConnectionPhase.Closed) {
+                    currentPhase.value = ConnectionPhase.Closed(CloseCause.Aborted)
+                }
+                strategy.refuseSends()
             }
+            val cause = terminalCause()
+            // Always cancel, even from the writer's own lineage: an abort that does not stop the
+            // writer is not an abort. Only the join is lineage-conditional — joining a job we are
+            // (or descend from) would deadlock.
+            writerJob.cancel()
+            if (!reentrant) writerJob.join()
+            // The discard must complete even if the caller is itself being cancelled — a dropped
+            // discard is a lost report, which is exactly what exactly-once forbids.
             strategy.discardQueued(cause)
         }
         if (!reentrant) scope.cancel()
@@ -298,19 +330,31 @@ class OutboundWriter<T>(
             else -> CloseCause.Graceful
         }
 
-    /** True when the calling coroutine *is* this component's writer (a re-entrant user handler). */
+    /**
+     * True when the caller is the writer coroutine **or a coroutine launched from it** — the
+     * marker is a context element, so it is inherited by children of `transmit`/`onNotSent`.
+     * Lineage is deliberately the right question for the only thing this gates: whether [abort]
+     * may `join` the writer. A child of the writer joining it deadlocks exactly as the writer
+     * itself would. It must never gate whether the writer is *cancelled* — see [abort].
+     */
     private suspend fun insideWriter(): Boolean = currentCoroutineContext()[WriterMark]?.owner === this
 
     /**
      * Fails the writer: terminal phase first, then refusal, so anyone who observes the failure
      * already sees the terminal cause. Loss reporting is the caller's (mode-specific) job.
+     *
+     * [NonCancellable]: this runs on paths that are already unwinding (a transmit throw racing an
+     * [abort]), and a phase transition lost to the caller's cancellation leaves a dead writer
+     * under an [ConnectionPhase.Open] phase — the silent hang this component exists to kill.
      */
     private suspend fun failWriter(cause: Throwable) {
-        lock.withLock {
-            if (currentPhase.value !is ConnectionPhase.Closed) {
-                currentPhase.value = ConnectionPhase.Closed(CloseCause.Failed(cause))
+        withContext(NonCancellable) {
+            lock.withLock {
+                if (currentPhase.value !is ConnectionPhase.Closed) {
+                    currentPhase.value = ConnectionPhase.Closed(CloseCause.Failed(cause))
+                }
+                strategy.refuseSends()
             }
-            strategy.refuseSends()
         }
     }
 
@@ -347,25 +391,47 @@ class OutboundWriter<T>(
         @Suppress("TooGenericExceptionCaught") // any transmit throwable = transport failure, fails the writer
         override suspend fun drive() {
             for (element in handoffs) {
-                val outcome =
-                    try {
-                        transmit(element.payload.toOutgoing())
-                    } catch (cancellation: CancellationException) {
-                        // abort() cancelled us mid-frame. The frame may be truncated on a dying
-                        // connection (by design); the sender still gets its exactly-one answer.
-                        element.discard(terminalCause())
-                        throw cancellation
-                    } catch (failure: Throwable) {
-                        element.payload.release()
-                        failWriter(failure)
-                        element.ack.completeExceptionally(failure)
-                        return
+                try {
+                    val outcome =
+                        try {
+                            transmit(element.payload.toOutgoing())
+                        } catch (cancellation: CancellationException) {
+                            if (currentCoroutineContext().isActive) {
+                                // NOT our cancellation: the adopter's transmit raised it itself (a
+                                // `withTimeout` around the sink write). That is a transport
+                                // failure, and misreading it as an abort would leave a dead writer
+                                // under an Open phase.
+                                element.ack.completeExceptionally(cancellation)
+                                failWriter(cancellation)
+                                return
+                            }
+                            // abort() cancelled us mid-frame. The frame may be truncated on a dying
+                            // connection (by design); the sender still gets its exactly-one answer.
+                            element.ack.completeExceptionally(OutboundClosedException(terminalCause()))
+                            throw cancellation
+                        } catch (failure: Throwable) {
+                            // The sender's answer is settled BEFORE any cancellable suspension: an
+                            // abort racing this throw must not be able to strand it in await().
+                            element.ack.completeExceptionally(failure)
+                            failWriter(failure)
+                            return
+                        }
+                    when (outcome) {
+                        TransmitOutcome.Written -> element.ack.complete(Unit)
+                        // Encode failure is per-message: the sender hears it, the connection lives.
+                        is TransmitOutcome.EncodeFailed -> element.ack.completeExceptionally(outcome.cause)
                     }
-                element.payload.release()
-                when (outcome) {
-                    TransmitOutcome.Written -> element.ack.complete(Unit)
-                    // Encode failure is per-message: the sender hears it, the connection lives.
-                    is TransmitOutcome.EncodeFailed -> element.ack.completeExceptionally(outcome.cause)
+                } finally {
+                    // The two obligations every taken element carries, on every exit path — which
+                    // is what makes "released exactly once" and "never hangs its sender"
+                    // structural rather than a property of every branch remembering to spell
+                    // them. The `isCompleted` guard is not correctness (completeExceptionally is
+                    // already a no-op on a settled ack) but allocation: this is the hot path, and
+                    // the success case must not build an exception it will immediately discard.
+                    element.payload.release()
+                    if (!element.ack.isCompleted) {
+                        element.ack.completeExceptionally(OutboundClosedException(terminalCause()))
+                    }
                 }
             }
         }
@@ -406,17 +472,32 @@ class OutboundWriter<T>(
         /** Reactive writer wakeup. Conflated: a wakeup is never lost and never accumulates. */
         private val wakeup = Channel<Unit>(Channel.CONFLATED)
 
+        @Suppress("TooGenericExceptionCaught") // the transferred reference is owed a release on every path
         override suspend fun send(payload: OutboundPayload<T>) {
-            when (val admission = lock.withLock { admit(payload) }) {
+            val admission =
+                try {
+                    lock.withLock { admit(payload) }
+                } catch (t: Throwable) {
+                    // Cancelled (or failed) while suspended on the contended lock: nothing was ever
+                    // queued, so nothing is reported — but the reference this call took ownership of
+                    // still owes its single release. `AwaitWritten` covers the identical window via
+                    // `onUndeliveredElement`; this is Handoff's equivalent.
+                    payload.release()
+                    throw t
+                }
+            when (admission) {
                 Admission.Accepted -> Unit
                 Admission.Refused -> {
                     payload.release()
                     throw OutboundClosedException(senderCloseCause())
                 }
-                // User code, deliberately outside the lock: re-entrant send/close is legal.
+                // User code, deliberately outside the lock: re-entrant send/close is legal. The
+                // victim was *already accepted*, so its exactly-once report is not this sender's
+                // to drop — [reportLost] is NonCancellable and routes a throwing handler to the
+                // writer rather than to the unrelated call site that triggered the eviction.
                 is Admission.Displaced -> {
                     admission.victim.release()
-                    handoff.onNotSent(admission.victim.origin, NotSentReason.CapacityExceeded)
+                    reportLost(admission.victim, NotSentReason.CapacityExceeded)
                 }
                 is Admission.Parked -> awaitSlot(admission.sender, payload)
             }
@@ -480,39 +561,81 @@ class OutboundWriter<T>(
             if (failure != null) throw failure
         }
 
-        @Suppress("TooGenericExceptionCaught") // any transmit throwable = transport failure, fails the writer
         override suspend fun drive() {
-            while (true) {
+            var alive = true
+            while (alive) {
                 val next = lock.withLock { dequeue() }
                 if (next == null) {
                     // Drained. Only close()/abort()/failure move the phase off Open, so this is
                     // the graceful exit; otherwise park until there is work or the phase moves.
                     if (currentPhase.value !== ConnectionPhase.Open) return
                     wakeup.receive()
-                    continue
+                } else {
+                    alive = transmitOne(next)
                 }
+            }
+        }
+
+        /**
+         * Transmits one element and discharges its obligations. Returns `false` when the writer
+         * must stop — a transport failure, whose queue this has already discarded.
+         */
+        @Suppress("TooGenericExceptionCaught") // any transmit throwable = transport failure, fails the writer
+        private suspend fun transmitOne(next: OutboundPayload<T>): Boolean {
+            var alive = true
+            try {
                 val outcome =
                     try {
                         transmit(next.toOutgoing())
                     } catch (cancellation: CancellationException) {
-                        next.release()
-                        // Accepted but unfinished: it owes exactly one report even though we are
-                        // being torn down mid-frame.
-                        withContext(NonCancellable) {
-                            handoff.onNotSent(next.origin, NotSentReason.ConnectionClosed(terminalCause()))
+                        if (!currentCoroutineContext().isActive) {
+                            // Accepted but unfinished: it owes exactly one report even though we
+                            // are being torn down mid-frame.
+                            reportLost(next, NotSentReason.ConnectionClosed(terminalCause()))
+                            throw cancellation
                         }
-                        throw cancellation
+                        // NOT our cancellation — the adopter's own transmit raised it. A transport
+                        // failure, not an abort; see the AwaitWritten twin.
+                        failWriter(cancellation)
+                        alive = false
+                        null
                     } catch (failure: Throwable) {
-                        next.release()
                         failWriter(failure)
-                        val cause = terminalCause()
-                        handoff.onNotSent(next.origin, NotSentReason.ConnectionClosed(cause))
-                        discardQueued(cause)
-                        return
+                        alive = false
+                        null
                     }
+                when {
+                    !alive -> {
+                        val cause = terminalCause()
+                        reportLost(next, NotSentReason.ConnectionClosed(cause))
+                        discardQueued(cause)
+                    }
+                    outcome is TransmitOutcome.EncodeFailed ->
+                        reportLost(next, NotSentReason.EncodeFailed(outcome.cause))
+                }
+            } finally {
+                // One release site per strategy: the load-bearing exactly-once-release invariant
+                // is structural, not a property of every exit path remembering to spell it.
                 next.release()
-                if (outcome is TransmitOutcome.EncodeFailed) {
-                    handoff.onNotSent(next.origin, NotSentReason.EncodeFailed(outcome.cause))
+            }
+            return alive
+        }
+
+        /**
+         * The writer's loss-report path: [NonCancellable] so a teardown cannot swallow an owed
+         * report, and guarded so a throwing handler fails the writer rather than unwinding the
+         * loop past the releases it still owes.
+         */
+        @Suppress("TooGenericExceptionCaught") // handler contract: a throw fails the writer, never escapes
+        private suspend fun reportLost(
+            payload: OutboundPayload<T>,
+            reason: NotSentReason,
+        ) {
+            withContext(NonCancellable) {
+                try {
+                    handoff.onNotSent(payload.origin, reason)
+                } catch (t: Throwable) {
+                    if (t !is CancellationException) failWriter(t)
                 }
             }
         }
@@ -544,11 +667,21 @@ class OutboundWriter<T>(
             wakeup.trySend(Unit)
         }
 
+        /**
+         * Drains the queue's obligations. Every element is released unconditionally and reported
+         * under its own guard, so one throwing handler degrades *its own* report to best-effort
+         * (as documented) without stranding the references and reports of everything behind it.
+         */
         override suspend fun discardQueued(cause: CloseCause) {
-            while (true) {
-                val lost = lock.withLock { queue.removeFirstOrNull() } ?: return
-                lost.release()
-                handoff.onNotSent(lost.origin, NotSentReason.ConnectionClosed(cause))
+            withContext(NonCancellable) {
+                while (true) {
+                    val lost = lock.withLock { queue.removeFirstOrNull() } ?: break
+                    try {
+                        runCatching { handoff.onNotSent(lost.origin, NotSentReason.ConnectionClosed(cause)) }
+                    } finally {
+                        lost.release()
+                    }
+                }
             }
         }
     }

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/OutboundWriter.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/OutboundWriter.kt
@@ -1,0 +1,137 @@
+package com.ditchoom.buffer.flow
+
+import com.ditchoom.buffer.ExperimentalFanoutApi
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.pool.SharedBytes
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * The element the writer hands to [OutboundWriter]'s `transmit` stage: either a message still to
+ * be encoded (encode-on-writer keeps buffer lifetime and pool discipline inside the adopter's
+ * transmit closure), or bytes already encoded once for fan-out. "Pre-encoded" is a queue-element
+ * arm, not a connection flag — both send modes carry both arms.
+ */
+@ExperimentalFanoutApi
+sealed interface Outgoing<out T> {
+    /** Encode [message] on the writer, then write the frame fully. */
+    @ExperimentalFanoutApi
+    data class Encode<T>(
+        val message: T,
+    ) : Outgoing<T>
+
+    /**
+     * Write [view] fully — it is a private-cursor slice of shared, already-encoded bytes.
+     * The writer owns the underlying reference; the transmit stage only writes.
+     */
+    @ExperimentalFanoutApi
+    class Prewritten<T>(
+        val view: ReadBuffer,
+        /** The message the bytes encode, for loss reporting. */
+        val origin: T,
+    ) : Outgoing<T>
+}
+
+/** What the adopter's transmit stage reports back to the writer, per element. */
+@ExperimentalFanoutApi
+sealed interface TransmitOutcome {
+    /** The frame reached the wire whole. */
+    @ExperimentalFanoutApi
+    data object Written : TransmitOutcome
+
+    /**
+     * The element failed to **encode** — deterministic, per-message, no bytes written. The
+     * connection survives: in `AwaitWritten` the cause throws at the sender's call site; in
+     * `Handoff` it reports through `onNotSent` as [NotSentReason.EncodeFailed].
+     * Transport/write failures are different: transmit *throws* those, and they fail the
+     * connection.
+     */
+    @ExperimentalFanoutApi
+    data class EncodeFailed(
+        val cause: Throwable,
+    ) : TransmitOutcome
+}
+
+/** Thrown by [OutboundWriter.send]/[OutboundWriter.sendShared] once the writer is closed. */
+@ExperimentalFanoutApi
+class OutboundClosedException(
+    /** Why the writer closed — the same cause carried by [ConnectionPhase.Closed]. */
+    val closeCause: CloseCause,
+) : IllegalStateException(
+        "outbound writer is closed: $closeCause",
+        (closeCause as? CloseCause.Failed)?.cause,
+    )
+
+/**
+ * A connection-owned single writer: the component that makes send atomicity and serialization
+ * structural rather than by-discipline.
+ *
+ * One writer coroutine — owned by this component, living on an internal scope whose lifetime
+ * equals the component's ([close]/[abort] end it) — performs every transmit. Callers hand
+ * elements off; they never run the write themselves, so cancelling a caller can never truncate a
+ * frame, and concurrent senders cannot interleave. The [mode] decides how `send` completes; see
+ * [SendMode].
+ *
+ * ## Contract with the adopter's [transmit]
+ *
+ * - Called serially, only from the writer coroutine, one [Outgoing] element at a time.
+ * - Must write the frame **fully or throw** (`writeFully` semantics). A throw is a transport
+ *   failure: the writer fails with [CloseCause.Failed], suspended senders and future sends get
+ *   [OutboundClosedException], and remaining queued elements report not-sent.
+ * - Encode failures are not throws — return [TransmitOutcome.EncodeFailed] instead; the
+ *   connection survives them (see [TransmitOutcome]).
+ *
+ * ## Exactly-once accounting (the load-bearing invariant)
+ *
+ * Every accepted element leaves through exactly one of: transmit-completed, or the loss path
+ * (mode-appropriate: `onNotSent` in Handoff, a thrown cause in AwaitWritten). Shared-bytes
+ * references transferred via [sendShared] are released by this component exactly once, on
+ * whichever path the element takes. Capacity eviction, linger expiry, `close()` racing
+ * `abort()`, and writer failure are all instances of the same rule, not special cases.
+ *
+ * ## Close ladder
+ *
+ * [close] is graceful: the phase moves to [ConnectionPhase.Draining] (the phase transition and
+ * the enqueue check are one atomic step — no send can slip into a drained queue), queued frames
+ * flush (bounded by the Handoff `linger`, which escalates to abort on expiry; AwaitWritten
+ * finishes the in-flight frame and fails the waiting senders), the writer joins, and the phase
+ * reaches [ConnectionPhase.Closed]. [abort] is immediate: cancel the writer wherever it is —
+ * truncating a frame on a dying connection harms nobody, which is the whole point of the
+ * ownership design — and report the queue not-sent. Both are idempotent and converge under
+ * concurrent calls.
+ *
+ * The prompt-cancellation edge, stated once: in `AwaitWritten`, a sender whose handoff succeeded
+ * may still unwind with `CancellationException` while the writer finishes the frame — "cancelled"
+ * does not imply "not sent". The writer completes every taken element's acknowledgement exactly
+ * once regardless of whether anyone is still listening.
+ */
+@ExperimentalFanoutApi
+class OutboundWriter<T>(
+    private val mode: SendMode<T>,
+    private val transmit: suspend (Outgoing<T>) -> TransmitOutcome,
+) {
+    /** The send/close lifecycle, reactively. Single source of truth — there is no separate flag. */
+    val phase: StateFlow<ConnectionPhase>
+        get() = TODO("implemented by the writer-component work")
+
+    /**
+     * Sends [message] per the [mode]'s completion semantics. Throws [OutboundClosedException]
+     * once the writer is not [ConnectionPhase.Open].
+     */
+    suspend fun send(message: T): Unit = TODO("implemented by the writer-component work")
+
+    /**
+     * Sends already-encoded shared bytes. **Transfers one [SharedBytes] reference** — the caller
+     * retains for this call, and this component releases exactly once on whichever path the
+     * element takes. [origin] is the message the bytes encode, for loss reporting.
+     */
+    suspend fun sendShared(
+        bytes: SharedBytes,
+        origin: T,
+    ): Unit = TODO("implemented by the writer-component work")
+
+    /** Graceful close: drain per mode, join the writer, settle at [ConnectionPhase.Closed]. */
+    suspend fun close(): Unit = TODO("implemented by the writer-component work")
+
+    /** Immediate close: cancel the writer, report the queue not-sent, settle at [ConnectionPhase.Closed]. */
+    suspend fun abort(): Unit = TODO("implemented by the writer-component work")
+}

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/OutboundWriter.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/OutboundWriter.kt
@@ -181,6 +181,9 @@ class OutboundWriter<T> internal constructor(
             is SendMode.Handoff -> mode.linger
         }
 
+    // Broad catches below are the component boundary: ANY non-cancellation throwable from user
+    // code or transport must fail the writer with its cause, never escape uncategorized.
+    @Suppress("TooGenericExceptionCaught")
     private val writerJob: Job =
         scope.launch(mark) {
             try {
@@ -341,6 +344,7 @@ class OutboundWriter<T> internal constructor(
             element.ack.await()
         }
 
+        @Suppress("TooGenericExceptionCaught") // any transmit throwable = transport failure, fails the writer
         override suspend fun drive() {
             for (element in handoffs) {
                 val outcome =
@@ -419,26 +423,27 @@ class OutboundWriter<T> internal constructor(
         }
 
         /** Decides the fate of [payload] under [lock] — phase check and enqueue in one step. */
-        private fun admit(payload: OutboundPayload<T>): Admission<T> {
-            if (currentPhase.value !== ConnectionPhase.Open) return Admission.Refused
-            if (queue.size < capacity) {
+        private fun admit(payload: OutboundPayload<T>): Admission<T> =
+            if (currentPhase.value !== ConnectionPhase.Open) {
+                Admission.Refused
+            } else if (queue.size < capacity) {
                 enqueue(payload)
-                return Admission.Accepted
-            }
-            return when (handoff.onCapacity) {
-                CapacityBehavior.Suspend -> {
-                    val sender = ParkedSend(payload)
-                    parked.addLast(sender)
-                    Admission.Parked(sender)
+                Admission.Accepted
+            } else {
+                when (handoff.onCapacity) {
+                    CapacityBehavior.Suspend -> {
+                        val sender = ParkedSend(payload)
+                        parked.addLast(sender)
+                        Admission.Parked(sender)
+                    }
+                    CapacityBehavior.DropOldest -> {
+                        val victim = queue.removeFirst()
+                        enqueue(payload)
+                        Admission.Displaced(victim)
+                    }
+                    CapacityBehavior.DropNewest -> Admission.Displaced(payload)
                 }
-                CapacityBehavior.DropOldest -> {
-                    val victim = queue.removeFirst()
-                    enqueue(payload)
-                    Admission.Displaced(victim)
-                }
-                CapacityBehavior.DropNewest -> Admission.Displaced(payload)
             }
-        }
 
         /** Under [lock]. */
         private fun enqueue(payload: OutboundPayload<T>) {
@@ -451,6 +456,7 @@ class OutboundWriter<T> internal constructor(
          * whether an admitter already moved it into the queue — the only question that matters on
          * every exit path (admitted, refused, or cancelled).
          */
+        @Suppress("TooGenericExceptionCaught") // the await outcome is re-thrown after ownership settles
         private suspend fun awaitSlot(
             sender: ParkedSend<T>,
             payload: OutboundPayload<T>,
@@ -474,6 +480,7 @@ class OutboundWriter<T> internal constructor(
             if (failure != null) throw failure
         }
 
+        @Suppress("TooGenericExceptionCaught") // any transmit throwable = transport failure, fails the writer
         override suspend fun drive() {
             while (true) {
                 val next = lock.withLock { dequeue() }

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/OutboundWriter.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/OutboundWriter.kt
@@ -3,7 +3,25 @@ package com.ditchoom.buffer.flow
 import com.ditchoom.buffer.ExperimentalFanoutApi
 import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.pool.SharedBytes
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ClosedSendChannelException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
 
 /**
  * The element the writer hands to [OutboundWriter]'s `transmit` stage: either a message still to
@@ -88,6 +106,12 @@ class OutboundClosedException(
  * whichever path the element takes. Capacity eviction, linger expiry, `close()` racing
  * `abort()`, and writer failure are all instances of the same rule, not special cases.
  *
+ * "Accepted" is the pivot: a message is accepted the instant it enters the writer's queue (in
+ * `Handoff`) or reaches the writer's hands (in `AwaitWritten`). A sender cancelled *before* that
+ * instant never sent anything and is reported nowhere — its `send` simply unwinds. A frame the
+ * writer took and then could not finish (an [abort] mid-transmit, a linger expiry) *is* accepted,
+ * so it takes the loss path like any other.
+ *
  * ## Close ladder
  *
  * [close] is graceful: the phase moves to [ConnectionPhase.Draining] (the phase transition and
@@ -97,41 +121,523 @@ class OutboundClosedException(
  * reaches [ConnectionPhase.Closed]. [abort] is immediate: cancel the writer wherever it is —
  * truncating a frame on a dying connection harms nobody, which is the whole point of the
  * ownership design — and report the queue not-sent. Both are idempotent and converge under
- * concurrent calls.
+ * concurrent calls: the **first** terminal cause to settle wins and is never overwritten, so a
+ * writer failure racing a `close()` reports [CloseCause.Failed], not [CloseCause.Graceful].
+ *
+ * Senders that arrive during [ConnectionPhase.Draining] are refused with
+ * [OutboundClosedException] carrying [CloseCause.Graceful]: draining is closed to senders, and
+ * the graceful cause is the one the phase is on its way to.
  *
  * The prompt-cancellation edge, stated once: in `AwaitWritten`, a sender whose handoff succeeded
  * may still unwind with `CancellationException` while the writer finishes the frame — "cancelled"
  * does not imply "not sent". The writer completes every taken element's acknowledgement exactly
- * once regardless of whether anyone is still listening.
+ * once regardless of whether anyone is still listening. `Handoff`'s parked senders have the same
+ * edge at the same boundary: a sender cancelled after a freed slot admitted its message loses the
+ * *wait*, not the message.
  */
 @ExperimentalFanoutApi
-class OutboundWriter<T>(
+class OutboundWriter<T> internal constructor(
     private val mode: SendMode<T>,
     private val transmit: suspend (Outgoing<T>) -> TransmitOutcome,
+    /**
+     * Where the writer coroutine runs. Internal seam only: tests inject a test dispatcher so the
+     * writer is under the scheduler's control instead of racing it on [Dispatchers.Default].
+     */
+    writerContext: CoroutineContext,
 ) {
+    constructor(
+        mode: SendMode<T>,
+        transmit: suspend (Outgoing<T>) -> TransmitOutcome,
+    ) : this(mode, transmit, Dispatchers.Default)
+
+    private val currentPhase = MutableStateFlow<ConnectionPhase>(ConnectionPhase.Open)
+
     /** The send/close lifecycle, reactively. Single source of truth — there is no separate flag. */
     val phase: StateFlow<ConnectionPhase>
-        get() = TODO("implemented by the writer-component work")
+        get() = currentPhase
+
+    /**
+     * Guards the phase *and* the queue, so "is this writer still open?" and "is this message in
+     * the queue?" are decided in one step and the send-after-close TOCTOU cannot exist. User code
+     * ([SendMode.Handoff.onNotSent]) and [transmit] are never invoked while it is held.
+     */
+    private val lock = Mutex()
+
+    /** Identity marker for re-entrancy detection; see [insideWriter]. */
+    private val mark = WriterMark(this)
+
+    private val scope = CoroutineScope(writerContext + Job())
+
+    private val strategy: OutboundStrategy<T> =
+        when (mode) {
+            SendMode.AwaitWritten -> AwaitWrittenStrategy()
+            is SendMode.Handoff -> HandoffStrategy(mode)
+        }
+
+    /** How long a graceful close may drain. Only `Handoff` has an unattended queue to bound. */
+    private val linger: Linger =
+        when (mode) {
+            SendMode.AwaitWritten -> Linger.UntilDrained
+            is SendMode.Handoff -> mode.linger
+        }
+
+    private val writerJob: Job =
+        scope.launch(mark) {
+            strategy.drive()
+            // A normal loop exit means the queue drained after close() opened the window. Whoever
+            // settled first keeps their cause; this only fills in the graceful case.
+            settle(CloseCause.Graceful)
+        }
 
     /**
      * Sends [message] per the [mode]'s completion semantics. Throws [OutboundClosedException]
      * once the writer is not [ConnectionPhase.Open].
      */
-    suspend fun send(message: T): Unit = TODO("implemented by the writer-component work")
+    suspend fun send(message: T): Unit = strategy.send(MessageSend(message))
 
     /**
      * Sends already-encoded shared bytes. **Transfers one [SharedBytes] reference** — the caller
      * retains for this call, and this component releases exactly once on whichever path the
      * element takes. [origin] is the message the bytes encode, for loss reporting.
+     *
+     * The transfer is unconditional: the reference is released even when this call throws
+     * [OutboundClosedException], because a refused send is one of the paths the element can take.
      */
     suspend fun sendShared(
         bytes: SharedBytes,
         origin: T,
-    ): Unit = TODO("implemented by the writer-component work")
+    ): Unit = strategy.send(SharedSend(bytes, origin))
 
     /** Graceful close: drain per mode, join the writer, settle at [ConnectionPhase.Closed]. */
-    suspend fun close(): Unit = TODO("implemented by the writer-component work")
+    suspend fun close() {
+        lock.withLock {
+            if (currentPhase.value === ConnectionPhase.Open) {
+                // One atomic step: the phase leaves Open and the strategy stops accepting in the
+                // same critical section, so no send can slip into a queue that is already draining.
+                currentPhase.value = ConnectionPhase.Draining
+                strategy.refuseSends()
+            }
+        }
+        if (insideWriter()) {
+            // Re-entrant close from a handler running on the writer coroutine: the drain *is* this
+            // coroutine, so opening the window is the whole job. Joining here would join ourselves.
+            return
+        }
+        when (val bound = linger) {
+            Linger.UntilDrained -> writerJob.join()
+            is Linger.Bounded ->
+                if (withTimeoutOrNull(bound.timeout) { writerJob.join() } == null) {
+                    // Linger expired with the queue unflushed: the ladder's last rung.
+                    abort()
+                    return
+                }
+        }
+        settle(CloseCause.Graceful)
+        scope.cancel()
+    }
 
     /** Immediate close: cancel the writer, report the queue not-sent, settle at [ConnectionPhase.Closed]. */
-    suspend fun abort(): Unit = TODO("implemented by the writer-component work")
+    suspend fun abort() {
+        lock.withLock {
+            if (currentPhase.value !is ConnectionPhase.Closed) {
+                currentPhase.value = ConnectionPhase.Closed(CloseCause.Aborted)
+            }
+            strategy.refuseSends()
+        }
+        val cause = terminalCause()
+        val reentrant = insideWriter()
+        // The discard must complete even if the caller is itself being cancelled — a dropped
+        // discard is a lost report, which is exactly what exactly-once forbids.
+        withContext(NonCancellable) {
+            if (!reentrant) {
+                writerJob.cancel()
+                writerJob.join()
+            }
+            strategy.discardQueued(cause)
+        }
+        if (!reentrant) scope.cancel()
+    }
+
+    /** Settles the terminal phase. The first cause wins; later ones are dropped, never overwritten. */
+    private suspend fun settle(cause: CloseCause) {
+        lock.withLock {
+            if (currentPhase.value !is ConnectionPhase.Closed) {
+                currentPhase.value = ConnectionPhase.Closed(cause)
+            }
+        }
+    }
+
+    /** Terminal-phase cause, for reporting. Callers settle first, so the fallback is unreachable. */
+    private fun terminalCause(): CloseCause = (currentPhase.value as? ConnectionPhase.Closed)?.cause ?: CloseCause.Aborted
+
+    /**
+     * The cause a refused sender sees. `Draining` is closed to senders and its eventual cause is
+     * graceful, so a send racing a graceful close reports [CloseCause.Graceful] rather than
+     * inventing a phase-specific one.
+     */
+    private fun senderCloseCause(): CloseCause =
+        when (val observed = currentPhase.value) {
+            is ConnectionPhase.Closed -> observed.cause
+            else -> CloseCause.Graceful
+        }
+
+    /** True when the calling coroutine *is* this component's writer (a re-entrant user handler). */
+    private suspend fun insideWriter(): Boolean = currentCoroutineContext()[WriterMark]?.owner === this
+
+    /**
+     * Fails the writer: terminal phase first, then refusal, so anyone who observes the failure
+     * already sees the terminal cause. Loss reporting is the caller's (mode-specific) job.
+     */
+    private suspend fun failWriter(cause: Throwable) {
+        lock.withLock {
+            if (currentPhase.value !is ConnectionPhase.Closed) {
+                currentPhase.value = ConnectionPhase.Closed(CloseCause.Failed(cause))
+            }
+            strategy.refuseSends()
+        }
+    }
+
+    /**
+     * `AwaitWritten`: a rendezvous handoff whose queue is its suspended senders.
+     *
+     * kotlinx's rendezvous channel is used here — and only here — because its semantics *are* the
+     * contract: an element is either taken by the writer or it never happened, and
+     * `onUndeliveredElement` fires on exactly the paths where it never happened (sender cancelled
+     * before the rendezvous, or the channel closed under a parked sender). No buffering, hence
+     * none of the `BufferOverflow` gaps that force [HandoffStrategy] to hand-roll its deque.
+     */
+    private inner class AwaitWrittenStrategy : OutboundStrategy<T> {
+        private val handoffs =
+            Channel<AckedSend<T>>(
+                capacity = Channel.RENDEZVOUS,
+                onUndeliveredElement = { undelivered -> undelivered.discard(senderCloseCause()) },
+            )
+
+        override suspend fun send(payload: OutboundPayload<T>) {
+            val element = AckedSend(payload, CompletableDeferred())
+            try {
+                handoffs.send(element)
+            } catch (closed: ClosedSendChannelException) {
+                // The element never reached the writer; `onUndeliveredElement` already released the
+                // transferred reference, so this path only reports.
+                throw OutboundClosedException(senderCloseCause()).apply { addSuppressed(closed) }
+            }
+            // Past this point the writer owns the element: cancelling here abandons the wait, not
+            // the write, and the ack is completed exactly once whether or not anyone is listening.
+            element.ack.await()
+        }
+
+        override suspend fun drive() {
+            for (element in handoffs) {
+                val outcome =
+                    try {
+                        transmit(element.payload.toOutgoing())
+                    } catch (cancellation: CancellationException) {
+                        // abort() cancelled us mid-frame. The frame may be truncated on a dying
+                        // connection (by design); the sender still gets its exactly-one answer.
+                        element.discard(terminalCause())
+                        throw cancellation
+                    } catch (failure: Throwable) {
+                        element.payload.release()
+                        failWriter(failure)
+                        element.ack.completeExceptionally(failure)
+                        return
+                    }
+                element.payload.release()
+                when (outcome) {
+                    TransmitOutcome.Written -> element.ack.complete(Unit)
+                    // Encode failure is per-message: the sender hears it, the connection lives.
+                    is TransmitOutcome.EncodeFailed -> element.ack.completeExceptionally(outcome.cause)
+                }
+            }
+        }
+
+        override fun refuseSends() {
+            handoffs.close()
+        }
+
+        override suspend fun discardQueued(cause: CloseCause) {
+            // Nothing is ever buffered here: the queue is the suspended senders, and closing for
+            // send hands every one of them back through `onUndeliveredElement`.
+            handoffs.close()
+        }
+    }
+
+    /**
+     * `Handoff`: a hand-rolled bounded deque plus parked senders, drained by the writer.
+     *
+     * Hand-rolled on purpose. `onNotSent` is a *suspend* handler that must fire for evictions, and
+     * kotlinx's only loss hook (`onUndeliveredElement`) is non-suspend *and* skipped entirely for
+     * `DROP_OLDEST`, so this mode's promised contract is inexpressible on a `BufferedChannel`.
+     *
+     * There are no permits: the deque's own size is the accounting, and a slot is handed to a
+     * parked sender under [lock] in the same step that enqueues its message. A sender cancelled
+     * between grant and enqueue therefore cannot leak capacity — the two are not separable.
+     */
+    private inner class HandoffStrategy(
+        private val handoff: SendMode.Handoff<T>,
+    ) : OutboundStrategy<T> {
+        private val capacity = handoff.capacity.messages
+
+        /** Accepted-but-unwritten messages. Guarded by [lock]. */
+        private val queue = ArrayDeque<OutboundPayload<T>>()
+
+        /** Senders parked for space, in arrival order. Guarded by [lock]. */
+        private val parked = ArrayDeque<ParkedSend<T>>()
+
+        /** Reactive writer wakeup. Conflated: a wakeup is never lost and never accumulates. */
+        private val wakeup = Channel<Unit>(Channel.CONFLATED)
+
+        override suspend fun send(payload: OutboundPayload<T>) {
+            when (val admission = lock.withLock { admit(payload) }) {
+                Admission.Accepted -> Unit
+                Admission.Refused -> {
+                    payload.release()
+                    throw OutboundClosedException(senderCloseCause())
+                }
+                // User code, deliberately outside the lock: re-entrant send/close is legal.
+                is Admission.Displaced -> {
+                    admission.victim.release()
+                    handoff.onNotSent(admission.victim.origin, NotSentReason.CapacityExceeded)
+                }
+                is Admission.Parked -> awaitSlot(admission.sender, payload)
+            }
+        }
+
+        /** Decides the fate of [payload] under [lock] — phase check and enqueue in one step. */
+        private fun admit(payload: OutboundPayload<T>): Admission<T> {
+            if (currentPhase.value !== ConnectionPhase.Open) return Admission.Refused
+            if (queue.size < capacity) {
+                enqueue(payload)
+                return Admission.Accepted
+            }
+            return when (handoff.onCapacity) {
+                CapacityBehavior.Suspend -> {
+                    val sender = ParkedSend(payload)
+                    parked.addLast(sender)
+                    Admission.Parked(sender)
+                }
+                CapacityBehavior.DropOldest -> {
+                    val victim = queue.removeFirst()
+                    enqueue(payload)
+                    Admission.Displaced(victim)
+                }
+                CapacityBehavior.DropNewest -> Admission.Displaced(payload)
+            }
+        }
+
+        /** Under [lock]. */
+        private fun enqueue(payload: OutboundPayload<T>) {
+            queue.addLast(payload)
+            wakeup.trySend(Unit)
+        }
+
+        /**
+         * Waits for a slot. Ownership of [payload] is settled once, under [lock], by asking
+         * whether an admitter already moved it into the queue — the only question that matters on
+         * every exit path (admitted, refused, or cancelled).
+         */
+        private suspend fun awaitSlot(
+            sender: ParkedSend<T>,
+            payload: OutboundPayload<T>,
+        ) {
+            var failure: Throwable? = null
+            try {
+                sender.slot.await()
+            } catch (t: Throwable) {
+                failure = t
+            }
+            val ours =
+                withContext(NonCancellable) {
+                    lock.withLock {
+                        parked.remove(sender)
+                        !sender.enqueued
+                    }
+                }
+            // Never accepted: the transferred reference dies with the send, unreported (nothing
+            // was ever queued to lose).
+            if (ours) payload.release()
+            if (failure != null) throw failure
+        }
+
+        override suspend fun drive() {
+            while (true) {
+                val next = lock.withLock { dequeue() }
+                if (next == null) {
+                    // Drained. Only close()/abort()/failure move the phase off Open, so this is
+                    // the graceful exit; otherwise park until there is work or the phase moves.
+                    if (currentPhase.value !== ConnectionPhase.Open) return
+                    wakeup.receive()
+                    continue
+                }
+                val outcome =
+                    try {
+                        transmit(next.toOutgoing())
+                    } catch (cancellation: CancellationException) {
+                        next.release()
+                        // Accepted but unfinished: it owes exactly one report even though we are
+                        // being torn down mid-frame.
+                        withContext(NonCancellable) {
+                            handoff.onNotSent(next.origin, NotSentReason.ConnectionClosed(terminalCause()))
+                        }
+                        throw cancellation
+                    } catch (failure: Throwable) {
+                        next.release()
+                        failWriter(failure)
+                        val cause = terminalCause()
+                        handoff.onNotSent(next.origin, NotSentReason.ConnectionClosed(cause))
+                        discardQueued(cause)
+                        return
+                    }
+                next.release()
+                if (outcome is TransmitOutcome.EncodeFailed) {
+                    handoff.onNotSent(next.origin, NotSentReason.EncodeFailed(outcome.cause))
+                }
+            }
+        }
+
+        /** Under [lock]: take the head and hand the freed slot straight to the longest-parked sender. */
+        private fun dequeue(): OutboundPayload<T>? {
+            val next = queue.removeFirstOrNull() ?: return null
+            admitParked()
+            return next
+        }
+
+        /** Under [lock]: FIFO slot handoff. Grant and enqueue are the same step, so nothing leaks. */
+        private fun admitParked() {
+            while (queue.size < capacity) {
+                val sender = parked.removeFirstOrNull() ?: return
+                sender.enqueued = true
+                enqueue(sender.payload)
+                sender.slot.complete(Unit)
+            }
+        }
+
+        override fun refuseSends() {
+            // Parked senders were never accepted, so they leave through their own call site with
+            // OutboundClosedException — not through onNotSent.
+            while (true) {
+                val sender = parked.removeFirstOrNull() ?: break
+                sender.slot.completeExceptionally(OutboundClosedException(senderCloseCause()))
+            }
+            wakeup.trySend(Unit)
+        }
+
+        override suspend fun discardQueued(cause: CloseCause) {
+            while (true) {
+                val lost = lock.withLock { queue.removeFirstOrNull() } ?: return
+                lost.release()
+                handoff.onNotSent(lost.origin, NotSentReason.ConnectionClosed(cause))
+            }
+        }
+    }
+}
+
+/**
+ * The per-mode machinery behind [OutboundWriter]. Each arm owns its own element type and queue,
+ * so the states the other arm would make possible — an acknowledgement with no waiter, a bounded
+ * deque with no loss handler — are unconstructible rather than merely unused.
+ */
+@ExperimentalFanoutApi
+private interface OutboundStrategy<T> {
+    /** The caller's side of the mode's completion semantics. */
+    suspend fun send(payload: OutboundPayload<T>)
+
+    /** The writer coroutine's loop. Returns when the queue is drained and the phase left Open. */
+    suspend fun drive()
+
+    /** Stop accepting. Called under the writer's lock, atomically with the phase transition. */
+    fun refuseSends()
+
+    /** Report every still-queued element as lost, exactly once, with user code outside the lock. */
+    suspend fun discardQueued(cause: CloseCause)
+}
+
+/**
+ * What the writer holds per accepted message: the message itself plus, for `sendShared`, the one
+ * transferred [SharedBytes] reference this component owes exactly one [release] to.
+ */
+@ExperimentalFanoutApi
+private sealed interface OutboundPayload<T> {
+    val origin: T
+
+    fun toOutgoing(): Outgoing<T>
+
+    fun release()
+}
+
+@ExperimentalFanoutApi
+private class MessageSend<T>(
+    override val origin: T,
+) : OutboundPayload<T> {
+    override fun toOutgoing(): Outgoing<T> = Outgoing.Encode(origin)
+
+    override fun release() = Unit
+}
+
+@ExperimentalFanoutApi
+private class SharedSend<T>(
+    private val bytes: SharedBytes,
+    override val origin: T,
+) : OutboundPayload<T> {
+    /** The private-cursor view is minted on the writer, immediately before the write. */
+    override fun toOutgoing(): Outgoing<T> = Outgoing.Prewritten(bytes.view(), origin)
+
+    override fun release() = bytes.release()
+}
+
+/** `AwaitWritten`'s element: a payload plus the acknowledgement its sender is waiting on. */
+@ExperimentalFanoutApi
+private class AckedSend<T>(
+    val payload: OutboundPayload<T>,
+    val ack: CompletableDeferred<Unit>,
+) {
+    /** The loss path: release the transferred reference, then answer the sender exactly once. */
+    fun discard(cause: CloseCause) {
+        payload.release()
+        ack.completeExceptionally(OutboundClosedException(cause))
+    }
+}
+
+/** `Handoff`'s parked sender: a payload waiting for a slot, plus the grant it is suspended on. */
+@ExperimentalFanoutApi
+private class ParkedSend<T>(
+    val payload: OutboundPayload<T>,
+) {
+    /** Set under the writer's lock in the same step that moves [payload] into the queue. */
+    var enqueued: Boolean = false
+
+    /** Completes on admission, fails with [OutboundClosedException] on refusal. */
+    val slot = CompletableDeferred<Unit>()
+}
+
+/** The fate `Handoff` decides for a message under the lock, acted on once the lock is released. */
+@ExperimentalFanoutApi
+private sealed interface Admission<out T> {
+    /** Queued. */
+    data object Accepted : Admission<Nothing>
+
+    /** The writer is no longer open. */
+    data object Refused : Admission<Nothing>
+
+    /** Capacity policy chose a victim: the queue head (DropOldest) or the arrival (DropNewest). */
+    class Displaced<T>(
+        val victim: OutboundPayload<T>,
+    ) : Admission<T>
+
+    /** The sender waits for a slot. */
+    class Parked<T>(
+        val sender: ParkedSend<T>,
+    ) : Admission<T>
+}
+
+/**
+ * Identity marker installed in the writer coroutine's context so a re-entrant `close()`/`abort()`
+ * from a user handler can tell "I *am* the writer" and initiate instead of joining itself. It
+ * survives `withContext(NonCancellable)`, which replaces only the job.
+ */
+private class WriterMark(
+    val owner: Any,
+) : AbstractCoroutineContextElement(WriterMark) {
+    companion object Key : CoroutineContext.Key<WriterMark>
 }

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/OutboundWriter.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/OutboundWriter.kt
@@ -136,20 +136,17 @@ class OutboundClosedException(
  * *wait*, not the message.
  */
 @ExperimentalFanoutApi
-class OutboundWriter<T> internal constructor(
+class OutboundWriter<T>(
     private val mode: SendMode<T>,
     private val transmit: suspend (Outgoing<T>) -> TransmitOutcome,
     /**
-     * Where the writer coroutine runs. Internal seam only: tests inject a test dispatcher so the
-     * writer is under the scheduler's control instead of racing it on [Dispatchers.Default].
+     * Where the writer coroutine runs. Public on purpose: an adopter's virtual-time test can only
+     * observe "send completed" deterministically if the writer itself runs under the test
+     * scheduler, so the seam must reach adopters, not just this module's own tests. Production
+     * code leaves the default.
      */
-    writerContext: CoroutineContext,
+    writerContext: CoroutineContext = Dispatchers.Default,
 ) {
-    constructor(
-        mode: SendMode<T>,
-        transmit: suspend (Outgoing<T>) -> TransmitOutcome,
-    ) : this(mode, transmit, Dispatchers.Default)
-
     private val currentPhase = MutableStateFlow<ConnectionPhase>(ConnectionPhase.Open)
 
     /** The send/close lifecycle, reactively. Single source of truth — there is no separate flag. */

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/OutboundWriter.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/OutboundWriter.kt
@@ -183,7 +183,21 @@ class OutboundWriter<T> internal constructor(
 
     private val writerJob: Job =
         scope.launch(mark) {
-            strategy.drive()
+            try {
+                strategy.drive()
+            } catch (t: Throwable) {
+                if (t is CancellationException) throw t
+                // Only a throwing user handler (onNotSent) reaches here — drive() settles its own
+                // transmit failures. The writer cannot continue, but it must not die with the
+                // phase still Open: senders would keep filling a queue nobody drains, the silent
+                // hang this component exists to kill. Surface the error through the API — phase
+                // Closed(Failed(t)), every subsequent send refused with the same cause — and
+                // best-effort the owed reports. Deliberately NOT rethrown: the error is already
+                // loud where consumers look, and an uncaught writer exception would only reach
+                // the process-level CoroutineExceptionHandler (a crash on some platforms).
+                failWriter(t)
+                runCatching { strategy.discardQueued(terminalCause()) }
+            }
             // A normal loop exit means the queue drained after close() opened the window. Whoever
             // settled first keeps their cause; this only fills in the graceful case.
             settle(CloseCause.Graceful)

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/SendMode.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/SendMode.kt
@@ -1,0 +1,144 @@
+package com.ditchoom.buffer.flow
+
+import com.ditchoom.buffer.ExperimentalFanoutApi
+import kotlin.jvm.JvmInline
+import kotlin.time.Duration
+
+/**
+ * How a connection's `send` completes, once the connection owns its writer.
+ *
+ * Two things are **invariants** of a conforming connection and hold in every mode: a message
+ * reaches the wire whole or not at all (cancelling the sender can never truncate a frame), and
+ * concurrent `send`s never interleave. What a mode chooses is *policy*: who waits, and what
+ * happens when nobody can.
+ *
+ * `SendMode` is contravariant — a mode only ever **consumes** messages (via
+ * [Handoff.onNotSent]), so a mode that handles `Any?` serves every connection. That is why
+ * [AwaitWritten] is a single shared object usable as the default for any `T`, with no casts
+ * (the `Comparator<in T>` pattern).
+ */
+sealed interface SendMode<in T> {
+    /**
+     * `send` returns when the frame is on the wire; write errors throw at the call site.
+     *
+     * The drop-in default: observable semantics match a direct write — send-then-close needs no
+     * drain contract, and failures surface synchronously to the sender. What changes is only what
+     * was broken: the connection-owned writer finishes the frame even if the sender is cancelled
+     * mid-wait (the sender abandons the *wait*, never the *write*), and concurrent senders are
+     * serialized. One documented edge follows: a cancelled `send` may have sent anyway — the frame
+     * completes whole and cannot be un-sent. This mode has **zero configuration** because its
+     * queue is its suspended senders: capacity, overflow, and linger are not defaulted here, they
+     * are inexpressible.
+     */
+    data object AwaitWritten : SendMode<Any?>
+
+    /**
+     * `send` returns on enqueue; no sender ever waits on a peer; loss is possible and always
+     * reported through [onNotSent].
+     *
+     * The fan-out mode: a producer looping over many connections hands each its message in
+     * O(enqueue) and cannot be stalled by any single slow peer. All four fields are required —
+     * the library guarantees the invariants, the adopter states the policy. A message that does
+     * not reach the wire is reported exactly once with a [NotSentReason]; no silent-loss path
+     * exists.
+     *
+     * [linger] lives here and not on the connection because only this mode has an unattended
+     * queue to drain at close: in [AwaitWritten], graceful close finishes the in-flight frame and
+     * fails the remaining senders, who are by construction present to hear it.
+     */
+    @ExperimentalFanoutApi
+    class Handoff<in T>(
+        /** Queue bound, in messages. The overflow policy engages at exactly this depth. */
+        val capacity: OutboundCapacity,
+        /** What `send` does when the queue is at [capacity]. */
+        val onCapacity: CapacityBehavior,
+        /** How long a graceful close may drain the queue before escalating to abort. */
+        val linger: Linger,
+        /**
+         * Invoked exactly once for every accepted message that will not reach the wire —
+         * capacity eviction, close-time discard, or a message that failed to encode. Runs
+         * outside the queue lock: re-entrant `send`/`close` from the handler is legal.
+         */
+        val onNotSent: suspend (T, NotSentReason) -> Unit,
+    ) : SendMode<T>
+}
+
+/**
+ * A [SendMode.Handoff] queue bound, counted in **messages** (the queue holds messages, never
+ * encoded buffers). Value-typed so the unit is in the signature and illegal depths are
+ * unconstructible.
+ */
+@ExperimentalFanoutApi
+@JvmInline
+value class OutboundCapacity(
+    val messages: Int,
+) {
+    init {
+        require(messages > 0) { "outbound capacity must be positive: $messages" }
+    }
+}
+
+/** What [SendMode.Handoff]'s `send` does when the queue is full. */
+@ExperimentalFanoutApi
+sealed interface CapacityBehavior {
+    /** Backpressure: `send` suspends until space frees. A cancelled wait loses only its own message. */
+    @ExperimentalFanoutApi
+    data object Suspend : CapacityBehavior
+
+    /** Evict the queue head (stale-first) to admit the new message; the evictee goes to `onNotSent`. */
+    @ExperimentalFanoutApi
+    data object DropOldest : CapacityBehavior
+
+    /** Reject the incoming message; it goes to `onNotSent`, the queue is untouched. */
+    @ExperimentalFanoutApi
+    data object DropNewest : CapacityBehavior
+}
+
+/**
+ * How long a graceful close may keep draining a [SendMode.Handoff] queue before escalating to
+ * abort — the same shape as `WritePolicy.UntilClosed`/`Bounded`, for the same reason: a stalled
+ * peer must not turn `close()` into a hang. A zero linger is spelled `abort()`, not `Bounded(0)`.
+ */
+@ExperimentalFanoutApi
+sealed interface Linger {
+    /** Drain until the queue is empty, however long the writes take (each still bounded by the sink's `WritePolicy`). */
+    @ExperimentalFanoutApi
+    data object UntilDrained : Linger
+
+    /** Drain for at most [timeout], then escalate to abort; the remainder is reported not-sent. */
+    @ExperimentalFanoutApi
+    data class Bounded(
+        val timeout: Duration,
+    ) : Linger {
+        init {
+            require(timeout.isPositive()) { "linger timeout must be positive: $timeout (zero linger is spelled abort())" }
+        }
+    }
+}
+
+/**
+ * Why an accepted message will not reach the wire. Reported through
+ * [SendMode.Handoff.onNotSent], exactly once per lost message, with the message itself — the
+ * handback is always the *message*, never a buffer someone must free.
+ */
+@ExperimentalFanoutApi
+sealed interface NotSentReason {
+    /** Evicted (or rejected) by [CapacityBehavior] with the queue at capacity. */
+    @ExperimentalFanoutApi
+    data object CapacityExceeded : NotSentReason
+
+    /** The connection closed — gracefully, by abort, or by failure — with this message still queued. */
+    @ExperimentalFanoutApi
+    data class ConnectionClosed(
+        val cause: CloseCause,
+    ) : NotSentReason
+
+    /**
+     * The message failed to encode on the writer. The connection survives: encode failure is
+     * per-message and deterministic, and no bytes of the frame reached the wire.
+     */
+    @ExperimentalFanoutApi
+    data class EncodeFailed(
+        val cause: Throwable,
+    ) : NotSentReason
+}

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/SendMode.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/SendMode.kt
@@ -59,10 +59,21 @@ sealed interface SendMode<in T> {
          * capacity eviction, close-time discard, or a message that failed to encode. Runs
          * outside the queue lock: re-entrant `send`/`close` from the handler is legal.
          *
-         * **Must not throw.** A handler that throws on the writer's reporting path fails the
-         * writer with the thrown error (`CloseCause.Failed`) — surfaced loudly rather than left
-         * as a dead writer under an Open phase — and any reports still owed become best-effort.
-         * Count, log, hand off; do not raise.
+         * **Must be thread-safe — it can run concurrently with itself.** "Exactly once per
+         * message" is not "one at a time": reports are raised from three different coroutine
+         * identities (an evicting *sender*, the *writer*, and an *abort* caller), deliberately
+         * without mutual exclusion, so on a multi-threaded dispatcher two can be in flight at
+         * once. A plain `MutableList`/counter here will silently lose updates — exactly the
+         * under-counted ledger the exactly-once guarantee exists to prevent. Use an atomic, a
+         * concurrent collection, or a channel `trySend`.
+         *
+         * Note that guarding the handler body with a `Mutex` is *not* the fix: it deadlocks the
+         * re-entrant send-from-handler pattern documented as legal above.
+         *
+         * **Must not throw.** A handler that throws on any reporting path fails the writer with
+         * the thrown error (`CloseCause.Failed`) — surfaced loudly rather than left as a dead
+         * writer under an Open phase — and that message's own report degrades to best-effort.
+         * Reports owed to *other* messages are still delivered. Count, log, hand off; do not raise.
          */
         val onNotSent: suspend (T, NotSentReason) -> Unit,
     ) : SendMode<T>

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/SendMode.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/SendMode.kt
@@ -106,7 +106,10 @@ sealed interface CapacityBehavior {
  */
 @ExperimentalFanoutApi
 sealed interface Linger {
-    /** Drain until the queue is empty, however long the writes take (each still bounded by the sink's `WritePolicy`). */
+    /**
+     * Drain until the queue is empty, however long the writes take (each still bounded by
+     * the sink's `WritePolicy`).
+     */
     @ExperimentalFanoutApi
     data object UntilDrained : Linger
 
@@ -116,7 +119,9 @@ sealed interface Linger {
         val timeout: Duration,
     ) : Linger {
         init {
-            require(timeout.isPositive()) { "linger timeout must be positive: $timeout (zero linger is spelled abort())" }
+            require(timeout.isPositive()) {
+                "linger timeout must be positive: $timeout (zero linger is spelled abort())"
+            }
         }
     }
 }

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/SendMode.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/SendMode.kt
@@ -58,6 +58,11 @@ sealed interface SendMode<in T> {
          * Invoked exactly once for every accepted message that will not reach the wire —
          * capacity eviction, close-time discard, or a message that failed to encode. Runs
          * outside the queue lock: re-entrant `send`/`close` from the handler is legal.
+         *
+         * **Must not throw.** A handler that throws on the writer's reporting path fails the
+         * writer with the thrown error (`CloseCause.Failed`) — surfaced loudly rather than left
+         * as a dead writer under an Open phase — and any reports still owed become best-effort.
+         * Count, log, hand off; do not raise.
          */
         val onNotSent: suspend (T, NotSentReason) -> Unit,
     ) : SendMode<T>

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/Typed.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/Typed.kt
@@ -147,4 +147,16 @@ private class CodecConnection<T>(
     override suspend fun close() {
         stream.close()
     }
+
+    /**
+     * This view owns no writer and therefore has no queue to drop — its only send-side state is
+     * whatever the caller's own coroutine is doing inside [send]. What abort can still add over
+     * [close] is the byte layer's RST when the stream has one: a [close] on a stream whose peer
+     * stopped reading may park in the sink's own write policy, and [Resettable.reset] is the way
+     * out. Falls back to [close] for streams that cannot reset.
+     */
+    override suspend fun abort() {
+        val stream = stream
+        if (stream is Resettable) stream.reset(0L) else stream.close()
+    }
 }

--- a/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/TypedDatagram.kt
+++ b/buffer-flow/src/commonMain/kotlin/com/ditchoom/buffer/flow/TypedDatagram.kt
@@ -174,5 +174,11 @@ public fun <T> ConnectedDatagramChannel.typed(
         override fun receive(): Flow<T> = receiver.receive()
 
         override suspend fun close() = channel.close()
+
+        // Explicit even though it matches the inherited default: a datagram channel holds no
+        // outbound queue, so there is nothing for abort to drop that close would have drained.
+        // Stated rather than inherited so the next change here has to decide deliberately —
+        // any decorator overriding close() overrides abort().
+        override suspend fun abort() = channel.close()
     }
 }

--- a/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/ConnectionDecoratorAbortTests.kt
+++ b/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/ConnectionDecoratorAbortTests.kt
@@ -1,0 +1,62 @@
+package com.ditchoom.buffer.flow
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * [Connection.abort] defaults to [Connection.close] so the addition stays source-compatible. That
+ * default is a trap for *decorators*: a wrapper that overrides only `close()` inherits the default
+ * `abort()`, so `abort()` on the wrapper silently becomes a graceful drain and never reaches the
+ * inner connection's real abort — turning the escape hatch for a stalled peer back into the very
+ * hang it exists to break out of.
+ *
+ * Rule this pins: any decorator overriding `close()` must override `abort()`.
+ */
+class ConnectionDecoratorAbortTests {
+    private class Probe : Connection<String> {
+        var closed = false
+        var aborted = false
+
+        override val id: Long = 7L
+
+        override suspend fun send(message: String) = Unit
+
+        override fun receive(): Flow<String> = emptyFlow()
+
+        override suspend fun close() {
+            closed = true
+        }
+
+        override suspend fun abort() {
+            aborted = true
+        }
+    }
+
+    @Test
+    fun mapNotNullForwardsAbortToTheInnerConnection() =
+        runTest {
+            val probe = Probe()
+            val wrapped = probe.mapNotNull<String, String>(encode = { it }, decode = { it })
+
+            wrapped.abort()
+
+            assertTrue(probe.aborted, "abort() must reach the inner connection's real abort")
+            assertFalse(probe.closed, "abort() must not degrade into a graceful close")
+        }
+
+    @Test
+    fun mapNotNullStillForwardsCloseSeparately() =
+        runTest {
+            val probe = Probe()
+            val wrapped = probe.mapNotNull<String, String>(encode = { it }, decode = { it })
+
+            wrapped.close()
+
+            assertTrue(probe.closed)
+            assertFalse(probe.aborted, "close() must stay graceful")
+        }
+}

--- a/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/OutboundWriterCancellationTests.kt
+++ b/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/OutboundWriterCancellationTests.kt
@@ -1,0 +1,313 @@
+package com.ditchoom.buffer.flow
+
+import com.ditchoom.buffer.ExperimentalFanoutApi
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/** A handler failure with a specific type, so the throw sites are not generic exceptions. */
+private class HandlerBoom : IllegalStateException("handler boom")
+
+@OptIn(ExperimentalFanoutApi::class)
+private typealias Transmitting = suspend (Outgoing<String>) -> TransmitOutcome
+
+/**
+ * Regressions for the cancellation-boundary defects found reviewing the send-ownership PR.
+ *
+ * They all share one root cause: a cleanup or reporting obligation placed *after* a cancellable
+ * suspension point, so a caller (or writer) that is already unwinding drops it silently. That is
+ * the same failure class this component exists to eliminate on the wire — a cancelled participant
+ * leaving a job half-done — which is why each of these is a regression test and not a doc note.
+ */
+@OptIn(ExperimentalFanoutApi::class, ExperimentalCoroutinesApi::class)
+class OutboundWriterCancellationTests {
+    private fun TestScope.awaitWrittenWriter(transmit: Transmitting): OutboundWriter<String> =
+        OutboundWriter(SendMode.AwaitWritten, transmit, StandardTestDispatcher(testScheduler))
+
+    private fun TestScope.handoffWriter(
+        capacity: Int,
+        onCapacity: CapacityBehavior,
+        onNotSent: suspend (String, NotSentReason) -> Unit,
+        transmit: Transmitting,
+    ): OutboundWriter<String> =
+        OutboundWriter(
+            SendMode.Handoff(OutboundCapacity(capacity), onCapacity, Linger.UntilDrained, onNotSent),
+            transmit,
+            StandardTestDispatcher(testScheduler),
+        )
+
+    // ----- The adopter's own cancellation is not our abort ------------------------------------
+
+    /**
+     * A `withTimeout` *inside* the adopter's transmit raises a CancellationException that has
+     * nothing to do with `abort()`. Reading it as one left the writer dead under an `Open` phase:
+     * senders kept queueing onto a rendezvous nobody read, and a later `close()` joined the corpse,
+     * settled `Graceful`, and silently discarded the backlog.
+     */
+    @Test
+    fun adopterTimeoutInsideTransmitFailsTheWriterInsteadOfPassingForAbort() =
+        runTest {
+            val writer =
+                awaitWrittenWriter {
+                    // The adopter bounding its own sink write — the documented, expected pattern.
+                    withTimeout(50.milliseconds) { delay(1.seconds) }
+                    TransmitOutcome.Written
+                }
+            val failure = CompletableDeferred<Throwable>()
+            launch {
+                runCatching { writer.send("a") }.onFailure { failure.complete(it) }
+            }
+            advanceUntilIdle()
+
+            val phase = writer.phase.value
+            assertIs<ConnectionPhase.Closed>(phase, "an adopter-raised timeout must terminate the writer")
+            assertIs<CloseCause.Failed>(phase.cause, "it is a transport failure, not an abort")
+            assertTrue(failure.isCompleted, "the sender must hear it rather than park forever")
+
+            // The decisive part: the phase left Open, so the next sender is refused instead of
+            // queueing onto a writer that will never read again.
+            val refused = CompletableDeferred<Throwable>()
+            launch { runCatching { writer.send("b") }.onFailure { refused.complete(it) } }
+            advanceUntilIdle()
+            assertIs<OutboundClosedException>(refused.getCompleted())
+        }
+
+    // ----- close()/abort() from an already-cancelled caller -----------------------------------
+
+    /**
+     * `finally { close() }` from a cancelled scope is *the* teardown idiom. The drain's `join()`
+     * checks the invoker's cancellation, so it threw immediately and the ladder stopped there:
+     * phase stuck at `Draining`, the queue never discarded, its references never released.
+     */
+    @Test
+    fun closeFromACancelledCallerEscalatesInsteadOfStrandingTheQueue() =
+        runTest {
+            val stall = CompletableDeferred<Unit>()
+            val writer =
+                awaitWrittenWriter {
+                    stall.await()
+                    TransmitOutcome.Written
+                }
+            launch { runCatching { writer.send("in-flight") } }
+            advanceUntilIdle()
+
+            val owner =
+                launch {
+                    try {
+                        awaitCancellation()
+                    } finally {
+                        // Cancelled at this point: every suspension here throws.
+                        runCatching { writer.close() }
+                    }
+                }
+            advanceUntilIdle()
+            owner.cancelAndJoin()
+            advanceUntilIdle()
+
+            val phase = writer.phase.value
+            assertIs<ConnectionPhase.Closed>(phase, "close() from a cancelled caller must still settle")
+            assertIs<CloseCause.Aborted>(phase.cause, "an un-waitable drain escalates to the last rung")
+        }
+
+    /**
+     * The Handoff twin, which is where the stranding is observable: every queued message owes
+     * exactly one `onNotSent`, and a cancelled `close()` used to drop all of them.
+     */
+    @Test
+    fun closeFromACancelledCallerStillReportsEveryQueuedMessage() =
+        runTest {
+            val stall = CompletableDeferred<Unit>()
+            val lost = mutableListOf<String>()
+            val writer =
+                handoffWriter(capacity = 8, onCapacity = CapacityBehavior.Suspend, onNotSent = { m, _ -> lost += m }) {
+                    stall.await()
+                    TransmitOutcome.Written
+                }
+            listOf("a", "b", "c").forEach { writer.send(it) }
+            advanceUntilIdle()
+
+            val owner =
+                launch {
+                    try {
+                        awaitCancellation()
+                    } finally {
+                        runCatching { writer.close() }
+                    }
+                }
+            advanceUntilIdle()
+            owner.cancelAndJoin()
+            advanceUntilIdle()
+
+            assertIs<ConnectionPhase.Closed>(writer.phase.value)
+            assertEquals(
+                setOf("a", "b", "c"),
+                lost.toSet(),
+                "a cancelled close() must not swallow the exactly-once loss reports it owes",
+            )
+        }
+
+    // ----- A throwing handler must not strand what is behind it -------------------------------
+
+    /**
+     * `discardQueued` released-then-reported per element with no per-element guard, so a handler
+     * that threw at element k abandoned k+1..n — neither released nor reported. The documented
+     * degradation was "reports become best-effort"; it never blessed leaked references.
+     */
+    @Test
+    fun aThrowingOnNotSentDoesNotStrandTheRestOfTheQueue() =
+        runTest {
+            val stall = CompletableDeferred<Unit>()
+            val seen = mutableListOf<String>()
+            val writer =
+                handoffWriter(
+                    capacity = 8,
+                    onCapacity = CapacityBehavior.Suspend,
+                    onNotSent = { m, _ ->
+                        seen += m
+                        // "b" is a *queued* element, so the throw lands inside discardQueued with
+                        // "c" still behind it — the exact shape that used to abandon the tail.
+                        if (m == "b") throw HandlerBoom()
+                    },
+                ) {
+                    stall.await()
+                    TransmitOutcome.Written
+                }
+            listOf("a", "b", "c").forEach { writer.send(it) }
+            advanceUntilIdle() // the writer takes "a" and stalls; "b" and "c" stay queued
+
+            runCatching { writer.abort() }
+            advanceUntilIdle()
+
+            assertEquals(
+                setOf("a", "b", "c"),
+                seen.toSet(),
+                "one throwing report must not cancel the reports owed to everything behind it",
+            )
+        }
+
+    /**
+     * A capacity eviction reports a *previously accepted* message. Running that report on the
+     * evicting sender's coroutine with no protection meant a sender cancelled at the handler's
+     * first suspension point silently dropped someone else's loss report — an under-counted
+     * ledger, which adopters have no way to detect.
+     */
+    @Test
+    fun anEvictionReportSurvivesTheEvictingSenderBeingCancelled() =
+        runTest {
+            val stall = CompletableDeferred<Unit>()
+            val handlerEntered = CompletableDeferred<Unit>()
+            val releaseHandler = CompletableDeferred<Unit>()
+            val lost = mutableListOf<String>()
+            val writer =
+                handoffWriter(
+                    capacity = 1,
+                    onCapacity = CapacityBehavior.DropOldest,
+                    onNotSent = { m, _ ->
+                        handlerEntered.complete(Unit)
+                        releaseHandler.await() // the suspension point the cancellation lands on
+                        lost += m
+                    },
+                ) {
+                    stall.await()
+                    TransmitOutcome.Written
+                }
+            writer.send("first")
+            advanceUntilIdle() // the writer takes "first" and stalls, leaving the slot free
+            writer.send("victim") // fills the single queue slot
+            advanceUntilIdle()
+
+            // This sender evicts "victim" and then dies while its report is still suspended.
+            val evictor = launch { writer.send("winner") }
+            advanceUntilIdle()
+            assertTrue(handlerEntered.isCompleted, "precondition: the eviction report is in flight")
+
+            evictor.cancel()
+            releaseHandler.complete(Unit)
+            advanceUntilIdle()
+
+            assertTrue(
+                "victim" in lost,
+                "the evicted message's exactly-once report is not the evicting sender's to drop",
+            )
+        }
+
+    // ----- abort() must abort, even from the writer's own lineage ------------------------------
+
+    /**
+     * `WriterMark` is a context element, so it is inherited by anything transmit launches. A
+     * watchdog child calling `abort()` therefore took the re-entrant branch and skipped cancelling
+     * the writer entirely — an abort that discarded the queue, settled `Closed`, and left the stuck
+     * transmit running. Lineage may gate the `join` (a child joining its parent deadlocks); it must
+     * never gate the `cancel`.
+     */
+    @Test
+    fun abortFromAWatchdogLaunchedInsideTransmitStillCancelsTheWriter() =
+        runTest {
+            val writerRef = CompletableDeferred<OutboundWriter<String>>()
+            val transmitJob = CompletableDeferred<Job>()
+            val writer =
+                awaitWrittenWriter {
+                    val writerContext = currentCoroutineContext()
+                    transmitJob.complete(assertNotNull(writerContext[Job]))
+                    // A watchdog *child of the writer* — which is what makes it inherit WriterMark
+                    // and take the re-entrant branch. Launching from the enclosing TestScope would
+                    // not reproduce the defect at all.
+                    CoroutineScope(writerContext).launch { writerRef.await().abort() }
+                    awaitCancellation() // the stuck write the watchdog exists to break
+                }
+            writerRef.complete(writer)
+            launch { runCatching { writer.send("a") } }
+            advanceUntilIdle()
+
+            assertIs<ConnectionPhase.Closed>(writer.phase.value)
+            assertTrue(
+                transmitJob.getCompleted().isCancelled,
+                "an abort that leaves the stuck writer running is not an abort",
+            )
+        }
+
+    // ----- structural: a failed writer never leaves a sender suspended --------------------------
+
+    /**
+     * Whatever kills the writer, every element it already took must still receive exactly one
+     * answer. This is the property the per-element `finally` makes structural rather than a
+     * consequence of each exit path remembering to settle its ack.
+     */
+    @Test
+    fun aWriterThatDiesMidFrameStillAnswersTheSenderItTookFrom() =
+        runTest {
+            val entered = CompletableDeferred<Unit>()
+            val writer =
+                awaitWrittenWriter {
+                    entered.complete(Unit)
+                    awaitCancellation()
+                }
+            val outcome = CompletableDeferred<Throwable>()
+            launch { runCatching { writer.send("a") }.onFailure { outcome.complete(it) } }
+            advanceUntilIdle()
+            assertTrue(entered.isCompleted, "precondition: the writer took the element")
+
+            writer.abort()
+            advanceUntilIdle()
+
+            assertTrue(outcome.isCompleted, "the sender must never be left suspended on its ack")
+        }
+}

--- a/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/OutboundWriterSharedBytesTests.kt
+++ b/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/OutboundWriterSharedBytesTests.kt
@@ -1,0 +1,162 @@
+package com.ditchoom.buffer.flow
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.ExperimentalFanoutApi
+import com.ditchoom.buffer.pool.SharedBytes
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Integration of the two halves that were built (and unit-tested) apart: [OutboundWriter]'s
+ * exactly-once accounting driving real [SharedBytes] reference releases. The contract under test
+ * is single-sentence: a reference transferred via [OutboundWriter.sendShared] is released exactly
+ * once on WHICHEVER path the element takes — written, refused, evicted, or discarded at abort.
+ *
+ * Release-exactly-once is probed through [SharedBytes]' own strictness: a missed release leaves
+ * `retain()` succeeding after the creator's close; a double release makes the creator's close
+ * throw. No test-only counters — the accounting under test is the accounting doing the asserting.
+ */
+@OptIn(ExperimentalFanoutApi::class, ExperimentalCoroutinesApi::class)
+class OutboundWriterSharedBytesTests {
+    private val marker = 0x5EED_BEEF.toInt()
+
+    private fun encodedFrame(): SharedBytes {
+        val buffer = BufferFactory.Default.allocate(8)
+        buffer.writeInt(marker)
+        buffer.writeInt(marker + 1)
+        buffer.resetForRead()
+        return SharedBytes.adopt(buffer)
+    }
+
+    /** Asserts the storage is fully freed: strict refcounting refuses to resurrect it. */
+    private fun assertFreed(bytes: SharedBytes) {
+        assertFailsWith<IllegalStateException> { bytes.retain() }
+    }
+
+    private fun TestScope.sharedWriter(
+        mode: SendMode<String>,
+        onView: (bytesRead: Int) -> Unit = {},
+    ): OutboundWriter<String> =
+        OutboundWriter(mode, { outgoing ->
+            when (outgoing) {
+                is Outgoing.Encode -> TransmitOutcome.Written
+                is Outgoing.Prewritten -> {
+                    // Prove the view is a full, private-cursor window: both ints readable here,
+                    // regardless of what any other consumer's cursor has done.
+                    assertEquals(marker, outgoing.view.readInt())
+                    assertEquals(marker + 1, outgoing.view.readInt())
+                    onView(8)
+                    TransmitOutcome.Written
+                }
+            }
+        }, StandardTestDispatcher(testScheduler))
+
+    @Test
+    fun writtenPathReleasesTheTransferredReferenceExactlyOnce() =
+        runTest {
+            val bytes = encodedFrame()
+            var viewedBytes = 0
+            val writer = sharedWriter(SendMode.AwaitWritten) { viewedBytes += it }
+
+            writer.sendShared(bytes.retain(), "m1")
+            assertEquals(8, viewedBytes)
+
+            // Writer released its transferred ref; the creator's is the last one standing.
+            bytes.release()
+            assertFreed(bytes)
+            writer.close()
+        }
+
+    @Test
+    fun fanOutToThreeWritersFreesOnceAfterTheLastRelease() =
+        runTest {
+            val bytes = encodedFrame()
+            var views = 0
+            val writers = List(3) { sharedWriter(SendMode.AwaitWritten) { views++ } }
+
+            writers.forEach { writer -> writer.sendShared(bytes.retain(), "broadcast") }
+            assertEquals(3, views)
+
+            bytes.release()
+            assertFreed(bytes)
+            writers.forEach { it.close() }
+        }
+
+    @Test
+    fun refusedSendStillReleasesTheTransfer() =
+        runTest {
+            val bytes = encodedFrame()
+            val writer = sharedWriter(SendMode.AwaitWritten)
+            writer.close()
+
+            assertFailsWith<OutboundClosedException> { writer.sendShared(bytes.retain(), "late") }
+
+            bytes.release()
+            assertFreed(bytes)
+        }
+
+    @Test
+    fun capacityEvictionReleasesTheVictimAndReportsItsOrigin() =
+        runTest {
+            val lost = mutableListOf<Pair<String, NotSentReason>>()
+            val bytes = encodedFrame()
+            // A writer that never drains: transmit parks forever on a never-completed gate is not
+            // needed — simply never advance past a queue the writer hasn't been dispatched to yet.
+            val writer =
+                OutboundWriter<String>(
+                    SendMode.Handoff(
+                        OutboundCapacity(1),
+                        CapacityBehavior.DropOldest,
+                        Linger.UntilDrained,
+                        { m, r -> lost += m to r },
+                    ),
+                    { TransmitOutcome.Written },
+                    StandardTestDispatcher(testScheduler),
+                )
+
+            // Two undispatched sends: the second evicts the first before the writer ever runs.
+            writer.sendShared(bytes.retain(), "victim")
+            writer.sendShared(bytes.retain(), "survivor")
+            assertEquals(listOf("victim" to (NotSentReason.CapacityExceeded as NotSentReason)), lost)
+
+            advanceUntilIdle()
+            writer.close()
+
+            bytes.release()
+            assertFreed(bytes)
+        }
+
+    @Test
+    fun abortReleasesEveryQueuedTransferAndReportsEachOnce() =
+        runTest {
+            val lost = mutableListOf<String>()
+            val bytes = encodedFrame()
+            val writer =
+                OutboundWriter<String>(
+                    SendMode.Handoff(
+                        OutboundCapacity(4),
+                        CapacityBehavior.Suspend,
+                        Linger.UntilDrained,
+                        { m, _ -> lost += m },
+                    ),
+                    { TransmitOutcome.Written },
+                    StandardTestDispatcher(testScheduler),
+                )
+
+            repeat(3) { index -> writer.sendShared(bytes.retain(), "q$index") }
+            writer.abort()
+            assertEquals(listOf("q0", "q1", "q2"), lost.sorted())
+            assertTrue(writer.phase.value.let { it is ConnectionPhase.Closed && it.cause is CloseCause.Aborted })
+
+            bytes.release()
+            assertFreed(bytes)
+        }
+}

--- a/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/OutboundWriterTests.kt
+++ b/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/OutboundWriterTests.kt
@@ -18,6 +18,9 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 
+@OptIn(ExperimentalFanoutApi::class)
+private typealias TestTransmit = suspend (Outgoing<String>) -> TransmitOutcome
+
 /** A transport failure: transmit *throws* these, and they fail the writer. */
 private class TransmitBoom(
     message: String,
@@ -83,7 +86,7 @@ private fun assertExactlyOnce(
 }
 
 @OptIn(ExperimentalFanoutApi::class, ExperimentalCoroutinesApi::class)
-private fun TestScope.awaitWrittenWriter(transmit: suspend (Outgoing<String>) -> TransmitOutcome): OutboundWriter<String> =
+private fun TestScope.awaitWrittenWriter(transmit: TestTransmit): OutboundWriter<String> =
     OutboundWriter(SendMode.AwaitWritten, transmit, StandardTestDispatcher(testScheduler))
 
 @OptIn(ExperimentalFanoutApi::class, ExperimentalCoroutinesApi::class)
@@ -704,7 +707,8 @@ class OutboundWriterTests {
     // ----- Exactly-once sweep ------------------------------------------------------------------
 
     @Test
-    @Suppress("LongMethod") // one narrative on purpose: the sweep exercises three loss paths against ONE ledger contract
+    // One narrative on purpose: three loss paths exercised against ONE ledger contract.
+    @Suppress("LongMethod")
     fun exactlyOnceSweepAcrossEveryLossPath() =
         runTest {
             // Eviction under DropOldest, then a graceful close of what survived.

--- a/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/OutboundWriterTests.kt
+++ b/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/OutboundWriterTests.kt
@@ -73,7 +73,11 @@ private fun assertExactlyOnce(
     ledger: Ledger,
 ) {
     val outcomes = ledger.transmitted + ledger.lost
-    assertEquals(accepted.size, outcomes.size, "accepted=$accepted transmitted=${ledger.transmitted} lost=${ledger.lost}")
+    assertEquals(
+        accepted.size,
+        outcomes.size,
+        "accepted=$accepted transmitted=${ledger.transmitted} lost=${ledger.lost}",
+    )
     assertEquals(accepted.toSet(), outcomes.toSet(), "every accepted message must leave exactly once")
     assertTrue(ledger.transmitted.none { it in ledger.lost }, "a message left through both paths")
 }
@@ -634,7 +638,11 @@ class OutboundWriterTests {
             closing.join()
             aborting.join()
 
-            assertEquals(ConnectionPhase.Closed(CloseCause.Aborted), writer.phase.value, "the first terminal cause wins")
+            assertEquals(
+                ConnectionPhase.Closed(CloseCause.Aborted),
+                writer.phase.value,
+                "the first terminal cause wins",
+            )
             assertEquals(accepted, ledger.lost)
             assertExactlyOnce(accepted, ledger)
         }
@@ -696,6 +704,7 @@ class OutboundWriterTests {
     // ----- Exactly-once sweep ------------------------------------------------------------------
 
     @Test
+    @Suppress("LongMethod") // one narrative on purpose: the sweep exercises three loss paths against ONE ledger contract
     fun exactlyOnceSweepAcrossEveryLossPath() =
         runTest {
             // Eviction under DropOldest, then a graceful close of what survived.

--- a/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/OutboundWriterTests.kt
+++ b/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/OutboundWriterTests.kt
@@ -1,0 +1,779 @@
+package com.ditchoom.buffer.flow
+
+import com.ditchoom.buffer.ExperimentalFanoutApi
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+
+/** A transport failure: transmit *throws* these, and they fail the writer. */
+private class TransmitBoom(
+    message: String,
+) : RuntimeException(message)
+
+/** The origin message of an element, whichever [Outgoing] arm carries it. */
+@OptIn(ExperimentalFanoutApi::class)
+private fun originOf(outgoing: Outgoing<String>): String =
+    when (outgoing) {
+        is Outgoing.Encode -> outgoing.message
+        is Outgoing.Prewritten -> outgoing.origin
+    }
+
+/**
+ * Records both halves of the exactly-once ledger: what reached the wire and what was reported
+ * lost. Every test runs on one test dispatcher, so plain collections are the honest recorders.
+ */
+@OptIn(ExperimentalFanoutApi::class)
+private class Ledger {
+    val transmitted = mutableListOf<String>()
+    val notSent = mutableListOf<Pair<String, NotSentReason>>()
+
+    /** Set if two transmits are ever in flight at once — the serialization invariant, observed. */
+    var overlapped = false
+    private var inTransmit = false
+
+    fun enterTransmit() {
+        if (inTransmit) overlapped = true
+        inTransmit = true
+    }
+
+    fun leaveTransmit(outgoing: Outgoing<String>) {
+        inTransmit = false
+        transmitted += originOf(outgoing)
+    }
+
+    fun record(outgoing: Outgoing<String>) {
+        transmitted += originOf(outgoing)
+    }
+
+    val lost: List<String> get() = notSent.map { it.first }
+
+    val reasons: List<NotSentReason> get() = notSent.map { it.second }
+}
+
+/**
+ * Every accepted message leaves through exactly one path. [accepted] is the set of messages whose
+ * `send` returned normally — a refused or cancelled-before-acceptance send is not accepted and is
+ * deliberately reported nowhere.
+ */
+private fun assertExactlyOnce(
+    accepted: List<String>,
+    ledger: Ledger,
+) {
+    val outcomes = ledger.transmitted + ledger.lost
+    assertEquals(accepted.size, outcomes.size, "accepted=$accepted transmitted=${ledger.transmitted} lost=${ledger.lost}")
+    assertEquals(accepted.toSet(), outcomes.toSet(), "every accepted message must leave exactly once")
+    assertTrue(ledger.transmitted.none { it in ledger.lost }, "a message left through both paths")
+}
+
+@OptIn(ExperimentalFanoutApi::class, ExperimentalCoroutinesApi::class)
+private fun TestScope.awaitWrittenWriter(transmit: suspend (Outgoing<String>) -> TransmitOutcome): OutboundWriter<String> =
+    OutboundWriter(SendMode.AwaitWritten, transmit, StandardTestDispatcher(testScheduler))
+
+@OptIn(ExperimentalFanoutApi::class, ExperimentalCoroutinesApi::class)
+private fun TestScope.handoffWriter(
+    capacity: Int,
+    onCapacity: CapacityBehavior,
+    onNotSent: suspend (String, NotSentReason) -> Unit,
+    linger: Linger = Linger.UntilDrained,
+    transmit: suspend (Outgoing<String>) -> TransmitOutcome,
+): OutboundWriter<String> =
+    OutboundWriter(
+        SendMode.Handoff(OutboundCapacity(capacity), onCapacity, linger, onNotSent),
+        transmit,
+        StandardTestDispatcher(testScheduler),
+    )
+
+@OptIn(ExperimentalFanoutApi::class)
+class OutboundWriterTests {
+    // ----- AwaitWritten: completion semantics -------------------------------------------------
+
+    @Test
+    fun awaitWrittenSendReturnsOnlyAfterTransmitCompletes() =
+        runTest {
+            val ledger = Ledger()
+            val gate = CompletableDeferred<Unit>()
+            val writer =
+                awaitWrittenWriter { outgoing ->
+                    gate.await()
+                    ledger.record(outgoing)
+                    TransmitOutcome.Written
+                }
+            var returned = false
+            val sender =
+                launch {
+                    writer.send("a")
+                    returned = true
+                }
+            advanceUntilIdle()
+            assertFalse(returned, "send returned before the frame reached the wire")
+            assertTrue(ledger.transmitted.isEmpty())
+
+            gate.complete(Unit)
+            advanceUntilIdle()
+            assertTrue(returned)
+            assertEquals(listOf("a"), ledger.transmitted)
+            sender.join()
+            writer.close()
+            assertEquals(ConnectionPhase.Closed(CloseCause.Graceful), writer.phase.value)
+        }
+
+    @Test
+    fun awaitWrittenTransmitFailureFailsTheSenderAndThePhase() =
+        runTest {
+            val boom = TransmitBoom("transport died")
+            val writer = awaitWrittenWriter { throw boom }
+
+            assertSame(boom, assertFailsWith<TransmitBoom> { writer.send("a") })
+            advanceUntilIdle()
+            assertEquals(ConnectionPhase.Closed(CloseCause.Failed(boom)), writer.phase.value)
+
+            val refused = assertFailsWith<OutboundClosedException> { writer.send("b") }
+            assertSame(boom, (refused.closeCause as CloseCause.Failed).cause)
+
+            // The first terminal cause wins: a later graceful close cannot overwrite the failure.
+            writer.close()
+            assertEquals(ConnectionPhase.Closed(CloseCause.Failed(boom)), writer.phase.value)
+        }
+
+    @Test
+    fun awaitWrittenEncodeFailureThrowsToTheSenderAndKeepsTheConnectionOpen() =
+        runTest {
+            val ledger = Ledger()
+            val encodeFailure = TransmitBoom("cannot encode")
+            val writer =
+                awaitWrittenWriter { outgoing ->
+                    if (originOf(outgoing) == "poison") {
+                        TransmitOutcome.EncodeFailed(encodeFailure)
+                    } else {
+                        ledger.record(outgoing)
+                        TransmitOutcome.Written
+                    }
+                }
+
+            assertSame(encodeFailure, assertFailsWith<TransmitBoom> { writer.send("poison") })
+            assertEquals(ConnectionPhase.Open, writer.phase.value)
+
+            writer.send("after")
+            assertEquals(listOf("after"), ledger.transmitted)
+            writer.close()
+            assertEquals(ConnectionPhase.Closed(CloseCause.Graceful), writer.phase.value)
+        }
+
+    @Test
+    fun awaitWrittenSerializesConcurrentSenders() =
+        runTest {
+            val ledger = Ledger()
+            val writer =
+                awaitWrittenWriter { outgoing ->
+                    ledger.enterTransmit()
+                    delay(5)
+                    ledger.leaveTransmit(outgoing)
+                    TransmitOutcome.Written
+                }
+            val senders = (0 until 8).map { index -> launch { writer.send("m$index") } }
+            advanceUntilIdle()
+
+            assertTrue(senders.all { it.isCompleted }, "every concurrent sender completed")
+            assertFalse(ledger.overlapped, "two transmits overlapped")
+            assertEquals((0 until 8).map { "m$it" }.toSet(), ledger.transmitted.toSet())
+            writer.close()
+        }
+
+    // ----- AwaitWritten: cancellation atomicity -----------------------------------------------
+
+    @Test
+    fun awaitWrittenSenderCancelledMidTransmitStillCompletesTheFrame() =
+        runTest {
+            val ledger = Ledger()
+            val gate = CompletableDeferred<Unit>()
+            val writer =
+                awaitWrittenWriter { outgoing ->
+                    if (originOf(outgoing) == "first") gate.await()
+                    ledger.record(outgoing)
+                    TransmitOutcome.Written
+                }
+            val sender = launch { writer.send("first") }
+            advanceUntilIdle()
+
+            // The writer holds the element and is inside transmit; the sender abandons the wait.
+            sender.cancel()
+            advanceUntilIdle()
+            assertTrue(ledger.transmitted.isEmpty())
+
+            gate.complete(Unit)
+            advanceUntilIdle()
+            assertEquals(listOf("first"), ledger.transmitted, "cancelled does not imply not sent")
+
+            // The next frame is intact and follows the abandoned one, whole.
+            writer.send("second")
+            assertEquals(listOf("first", "second"), ledger.transmitted)
+            writer.close()
+        }
+
+    @Test
+    fun awaitWrittenSenderCancelledBeforeHandoffNeverTransmits() =
+        runTest {
+            val ledger = Ledger()
+            val gate = CompletableDeferred<Unit>()
+            val writer =
+                awaitWrittenWriter { outgoing ->
+                    if (originOf(outgoing) == "first") gate.await()
+                    ledger.record(outgoing)
+                    TransmitOutcome.Written
+                }
+            val first = launch { writer.send("first") }
+            advanceUntilIdle()
+
+            // The writer is busy, so this one is still holding its element at the rendezvous.
+            val second = launch { writer.send("second") }
+            advanceUntilIdle()
+            second.cancel()
+            advanceUntilIdle()
+
+            gate.complete(Unit)
+            advanceUntilIdle()
+            first.join()
+            assertEquals(listOf("first"), ledger.transmitted, "an unhanded-off element never reaches transmit")
+            writer.close()
+        }
+
+    // ----- Handoff: capacity ------------------------------------------------------------------
+
+    @Test
+    fun handoffSuspendEngagesAtExactlyCapacity() =
+        runTest {
+            val ledger = Ledger()
+            val accepted = mutableListOf<String>()
+            val writer =
+                handoffWriter(capacity = 3, onCapacity = CapacityBehavior.Suspend, onNotSent = { m, r ->
+                    ledger.notSent += m to r
+                }) { outgoing ->
+                    ledger.record(outgoing)
+                    TransmitOutcome.Written
+                }
+
+            val senders =
+                (0 until 4).map { index ->
+                    launch(start = CoroutineStart.UNDISPATCHED) {
+                        writer.send("m$index")
+                        accepted += "m$index"
+                    }
+                }
+            // Nothing has been dispatched yet, so the writer has never run and no slot has been
+            // freed: the deque's own depth is the whole accounting, and it bounds at exactly 3.
+            assertEquals(listOf("m0", "m1", "m2"), accepted, "capacity must engage at exactly 3")
+
+            advanceUntilIdle()
+            senders.forEach { it.join() }
+            assertEquals(listOf("m0", "m1", "m2", "m3"), accepted)
+            assertEquals(listOf("m0", "m1", "m2", "m3"), ledger.transmitted)
+            assertTrue(ledger.notSent.isEmpty())
+            writer.close()
+            assertExactlyOnce(accepted, ledger)
+        }
+
+    @Test
+    fun handoffSuspendResumesParkedSendersInArrivalOrder() =
+        runTest {
+            val ledger = Ledger()
+            val accepted = mutableListOf<String>()
+            val writer =
+                handoffWriter(capacity = 1, onCapacity = CapacityBehavior.Suspend, onNotSent = { m, r ->
+                    ledger.notSent += m to r
+                }) { outgoing ->
+                    delay(1)
+                    ledger.record(outgoing)
+                    TransmitOutcome.Written
+                }
+
+            val senders =
+                (0 until 3).map { index ->
+                    launch(start = CoroutineStart.UNDISPATCHED) {
+                        writer.send("m$index")
+                        accepted += "m$index"
+                    }
+                }
+            assertEquals(listOf("m0"), accepted)
+
+            advanceUntilIdle()
+            senders.forEach { it.join() }
+            assertEquals(listOf("m0", "m1", "m2"), accepted, "freed slots go to the longest-parked sender")
+            assertEquals(listOf("m0", "m1", "m2"), ledger.transmitted)
+            writer.close()
+            assertExactlyOnce(accepted, ledger)
+        }
+
+    @Test
+    fun handoffSuspendCancelledParkedSenderLosesOnlyItsOwnMessage() =
+        runTest {
+            val ledger = Ledger()
+            val accepted = mutableListOf<String>()
+            var gate = CompletableDeferred<Unit>()
+            val writer =
+                handoffWriter(capacity = 2, onCapacity = CapacityBehavior.Suspend, onNotSent = { m, r ->
+                    ledger.notSent += m to r
+                }) { outgoing ->
+                    gate.await()
+                    ledger.record(outgoing)
+                    TransmitOutcome.Written
+                }
+
+            val senders =
+                (0 until 4).map { index ->
+                    launch(start = CoroutineStart.UNDISPATCHED) {
+                        writer.send("m$index")
+                        accepted += "m$index"
+                    }
+                }
+            assertEquals(listOf("m0", "m1"), accepted)
+
+            // The writer takes m0 and stalls inside transmit; the slot it freed admits m2, so m3
+            // is the one still parked when its sender dies.
+            advanceUntilIdle()
+            senders[3].cancel()
+            advanceUntilIdle()
+
+            gate.complete(Unit)
+            advanceUntilIdle()
+            assertEquals(listOf("m0", "m1", "m2"), ledger.transmitted, "only the cancelled sender's message is lost")
+            assertTrue(ledger.notSent.isEmpty(), "a never-accepted message is reported nowhere")
+
+            // No permit can leak because there are no permits: refill and the bound is still 2.
+            gate = CompletableDeferred()
+            val refill =
+                (0 until 4).map { index ->
+                    launch(start = CoroutineStart.UNDISPATCHED) {
+                        writer.send("n$index")
+                        accepted += "n$index"
+                    }
+                }
+            assertEquals(listOf("m0", "m1", "m2", "n0", "n1"), accepted, "capacity is still exactly 2")
+
+            gate.complete(Unit)
+            advanceUntilIdle()
+            refill.forEach { it.join() }
+            assertEquals(listOf("m0", "m1", "m2", "n0", "n1", "n2", "n3"), ledger.transmitted)
+            writer.close()
+            assertExactlyOnce(accepted, ledger)
+        }
+
+    @Test
+    fun handoffDropOldestEvictsTheQueueHead() =
+        runTest {
+            val ledger = Ledger()
+            val writer =
+                handoffWriter(capacity = 2, onCapacity = CapacityBehavior.DropOldest, onNotSent = { m, r ->
+                    ledger.notSent += m to r
+                }) { outgoing ->
+                    ledger.record(outgoing)
+                    TransmitOutcome.Written
+                }
+
+            writer.send("m0")
+            writer.send("m1")
+            writer.send("m2")
+            assertEquals(listOf("m0"), ledger.lost, "the stale head is the victim")
+            assertEquals(listOf(NotSentReason.CapacityExceeded), ledger.reasons)
+
+            advanceUntilIdle()
+            assertEquals(listOf("m1", "m2"), ledger.transmitted, "queue order survives the eviction")
+            writer.close()
+            assertExactlyOnce(listOf("m0", "m1", "m2"), ledger)
+        }
+
+    @Test
+    fun handoffDropNewestRejectsTheArrival() =
+        runTest {
+            val ledger = Ledger()
+            val writer =
+                handoffWriter(capacity = 2, onCapacity = CapacityBehavior.DropNewest, onNotSent = { m, r ->
+                    ledger.notSent += m to r
+                }) { outgoing ->
+                    ledger.record(outgoing)
+                    TransmitOutcome.Written
+                }
+
+            writer.send("m0")
+            writer.send("m1")
+            writer.send("m2")
+            assertEquals(listOf("m2"), ledger.lost, "the arrival is the victim")
+            assertEquals(listOf(NotSentReason.CapacityExceeded), ledger.reasons)
+
+            advanceUntilIdle()
+            assertEquals(listOf("m0", "m1"), ledger.transmitted, "the queue is untouched")
+            writer.close()
+            assertExactlyOnce(listOf("m0", "m1", "m2"), ledger)
+        }
+
+    // ----- Handoff: re-entrancy from the loss handler ------------------------------------------
+
+    @Test
+    fun onNotSentMayReenterSend() =
+        runTest {
+            val ledger = Ledger()
+            var replaced = false
+            lateinit var writer: OutboundWriter<String>
+            writer =
+                handoffWriter(capacity = 2, onCapacity = CapacityBehavior.DropOldest, onNotSent = { message, reason ->
+                    ledger.notSent += message to reason
+                    if (!replaced) {
+                        replaced = true
+                        writer.send("$message-retry")
+                    }
+                }) { outgoing ->
+                    ledger.record(outgoing)
+                    TransmitOutcome.Written
+                }
+
+            writer.send("m0")
+            writer.send("m1")
+            // Evicts m0; the handler immediately re-enters send, which evicts m1 in turn.
+            writer.send("m2")
+            assertEquals(listOf("m0", "m1"), ledger.lost)
+
+            advanceUntilIdle()
+            assertEquals(listOf("m2", "m0-retry"), ledger.transmitted)
+            writer.close()
+            assertExactlyOnce(listOf("m0", "m1", "m2", "m0-retry"), ledger)
+        }
+
+    @Test
+    fun onNotSentMayReenterCloseFromTheSender() =
+        runTest {
+            val ledger = Ledger()
+            lateinit var writer: OutboundWriter<String>
+            writer =
+                handoffWriter(capacity = 1, onCapacity = CapacityBehavior.DropNewest, onNotSent = { message, reason ->
+                    ledger.notSent += message to reason
+                    writer.close()
+                }) { outgoing ->
+                    ledger.record(outgoing)
+                    TransmitOutcome.Written
+                }
+
+            writer.send("m0")
+            // Drops m1; the handler closes from the sender's coroutine and must not deadlock.
+            writer.send("m1")
+            assertEquals(listOf("m1"), ledger.lost)
+            assertEquals(listOf("m0"), ledger.transmitted)
+            assertEquals(ConnectionPhase.Closed(CloseCause.Graceful), writer.phase.value)
+            assertExactlyOnce(listOf("m0", "m1"), ledger)
+        }
+
+    @Test
+    fun onNotSentMayReenterCloseFromTheWriter() =
+        runTest {
+            val ledger = Ledger()
+            val encodeFailure = TransmitBoom("cannot encode")
+            lateinit var writer: OutboundWriter<String>
+            writer =
+                handoffWriter(capacity = 4, onCapacity = CapacityBehavior.DropNewest, onNotSent = { message, reason ->
+                    ledger.notSent += message to reason
+                    // Runs on the writer coroutine: closing here must initiate, not join itself.
+                    writer.close()
+                }) { outgoing ->
+                    if (originOf(outgoing) == "poison") {
+                        TransmitOutcome.EncodeFailed(encodeFailure)
+                    } else {
+                        ledger.record(outgoing)
+                        TransmitOutcome.Written
+                    }
+                }
+
+            writer.send("poison")
+            writer.send("later")
+            advanceUntilIdle()
+
+            assertEquals(listOf("poison"), ledger.lost)
+            assertEquals(listOf(NotSentReason.EncodeFailed(encodeFailure)), ledger.reasons)
+            assertEquals(listOf("later"), ledger.transmitted, "the drain finishes after the re-entrant close")
+            assertEquals(ConnectionPhase.Closed(CloseCause.Graceful), writer.phase.value)
+            assertExactlyOnce(listOf("poison", "later"), ledger)
+        }
+
+    // ----- Close ladder ------------------------------------------------------------------------
+
+    @Test
+    fun gracefulCloseDrainsEveryQueuedMessage() =
+        runTest {
+            val ledger = Ledger()
+            val writer =
+                handoffWriter(capacity = 8, onCapacity = CapacityBehavior.Suspend, onNotSent = { m, r ->
+                    ledger.notSent += m to r
+                }) { outgoing ->
+                    delay(1)
+                    ledger.record(outgoing)
+                    TransmitOutcome.Written
+                }
+            val accepted = (0 until 5).map { "m$it" }
+            accepted.forEach { writer.send(it) }
+
+            writer.close()
+            assertEquals(accepted, ledger.transmitted)
+            assertTrue(ledger.notSent.isEmpty())
+            assertEquals(ConnectionPhase.Closed(CloseCause.Graceful), writer.phase.value)
+            assertExactlyOnce(accepted, ledger)
+        }
+
+    @Test
+    fun boundedLingerEscalatesToAbort() =
+        runTest {
+            val ledger = Ledger()
+            val stall = CompletableDeferred<Unit>()
+            val writer =
+                handoffWriter(
+                    capacity = 8,
+                    onCapacity = CapacityBehavior.Suspend,
+                    onNotSent = { m, r -> ledger.notSent += m to r },
+                    linger = Linger.Bounded(100.milliseconds),
+                ) { outgoing ->
+                    stall.await()
+                    ledger.record(outgoing)
+                    TransmitOutcome.Written
+                }
+            val accepted = (0 until 3).map { "m$it" }
+            accepted.forEach { writer.send(it) }
+
+            writer.close()
+            assertTrue(ledger.transmitted.isEmpty(), "a stalled peer wrote nothing")
+            assertEquals(accepted, ledger.lost, "the in-flight frame and the remainder are all reported")
+            assertTrue(ledger.reasons.all { it == NotSentReason.ConnectionClosed(CloseCause.Aborted) })
+            assertEquals(ConnectionPhase.Closed(CloseCause.Aborted), writer.phase.value)
+            assertExactlyOnce(accepted, ledger)
+        }
+
+    @Test
+    fun abortReportsEveryQueuedMessageExactlyOnce() =
+        runTest {
+            val ledger = Ledger()
+            val stall = CompletableDeferred<Unit>()
+            val writer =
+                handoffWriter(capacity = 8, onCapacity = CapacityBehavior.Suspend, onNotSent = { m, r ->
+                    ledger.notSent += m to r
+                }) { outgoing ->
+                    stall.await()
+                    ledger.record(outgoing)
+                    TransmitOutcome.Written
+                }
+            val accepted = (0 until 3).map { "m$it" }
+            accepted.forEach { writer.send(it) }
+            advanceUntilIdle()
+
+            writer.abort()
+            assertEquals(accepted, ledger.lost)
+            assertTrue(ledger.reasons.all { it == NotSentReason.ConnectionClosed(CloseCause.Aborted) })
+            assertEquals(ConnectionPhase.Closed(CloseCause.Aborted), writer.phase.value)
+
+            // Idempotent and convergent: a second abort reports nothing twice.
+            writer.abort()
+            assertEquals(accepted, ledger.lost)
+            assertExactlyOnce(accepted, ledger)
+        }
+
+    @Test
+    fun doubleCloseIsIdempotent() =
+        runTest {
+            val ledger = Ledger()
+            val writer =
+                handoffWriter(capacity = 4, onCapacity = CapacityBehavior.Suspend, onNotSent = { m, r ->
+                    ledger.notSent += m to r
+                }) { outgoing ->
+                    delay(1)
+                    ledger.record(outgoing)
+                    TransmitOutcome.Written
+                }
+            writer.send("m0")
+
+            val closers = (0 until 2).map { launch { writer.close() } }
+            advanceUntilIdle()
+            closers.forEach { it.join() }
+
+            assertEquals(listOf("m0"), ledger.transmitted)
+            assertEquals(ConnectionPhase.Closed(CloseCause.Graceful), writer.phase.value)
+            writer.close()
+            assertEquals(ConnectionPhase.Closed(CloseCause.Graceful), writer.phase.value)
+            assertExactlyOnce(listOf("m0"), ledger)
+        }
+
+    @Test
+    fun closeRacingAbortConvergesOnOneTerminalCause() =
+        runTest {
+            val ledger = Ledger()
+            val stall = CompletableDeferred<Unit>()
+            val writer =
+                handoffWriter(capacity = 8, onCapacity = CapacityBehavior.Suspend, onNotSent = { m, r ->
+                    ledger.notSent += m to r
+                }) { outgoing ->
+                    stall.await()
+                    ledger.record(outgoing)
+                    TransmitOutcome.Written
+                }
+            val accepted = listOf("m0", "m1")
+            accepted.forEach { writer.send(it) }
+            advanceUntilIdle()
+
+            val closing = launch { writer.close() }
+            advanceUntilIdle()
+            assertEquals(ConnectionPhase.Draining, writer.phase.value, "an unbounded linger waits on the stalled peer")
+
+            val aborting = launch { writer.abort() }
+            advanceUntilIdle()
+            closing.join()
+            aborting.join()
+
+            assertEquals(ConnectionPhase.Closed(CloseCause.Aborted), writer.phase.value, "the first terminal cause wins")
+            assertEquals(accepted, ledger.lost)
+            assertExactlyOnce(accepted, ledger)
+        }
+
+    @Test
+    fun sendAfterCloseThrowsOutboundClosed() =
+        runTest {
+            val ledger = Ledger()
+            val handoff =
+                handoffWriter(capacity = 4, onCapacity = CapacityBehavior.Suspend, onNotSent = { m, r ->
+                    ledger.notSent += m to r
+                }) { outgoing ->
+                    ledger.record(outgoing)
+                    TransmitOutcome.Written
+                }
+            handoff.close()
+            assertEquals(CloseCause.Graceful, assertFailsWith<OutboundClosedException> { handoff.send("x") }.closeCause)
+            assertTrue(ledger.notSent.isEmpty(), "a refused send was never accepted, so it is reported nowhere")
+
+            val awaited = awaitWrittenWriter { TransmitOutcome.Written }
+            awaited.close()
+            assertEquals(CloseCause.Graceful, assertFailsWith<OutboundClosedException> { awaited.send("x") }.closeCause)
+
+            val aborted = awaitWrittenWriter { TransmitOutcome.Written }
+            aborted.abort()
+            assertEquals(CloseCause.Aborted, assertFailsWith<OutboundClosedException> { aborted.send("x") }.closeCause)
+        }
+
+    // ----- Writer failure ----------------------------------------------------------------------
+
+    @Test
+    fun writerFailureReportsTheRemainingQueueExactlyOnce() =
+        runTest {
+            val ledger = Ledger()
+            val boom = TransmitBoom("transport died")
+            val writer =
+                handoffWriter(capacity = 8, onCapacity = CapacityBehavior.Suspend, onNotSent = { m, r ->
+                    ledger.notSent += m to r
+                }) { outgoing ->
+                    if (originOf(outgoing) == "poison") throw boom
+                    ledger.record(outgoing)
+                    TransmitOutcome.Written
+                }
+            val accepted = listOf("m0", "poison", "m1", "m2")
+            accepted.forEach { writer.send(it) }
+            advanceUntilIdle()
+
+            assertEquals(listOf("m0"), ledger.transmitted)
+            assertEquals(listOf("poison", "m1", "m2"), ledger.lost)
+            val phase = writer.phase.value as ConnectionPhase.Closed
+            assertSame(boom, (phase.cause as CloseCause.Failed).cause)
+            assertTrue(ledger.reasons.all { it == NotSentReason.ConnectionClosed(phase.cause) })
+
+            val refused = assertFailsWith<OutboundClosedException> { writer.send("later") }
+            assertSame(phase.cause, refused.closeCause, "the sender sees the same terminal cause instance")
+            assertExactlyOnce(accepted, ledger)
+        }
+
+    // ----- Exactly-once sweep ------------------------------------------------------------------
+
+    @Test
+    fun exactlyOnceSweepAcrossEveryLossPath() =
+        runTest {
+            // Eviction under DropOldest, then a graceful close of what survived.
+            val evicting = Ledger()
+            val evictingAccepted = mutableListOf<String>()
+            val evictingWriter =
+                handoffWriter(capacity = 2, onCapacity = CapacityBehavior.DropOldest, onNotSent = { m, r ->
+                    evicting.notSent += m to r
+                }) { outgoing ->
+                    evicting.record(outgoing)
+                    TransmitOutcome.Written
+                }
+            repeat(6) { index ->
+                evictingWriter.send("e$index")
+                evictingAccepted += "e$index"
+            }
+            evictingWriter.close()
+            assertExactlyOnce(evictingAccepted, evicting)
+
+            // Abort with a stalled peer: nothing on the wire, everything reported.
+            val aborting = Ledger()
+            val stall = CompletableDeferred<Unit>()
+            val abortingAccepted = mutableListOf<String>()
+            val abortingWriter =
+                handoffWriter(capacity = 8, onCapacity = CapacityBehavior.Suspend, onNotSent = { m, r ->
+                    aborting.notSent += m to r
+                }) { outgoing ->
+                    stall.await()
+                    aborting.record(outgoing)
+                    TransmitOutcome.Written
+                }
+            repeat(4) { index ->
+                abortingWriter.send("a$index")
+                abortingAccepted += "a$index"
+            }
+            advanceUntilIdle()
+            abortingWriter.abort()
+            assertExactlyOnce(abortingAccepted, aborting)
+
+            // Writer failure mid-queue.
+            val failing = Ledger()
+            val failingAccepted = mutableListOf<String>()
+            val failingWriter =
+                handoffWriter(capacity = 8, onCapacity = CapacityBehavior.Suspend, onNotSent = { m, r ->
+                    failing.notSent += m to r
+                }) { outgoing ->
+                    if (originOf(outgoing) == "f2") throw TransmitBoom("transport died")
+                    failing.record(outgoing)
+                    TransmitOutcome.Written
+                }
+            repeat(5) { index ->
+                failingWriter.send("f$index")
+                failingAccepted += "f$index"
+            }
+            advanceUntilIdle()
+            failingWriter.close()
+            assertExactlyOnce(failingAccepted, failing)
+
+            // Encode failure: reported, connection survives, later frames still land.
+            val encoding = Ledger()
+            val encodingAccepted = mutableListOf<String>()
+            val encodingWriter =
+                handoffWriter(capacity = 8, onCapacity = CapacityBehavior.Suspend, onNotSent = { m, r ->
+                    encoding.notSent += m to r
+                }) { outgoing ->
+                    if (originOf(outgoing) == "c1") {
+                        TransmitOutcome.EncodeFailed(TransmitBoom("cannot encode"))
+                    } else {
+                        encoding.record(outgoing)
+                        TransmitOutcome.Written
+                    }
+                }
+            repeat(3) { index ->
+                encodingWriter.send("c$index")
+                encodingAccepted += "c$index"
+            }
+            encodingWriter.close()
+            assertEquals(listOf("c1"), encoding.lost)
+            assertExactlyOnce(encodingAccepted, encoding)
+        }
+}

--- a/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/OutboundWriterTests.kt
+++ b/buffer-flow/src/commonTest/kotlin/com/ditchoom/buffer/flow/OutboundWriterTests.kt
@@ -777,3 +777,41 @@ class OutboundWriterTests {
             assertExactlyOnce(encodingAccepted, encoding)
         }
 }
+
+/**
+ * The handler-contract hardening: `onNotSent` must not throw, and when it does anyway the writer
+ * fails LOUDLY — `Closed(Failed(handlerError))`, senders refused — instead of dying under an Open
+ * phase with senders still filling a queue nobody drains (the silent hang the component exists to
+ * kill).
+ */
+@OptIn(ExperimentalFanoutApi::class, ExperimentalCoroutinesApi::class)
+class OutboundWriterHandlerContractTests {
+    @Test
+    fun throwingOnNotSentFailsTheWriterInsteadOfHangingIt() =
+        runTest {
+            val handlerBoom = TransmitBoom("handler threw")
+            val writer =
+                handoffWriter(capacity = 4, onCapacity = CapacityBehavior.Suspend, onNotSent = { _, _ ->
+                    throw handlerBoom
+                }) { outgoing ->
+                    // First element hits the writer's reporting path via a per-message encode
+                    // failure; the throwing handler then escapes drive() itself.
+                    if (originOf(outgoing) == "poison") {
+                        TransmitOutcome.EncodeFailed(TransmitBoom("cannot encode"))
+                    } else {
+                        TransmitOutcome.Written
+                    }
+                }
+            writer.send("poison")
+            advanceUntilIdle()
+
+            val settled = writer.phase.value
+            assertTrue(settled is ConnectionPhase.Closed, "phase must not stay Open under a dead writer, was $settled")
+            val cause = settled.cause
+            assertTrue(cause is CloseCause.Failed, "handler error must surface as Failed, was $cause")
+            assertSame(handlerBoom, cause.cause)
+
+            val refused = assertFailsWith<OutboundClosedException> { writer.send("after") }
+            assertSame(handlerBoom, (refused.closeCause as CloseCause.Failed).cause)
+        }
+}

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/ExperimentalFanoutApi.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/ExperimentalFanoutApi.kt
@@ -1,0 +1,33 @@
+package com.ditchoom.buffer
+
+/**
+ * Marks the fan-out / shared-send surface ([SharedBytes][com.ditchoom.buffer.pool.SharedBytes],
+ * `SharedFrame` / `ContextFreeCodec` in `buffer-codec`, and the `SendMode.Handoff` arm plus its
+ * policy types in `buffer-flow`) as **experimental and opt-in**.
+ *
+ * The default send path (`SendMode.AwaitWritten`) is stable from day one — it preserves the
+ * observable semantics existing consumers already rely on. The gated surface is the part with
+ * genuine design freedom left: bounded-queue loss policy, linger semantics, and cross-connection
+ * encode sharing. Changing an opt-in-experimental API is not a semver-major break — that is what
+ * this marker buys while downstream adoption exercises the shape. Stabilization (dropping the
+ * marker) requires the sealed hierarchies gated here to be finalized first, since adding an arm
+ * to a stabilized sealed type breaks exhaustive `when`s in consumers.
+ *
+ * Opt in with `@OptIn(ExperimentalFanoutApi::class)` at the call site, or propagate by annotating
+ * your own declaration `@ExperimentalFanoutApi`.
+ */
+@RequiresOptIn(
+    level = RequiresOptIn.Level.WARNING,
+    message =
+        "The fan-out/shared-send surface is experimental and may change until its sealed " +
+            "hierarchies are finalized. Opt in with @OptIn(ExperimentalFanoutApi::class).",
+)
+@Retention(AnnotationRetention.BINARY)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.CONSTRUCTOR,
+    AnnotationTarget.TYPEALIAS,
+)
+annotation class ExperimentalFanoutApi

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/SharedBytes.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/SharedBytes.kt
@@ -128,7 +128,50 @@ class SharedBytes private constructor(
         /**
          * Takes ownership of [buffer] (already `resetForRead()`) and returns a `SharedBytes`
          * holding the creator's single reference.
+         *
+         * **[buffer] must not be written or have its cursor moved after this call.** Views are
+         * slices of a stable `position..limit` window, and every consumer reads that window
+         * concurrently; mutating it afterwards races every live view.
+         *
+         * **A pooled [buffer] must come from a [ThreadingMode.MultiThreaded] pool**, enforced
+         * here. The whole point of this type is that the *last* reference may be dropped on any
+         * thread, and that release returns the chunk to its pool — against
+         * [ThreadingMode.SingleThreaded]'s unsynchronized freelist that is a silent corruption
+         * (a mangled freelist, or one chunk handed to two owners). `BufferPool()` defaults to
+         * single-threaded, so this is the easy mistake to make and the reason it fails loudly
+         * here rather than sporadically at some later acquire.
          */
-        fun adopt(buffer: PlatformBuffer): SharedBytes = SharedBytes(buffer)
+        fun adopt(buffer: PlatformBuffer): SharedBytes {
+            val pool = poolOf(buffer)
+            require(pool == null || pool.threadingMode == ThreadingMode.MultiThreaded) {
+                "SharedBytes.adopt() requires a ThreadingMode.MultiThreaded BufferPool: shared " +
+                    "references are released from arbitrary threads, and a SingleThreaded pool's " +
+                    "freelist is not safe to return a chunk to off its owning thread."
+            }
+            return SharedBytes(buffer)
+        }
+
+        /**
+         * The pool backing [buffer], found by walking the same wrapper layers [unwrapFully]
+         * resolves through. `null` for unpooled buffers, which have no freelist to corrupt.
+         */
+        @Suppress("DEPRECATION")
+        private fun poolOf(buffer: PlatformBuffer): BufferPool? {
+            var current: ReadBuffer? = buffer
+            var found: BufferPool? = null
+            while (found == null && current != null) {
+                // Each step either identifies the pool or descends one wrapper; `null` means the
+                // walk bottomed out at a plain buffer that carries no pool identity.
+                current =
+                    when (val layer = current) {
+                        // Specific wrappers first: both also satisfy `is PlatformBuffer`.
+                        is PooledBuffer -> null.also { found = layer.pool }
+                        is TrackedSlice -> null.also { found = layer.parentPool }
+                        is PlatformBuffer -> layer.unwrap().takeIf { it !== layer }
+                        else -> null
+                    }
+            }
+            return found
+        }
     }
 }

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/SharedBytes.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/SharedBytes.kt
@@ -1,0 +1,72 @@
+package com.ditchoom.buffer.pool
+
+import com.ditchoom.buffer.ExperimentalFanoutApi
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+
+/**
+ * Immutable encoded bytes shared across concurrent consumers, freed exactly once.
+ *
+ * The primitive behind encode-once fan-out: one buffer of encoded bytes handed to N independent
+ * writers, each reading through its own cursor, with the backing storage released when — and only
+ * when — the last reference is dropped. [PooledBuffer]'s existing chunk-plus-slices refcount is
+ * the single-owner ancestor of this type; `SharedBytes` exists because that count is deliberately
+ * NOT thread-safe (the single-consumer hot path must not pay for atomics), while sharing across
+ * connections requires an atomic count. The atomicity lives here, in the sharing wrapper, and
+ * nowhere else.
+ *
+ * ## Reference protocol
+ *
+ * - [adopt] takes **ownership** of a fully-written buffer (call `resetForRead()` first) and starts
+ *   the count at 1 — the creator's reference.
+ * - [retain] adds a reference; call it when transferring the bytes to another owner (e.g. enqueueing
+ *   onto another connection's outbound queue). Returns `this` for chaining.
+ * - [release] drops a reference. At zero the adopted buffer is freed via its own discipline
+ *   (`use`-equivalent: pooled buffers return to their pool, deterministic buffers free native
+ *   memory, GC-managed buffers no-op). Releasing below zero throws — an accounting bug must fail
+ *   loudly, not double-free.
+ * - Every reference is released **exactly once**. In the outbound-writer integration this rides the
+ *   writer's exactly-once loss accounting: a transferred reference is released either after the
+ *   write completes or on the not-sent path — never both, never neither.
+ *
+ * ## Views
+ *
+ * [view] returns a read-only-typed slice with an **independent cursor** over the shared storage:
+ * concurrent writers never contend on position/limit. A view is valid only while the caller holds
+ * an undropped reference; it is not individually guarded (experimental v1 — the parent's liveness
+ * check fails fast on the storage, not per-view).
+ *
+ * Thread safety: [retain]/[release] are safe from any thread. [view] is safe concurrently with
+ * other [view] calls and reads.
+ */
+@ExperimentalFanoutApi
+class SharedBytes private constructor(
+    private val adopted: PlatformBuffer,
+) {
+    /** Total readable bytes (every [view] starts with exactly this many remaining). */
+    val size: Int
+        get() = TODO("implemented by the shared-send work")
+
+    /** Adds a reference. Throws [IllegalStateException] if the count already reached zero. */
+    fun retain(): SharedBytes = TODO("implemented by the shared-send work")
+
+    /**
+     * Drops a reference; frees the adopted buffer at zero.
+     * Throws [IllegalStateException] on over-release.
+     */
+    fun release(): Unit = TODO("implemented by the shared-send work")
+
+    /**
+     * A read-only slice with an independent cursor over the shared storage.
+     * The caller must hold an undropped reference for the view's whole lifetime.
+     */
+    fun view(): ReadBuffer = TODO("implemented by the shared-send work")
+
+    companion object {
+        /**
+         * Takes ownership of [buffer] (already `resetForRead()`) and returns a `SharedBytes`
+         * holding the creator's single reference.
+         */
+        fun adopt(buffer: PlatformBuffer): SharedBytes = TODO("implemented by the shared-send work")
+    }
+}

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/SharedBytes.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/SharedBytes.kt
@@ -3,6 +3,9 @@ package com.ditchoom.buffer.pool
 import com.ditchoom.buffer.ExperimentalFanoutApi
 import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.unwrapFully
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
 /**
  * Immutable encoded bytes shared across concurrent consumers, freed exactly once.
@@ -40,33 +43,92 @@ import com.ditchoom.buffer.ReadBuffer
  * other [view] calls and reads.
  */
 @ExperimentalFanoutApi
+@OptIn(ExperimentalAtomicApi::class)
 class SharedBytes private constructor(
     private val adopted: PlatformBuffer,
 ) {
+    /**
+     * The raw buffer under [adopted]'s wrapper layers, captured once at [adopt].
+     *
+     * [view] slices **this**, not [adopted], and that is the whole reason this class exists.
+     * `PooledBuffer.slice()` (and `TrackedSlice.slice()`) bumps a plain, non-atomic `refCount`
+     * field before delegating, so two threads calling `view()` through a pooled wrapper would race
+     * on that increment and lose one — the pooled chunk would then return to its pool while a live
+     * view still aliased it. Slicing the unwrapped buffer sidesteps the wrapper's per-slice
+     * tracking entirely: every plain buffer's `slice()` only *reads* the parent's position/limit
+     * and allocates a new view object (verified on `HeapJvmBuffer`/`DirectJvmBuffer` →
+     * `ByteBuffer.slice()`, `FfmBuffer` → `MemorySegment.asSlice`, `NativeBuffer`/`ByteArrayBuffer`
+     * → offset arithmetic, `MutableDataBuffer` → pointer arithmetic, `JsBuffer` → `subarray`,
+     * `LinearBuffer` → base-offset arithmetic), so concurrent slicing of a buffer whose cursor
+     * never moves is race-free.
+     *
+     * Bypassing the wrapper's own count is deliberate and safe here because `SharedBytes`' atomic
+     * [refCount] is the sole authority on lifetime. What gets released at zero is still [adopted],
+     * the *wrapper* — so a pooled buffer goes back to its pool instead of being freed outright —
+     * and it is released exactly once, by the single thread whose [release] drives the count to
+     * zero.
+     *
+     * Invariant: nothing may move [adopted]'s (and therefore this buffer's) cursor after [adopt].
+     * Views are slices of a stable `position..limit` window.
+     */
+    private val storage: ReadBuffer = adopted.unwrapFully()
+
+    /**
+     * Live reference count. Atomic because references are taken and dropped from unrelated
+     * connection coroutines, which may be on different threads.
+     */
+    private val refCount = AtomicInt(1)
+
     /** Total readable bytes (every [view] starts with exactly this many remaining). */
-    val size: Int
-        get() = TODO("implemented by the shared-send work")
+    val size: Int = storage.remaining()
 
     /** Adds a reference. Throws [IllegalStateException] if the count already reached zero. */
-    fun retain(): SharedBytes = TODO("implemented by the shared-send work")
+    fun retain(): SharedBytes {
+        // CAS loop rather than a blind increment: incrementing from zero would resurrect storage
+        // that has already been freed/returned to its pool, and hand out views onto memory some
+        // other acquirer now owns. A freed SharedBytes stays freed.
+        while (true) {
+            val current = refCount.load()
+            check(current > 0) { "SharedBytes.retain() after the last reference was released" }
+            if (refCount.compareAndSet(current, current + 1)) return this
+        }
+    }
 
     /**
      * Drops a reference; frees the adopted buffer at zero.
      * Throws [IllegalStateException] on over-release.
      */
-    fun release(): Unit = TODO("implemented by the shared-send work")
+    fun release() {
+        while (true) {
+            val current = refCount.load()
+            check(current > 0) { "SharedBytes.release() called more times than it was retained" }
+            if (refCount.compareAndSet(current, current - 1)) {
+                // Exactly one thread observes the 1 -> 0 transition, so the free happens once.
+                // freeNativeMemory() is the buffer's own discipline: a pooled buffer returns to
+                // its pool, a deterministic buffer frees native memory, a GC-managed buffer no-ops.
+                if (current == 1) adopted.freeNativeMemory()
+                return
+            }
+        }
+    }
 
     /**
      * A read-only slice with an independent cursor over the shared storage.
      * The caller must hold an undropped reference for the view's whole lifetime.
      */
-    fun view(): ReadBuffer = TODO("implemented by the shared-send work")
+    fun view(): ReadBuffer {
+        // Guards view *creation* only. Per the class contract a view handed out while the count
+        // was positive is not individually tracked afterwards; the caller's reference is what
+        // keeps it valid.
+        check(refCount.load() > 0) { "SharedBytes.view() after the last reference was released" }
+        return storage.slice()
+    }
 
     companion object {
         /**
          * Takes ownership of [buffer] (already `resetForRead()`) and returns a `SharedBytes`
          * holding the creator's single reference.
          */
-        fun adopt(buffer: PlatformBuffer): SharedBytes = TODO("implemented by the shared-send work")
+        fun adopt(buffer: PlatformBuffer): SharedBytes = SharedBytes(buffer)
     }
 }

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/TrackedSlice.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/TrackedSlice.kt
@@ -50,6 +50,13 @@ internal class TrackedSlice(
     private var released = false
 
     /**
+     * The pool this slice's storage ultimately returns to. Internal so [SharedBytes.adopt] can
+     * reject a pool whose freelist is not safe to touch from the thread that drops the last
+     * shared reference — [inner] is the raw slice and carries no pool identity of its own.
+     */
+    internal val parentPool: BufferPool get() = parent.pool
+
+    /**
      * Fails fast if this slice has been released back to the pool. Mirrors
      * [PooledBuffer]'s `checkNotFreed` use-after-free contract (same exception
      * type and intent). Internal so [ReadBuffer.unwrapFully] can gate wrapper

--- a/buffer/src/commonTest/kotlin/com/ditchoom/buffer/pool/SharedBytesTests.kt
+++ b/buffer/src/commonTest/kotlin/com/ditchoom/buffer/pool/SharedBytesTests.kt
@@ -1,0 +1,365 @@
+package com.ditchoom.buffer.pool
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.CloseableBuffer
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.ExperimentalFanoutApi
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.deterministicAllocateOrSkip
+import com.ditchoom.buffer.unwrapFully
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Lifetime and concurrency invariants for [SharedBytes] — the encode-once fan-out primitive.
+ *
+ * The three failure modes these tests exist to make impossible:
+ *
+ *  1. **Free too early.** Storage returns to its pool (or has its native memory released) while a
+ *     fan-out consumer still holds a reference, so the consumer reads memory another acquirer now
+ *     owns. Pinned by asserting the pool observable stays empty for the whole race.
+ *  2. **Free twice / never.** [PooledBuffer]'s own refcount is deliberately non-atomic; `SharedBytes`
+ *     carries the atomic count instead, and its 1→0 transition must be observed by exactly one
+ *     thread. Pinned by count arithmetic plus loud failure on over-release.
+ *  3. **Resurrect from zero.** A blind `refCount++` in [SharedBytes.retain] would revive a freed
+ *     buffer; the CAS loop must refuse instead.
+ *
+ * Runs on every platform via commonTest: the count is common Kotlin, but the free at zero lands on
+ * a different discipline per backend (pool return, `Arena`/`free()`, ARC, GC no-op) and the view
+ * path slices a different concrete buffer type on each.
+ */
+@OptIn(ExperimentalFanoutApi::class)
+class SharedBytesTests {
+    // ========================================================================
+    // 1. adopt -> release frees exactly once
+    // ========================================================================
+
+    @Test
+    fun pooledStorageReturnsToItsPoolExactlyOnceAtZero() {
+        val pool = newPool()
+        val shared = SharedBytes.adopt(pooledPayload(pool))
+
+        assertEquals(PAYLOAD_SIZE, shared.size, "size is the readable byte count, not the capacity")
+        assertEquals(0, pool.stats().currentPoolSize, "the creator's reference must pin the chunk")
+
+        shared.release()
+        assertEquals(1, pool.stats().currentPoolSize, "the last release must return the chunk to its pool")
+
+        // "Exactly once" is the whole point: a duplicate release is an accounting bug and must fail
+        // loudly rather than push the same chunk onto the freelist a second time.
+        assertFailsWith<IllegalStateException> { shared.release() }
+        assertEquals(1, pool.stats().currentPoolSize, "over-release must not re-pool the chunk")
+
+        pool.clear()
+    }
+
+    @Test
+    fun deterministicStorageIsFreedOnlyWhenTheLastReferenceDrops() {
+        val buffer = deterministicAllocateOrSkip(PAYLOAD_SIZE) ?: return
+        val closeable = buffer as? CloseableBuffer
+        if (closeable == null) {
+            // Apple's deterministic buffer is ARC-managed and exposes no freed observable; the
+            // pooled tests cover the free-at-zero contract on that platform.
+            buffer.freeNativeMemory()
+            return
+        }
+        fillPattern(buffer)
+
+        val shared = SharedBytes.adopt(buffer)
+        shared.retain()
+        shared.release()
+        assertFalse(closeable.isFreed, "one outstanding reference must keep native memory alive")
+        assertPattern(shared.view(), "view while still referenced")
+
+        shared.release()
+        assertTrue(closeable.isFreed, "the last release must free the native memory")
+    }
+
+    // ========================================================================
+    // 2. retain/release balance
+    // ========================================================================
+
+    @Test
+    fun nRetainsRequireNPlusOneReleases() {
+        val pool = newPool()
+        val shared = SharedBytes.adopt(pooledPayload(pool))
+        val extraReferences = 5
+
+        repeat(extraReferences) { assertSame(shared, shared.retain(), "retain() returns this for chaining") }
+        repeat(extraReferences) { shared.release() }
+        assertEquals(
+            0,
+            pool.stats().currentPoolSize,
+            "N retains balanced by N releases still leaves the creator's reference outstanding",
+        )
+
+        shared.release()
+        assertEquals(1, pool.stats().currentPoolSize, "the N+1th release is the one that frees")
+        pool.clear()
+    }
+
+    @Test
+    fun overReleaseThrows() {
+        val pool = newPool()
+        val shared = SharedBytes.adopt(pooledPayload(pool))
+        shared.release()
+
+        assertFailsWith<IllegalStateException> { shared.release() }
+        pool.clear()
+    }
+
+    @Test
+    fun retainAfterZeroThrowsInsteadOfResurrecting() {
+        val pool = newPool()
+        val shared = SharedBytes.adopt(pooledPayload(pool))
+        shared.release()
+
+        assertFailsWith<IllegalStateException> { shared.retain() }
+        assertEquals(
+            1,
+            pool.stats().currentPoolSize,
+            "a refused retain must not disturb the already-returned chunk",
+        )
+        pool.clear()
+    }
+
+    @Test
+    fun viewAfterZeroThrows() {
+        val pool = newPool()
+        val shared = SharedBytes.adopt(pooledPayload(pool))
+        shared.release()
+
+        assertFailsWith<IllegalStateException> { shared.view() }
+        pool.clear()
+    }
+
+    // ========================================================================
+    // 3. Concurrent stress
+    // ========================================================================
+
+    @Test
+    fun racedRetainReleasePairsNeverFreeEarlyAndFreeExactlyOnce() =
+        runTest {
+            val pool = newPool()
+            val shared = SharedBytes.adopt(pooledPayload(pool))
+
+            withContext(Dispatchers.Default) {
+                coroutineScope {
+                    repeat(WORKERS) {
+                        launch {
+                            repeat(ITERATIONS) { iteration ->
+                                shared.retain()
+                                assertPattern(shared.view(), "raced view")
+                                shared.release()
+                                if (iteration % POOL_PROBE_INTERVAL == 0) {
+                                    assertEquals(
+                                        0,
+                                        pool.stats().currentPoolSize,
+                                        "the base reference must keep the chunk out of the pool for the whole race",
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            assertEquals(
+                0,
+                pool.stats().currentPoolSize,
+                "${WORKERS * ITERATIONS} balanced retain/release pairs must not free anything",
+            )
+            // The count is exactly 1 here: retain() only succeeds above zero, and the release that
+            // follows must be the one that frees.
+            shared.retain()
+            shared.release()
+            assertEquals(0, pool.stats().currentPoolSize)
+            shared.release()
+            assertEquals(1, pool.stats().currentPoolSize, "the final release frees, exactly once")
+            assertFailsWith<IllegalStateException> { shared.release() }
+
+            pool.clear()
+        }
+
+    @Test
+    fun concurrentViewsReadDisjointRegionsCorrectly() =
+        runTest {
+            val pool = newPool()
+            val shared = SharedBytes.adopt(pooledPayload(pool))
+            val region = PAYLOAD_SIZE / WORKERS
+
+            withContext(Dispatchers.Default) {
+                coroutineScope {
+                    repeat(WORKERS) { worker ->
+                        launch {
+                            val start = worker * region
+                            repeat(ITERATIONS) {
+                                // Every worker builds its own view concurrently with the others and
+                                // walks only its own window — the cursors must never interfere.
+                                val view = shared.view()
+                                view.position(start)
+                                for (i in start until start + region) {
+                                    assertEquals(patternByte(i), view.readByte(), "worker $worker byte $i")
+                                }
+                                assertEquals(PAYLOAD_SIZE - start - region, view.remaining())
+                            }
+                        }
+                    }
+                }
+            }
+
+            shared.release()
+            assertEquals(1, pool.stats().currentPoolSize)
+            pool.clear()
+        }
+
+    // ========================================================================
+    // 4. View independence
+    // ========================================================================
+
+    @Test
+    fun viewsAdvanceIndependentCursorsOverTheSameBytes() {
+        val buffer = BufferFactory.Default.allocate(PAYLOAD_SIZE)
+        fillPattern(buffer)
+        val shared = SharedBytes.adopt(buffer)
+
+        val first = shared.view()
+        val second = shared.view()
+        assertEquals(PAYLOAD_SIZE, first.remaining())
+        assertEquals(PAYLOAD_SIZE, second.remaining())
+
+        // Drain the first view halfway; the second must be untouched.
+        repeat(PAYLOAD_SIZE / 2) { i -> assertEquals(patternByte(i), first.readByte()) }
+        assertEquals(PAYLOAD_SIZE / 2, first.position(), "first view advanced")
+        assertEquals(0, second.position(), "second view must not see the first view's cursor")
+        assertEquals(PAYLOAD_SIZE, second.remaining())
+
+        // Both views still read the full, correct content from their own positions.
+        for (i in PAYLOAD_SIZE / 2 until PAYLOAD_SIZE) {
+            assertEquals(patternByte(i), first.readByte(), "first view tail byte $i")
+        }
+        assertPattern(second, "second view read in full afterwards")
+
+        // A third view minted after the other two are drained still starts at the beginning.
+        assertPattern(shared.view(), "third view")
+        shared.release()
+    }
+
+    @Test
+    fun viewsAreByteIdenticalToTheAdoptedSource() {
+        val source = BufferFactory.Default.allocate(PAYLOAD_SIZE)
+        fillPattern(source)
+        val expected = ByteArray(PAYLOAD_SIZE) { patternByte(it) }
+
+        val shared = SharedBytes.adopt(source)
+        val view = shared.view()
+        assertEquals(expected.size, view.remaining())
+        assertTrue(
+            view.contentEquals(BufferFactory.Default.wrap(expected)),
+            "a view must expose exactly the adopted bytes",
+        )
+        // contentEquals is non-consuming, so the same view still reads the same bytes byte-by-byte.
+        assertPattern(view, "view after contentEquals")
+        shared.release()
+    }
+
+    // ========================================================================
+    // 5. Pooled path
+    // ========================================================================
+
+    @Test
+    fun pooledStorageIsReAcquirableOnlyAfterTheFinalRelease() {
+        val pool = newPool()
+        val chunk = pooledPayload(pool)
+        val storage = chunk.unwrapFully()
+
+        val shared = SharedBytes.adopt(chunk)
+        shared.retain() // a fan-out consumer's reference
+
+        // Before the final release the chunk is still checked out and views read correctly.
+        assertEquals(0, pool.stats().currentPoolSize)
+        assertPattern(shared.view(), "view while the chunk is checked out")
+
+        shared.release()
+        assertEquals(0, pool.stats().currentPoolSize, "one reference left — the chunk stays checked out")
+        assertPattern(shared.view(), "view with the last reference still held")
+
+        shared.release()
+        assertEquals(1, pool.stats().currentPoolSize, "the chunk is back in the pool")
+
+        val reacquired = pool.acquire(PAYLOAD_SIZE) as PlatformBuffer
+        assertSame(storage, reacquired.unwrapFully(), "the pool must hand back the very same storage")
+        assertTrue(pool.stats().poolHits >= 1, "the re-acquire must be a pool hit, not a fresh allocation")
+
+        reacquired.freeNativeMemory()
+        pool.clear()
+    }
+
+    @Test
+    fun adoptingAPooledChunkDoesNotDisturbTheWrappersOwnRefcount() {
+        // view() slices the UNWRAPPED buffer on purpose, so it must not bump PooledBuffer's
+        // non-atomic per-slice count — if it did, the chunk would be pinned forever by views that
+        // nobody can release (view() hands back a read-only type with no release channel).
+        val pool = newPool()
+        val shared = SharedBytes.adopt(pooledPayload(pool))
+        repeat(16) { assertPattern(shared.view(), "view $it") }
+
+        shared.release()
+        assertEquals(1, pool.stats().currentPoolSize, "outstanding views must not pin the chunk")
+        pool.clear()
+    }
+
+    // ========================================================================
+    // Helpers
+    // ========================================================================
+
+    private fun newPool(): BufferPool =
+        BufferPool(
+            threadingMode = ThreadingMode.MultiThreaded,
+            maxPoolSize = 4,
+            defaultBufferSize = POOL_BUFFER_SIZE,
+            factory = BufferFactory.Default,
+        )
+
+    /** A pool-acquired chunk holding [PAYLOAD_SIZE] pattern bytes, positioned for reading. */
+    private fun pooledPayload(pool: BufferPool): PlatformBuffer {
+        val chunk = pool.acquire(PAYLOAD_SIZE) as PlatformBuffer
+        fillPattern(chunk)
+        return chunk
+    }
+
+    private fun fillPattern(buffer: PlatformBuffer) {
+        for (i in 0 until PAYLOAD_SIZE) buffer.writeByte(patternByte(i))
+        buffer.resetForRead()
+    }
+
+    private fun assertPattern(
+        view: ReadBuffer,
+        message: String,
+    ) {
+        assertEquals(PAYLOAD_SIZE, view.remaining(), "$message: remaining")
+        for (i in 0 until PAYLOAD_SIZE) {
+            assertEquals(patternByte(i), view.readByte(), "$message: byte $i")
+        }
+    }
+
+    private companion object {
+        const val PAYLOAD_SIZE = 64
+        const val POOL_BUFFER_SIZE = 256
+        const val WORKERS = 4
+        const val ITERATIONS = 1000
+        const val POOL_PROBE_INTERVAL = 64
+
+        fun patternByte(index: Int): Byte = (index * 31 + 7).toByte()
+    }
+}

--- a/buffer/src/commonTest/kotlin/com/ditchoom/buffer/pool/SharedBytesTests.kt
+++ b/buffer/src/commonTest/kotlin/com/ditchoom/buffer/pool/SharedBytesTests.kt
@@ -323,6 +323,40 @@ class SharedBytesTests {
     // Helpers
     // ========================================================================
 
+    // ========================================================================
+    // 4. adopt() refuses storage it could not safely free
+    // ========================================================================
+
+    /**
+     * `BufferPool()` defaults to [ThreadingMode.SingleThreaded], whose freelist is a plain
+     * `ArrayDeque`. Sharing is precisely the case where the *last* release lands on an arbitrary
+     * thread, so adopting single-threaded storage would race that unsynchronized freelist against
+     * its owner — a mangled list, or one chunk handed to two owners, surfacing much later at an
+     * innocent `acquire`. Fail at the boundary where the mistake is made instead.
+     *
+     * These tests hardcode [ThreadingMode.MultiThreaded] everywhere else, which is exactly why the
+     * requirement went unnoticed and needs its own pin.
+     */
+    @Test
+    fun adoptRejectsSingleThreadedPoolStorage() {
+        withPool(threadingMode = ThreadingMode.SingleThreaded, defaultBufferSize = POOL_BUFFER_SIZE) { pool ->
+            val chunk = pool.acquire(PAYLOAD_SIZE) as PlatformBuffer
+            fillPattern(chunk)
+            assertFailsWith<IllegalArgumentException>("single-threaded pool storage must be refused loudly") {
+                SharedBytes.adopt(chunk)
+            }
+            chunk.freeNativeMemory()
+        }
+    }
+
+    /** The unpooled case stays legal: no freelist exists to corrupt. */
+    @Test
+    fun adoptAcceptsUnpooledStorage() {
+        val buffer = BufferFactory.Default.allocate(PAYLOAD_SIZE)
+        fillPattern(buffer)
+        SharedBytes.adopt(buffer).release()
+    }
+
     private fun newPool(): BufferPool =
         BufferPool(
             threadingMode = ThreadingMode.MultiThreaded,


### PR DESCRIPTION
# Connection-owned send: SendMode + OutboundWriter + encode-once fan-out

> **Label: `minor`.** All-additive: no signature changes to existing API. The one semantic change is documentation — `Connection<T>`'s send contract is staged toward mandatory (see below). The new fan-out surface is gated behind `@ExperimentalFanoutApi` and excluded from the locked ABI.

Implements the buffer half of the send-ownership design (DitchOoM/socket#382): once a connection owns its writer, a cancelled sender can never truncate a frame mid-write, and concurrent senders can never interleave — invariants by construction, not by careful use.

## What's here

**`Connection<T>` contract, staged (buffer-flow).** The kdoc drops "not assumed thread-safe … use a `Mutex`" and states the strengthened guarantee — send is atomic and serialized, no external synchronization — as what conforming implementations provide. Third-party implementations written against the old contract remain callable; v7 makes the guarantee mandatory (#368). `abort()` joins the interface with a default (`= close()`): the RST-like counterpart to graceful close, mirroring the byte layer's `Resettable`.

**`SendMode` (buffer-flow, contravariant).** How `send` completes:
- `AwaitWritten` — stable, zero-config, the drop-in default: send returns when the frame is on the wire, errors throw at the call site. The connection-owned writer finishes the frame even if the sender is cancelled mid-wait (documented edge: "cancelled ≠ not sent").
- `Handoff` *(experimental)* — fan-out mode: send returns on enqueue; four required fields (`OutboundCapacity` value class, sealed `CapacityBehavior`, sealed `Linger`, `onNotSent`); every accepted-but-unsent message is reported exactly once with a sealed `NotSentReason`. No silent-loss path exists.

**`ConnectionPhase`/`CloseCause` (buffer-flow, stable).** The send/close lifecycle as a sealed state exposed via `StateFlow` — `Closed` cannot exist without a cause.

**`OutboundWriter<T>` *(experimental, buffer-flow)*.** The reusable component adopters compose: one owned writer coroutine, per-mode queue machinery (rendezvous for AwaitWritten; a hand-rolled bounded deque for Handoff — `onNotSent` is `suspend`, which kotlinx's non-suspend `onUndeliveredElement` cannot express, and DROP_OLDEST evictions skip that hook entirely), a graceful-drain/abort close ladder with linger escalation, and exactly-once loss accounting as the load-bearing invariant. User callbacks never run under the queue lock; re-entrant send/close from a handler is legal.

**`SharedBytes` (buffer core, experimental) + `ContextFreeCodec`/`SharedFrame`/`encodeShared` (buffer-codec, experimental).** Encode-once fan-out: one atomic-refcounted buffer of encoded bytes, N independent-cursor read views, freed exactly once by the last release. The atomicity lives only in the sharing wrapper — `PooledBuffer`'s single-owner count stays non-atomic and pays nothing. Views slice the *unwrapped* storage because the pooled wrapper's per-slice tracking is a non-atomic count (the data race this type exists to avoid); `SharedBytes`' own count is the sole lifetime authority. Sharability is a declared capability: `encodeShared` exists only on `ContextFreeCodec`, because a codec with per-connection encode state (dynamic tables, packet ids) produces different bytes per connection and sharing them is silent corruption.

## Verification

45 new tests, all deterministic and zero-I/O, green on JVM + linuxX64 (full modules) with jsNode/wasmJs spot-verified per work stream:

- **OutboundWriter (23)** — capacity engages at exactly N; Suspend/DropOldest/DropNewest semantics with FIFO slot handoff; cancelled-mid-transmit senders never truncate (writer finishes the frame); parked-sender cancellation loses the wait, not the message, and leaks no capacity; onNotSent re-entrancy (send/close from the handler); close ladder incl. bounded-linger escalation with the in-flight frame in the reported set; concurrent close/abort convergence (first terminal cause wins); writer failure reports the whole queue exactly once with the same `Failed` instance surfaced to refused senders; an exactly-once ledger sweep across all scenarios; and the handler-contract hardening (a throwing `onNotSent` settles `Closed(Failed)` instead of a dead writer under an Open phase — found in validation review, fixed, regression-tested). Suite was mutation-checked: reverting the FIFO handoff, the in-flight loss report, or first-cause-wins each breaks multiple tests.
- **SharedBytes (12)** — pooled chunk returns to its pool exactly once; N retains need N+1 releases; over-release/retain-after-zero/view-after-zero throw; 4 workers × 1000 raced retain/release pairs with liveness probes throughout; raced concurrent view creation; cursor independence; 16 outstanding views don't pin the chunk.
- **ContextFreeCodec (5)** — encodeShared byte-identity vs plain encode on both the `WireSize.Exact` and grow-and-retry `BackPatch` paths; 3-consumer frame lifecycle; pooled-factory round-trip; 8-cycle chunk-recycle leak check.
- **Integration (5)** — `sendShared`'s transferred reference released exactly once on the written, refused, evicted, and abort-discarded paths, probed through SharedBytes' own strict refcount rather than test counters.

## ABI

`:buffer-flow:apiCheck` green. The dump gains exactly the stable surface (`SendMode`+`AwaitWritten`, `ConnectionPhase`, `CloseCause`, `Connection.abort` default); everything `@ExperimentalFanoutApi`-gated is excluded via `nonPublicMarkers` (each sealed arm annotated individually — the filter does not descend into nested declarations).

## v7 ledger

Deferred tightening filed as milestone `v7`: #368 (contract mandatory), #369 (typed ids), #370 (finalize sealed arms, then stabilize this surface — includes the known v1 softness: `view()` is read-only by typing, not enforcement), #371 (datagram graduation).

## Consumer

The socket library adopts `OutboundWriter` in its codec connection/sender (draft PR follows; validated against this PR's `maven-local-merged` CI artifact).
