### PR TITLE
fix(pool): a MultiThreaded pool's per-buffer refcount was never thread-safe

### DIFF
--- a/buffer/build.gradle.kts
+++ b/buffer/build.gradle.kts
@@ -531,6 +531,13 @@ benchmark {
             iterationTimeUnit = "ms"
             include("largeBufferOperations")
         }
+        register("refcount") {
+            warmups = 3
+            iterations = 5
+            iterationTime = 500
+            iterationTimeUnit = "ms"
+            include("PooledRefCount")
+        }
         register("pool") {
             warmups = 3
             iterations = 5

--- a/buffer/src/commonBenchmark/kotlin/com/ditchoom/buffer/benchmark/PooledRefCountBenchmark.kt
+++ b/buffer/src/commonBenchmark/kotlin/com/ditchoom/buffer/benchmark/PooledRefCountBenchmark.kt
@@ -1,0 +1,117 @@
+package com.ditchoom.buffer.benchmark
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.buffer.pool.ThreadingMode
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.BenchmarkMode
+import kotlinx.benchmark.BenchmarkTimeUnit
+import kotlinx.benchmark.Measurement
+import kotlinx.benchmark.Mode
+import kotlinx.benchmark.OutputTimeUnit
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+import kotlinx.benchmark.TearDown
+import kotlinx.benchmark.Warmup
+
+/**
+ * Cost of `PooledBuffer`'s reference count on the slice/release path.
+ *
+ * Exists to settle one question with a number instead of an argument: making `PooledBuffer`'s
+ * refcount atomic buys thread safety for `MultiThreaded` pools, but only if the atomic is
+ * affordable — an unconditional atomic would tax every `SingleThreaded` pool too, which is the
+ * default and the single-consumer hot path.
+ *
+ * [sliceAndRelease] is the exact path that would change: `slice()` does `checkNotFreed()` +
+ * `addRef()` + two allocations (`inner.slice()` and the `TrackedSlice` wrapper), and
+ * `freeNativeMemory()` on the slice does the matching decrement. The parent chunk's own reference
+ * is held for the whole run, so the count never reaches zero and the pool never reclaims — this
+ * measures refcount traffic in steady state, not pool churn (that is [PoolChurnBenchmark]).
+ *
+ * Both threading modes are measured because the fix only needs to make `MultiThreaded` pools
+ * atomic; `SingleThreaded` is the baseline that must not regress.
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(BenchmarkTimeUnit.SECONDS)
+open class PooledRefCountBenchmark {
+    private lateinit var singleThreadedPool: BufferPool
+    private lateinit var multiThreadedPool: BufferPool
+    private lateinit var singleThreadedChunk: PlatformBuffer
+    private lateinit var multiThreadedChunk: PlatformBuffer
+
+    @Setup
+    fun setup() {
+        singleThreadedPool = newPool(ThreadingMode.SingleThreaded)
+        multiThreadedPool = newPool(ThreadingMode.MultiThreaded)
+        singleThreadedChunk = pinnedChunk(singleThreadedPool)
+        multiThreadedChunk = pinnedChunk(multiThreadedPool)
+    }
+
+    @TearDown
+    fun tearDown() {
+        singleThreadedChunk.freeNativeMemory()
+        multiThreadedChunk.freeNativeMemory()
+        singleThreadedPool.clear()
+        multiThreadedPool.clear()
+    }
+
+    /** Slice + release against a chunk whose own reference is held for the whole run. */
+    @Benchmark
+    fun sliceAndReleaseSingleThreaded(): Int = sliceAndRelease(singleThreadedChunk)
+
+    @Benchmark
+    fun sliceAndReleaseMultiThreaded(): Int = sliceAndRelease(multiThreadedChunk)
+
+    /**
+     * Same path, but the slice is actually read through before release.
+     *
+     * [sliceAndRelease] hands the JIT a slice whose only observed property is `capacity`, which
+     * escape analysis can scalar-replace — making the measurement a property of the optimiser
+     * rather than of the refcount. Reading a byte forces the wrapper to exist and go through
+     * `TrackedSlice`'s liveness check, which is what a real consumer does.
+     */
+    @Benchmark
+    fun sliceReadAndReleaseSingleThreaded(): Int = sliceReadAndRelease(singleThreadedChunk)
+
+    @Benchmark
+    fun sliceReadAndReleaseMultiThreaded(): Int = sliceReadAndRelease(multiThreadedChunk)
+
+    private fun sliceReadAndRelease(chunk: PlatformBuffer): Int {
+        val slice = chunk.slice()
+        val first = slice.readByte().toInt()
+        slice.freeNativeMemory()
+        return first
+    }
+
+    private fun sliceAndRelease(chunk: PlatformBuffer): Int {
+        val slice = chunk.slice()
+        val capacity = slice.capacity
+        slice.freeNativeMemory()
+        return capacity
+    }
+
+    private fun newPool(threadingMode: ThreadingMode) =
+        BufferPool(
+            threadingMode = threadingMode,
+            maxPoolSize = 16,
+            defaultBufferSize = CHUNK_SIZE,
+            factory = BufferFactory.Default,
+        )
+
+    private fun pinnedChunk(pool: BufferPool): PlatformBuffer {
+        val chunk = pool.acquire(CHUNK_SIZE) as PlatformBuffer
+        repeat(CHUNK_SIZE) { chunk.writeByte(1) }
+        chunk.resetForRead()
+        return chunk
+    }
+
+    private companion object {
+        const val CHUNK_SIZE = 1024
+    }
+}

--- a/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/PooledBuffer.kt
+++ b/buffer/src/commonMain/kotlin/com/ditchoom/buffer/pool/PooledBuffer.kt
@@ -8,6 +8,8 @@ import com.ditchoom.buffer.TextPolicy
 import com.ditchoom.buffer.WriteBuffer
 import com.ditchoom.buffer.bufferEquals
 import com.ditchoom.buffer.bufferHashCode
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
 /**
  * A buffer wrapper that returns its inner buffer to a pool when all references are released.
@@ -21,32 +23,76 @@ import com.ditchoom.buffer.bufferHashCode
  * All read/write operations throw [IllegalStateException] after [freeNativeMemory] is called,
  * preventing use-after-free bugs where the inner buffer may have been reused by another caller.
  */
+@OptIn(ExperimentalAtomicApi::class)
 internal class PooledBuffer(
     internal val inner: PlatformBuffer,
     internal val pool: BufferPool,
 ) : PlatformBuffer by inner {
-    private var freed = false
-    private var refCount = 1 // 1 for the chunk reference in StreamProcessor
+    /**
+     * Whether this chunk's references may be taken and dropped from more than one thread.
+     *
+     * Atomic reference counting is **not free**: on x86_64 it measured ~33% slower on the
+     * slice/read/release path (70.4M -> 47.5M ops/s, medians over three alternating rounds), and
+     * neither a CAS retry loop nor a single fetch-and-add avoided that — the cost is the atomic
+     * RMW itself, not the choice of primitive. On ARM64 (LSE) it was free. So the count is atomic
+     * exactly when correctness requires it and plain otherwise, rather than everywhere or nowhere.
+     *
+     * `SingleThreaded` is [BufferPool]'s default and the single-consumer hot path; it keeps the
+     * plain counter and is unchanged. `MultiThreaded` pools — the ones a buffer shared and
+     * released across more than one thread or coroutine must come from — pay for the safety they
+     * actually need.
+     */
+    private val shared = pool.threadingMode == ThreadingMode.MultiThreaded
+
+    // Exactly one of these two is live, chosen by [shared]. Both are always allocated: `AtomicInt`
+    // is a heap object on JVM/JS and PooledBuffer is constructed per `acquire()`, so making the
+    // atomic conditional would trade a branch for an allocation on the hot path.
+    private var plainRefCount = 1 // 1 for the chunk reference in StreamProcessor
+    private val sharedRefCount = AtomicInt(1)
+
+    private var plainFreed = false
+    private val sharedFreed = AtomicInt(0)
 
     private fun checkNotFreed() {
-        if (freed) throw IllegalStateException("Buffer has been freed and returned to pool")
+        val isFreed = if (shared) sharedFreed.load() != 0 else plainFreed
+        if (isFreed) throw IllegalStateException("Buffer has been freed and returned to pool")
     }
 
     internal fun addRef() {
-        refCount++
+        if (!shared) {
+            plainRefCount++
+            return
+        }
+        // Resurrection from zero is refused: it would hand out a slice onto storage another
+        // acquirer already owns. Detected after the increment and undone, because reaching it at
+        // all is a caller bug rather than a race to tolerate.
+        val previous = sharedRefCount.fetchAndAdd(1)
+        if (previous <= 0) {
+            sharedRefCount.fetchAndAdd(-1)
+            throw IllegalStateException("PooledBuffer.addRef() after the last reference was released")
+        }
     }
 
     internal fun releaseRef() {
-        if (--refCount == 0) {
-            pool.release(inner)
-        }
+        val remaining =
+            if (shared) {
+                sharedRefCount.fetchAndAdd(-1) - 1
+            } else {
+                --plainRefCount
+            }
+        check(remaining >= 0) { "PooledBuffer.releaseRef() called more times than it was retained" }
+        // Exactly one caller observes the 1 -> 0 transition, so the chunk is returned once.
+        if (remaining == 0) pool.release(inner)
     }
 
     override fun freeNativeMemory() {
-        if (!freed) {
-            freed = true
-            releaseRef()
-        }
+        val alreadyFreed =
+            if (shared) {
+                sharedFreed.exchange(1) != 0
+            } else {
+                plainFreed.also { plainFreed = true }
+            }
+        if (!alreadyFreed) releaseRef()
     }
 
     override fun slice(byteOrder: ByteOrder): PlatformBuffer {

--- a/buffer/src/jvmTest/kotlin/com/ditchoom/buffer/PooledBufferConcurrencyStressTest.kt
+++ b/buffer/src/jvmTest/kotlin/com/ditchoom/buffer/PooledBufferConcurrencyStressTest.kt
@@ -1,0 +1,158 @@
+package com.ditchoom.buffer
+
+import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.buffer.pool.ThreadingMode
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Real-thread stress test for `PooledBuffer`'s reference count under a
+ * [ThreadingMode.MultiThreaded] [BufferPool].
+ *
+ * `PooledBuffer.addRef()`/`releaseRef()` used to mutate a plain, non-atomic `Int` field. A
+ * `MultiThreaded` pool ([com.ditchoom.buffer.pool.LockFreeBufferPool]) is thread-safe in its
+ * freelist (a Treiber stack) but that says nothing about the per-buffer refcount `PooledBuffer`
+ * wraps around it — nothing prevented two threads from racing `refCount++` / `--refCount`. socket
+ * issue #401 hit this in production: a QUIC echo test received glibc tcache pointers instead of
+ * the payload it sent, reproducible 2-for-2 on CI under load. That is the signature of a genuine
+ * double-release-then-native-free: a lost update on a plain `Int` lets two threads both read the
+ * same pre-decrement value, both conclude "this was the last reference", and both call
+ * `pool.release()` on the same chunk — which the pool then hands out to two owners at once. (The
+ * mirror failure — a lost decrement that leaves the count permanently nonzero — is a leak
+ * instead; this test treats either outcome as proof of the race.)
+ *
+ * A single barrier-synchronized release per chunk (each thread decrements once, all released at
+ * the same instant) turns out to be a poor way to *reliably* provoke this: the read-modify-write
+ * sequence for a plain `Int` field is only a few machine instructions, so a single collision needs
+ * genuine luck even across dozens of threads and thousands of trials — proven flaky while
+ * developing this test (a run at 24 threads x 5,000 trials once passed clean against the
+ * plain-counter build). Instead this sustains **continuous, unsynchronized churn**: many threads
+ * loop `slice()` (`addRef`) + `freeNativeMemory()` (`releaseRef`) on the same [PooledBuffer]
+ * concurrently for hundreds of thousands of cycles. Given enough concurrent unsynchronized RMW
+ * traffic on one field, a lost update stops being a matter of luck — this is the textbook way to
+ * demonstrate a non-atomic counter race (cf. *Java Concurrency in Practice*'s unsafe-counter
+ * example), and it reproduces this bug close to 100% of runs against the plain counter (verified
+ * below).
+ *
+ * This test intentionally never touches real native memory: it allocates through
+ * [BufferFactory.managed], whose `freeNativeMemory()` is a GC no-op. A genuine double free of
+ * *native* memory here could crash the JVM outright instead of failing an assertion, which would
+ * defeat the point of a test that must be run — as part of proving it actually detects the bug —
+ * against the pre-fix plain counter. Instead, [FreeCountingFactory] wraps the raw buffer the pool
+ * allocates so `freeNativeMemory()` calls on it are countable, and `maxPoolSize = 0` forces
+ * [com.ditchoom.buffer.pool.LockFreeBufferPool.release] to call it immediately on every release
+ * (never push to the freelist) — so counting those calls is exactly counting how many times the
+ * pool believed this chunk's last reference had been dropped.
+ */
+class PooledBufferConcurrencyStressTest {
+    private val workerCount = 16
+    private val executor: ExecutorService = Executors.newFixedThreadPool(workerCount)
+
+    @AfterTest
+    fun shutdown() {
+        executor.shutdownNow()
+    }
+
+    @Test
+    fun sustainedConcurrentSliceChurnReleasesTheChunkExactlyOnce() {
+        val cyclesPerWorker = 150_000
+
+        val factory = FreeCountingFactory(BufferFactory.managed())
+        val pool =
+            BufferPool(
+                threadingMode = ThreadingMode.MultiThreaded,
+                maxPoolSize = 0,
+                defaultBufferSize = 64,
+                factory = factory,
+            )
+
+        // refCount starts at 1 for this chunk reference; every worker below takes and drops its
+        // own slice reference in a tight loop, netting zero if (and only if) addRef/releaseRef are
+        // race-free. The chunk's own reference is held until every worker finishes.
+        val chunk = pool.acquire(64) as PlatformBuffer
+        val tracked = factory.lastAllocated ?: error("factory.allocate() was never called")
+
+        val startBarrier = CyclicBarrier(workerCount)
+        val futures =
+            (0 until workerCount).map {
+                executor.submit {
+                    startBarrier.await()
+                    repeat(cyclesPerWorker) {
+                        val slice = chunk.slice()
+                        slice.freeNativeMemory()
+                    }
+                }
+            }
+        futures.forEach { it.get(60, TimeUnit.SECONDS) }
+
+        // No release should have happened yet: the chunk's own reference is still outstanding.
+        // A nonzero count here means a lost update let some worker's releaseRef() observe the
+        // count reaching zero while the chunk's own reference (and possibly other workers') was
+        // still live -- a premature, spurious release.
+        val duringChurnFreeCount = tracked.freeCount.get()
+
+        // Drop the chunk's own reference now that every worker has finished.
+        chunk.freeNativeMemory()
+        val finalFreeCount = tracked.freeCount.get()
+
+        assertEquals(
+            0,
+            duringChurnFreeCount,
+            "the pool believed this chunk's last reference was dropped $duringChurnFreeCount " +
+                "time(s) DURING the $workerCount-thread addRef/releaseRef churn, while the " +
+                "owner's own reference was still outstanding -- a lost update let a releaseRef() " +
+                "observe a premature zero",
+        )
+        assertEquals(
+            1,
+            finalFreeCount,
+            "the chunk must be returned to the pool exactly once, when the owner's own " +
+                "reference is dropped; observed $finalFreeCount release(s) in total after " +
+                "$workerCount threads x $cyclesPerWorker addRef/releaseRef cycles",
+        )
+    }
+
+    /**
+     * Wraps a delegate buffer so [freeNativeMemory] calls are countable without ever touching real
+     * native memory. See the class doc for why a genuine double free is unsafe in this test.
+     */
+    private class FreeCountingBuffer(
+        private val inner: PlatformBuffer,
+    ) : PlatformBuffer by inner {
+        val freeCount = AtomicInteger(0)
+
+        override fun freeNativeMemory() {
+            freeCount.incrementAndGet()
+            inner.freeNativeMemory()
+        }
+    }
+
+    /** Wraps every buffer [delegate] allocates in a [FreeCountingBuffer] and remembers the latest one. */
+    private class FreeCountingFactory(
+        private val delegate: BufferFactory,
+    ) : BufferFactory {
+        @Volatile
+        var lastAllocated: FreeCountingBuffer? = null
+            private set
+
+        override fun allocate(
+            size: Int,
+            byteOrder: ByteOrder,
+        ): PlatformBuffer {
+            val wrapped = FreeCountingBuffer(delegate.allocate(size, byteOrder))
+            lastAllocated = wrapped
+            return wrapped
+        }
+
+        override fun wrap(
+            array: ByteArray,
+            byteOrder: ByteOrder,
+        ): PlatformBuffer = delegate.wrap(array, byteOrder)
+    }
+}


### PR DESCRIPTION
## The bug

`PooledBuffer.addRef()`/`releaseRef()` mutate a plain, non-atomic `Int` (`refCount`) and a plain `Boolean` (`freed`). `LockFreeBufferPool`'s freelist is a genuine lock-free Treiber stack, so a `MultiThreaded` pool *looks* thread-safe — but nothing made the per-buffer refcount wrapped around that freelist thread-safe. Two threads racing `--refCount` can both read the same pre-decrement value, both conclude "this was the last reference", and both call `pool.release()` on the same chunk — which then hands the same backing storage to two owners at once. The mirror failure (a lost decrement that never reaches zero) is a permanent leak.

**Field evidence — socket #401** (DitchOoM/socket#401): a QUIC echo test received **glibc tcache pointers** instead of the payload it sent (`f0 49 11 50 10 7f 00 00 …` — the freed chunk's `next`/`key` metadata), reproducible 2-for-2 on CI under load. That signature requires a genuine double-release-then-native-free: `LockFreeBufferPool.release()` calls `raw.freeNativeMemory()` when the pool is at `maxPoolSize`, and a lost update triggers that path twice for one chunk. socket runs three `MultiThreaded` pools in production, including its TCP read path.

## The fix

The count becomes atomic **exactly when correctness requires it** — `pool.threadingMode == ThreadingMode.MultiThreaded` — via stdlib `kotlin.concurrent.atomics.AtomicInt`. `SingleThreaded` (the default, single-consumer hot path) keeps the plain counter unconditionally, because atomic RMW is not free: benchmarked ~33% slower on x86_64 (70.4M → 47.5M ops/s, medians over alternating rounds; free on ARM64/LSE — the cost is the RMW itself, not the primitive). `PooledRefCountBenchmark` (new `refcount` benchmark target) is the harness those numbers came from.

- `releaseRef()`: `fetchAndAdd(-1)` — exactly one caller observes the 1→0 transition; over-release now throws instead of corrupting.
- `freeNativeMemory()`: `exchange(1)` — idempotent with exactly one winner.
- `addRef()`: refuses resurrection from zero (a slice onto storage another acquirer already owns) loudly.

## Proof the test can catch the bug

The first test shape tried (barrier-synchronized release trials) **once passed clean against the unfixed code** at 24 threads × 5,000 trials — a test that would have lied. It was replaced with sustained unsynchronized churn: 16 threads × 150k `slice()`+`freeNativeMemory()` cycles on one `PooledBuffer`, with a counting wrapper factory and `maxPoolSize = 0` so every believed-last-reference becomes a countable release (never a real native free — a genuine double free could kill the JVM instead of failing the assertion).

**Mutation-verified:** with the plain counter restored, the test failed **4 consecutive runs** (6, 14, 34, 66 spurious pool releases, each run 0.4–1.2s). With the fix, it passed every run. Full module: 1258 tests, 0 failures.

Patch release intended; consumers repin and their existing suites become the field validation.